### PR TITLE
[vpj] Support running VTConsistencyCheckerJob via VenicePushJob

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -87,6 +87,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_DISCOVER_URL_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_STORE_NAME_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.VT_CONSISTENCY_CHECK_ONLY;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.d2.balancer.D2Client;
@@ -148,6 +149,7 @@ import com.linkedin.venice.schema.writecompute.WriteComputeOperation;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
+import com.linkedin.venice.spark.consistency.VTConsistencyCheckerJob;
 import com.linkedin.venice.spark.utils.RmdPushUtils;
 import com.linkedin.venice.status.PushJobDetailsStatus;
 import com.linkedin.venice.status.protocol.PushJobDetails;
@@ -536,7 +538,10 @@ public class VenicePushJob implements AutoCloseable {
       }
     }
 
-    pushJobSettingToReturn.inputURI = pushJobSettingToReturn.isSourceKafka ? "" : getInputURI(props);
+    pushJobSettingToReturn.inputURI =
+        (pushJobSettingToReturn.isSourceKafka || props.getBoolean(VT_CONSISTENCY_CHECK_ONLY, false))
+            ? ""
+            : getInputURI(props);
     pushJobSettingToReturn.storeName = props.getString(VENICE_STORE_NAME_PROP);
     pushJobSettingToReturn.rewindTimeInSecondsOverride = props.getLong(REWIND_TIME_IN_SECONDS_OVERRIDE, NOT_SET);
 
@@ -725,6 +730,11 @@ public class VenicePushJob implements AutoCloseable {
    */
   public void run() {
     try {
+      if (props.getBoolean(VT_CONSISTENCY_CHECK_ONLY, false)) {
+        LOGGER.info("VT consistency check-only mode: skipping push, running VTConsistencyCheckerJob.");
+        runVTConsistencyCheck();
+        return;
+      }
       initControllerClient(pushJobSetting.storeName);
       pushJobSetting.clusterName = controllerClient.getClusterName();
       LOGGER.info(
@@ -1032,6 +1042,17 @@ public class VenicePushJob implements AutoCloseable {
       timeoutExecutor.shutdownNow();
       LOGGER.info("Completed shutdown for timeoutExecutor");
     }
+  }
+
+  /**
+   * Delegates to {@link VTConsistencyCheckerJob#run(Properties)}. Bridges VPJ's
+   * {@code venice.store.name} key to the checker's {@code store.name} key since the two components
+   * use independent naming conventions.
+   */
+  void runVTConsistencyCheck() {
+    Properties checkerProps = props.toProperties();
+    checkerProps.setProperty(VTConsistencyCheckerJob.STORE_NAME, props.getString(VENICE_STORE_NAME_PROP));
+    VTConsistencyCheckerJob.run(checkerProps);
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJob.java
@@ -230,6 +230,7 @@ public class VTConsistencyCheckerJob {
 
       LongAccumulator partitionsProcessed = spark.sparkContext().longAccumulator("partitionsProcessed");
       LongAccumulator partitionsWithErrors = spark.sparkContext().longAccumulator("partitionsWithErrors");
+      LongAccumulator inconsistenciesFound = spark.sparkContext().longAccumulator("inconsistenciesFound");
 
       Dataset<Row> inconsistencies = spark.createDataset(partitions, Encoders.INT())
           .flatMap(
@@ -239,23 +240,29 @@ public class VTConsistencyCheckerJob {
                   jobProps,
                   numberOfRegions,
                   partitionsProcessed,
-                  partitionsWithErrors),
+                  partitionsWithErrors,
+                  inconsistenciesFound),
               RowEncoder.apply(OUTPUT_SCHEMA));
 
       inconsistencies.write().mode(SaveMode.ErrorIfExists).parquet(outputPath);
 
       LOGGER.info(
-          "VT consistency check complete. topic={} partitions={} processed={} errors={} output={}",
+          "VT consistency check complete. topic={} partitions={} processed={} errors={} inconsistencies={} output={}",
           versionTopic,
           partitionCount,
           partitionsProcessed.value(),
           partitionsWithErrors.value(),
+          inconsistenciesFound.value(),
           outputPath);
 
       if (partitionsWithErrors.value() > 0) {
-        throw new RuntimeException(
+        throw new VeniceException(
             partitionsWithErrors.value() + " partition(s) failed during scan of topic " + versionTopic
                 + ". Check executor logs for details.");
+      }
+      if (inconsistenciesFound.value() > 0) {
+        throw new VeniceException(
+            inconsistenciesFound.value() + " inconsistencies found for " + versionTopic + "; see " + outputPath);
       }
     } finally {
       if (spark != null) {
@@ -274,7 +281,8 @@ public class VTConsistencyCheckerJob {
       Properties jobProps,
       int numberOfRegions,
       LongAccumulator partitionsProcessed,
-      LongAccumulator partitionsWithErrors) {
+      LongAccumulator partitionsWithErrors,
+      LongAccumulator inconsistenciesFound) {
     int partition = dc0Split.getPartitionNumber();
     String versionTopic = dc0Split.getTopicName();
     try {
@@ -341,6 +349,7 @@ public class VTConsistencyCheckerJob {
             found.size());
 
         partitionsProcessed.add(1);
+        inconsistenciesFound.add(found.size());
         return found.stream().map(inc -> toRow(inc, versionTopic, partition)).iterator();
       } finally {
         Utils.closeQuietlyWithErrorLogged(dc0Consumer);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -323,6 +323,14 @@ public final class VenicePushJobConstants {
   public static final String ENABLE_WRITE_COMPUTE = "venice.write.compute.enable";
   public static final String ENABLE_SSL = "venice.ssl.enable";
   public static final String VENICE_STORE_NAME_PROP = "venice.store.name";
+
+  /**
+   * When set to {@code true}, {@link com.linkedin.venice.hadoop.VenicePushJob#run()} skips the
+   * push and instead invokes {@link com.linkedin.venice.spark.consistency.VTConsistencyCheckerJob}
+   * against the store's current version topic.
+   */
+  public static final String VT_CONSISTENCY_CHECK_ONLY = "vt.consistency.check.only";
+
   public static final String INPUT_PATH_PROP = "input.path";
   public static final String INPUT_PATH_LAST_MODIFIED_TIME = "input.path.last.modified.time";
   public static final String BATCH_NUM_BYTES_PROP = "batch.num.bytes";

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -37,6 +37,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_DISCOVER_URL_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_STORE_NAME_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.VT_CONSISTENCY_CHECK_ONLY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -201,6 +202,34 @@ public class VenicePushJobTest {
       TestWriteUtils.writeSimpleAvroFileWithStringToStringWithExtraSchema(inputDir);
       mockJob.checkLastModificationTimeAndLog();
       verify(mockJob, times(1)).updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.DATASET_CHANGED);
+    }
+  }
+
+  @Test
+  public void testRunShortCircuitsToVTConsistencyCheckWhenFlagSet() {
+    ControllerClient mockClient = mock(ControllerClient.class);
+    Properties props = new Properties();
+    props.setProperty(VT_CONSISTENCY_CHECK_ONLY, "true");
+    try (VenicePushJob spyJob = getSpyVenicePushJob(props, mockClient)) {
+      doNothing().when(spyJob).runVTConsistencyCheck();
+      spyJob.run();
+      verify(spyJob, times(1)).runVTConsistencyCheck();
+      verifyNoInteractions(mockClient);
+    }
+  }
+
+  @Test
+  public void testRunDoesNotShortCircuitWhenFlagAbsent() {
+    Properties props = new Properties();
+    try (VenicePushJob spyJob = getSpyVenicePushJob(props, null)) {
+      doNothing().when(spyJob).runVTConsistencyCheck();
+      try {
+        spyJob.run();
+      } catch (Exception ignored) {
+        // The push path will throw because the test stubs aren't wired for a full push.
+        // We only care that the checker gate wasn't taken.
+      }
+      verify(spyJob, never()).runVTConsistencyCheck();
     }
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJobTest.java
@@ -291,6 +291,7 @@ public class VTConsistencyCheckerJobTest {
   public void testFindInconsistenciesForPartitionReturnsErrorRowOnException() {
     LongAccumulator partitionsProcessed = mock(LongAccumulator.class);
     LongAccumulator partitionsWithErrors = mock(LongAccumulator.class);
+    LongAccumulator inconsistenciesFound = mock(LongAccumulator.class);
 
     PubSubTopicRepository repo = new PubSubTopicRepository();
     PubSubTopicPartition tp = new PubSubTopicPartitionImpl(repo.getTopic("store_v1"), 3);
@@ -305,7 +306,8 @@ public class VTConsistencyCheckerJobTest {
         new Properties(),
         3,
         partitionsProcessed,
-        partitionsWithErrors);
+        partitionsWithErrors,
+        inconsistenciesFound);
 
     List<Row> rows = collectRows(result);
     assertEquals(rows.size(), 1, "exactly one sentinel ERROR row");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVTConsistencyCheckerJob.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVTConsistencyCheckerJob.java
@@ -10,9 +10,12 @@ import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_DISCOVER_URL_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_STORE_NAME_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.VT_CONSISTENCY_CHECK_ONLY;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
 
 import com.linkedin.venice.annotation.PubSubAgnosticTest;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
@@ -20,6 +23,8 @@ import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.hadoop.VenicePushJob;
 import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.Version;
@@ -106,6 +111,42 @@ public class TestVTConsistencyCheckerJob extends AbstractMultiRegionTest {
    */
   @Test(timeOut = TEST_TIMEOUT)
   public void testFullPipelineWithBatchPushRTWritesAndInjectedInconsistency() throws Exception {
+    String storeName = setupAACorruptedStore();
+    String versionTopic = Version.composeKafkaTopic(storeName, 1);
+    File tempRoot = Files.createTempDirectory("vt-consistency-full-pipeline").toFile();
+    File outputDir = new File(tempRoot, "output");
+    try {
+      Properties jobProps = buildCheckerJobProps(storeName, outputDir);
+      assertThrows(VeniceException.class, () -> VTConsistencyCheckerJob.run(jobProps));
+      verifyMismatchInParquet(outputDir, versionTopic);
+    } finally {
+      org.apache.commons.io.FileUtils.deleteDirectory(tempRoot);
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testFullPipelineWithVPJDrivenCheckerThrowsOnInconsistency() throws Exception {
+    String storeName = setupAACorruptedStore();
+    String versionTopic = Version.composeKafkaTopic(storeName, 1);
+    File tempRoot = Files.createTempDirectory("vt-consistency-vpj-driven").toFile();
+    File outputDir = new File(tempRoot, "output");
+    try {
+      Properties jobProps = buildCheckerJobProps(storeName, outputDir);
+      // Simulate a real VPJ config: only venice.store.name is set, not the checker's store.name.
+      // VenicePushJob.runVTConsistencyCheck() must bridge the two keys.
+      jobProps.remove(VTConsistencyCheckerJob.STORE_NAME);
+      jobProps.setProperty(VT_CONSISTENCY_CHECK_ONLY, "true");
+      jobProps.setProperty(VENICE_STORE_NAME_PROP, storeName);
+      try (VenicePushJob vpj = new VenicePushJob(Utils.getUniqueString("vpj-vt-check"), jobProps)) {
+        assertThrows(VeniceException.class, vpj::run);
+      }
+      verifyMismatchInParquet(outputDir, versionTopic);
+    } finally {
+      org.apache.commons.io.FileUtils.deleteDirectory(tempRoot);
+    }
+  }
+
+  private String setupAACorruptedStore() throws Exception {
     // 1. Batch push with 5 records via VPJ
     File inputDir = getTempDataDirectory();
     Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir, 5);
@@ -227,46 +268,43 @@ public class TestVTConsistencyCheckerJob extends AbstractMultiRegionTest {
         }
       });
 
-      // 6. Run VT consistency checker
-      File tempRoot = Files.createTempDirectory("vt-consistency-full-pipeline").toFile();
-      File outputDir = new File(tempRoot, "output");
-      try {
-        Properties jobProps = new Properties();
-        jobProps.setProperty(
-            VTConsistencyCheckerJob.DC0_BROKER_URL,
-            childDatacenters.get(0).getPubSubBrokerWrapper().getAddress());
-        jobProps.setProperty(
-            VTConsistencyCheckerJob.DC1_BROKER_URL,
-            childDatacenters.get(1).getPubSubBrokerWrapper().getAddress());
-        jobProps.setProperty(VTConsistencyCheckerJob.STORE_NAME, storeName);
-        jobProps.setProperty(VENICE_DISCOVER_URL_PROP, childDatacenters.get(0).getControllerConnectString());
-        jobProps.setProperty(VTConsistencyCheckerJob.OUTPUT_PATH, outputDir.getAbsolutePath());
-        jobProps.setProperty(VTConsistencyCheckerJob.NUMBER_OF_REGIONS, "2");
+      return storeName;
+    }
+  }
 
-        VTConsistencyCheckerJob.run(jobProps);
+  private Properties buildCheckerJobProps(String storeName, File outputDir) {
+    Properties jobProps = new Properties();
+    jobProps.setProperty(
+        VTConsistencyCheckerJob.DC0_BROKER_URL,
+        childDatacenters.get(0).getPubSubBrokerWrapper().getAddress());
+    jobProps.setProperty(
+        VTConsistencyCheckerJob.DC1_BROKER_URL,
+        childDatacenters.get(1).getPubSubBrokerWrapper().getAddress());
+    jobProps.setProperty(VTConsistencyCheckerJob.STORE_NAME, storeName);
+    jobProps.setProperty(VENICE_DISCOVER_URL_PROP, childDatacenters.get(0).getControllerConnectString());
+    jobProps.setProperty(VTConsistencyCheckerJob.OUTPUT_PATH, outputDir.getAbsolutePath());
+    jobProps.setProperty(VTConsistencyCheckerJob.NUMBER_OF_REGIONS, "2");
+    return jobProps;
+  }
 
-        SparkSession reader =
-            SparkSession.builder().master("local[*]").appName("TestVTConsistencyCheckerJob-reader").getOrCreate();
-        try {
-          Dataset<Row> result = reader.read().parquet(outputDir.getAbsolutePath());
-          List<Row> rows = result.collectAsList();
+  private void verifyMismatchInParquet(File outputDir, String versionTopic) {
+    SparkSession reader =
+        SparkSession.builder().master("local[*]").appName("TestVTConsistencyCheckerJob-reader").getOrCreate();
+    try {
+      Dataset<Row> result = reader.read().parquet(outputDir.getAbsolutePath());
+      List<Row> rows = result.collectAsList();
 
-          // Expect at least one VALUE_MISMATCH for the overwritten key "buggy-key"
-          List<Row> mismatches =
-              rows.stream().filter(r -> "VALUE_MISMATCH".equals(r.getAs("type"))).collect(Collectors.toList());
-          assertFalse(mismatches.isEmpty(), "Expected at least one VALUE_MISMATCH for the corrupted key");
+      List<Row> mismatches =
+          rows.stream().filter(r -> "VALUE_MISMATCH".equals(r.getAs("type"))).collect(Collectors.toList());
+      assertFalse(mismatches.isEmpty(), "Expected at least one VALUE_MISMATCH for the corrupted key");
 
-          Row corruptRow = mismatches.get(0);
-          assertEquals(corruptRow.getAs("version_topic"), versionTopic);
-          assertFalse(
-              corruptRow.getAs("dc0_value_hash").equals(corruptRow.getAs("dc1_value_hash")),
-              "DC value hashes must differ for corrupted key");
-        } finally {
-          reader.stop();
-        }
-      } finally {
-        org.apache.commons.io.FileUtils.deleteDirectory(tempRoot);
-      }
+      Row corruptRow = mismatches.get(0);
+      assertEquals(corruptRow.getAs("version_topic"), versionTopic);
+      assertFalse(
+          corruptRow.getAs("dc0_value_hash").equals(corruptRow.getAs("dc1_value_hash")),
+          "DC value hashes must differ for corrupted key");
+    } finally {
+      reader.stop();
     }
   }
 


### PR DESCRIPTION
## Problem Statement

VTConsistencyCheckerJob (recently introduced) is a Spark job that scans Version Topics across two DCs to detect cross-region inconsistencies. Currently, we integrate it via VBnP using HadoopJavaOperator which complicates the wiring process. We want to integrate it to VenicePushOperator so it can be seamlessly added to the airflow DAGs. Also, the spark job today doesn't fail the operator when inconsistencies are found, rather it silently ends by writing the errors to parquet. We need to throw an error, so the DAG step can be failed. 


## Solution

1. VPJ as the entry point. Added a vt.consistency.check.only flag. When set, VenicePushJob.run() short-circuits the push and delegates to VTConsistencyCheckerJob.run(props) via runVTConsistencyCheck().
2. Fail-fast on findings. Added a LongAccumulator inconsistenciesFound in the checker, incremented per detected mismatch. After the Parquet write completes (so forensics are preserved on disk), the job throws VeniceException if the count is non-zero.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
- [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [x] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.