### PR TITLE
[admin-tool] adding optional dump header in control messages

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1877,13 +1877,16 @@ public class AdminTool {
     ConsumerContext context = createConsumerContext(cmd);
     PubSubPosition startingPosition = parsePositionFromArgs(cmd, context.getPositionDeserializer(), true);
     int messageCount = Integer.parseInt(getRequiredArgument(cmd, Arg.MESSAGE_COUNT));
+    boolean logHeaders = cmd.hasOption(Arg.LOG_HEADERS.toString());
     LOGGER.info(
-        "Dump control messages from topic-partition: {}, starting position: {}, message count: {}",
+        "Dump control messages from topic-partition: {}, starting position: {}, message count: {}, log headers: {}",
         Utils.getReplicaId(topic, partitionNumber),
         startingPosition,
-        messageCount);
+        messageCount,
+        logHeaders);
     try (PubSubConsumerAdapter consumer = getConsumer(pubSubClientsFactory, context)) {
-      new ControlMessageDumper(consumer, topic, partitionNumber, startingPosition, messageCount).fetch().display();
+      new ControlMessageDumper(consumer, topic, partitionNumber, startingPosition, messageCount, logHeaders).fetch()
+          .display();
     }
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -203,6 +203,7 @@ public enum Arg {
   LOG_DATA_RECORD("log-data-record", "ldr", false, "Log the data record for each kafka message on console"),
   LOG_RMD_RECORD("log-rmd-record", "lrr", false, "Log the RMD record for each kafka message on console"),
   LOG_TS_RECORD("log-ts-record", "lts", false, "Log the topic switch message on console"),
+  LOG_HEADERS("log-headers", "lh", false, "Log the PubSub headers for each control message on console"),
   NATIVE_REPLICATION_SOURCE_FABRIC(
       "native-replication-source-fabric", "nrsf", true,
       "The source fabric name to be used in native replication. Remote consumption will happen from kafka in this fabric."

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -85,6 +85,7 @@ import static com.linkedin.venice.Arg.LARGEST_USED_RT_VERSION_NUMBER;
 import static com.linkedin.venice.Arg.LARGEST_USED_VERSION_NUMBER;
 import static com.linkedin.venice.Arg.LATEST_SUPERSET_SCHEMA_ID;
 import static com.linkedin.venice.Arg.LOG_DATA_RECORD;
+import static com.linkedin.venice.Arg.LOG_HEADERS;
 import static com.linkedin.venice.Arg.LOG_METADATA;
 import static com.linkedin.venice.Arg.LOG_RMD_RECORD;
 import static com.linkedin.venice.Arg.LOG_TS_RECORD;
@@ -408,7 +409,8 @@ public enum Command {
   DUMP_CONTROL_MESSAGES(
       "dump-control-messages", "Dump control messages in a partition",
       new Arg[] { KAFKA_BOOTSTRAP_SERVERS, KAFKA_CONSUMER_CONFIG_FILE, KAFKA_TOPIC_NAME, KAFKA_TOPIC_PARTITION,
-          STARTING_OFFSET, STARTING_POSITION, MESSAGE_COUNT }
+          STARTING_OFFSET, STARTING_POSITION, MESSAGE_COUNT },
+      new Arg[] { LOG_HEADERS }
   ),
   DUMP_KAFKA_TOPIC(
       "dump-kafka-topic",

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/ControlMessageDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/ControlMessageDumper.java
@@ -11,9 +11,12 @@ import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.Utils;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -26,6 +29,7 @@ public class ControlMessageDumper {
   private Map<GUID, List<DefaultPubSubMessage>> producerToRecords = new HashMap<>();
   private PubSubConsumerAdapter consumer;
   private int messageCount;
+  private boolean logHeaders;
   private int COUNTDOWN = 3; // TODO: make this configurable
 
   public ControlMessageDumper(
@@ -34,8 +38,19 @@ public class ControlMessageDumper {
       int partitionNumber,
       PubSubPosition startingPosition,
       int messageCount) {
+    this(consumer, topic, partitionNumber, startingPosition, messageCount, false);
+  }
+
+  public ControlMessageDumper(
+      PubSubConsumerAdapter consumer,
+      String topic,
+      int partitionNumber,
+      PubSubPosition startingPosition,
+      int messageCount,
+      boolean logHeaders) {
     this.consumer = consumer;
     this.messageCount = messageCount;
+    this.logHeaders = logHeaders;
     PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
     PubSubTopicPartition partition =
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partitionNumber);
@@ -99,6 +114,23 @@ public class ControlMessageDumper {
           System.out.println("timestamp1: " + metadata.messageTimestamp);
           System.out.println("timestamp2: " + record.getPubSubMessageTime());
           System.out.println(msgType);
+
+          PubSubMessageHeaders headers = logHeaders ? record.getPubSubMessageHeaders() : null;
+          if (headers != null && !headers.isEmpty()) {
+            System.out.println("headers:");
+            for (PubSubMessageHeader header: headers) {
+              byte[] value = header.value();
+              String display;
+              if (value == null) {
+                display = "null";
+              } else if (value.length == Long.BYTES) {
+                display = Long.toString(ByteBuffer.wrap(value).getLong()) + " (long)";
+              } else {
+                display = Arrays.toString(value);
+              }
+              System.out.println("  " + header.key() + " = " + display);
+            }
+          }
 
           if (msgType == ControlMessageType.END_OF_SEGMENT) {
             EndOfSegment end = (EndOfSegment) msg.controlMessageUnion;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/ControlMessageDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/ControlMessageDumper.java
@@ -16,7 +16,9 @@ import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.writer.LeaderCompleteState;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -26,6 +28,9 @@ import java.util.Map;
 
 
 public class ControlMessageDumper {
+  /** Cap on inline display of the ~16 KB Avro envelope schema carried in the {@code vtp} header. */
+  static final int VTP_DISPLAY_CHAR_LIMIT = 200;
+
   private Map<GUID, List<DefaultPubSubMessage>> producerToRecords = new HashMap<>();
   private PubSubConsumerAdapter consumer;
   private int messageCount;
@@ -119,16 +124,7 @@ public class ControlMessageDumper {
           if (headers != null && !headers.isEmpty()) {
             System.out.println("headers:");
             for (PubSubMessageHeader header: headers) {
-              byte[] value = header.value();
-              String display;
-              if (value == null) {
-                display = "null";
-              } else if (value.length == Long.BYTES) {
-                display = Long.toString(ByteBuffer.wrap(value).getLong()) + " (long)";
-              } else {
-                display = Arrays.toString(value);
-              }
-              System.out.println("  " + header.key() + " = " + display);
+              System.out.println("  " + header.key() + " = " + formatHeaderValue(header.key(), header.value()));
             }
           }
 
@@ -141,5 +137,54 @@ public class ControlMessageDumper {
       }
     }
     return totalMessages;
+  }
+
+  /**
+   * Decode {@link PubSubMessageHeaders} values into the schema each well-known Venice header carries.
+   * Falls back to long-decoded (for 8-byte values) or raw byte-array text for unknown keys.
+   */
+  static String formatHeaderValue(String key, byte[] value) {
+    if (value == null) {
+      return "null";
+    }
+    switch (key) {
+      case PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER:
+        if (value.length == Long.BYTES) {
+          long count = ByteBuffer.wrap(value).getLong();
+          return count == PubSubMessageHeaders.PRC_HEADER_UNAVAILABLE_SENTINEL
+              ? count + " (unavailable)"
+              : Long.toString(count);
+        }
+        break;
+      case PubSubMessageHeaders.EXECUTION_ID_KEY:
+        if (value.length == Long.BYTES) {
+          return Long.toString(ByteBuffer.wrap(value).getLong());
+        }
+        break;
+      case PubSubMessageHeaders.VENICE_LEADER_COMPLETION_STATE_HEADER:
+        if (value.length == 1) {
+          try {
+            return LeaderCompleteState.valueOf(value[0]).name();
+          } catch (RuntimeException e) {
+            return "unknown(" + value[0] + ")";
+          }
+        }
+        break;
+      case PubSubMessageHeaders.VENICE_VIEW_PARTITIONS_MAP_HEADER:
+        return new String(value, StandardCharsets.UTF_8);
+      case PubSubMessageHeaders.VENICE_TRANSPORT_PROTOCOL_HEADER:
+        String vtp = new String(value, StandardCharsets.UTF_8);
+        if (vtp.length() > VTP_DISPLAY_CHAR_LIMIT) {
+          return vtp.substring(0, VTP_DISPLAY_CHAR_LIMIT) + "... (avro envelope schema, " + value.length
+              + " bytes total)";
+        }
+        return vtp;
+      default:
+        break;
+    }
+    if (value.length == Long.BYTES) {
+      return ByteBuffer.wrap(value).getLong() + " (long)";
+    }
+    return Arrays.toString(value);
   }
 }

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/ControlMessageDumperTest.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/ControlMessageDumperTest.java
@@ -23,8 +23,10 @@ import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.writer.LeaderCompleteState;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -42,33 +44,108 @@ public class ControlMessageDumperTest {
 
   @Test
   public void testDisplayPrintsPrcHeaderAsLongWhenLogHeadersEnabled() {
-    GUID producerGuid = new GUID();
     long expectedRecordCount = 49925L;
-    byte[] prcBytes = ByteBuffer.allocate(Long.BYTES).putLong(expectedRecordCount).array();
-    PubSubMessageHeaders headers =
-        new PubSubMessageHeaders().add(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER, prcBytes);
+    String output = runWithHeader(
+        PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER,
+        ByteBuffer.allocate(Long.BYTES).putLong(expectedRecordCount).array(),
+        true);
 
-    DefaultPubSubMessage eopWithPrc = buildControlMessage(producerGuid, ControlMessageType.END_OF_PUSH, headers, 100L);
-
-    String output = runDumperAndCaptureOutput(Collections.singletonList(eopWithPrc), true);
-
-    assertTrue(output.contains("END_OF_PUSH"), "EOP type should be printed: " + output);
-    assertTrue(output.contains("headers:"), "headers: prefix should be printed: " + output);
+    assertTrue(output.contains("END_OF_PUSH"), output);
+    assertTrue(output.contains("headers:"), output);
     assertTrue(
-        output.contains("prc = " + expectedRecordCount + " (long)"),
-        "prc header should be decoded as long: " + output);
+        output.contains("prc = " + expectedRecordCount + "\n"),
+        "prc should be decoded as bare long without sentinel tag: " + output);
+    assertFalse(output.contains("(unavailable)"), "Non-sentinel value should not be tagged unavailable: " + output);
+  }
+
+  @Test
+  public void testDisplayMarksPrcUnavailableSentinel() {
+    String output = runWithHeader(
+        PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER,
+        ByteBuffer.allocate(Long.BYTES).putLong(PubSubMessageHeaders.PRC_HEADER_UNAVAILABLE_SENTINEL).array(),
+        true);
+
+    assertTrue(
+        output.contains("prc = " + PubSubMessageHeaders.PRC_HEADER_UNAVAILABLE_SENTINEL + " (unavailable)"),
+        "PRC sentinel value should be tagged as unavailable: " + output);
+  }
+
+  @Test
+  public void testDisplayDecodesExecutionIdAsLong() {
+    long executionId = 8675309L;
+    String output = runWithHeader(
+        PubSubMessageHeaders.EXECUTION_ID_KEY,
+        ByteBuffer.allocate(Long.BYTES).putLong(executionId).array(),
+        true);
+
+    assertTrue(
+        output.contains(PubSubMessageHeaders.EXECUTION_ID_KEY + " = " + executionId + "\n"),
+        "EXECUTION_ID should be decoded as bare long: " + output);
+  }
+
+  @Test
+  public void testDisplayDecodesLeaderCompletionStateAsEnumName() {
+    String output = runWithHeader(
+        PubSubMessageHeaders.VENICE_LEADER_COMPLETION_STATE_HEADER,
+        new byte[] { (byte) LeaderCompleteState.LEADER_COMPLETED.getValue() },
+        true);
+
+    assertTrue(
+        output.contains("lcs = " + LeaderCompleteState.LEADER_COMPLETED.name()),
+        "lcs should be decoded to enum name: " + output);
+  }
+
+  @Test
+  public void testDisplayHandlesUnknownLeaderCompletionStateValue() {
+    String output =
+        runWithHeader(PubSubMessageHeaders.VENICE_LEADER_COMPLETION_STATE_HEADER, new byte[] { (byte) 99 }, true);
+
+    assertTrue(output.contains("lcs = unknown(99)"), "Unknown lcs value should be flagged: " + output);
+  }
+
+  @Test
+  public void testDisplayDecodesViewPartitionsMapAsJsonString() {
+    String json = "{\"view1\":[0],\"view2\":[1,2]}";
+    String output = runWithHeader(
+        PubSubMessageHeaders.VENICE_VIEW_PARTITIONS_MAP_HEADER,
+        json.getBytes(StandardCharsets.UTF_8),
+        true);
+
+    assertTrue(output.contains("vpm = " + json), "vpm should be decoded as raw JSON UTF-8 string: " + output);
+  }
+
+  @Test
+  public void testDisplayDecodesShortVtpAsUtf8String() {
+    String shortSchema = "{\"type\":\"record\",\"name\":\"K\"}";
+    String output = runWithHeader(
+        PubSubMessageHeaders.VENICE_TRANSPORT_PROTOCOL_HEADER,
+        shortSchema.getBytes(StandardCharsets.UTF_8),
+        true);
+
+    assertTrue(output.contains("vtp = " + shortSchema), "Short vtp should be decoded inline: " + output);
+    assertFalse(output.contains("avro envelope schema"), "Short vtp should not be truncated-tagged: " + output);
+  }
+
+  @Test
+  public void testDisplayTruncatesLongVtpAndReportsTotalSize() {
+    StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < ControlMessageDumper.VTP_DISPLAY_CHAR_LIMIT + 50; i++) {
+      builder.append('a');
+    }
+    String longSchema = builder.toString();
+    byte[] vtpBytes = longSchema.getBytes(StandardCharsets.UTF_8);
+
+    String output = runWithHeader(PubSubMessageHeaders.VENICE_TRANSPORT_PROTOCOL_HEADER, vtpBytes, true);
+
+    assertTrue(
+        output.contains("... (avro envelope schema, " + vtpBytes.length + " bytes total)"),
+        "Long vtp should be truncated with size suffix: " + output);
   }
 
   @Test
   public void testDisplaySuppressesHeadersByDefault() {
-    GUID producerGuid = new GUID();
     byte[] prcBytes = ByteBuffer.allocate(Long.BYTES).putLong(123L).array();
-    PubSubMessageHeaders headers =
-        new PubSubMessageHeaders().add(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER, prcBytes);
-
-    DefaultPubSubMessage eopWithPrc = buildControlMessage(producerGuid, ControlMessageType.END_OF_PUSH, headers, 100L);
-
-    String output = runDumperAndCaptureOutput(Collections.singletonList(eopWithPrc), false);
+    String output = runWithHeader(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER, prcBytes, false);
 
     assertTrue(output.contains("END_OF_PUSH"), output);
     assertFalse(output.contains("headers:"), "headers should be suppressed by default: " + output);
@@ -82,38 +159,42 @@ public class ControlMessageDumperTest {
 
     String output = runDumperAndCaptureOutput(Collections.singletonList(eopNoHeaders), true);
 
-    assertTrue(output.contains("END_OF_PUSH"), "EOP type should be printed: " + output);
+    assertTrue(output.contains("END_OF_PUSH"), output);
     assertFalse(output.contains("headers:"), "no headers: block should be printed when no headers: " + output);
   }
 
   @Test
-  public void testDisplayPrintsNonLongHeaderAsByteArray() {
-    GUID producerGuid = new GUID();
-    byte[] vtpBytes = "schema".getBytes(StandardCharsets.UTF_8);
-    PubSubMessageHeaders headers =
-        new PubSubMessageHeaders().add(PubSubMessageHeaders.VENICE_TRANSPORT_PROTOCOL_HEADER, vtpBytes);
+  public void testDisplayFallsBackToLongForUnknown8ByteHeader() {
+    byte[] eightBytes = ByteBuffer.allocate(Long.BYTES).putLong(42L).array();
+    String output = runWithHeader("custom-long", eightBytes, true);
 
-    DefaultPubSubMessage eopWithVtp = buildControlMessage(producerGuid, ControlMessageType.END_OF_PUSH, headers, 100L);
-
-    String output = runDumperAndCaptureOutput(Collections.singletonList(eopWithVtp), true);
-
-    assertTrue(output.contains("headers:"), output);
     assertTrue(
-        output.contains("vtp = " + Arrays.toString(vtpBytes)),
-        "Non-8-byte header should fall back to Arrays.toString(): " + output);
-    assertFalse(output.contains("(long)"), "Non-8-byte header should not be decoded as long: " + output);
+        output.contains("custom-long = 42 (long)"),
+        "Unknown 8-byte header should fall back to long decode with (long) tag: " + output);
+  }
+
+  @Test
+  public void testDisplayFallsBackToByteArrayForUnknownArbitraryHeader() {
+    byte[] arbitrary = new byte[] { 1, 2, 3 };
+    String output = runWithHeader("custom-bytes", arbitrary, true);
+
+    assertTrue(
+        output.contains("custom-bytes = " + Arrays.toString(arbitrary)),
+        "Unknown non-8-byte header should fall back to Arrays.toString: " + output);
   }
 
   @Test
   public void testDisplayHandlesNullHeaderValue() {
-    GUID producerGuid = new GUID();
-    PubSubMessageHeaders headers = new PubSubMessageHeaders().add("custom", null);
-
-    DefaultPubSubMessage eop = buildControlMessage(producerGuid, ControlMessageType.END_OF_PUSH, headers, 100L);
-
-    String output = runDumperAndCaptureOutput(Collections.singletonList(eop), true);
+    String output = runWithHeader("custom", null, true);
 
     assertTrue(output.contains("custom = null"), "Null header value should print 'null': " + output);
+  }
+
+  private static String runWithHeader(String key, byte[] value, boolean logHeaders) {
+    GUID producerGuid = new GUID();
+    PubSubMessageHeaders headers = new PubSubMessageHeaders().add(key, value);
+    DefaultPubSubMessage eop = buildControlMessage(producerGuid, ControlMessageType.END_OF_PUSH, headers, 100L);
+    return runDumperAndCaptureOutput(Collections.singletonList(eop), logHeaders);
   }
 
   private static String runDumperAndCaptureOutput(List<DefaultPubSubMessage> messages, boolean logHeaders) {
@@ -128,13 +209,15 @@ public class ControlMessageDumperTest {
 
     PrintStream originalOut = System.out;
     ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    try (PrintStream capturing = new PrintStream(buffer)) {
+    try (PrintStream capturing = new PrintStream(buffer, true, StandardCharsets.UTF_8.name())) {
       System.setOut(capturing);
       dumper.fetch().display();
+      return buffer.toString(StandardCharsets.UTF_8.name());
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError("UTF-8 is required by the JDK spec", e);
     } finally {
       System.setOut(originalOut);
     }
-    return buffer.toString();
   }
 
   private static PubSubConsumerAdapter mockConsumer(List<DefaultPubSubMessage> messages) {
@@ -167,7 +250,8 @@ public class ControlMessageDumperTest {
       ControlMessage controlMessage,
       PubSubMessageHeaders headers,
       long offset) {
-    KafkaKey kafkaKey = new KafkaKey(MessageType.CONTROL_MESSAGE, Utils.getUniqueString("key-").getBytes());
+    KafkaKey kafkaKey =
+        new KafkaKey(MessageType.CONTROL_MESSAGE, Utils.getUniqueString("key-").getBytes(StandardCharsets.UTF_8));
     KafkaMessageEnvelope envelope = new KafkaMessageEnvelope();
     envelope.messageType = MessageType.CONTROL_MESSAGE.getValue();
     envelope.producerMetadata = new ProducerMetadata();

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/ControlMessageDumperTest.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/ControlMessageDumperTest.java
@@ -1,0 +1,190 @@
+package com.linkedin.venice;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.kafka.protocol.ControlMessage;
+import com.linkedin.venice.kafka.protocol.EndOfPush;
+import com.linkedin.venice.kafka.protocol.GUID;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.ProducerMetadata;
+import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
+import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.utils.Utils;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class ControlMessageDumperTest {
+  private static final PubSubTopicRepository TOPIC_REPOSITORY = new PubSubTopicRepository();
+  private static final String TOPIC = "test_store_v1";
+  private static final int PARTITION = 0;
+
+  @Test
+  public void testDisplayPrintsPrcHeaderAsLongWhenLogHeadersEnabled() {
+    GUID producerGuid = new GUID();
+    long expectedRecordCount = 49925L;
+    byte[] prcBytes = ByteBuffer.allocate(Long.BYTES).putLong(expectedRecordCount).array();
+    PubSubMessageHeaders headers =
+        new PubSubMessageHeaders().add(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER, prcBytes);
+
+    DefaultPubSubMessage eopWithPrc = buildControlMessage(producerGuid, ControlMessageType.END_OF_PUSH, headers, 100L);
+
+    String output = runDumperAndCaptureOutput(Collections.singletonList(eopWithPrc), true);
+
+    assertTrue(output.contains("END_OF_PUSH"), "EOP type should be printed: " + output);
+    assertTrue(output.contains("headers:"), "headers: prefix should be printed: " + output);
+    assertTrue(
+        output.contains("prc = " + expectedRecordCount + " (long)"),
+        "prc header should be decoded as long: " + output);
+  }
+
+  @Test
+  public void testDisplaySuppressesHeadersByDefault() {
+    GUID producerGuid = new GUID();
+    byte[] prcBytes = ByteBuffer.allocate(Long.BYTES).putLong(123L).array();
+    PubSubMessageHeaders headers =
+        new PubSubMessageHeaders().add(PubSubMessageHeaders.VENICE_PARTITION_RECORD_COUNT_HEADER, prcBytes);
+
+    DefaultPubSubMessage eopWithPrc = buildControlMessage(producerGuid, ControlMessageType.END_OF_PUSH, headers, 100L);
+
+    String output = runDumperAndCaptureOutput(Collections.singletonList(eopWithPrc), false);
+
+    assertTrue(output.contains("END_OF_PUSH"), output);
+    assertFalse(output.contains("headers:"), "headers should be suppressed by default: " + output);
+    assertFalse(output.contains("prc"), "prc value should not be printed without flag: " + output);
+  }
+
+  @Test
+  public void testDisplayOmitsHeadersBlockWhenNoHeaders() {
+    GUID producerGuid = new GUID();
+    DefaultPubSubMessage eopNoHeaders = buildControlMessage(producerGuid, ControlMessageType.END_OF_PUSH, null, 100L);
+
+    String output = runDumperAndCaptureOutput(Collections.singletonList(eopNoHeaders), true);
+
+    assertTrue(output.contains("END_OF_PUSH"), "EOP type should be printed: " + output);
+    assertFalse(output.contains("headers:"), "no headers: block should be printed when no headers: " + output);
+  }
+
+  @Test
+  public void testDisplayPrintsNonLongHeaderAsByteArray() {
+    GUID producerGuid = new GUID();
+    byte[] vtpBytes = "schema".getBytes(StandardCharsets.UTF_8);
+    PubSubMessageHeaders headers =
+        new PubSubMessageHeaders().add(PubSubMessageHeaders.VENICE_TRANSPORT_PROTOCOL_HEADER, vtpBytes);
+
+    DefaultPubSubMessage eopWithVtp = buildControlMessage(producerGuid, ControlMessageType.END_OF_PUSH, headers, 100L);
+
+    String output = runDumperAndCaptureOutput(Collections.singletonList(eopWithVtp), true);
+
+    assertTrue(output.contains("headers:"), output);
+    assertTrue(
+        output.contains("vtp = " + Arrays.toString(vtpBytes)),
+        "Non-8-byte header should fall back to Arrays.toString(): " + output);
+    assertFalse(output.contains("(long)"), "Non-8-byte header should not be decoded as long: " + output);
+  }
+
+  @Test
+  public void testDisplayHandlesNullHeaderValue() {
+    GUID producerGuid = new GUID();
+    PubSubMessageHeaders headers = new PubSubMessageHeaders().add("custom", null);
+
+    DefaultPubSubMessage eop = buildControlMessage(producerGuid, ControlMessageType.END_OF_PUSH, headers, 100L);
+
+    String output = runDumperAndCaptureOutput(Collections.singletonList(eop), true);
+
+    assertTrue(output.contains("custom = null"), "Null header value should print 'null': " + output);
+  }
+
+  private static String runDumperAndCaptureOutput(List<DefaultPubSubMessage> messages, boolean logHeaders) {
+    PubSubConsumerAdapter consumer = mockConsumer(messages);
+    ControlMessageDumper dumper = new ControlMessageDumper(
+        consumer,
+        TOPIC,
+        PARTITION,
+        ApacheKafkaOffsetPosition.of(0),
+        messages.size() + 1,
+        logHeaders);
+
+    PrintStream originalOut = System.out;
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (PrintStream capturing = new PrintStream(buffer)) {
+      System.setOut(capturing);
+      dumper.fetch().display();
+    } finally {
+      System.setOut(originalOut);
+    }
+    return buffer.toString();
+  }
+
+  private static PubSubConsumerAdapter mockConsumer(List<DefaultPubSubMessage> messages) {
+    PubSubConsumerAdapter consumer = mock(PubSubConsumerAdapter.class);
+    PubSubTopicPartition partition = new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic(TOPIC), PARTITION);
+
+    Map<PubSubTopicPartition, List<DefaultPubSubMessage>> firstPoll = new HashMap<>();
+    firstPoll.put(partition, messages);
+    Map<PubSubTopicPartition, List<DefaultPubSubMessage>> emptyPoll = Collections.emptyMap();
+
+    when(consumer.poll(anyLong())).thenReturn(firstPoll).thenReturn(emptyPoll);
+    return consumer;
+  }
+
+  private static DefaultPubSubMessage buildControlMessage(
+      GUID producerGuid,
+      ControlMessageType type,
+      PubSubMessageHeaders headers,
+      long offset) {
+    ControlMessage controlMessage = new ControlMessage();
+    controlMessage.controlMessageType = type.getValue();
+    if (type == ControlMessageType.END_OF_PUSH) {
+      controlMessage.controlMessageUnion = new EndOfPush();
+    }
+    return wrap(producerGuid, controlMessage, headers, offset);
+  }
+
+  private static DefaultPubSubMessage wrap(
+      GUID producerGuid,
+      ControlMessage controlMessage,
+      PubSubMessageHeaders headers,
+      long offset) {
+    KafkaKey kafkaKey = new KafkaKey(MessageType.CONTROL_MESSAGE, Utils.getUniqueString("key-").getBytes());
+    KafkaMessageEnvelope envelope = new KafkaMessageEnvelope();
+    envelope.messageType = MessageType.CONTROL_MESSAGE.getValue();
+    envelope.producerMetadata = new ProducerMetadata();
+    envelope.producerMetadata.producerGUID = producerGuid;
+    envelope.producerMetadata.segmentNumber = 0;
+    envelope.producerMetadata.messageSequenceNumber = 0;
+    envelope.producerMetadata.messageTimestamp = 0L;
+    envelope.payloadUnion = controlMessage;
+
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic(TOPIC), PARTITION);
+    return new ImmutablePubSubMessage(
+        kafkaKey,
+        envelope,
+        topicPartition,
+        ApacheKafkaOffsetPosition.of(offset),
+        0L,
+        0,
+        headers);
+  }
+}


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
When debugging push correctness — especially partition record count verification — operators need to inspect the PubSub headers attached to control messages (e.g. prc on END_OF_PUSH, vtp on START_OF_PUSH). Today admin-tool dump-control-messages prints the control message body but drops headers entirely, so there is no operator-facing way to confirm what producers actually stamped on the wire. This forces ad-hoc Kafka tooling or custom scripts whenever a header-related discrepancy is suspected.

## Solution
Add an opt-in `--log-headers / -lh` flag to the dump-control-messages command. When set, ControlMessageDumper#display() prints a headers: block per control message with one line per header, formatted as:

  - `<key> = <long value> (long)` when the value is exactly 8 bytes — covers prc (partition record count) and other long-encoded headers,
  - `<key> = [b0, b1, ...] (raw Arrays.toString)` for any other length,
  - `<key> = null `when the value is `null`.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.