### PR TITLE
[server][vpj][admin-tool] Plumb KME SchemaReader through consumer-side dictionary fetch and topic dump paths

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -550,6 +550,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         .setDiskUsage(diskUsage)
         .setAggKafkaConsumerService(aggKafkaConsumerService)
         .setPartitionStateSerializer(partitionStateSerializer)
+        .setKafkaMessageEnvelopeSchemaReader(kafkaMessageEnvelopeSchemaReader.orElse(null))
         .setIsDaVinciClient(isDaVinciClient)
         .setRemoteIngestionRepairService(remoteIngestionRepairService)
         .setMetaStoreWriter(metaStoreWriter)

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3919,6 +3919,26 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
   }
 
+  /**
+   * No SoP-available dictionary fetch from the VT reuses the same KME SchemaReader the host's
+   * main KafkaValueSerializer was wired with so this fallback consumer can decode a control
+   * message even if it lacks the vtp protocol-schema header. If the SchemaReader wasn't plumbed,
+   * log and fall back to the jar-only deserializer - the on-wire vtp header bootstrap still
+   * applies on the fallback path.
+   */
+  @VisibleForTesting
+  PubSubMessageDeserializer buildDictionaryFetchDeserializer() {
+    if (kafkaMessageEnvelopeSchemaReader != null) {
+      return PubSubMessageDeserializer.createWithSchemaReader(kafkaMessageEnvelopeSchemaReader);
+    }
+    LOGGER.warn(
+        "kafkaMessageEnvelopeSchemaReader is null on StoreIngestionTask for {}; using the jar-only "
+            + "KME deserializer for the SoP-null dictionary fallback. The on-wire vtp header bootstrap "
+            + "still applies.",
+        kafkaVersionTopic);
+    return PubSubMessageDeserializer.createDefaultDeserializer();
+  }
+
   @VisibleForTesting
   StoreVersionState getNewStoreVersionState(long timestamp, boolean sorted, StartOfPush startOfPush) {
     StoreVersionState newStoreVersionState = new StoreVersionState();
@@ -3932,26 +3952,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         throw new VeniceException(
             "compression Dictionary should not be empty if CompressionStrategy is ZSTD_WITH_DICT");
       } else if (startOfPush == null) {
-        /*
-         * No SoP available; retrieve the dictionary directly from the VT. Reuse the same KME
-         * SchemaReader the host's main KafkaValueSerializer was wired with so this fallback
-         * consumer can decode a control message that lacks the vtp protocol-schema header.
-         * If the SchemaReader wasn't plumbed, log and fall back to the jar-only deserializer.
-         * The on-wire vtp header bootstrap still applies on the fallback path.
-         */
-        PubSubMessageDeserializer dictDeserializer;
-        if (kafkaMessageEnvelopeSchemaReader != null) {
-          dictDeserializer = PubSubMessageDeserializer.createWithSchemaReader(kafkaMessageEnvelopeSchemaReader);
-        } else {
-          LOGGER.warn(
-              "kafkaMessageEnvelopeSchemaReader is null on StoreIngestionTask for {}; using the jar-only "
-                  + "KME deserializer for the SoP-null dictionary fallback. The on-wire vtp header bootstrap "
-                  + "still applies.",
-              kafkaVersionTopic);
-          dictDeserializer = PubSubMessageDeserializer.createDefaultDeserializer();
-        }
-        newStoreVersionState.compressionDictionary = DictionaryUtils
-            .readDictionaryFromKafka(kafkaVersionTopic, new VeniceProperties(kafkaProps), dictDeserializer);
+        newStoreVersionState.compressionDictionary = DictionaryUtils.readDictionaryFromKafka(
+            kafkaVersionTopic,
+            new VeniceProperties(kafkaProps),
+            buildDictionaryFetchDeserializer());
       }
     }
     newStoreVersionState.batchConflictResolutionPolicy = startOfPush != null ? startOfPush.timestampPolicy : 1;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3934,22 +3934,22 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       } else if (startOfPush == null) {
         /*
          * No SoP available; retrieve the dictionary directly from the VT. Reuse the same KME
-         * SchemaReader the host's main KafkaValueSerializer was wired with, so this fallback
+         * SchemaReader the host's main KafkaValueSerializer was wired with so this fallback
          * consumer can decode a control message that lacks the vtp protocol-schema header.
-         *
-         * Strict first-iteration: throws if the schema reader wasn't plumbed. Surfaces SIT
-         * construction paths that didn't call setKafkaMessageEnvelopeSchemaReader. Follow-up
-         * PR will soften to a logged fallback to createDefaultDeserializer.
+         * If the SchemaReader wasn't plumbed, log and fall back to the jar-only deserializer.
+         * The on-wire vtp header bootstrap still applies on the fallback path.
          */
-        if (kafkaMessageEnvelopeSchemaReader == null) {
-          throw new IllegalStateException(
-              "kafkaMessageEnvelopeSchemaReader is null on this StoreIngestionTask; cannot decode "
-                  + "the source-of-truth VT for the SoP-null dictionary fallback path. The "
-                  + "StoreIngestionTaskFactory.Builder caller did not plumb the KME SchemaReader from "
-                  + "KafkaStoreIngestionService.");
+        PubSubMessageDeserializer dictDeserializer;
+        if (kafkaMessageEnvelopeSchemaReader != null) {
+          dictDeserializer = PubSubMessageDeserializer.createWithSchemaReader(kafkaMessageEnvelopeSchemaReader);
+        } else {
+          LOGGER.warn(
+              "kafkaMessageEnvelopeSchemaReader is null on StoreIngestionTask for {}; using the jar-only "
+                  + "KME deserializer for the SoP-null dictionary fallback. The on-wire vtp header bootstrap "
+                  + "still applies.",
+              kafkaVersionTopic);
+          dictDeserializer = PubSubMessageDeserializer.createDefaultDeserializer();
         }
-        PubSubMessageDeserializer dictDeserializer =
-            PubSubMessageDeserializer.createWithSchemaReader(kafkaMessageEnvelopeSchemaReader);
         newStoreVersionState.compressionDictionary = DictionaryUtils
             .readDictionaryFromKafka(kafkaVersionTopic, new VeniceProperties(kafkaProps), dictDeserializer);
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -120,6 +120,7 @@ import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
@@ -279,6 +280,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected final int versionNumber;
   protected final ReadOnlySchemaRepository schemaRepository;
   protected final ReadOnlyStoreRepository storeRepository;
+  protected final SchemaReader kafkaMessageEnvelopeSchemaReader;
   protected final String ingestionTaskName;
   protected final Properties kafkaProps;
   protected final AtomicBoolean isRunning;
@@ -543,6 +545,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.storageMetadataService = builder.getStorageMetadataService();
     this.storeRepository = builder.getMetadataRepo();
     this.schemaRepository = builder.getSchemaRepo();
+    this.kafkaMessageEnvelopeSchemaReader = builder.getKafkaMessageEnvelopeSchemaReader();
     this.kafkaVersionTopic = storeVersionConfig.getStoreVersionName();
     this.pubSubContext = builder.getPubSubContext();
     this.pubSubTopicRepository = pubSubContext.getPubSubTopicRepository();
@@ -3929,11 +3932,26 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         throw new VeniceException(
             "compression Dictionary should not be empty if CompressionStrategy is ZSTD_WITH_DICT");
       } else if (startOfPush == null) {
-        // No SOP available; retrieve the dictionary directly from the VT
-        newStoreVersionState.compressionDictionary = DictionaryUtils.readDictionaryFromKafka(
-            kafkaVersionTopic,
-            new VeniceProperties(kafkaProps),
-            PubSubMessageDeserializer.createDefaultDeserializer());
+        /*
+         * No SoP available; retrieve the dictionary directly from the VT. Reuse the same KME
+         * SchemaReader the host's main KafkaValueSerializer was wired with, so this fallback
+         * consumer can decode a control message that lacks the vtp protocol-schema header.
+         *
+         * Strict first-iteration: throws if the schema reader wasn't plumbed. Surfaces SIT
+         * construction paths that didn't call setKafkaMessageEnvelopeSchemaReader. Follow-up
+         * PR will soften to a logged fallback to createDefaultDeserializer.
+         */
+        if (kafkaMessageEnvelopeSchemaReader == null) {
+          throw new IllegalStateException(
+              "kafkaMessageEnvelopeSchemaReader is null on this StoreIngestionTask; cannot decode "
+                  + "the source-of-truth VT for the SoP-null dictionary fallback path. The "
+                  + "StoreIngestionTaskFactory.Builder caller did not plumb the KME SchemaReader from "
+                  + "KafkaStoreIngestionService.");
+        }
+        PubSubMessageDeserializer dictDeserializer =
+            PubSubMessageDeserializer.createWithSchemaReader(kafkaMessageEnvelopeSchemaReader);
+        newStoreVersionState.compressionDictionary = DictionaryUtils
+            .readDictionaryFromKafka(kafkaVersionTopic, new VeniceProperties(kafkaProps), dictDeserializer);
       }
     }
     newStoreVersionState.batchConflictResolutionPolicy = startOfPush != null ? startOfPush.timestampPolicy : 1;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
@@ -21,6 +21,7 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubContext;
+import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.system.store.MetaStoreWriter;
 import com.linkedin.venice.utils.DiskUsage;
@@ -116,6 +117,7 @@ public class StoreIngestionTaskFactory {
     private DiskUsage diskUsage;
     private AggKafkaConsumerService aggKafkaConsumerService;
     private InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer;
+    private SchemaReader kafkaMessageEnvelopeSchemaReader;
     private boolean isDaVinciClient;
     private RemoteIngestionRepairService remoteIngestionRepairService;
     private MetaStoreWriter metaStoreWriter;
@@ -288,6 +290,23 @@ public class StoreIngestionTaskFactory {
     public Builder setPartitionStateSerializer(
         InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer) {
       return set(() -> this.partitionStateSerializer = partitionStateSerializer);
+    }
+
+    public SchemaReader getKafkaMessageEnvelopeSchemaReader() {
+      return kafkaMessageEnvelopeSchemaReader;
+    }
+
+    /**
+     * Hand the KME ({@link com.linkedin.venice.serialization.avro.AvroProtocolDefinition#KAFKA_MESSAGE_ENVELOPE})
+     * {@link SchemaReader} that {@link KafkaStoreIngestionService} already uses to wire its main
+     * {@code KafkaValueSerializer}. Re-used by store-ingestion paths that open their own
+     * deserializer outside the main consumer (e.g., the {@code DictionaryUtils} fallback in
+     * {@link StoreIngestionTask#getNewStoreVersionState} when SoP isn't available) so they can
+     * resolve unknown KME protocol versions without depending on a {@code vtp} header surviving
+     * every writer regression.
+     */
+    public Builder setKafkaMessageEnvelopeSchemaReader(SchemaReader kafkaMessageEnvelopeSchemaReader) {
+      return set(() -> this.kafkaMessageEnvelopeSchemaReader = kafkaMessageEnvelopeSchemaReader);
     }
 
     public boolean isDaVinciClient() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -201,6 +201,7 @@ import com.linkedin.venice.pubsub.mock.adapter.consumer.poll.RandomPollStrategy;
 import com.linkedin.venice.pubsub.mock.adapter.producer.MockInMemoryProducerAdapter;
 import com.linkedin.venice.pubsub.mock.adapter.producer.MockInMemoryTransformingProducerAdapter;
 import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.serialization.DefaultSerializer;
@@ -7532,6 +7533,52 @@ public abstract class StoreIngestionTaskTest {
 
     assertThrows(VeniceException.class, () -> sit.getNewStoreVersionState(12345L, true, sopNullDict));
 
+  }
+
+  @Test
+  public void testBuildDictionaryFetchDeserializerWithSchemaReader() {
+    /*
+     * Covers the SoP-null dictionary fallback branch where the host already wired a KME
+     * SchemaReader through StoreIngestionTaskFactory.Builder. Should return a
+     * SchemaReader-backed deserializer (no jar-only fallback).
+     */
+    StoreIngestionTask sit = mock(StoreIngestionTask.class);
+    SchemaReader schemaReader = mock(SchemaReader.class);
+    Field readerField;
+    try {
+      readerField = StoreIngestionTask.class.getDeclaredField("kafkaMessageEnvelopeSchemaReader");
+      readerField.setAccessible(true);
+      readerField.set(sit, schemaReader);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+    doCallRealMethod().when(sit).buildDictionaryFetchDeserializer();
+    PubSubMessageDeserializer deserializer = sit.buildDictionaryFetchDeserializer();
+    assertNotNull(deserializer);
+    assertNotNull(deserializer.getValueSerializer());
+  }
+
+  @Test
+  public void testBuildDictionaryFetchDeserializerWithoutSchemaReaderFallsBack() {
+    /*
+     * Covers the SoP-null dictionary fallback branch where the host did NOT wire a KME
+     * SchemaReader (e.g., StoreIngestionTaskFactory.Builder caller hasn't migrated yet).
+     * Should log a warning and return a jar-only default deserializer.
+     */
+    StoreIngestionTask sit = mock(StoreIngestionTask.class);
+    Field topicField;
+    try {
+      topicField = StoreIngestionTask.class.getDeclaredField("kafkaVersionTopic");
+      topicField.setAccessible(true);
+      topicField.set(sit, "test_store_v1");
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+    // kafkaMessageEnvelopeSchemaReader is null (never set), so the fallback path fires.
+    doCallRealMethod().when(sit).buildDictionaryFetchDeserializer();
+    PubSubMessageDeserializer deserializer = sit.buildDictionaryFetchDeserializer();
+    assertNotNull(deserializer);
+    assertNotNull(deserializer.getValueSerializer());
   }
 
   @Test

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -3952,21 +3952,28 @@ public class AdminTool {
    * {@link KmeSchemaReader} populated from the {@code venice_system_store_kafka_message_envelope}
    * system store via the static {@code controllerClient}.
    *
-   * <p>First-iteration strict mode: throws when {@code controllerClient} is null (so callers
-   * that don't initialize cluster context first — e.g., admin-message dump paths — are surfaced
-   * during code review). A follow-up PR will soften this with a logged fallback for admin-only
-   * topics that don't carry KME envelopes.
-   *
-   * @throws IllegalStateException if cluster discovery hasn't wired {@code controllerClient}
+   * <p>Falls back to {@link PubSubMessageDeserializer#createOptimizedDeserializer} when
+   * {@code controllerClient} hasn't been wired yet (e.g., admin-message dump that runs before
+   * cluster discovery) or when the schema fetch fails. The on-wire {@code vtp} header bootstrap
+   * still applies on the fallback path.
    */
   private static PubSubMessageDeserializer buildAdminToolDeserializer() {
     if (controllerClient == null) {
-      throw new IllegalStateException(
-          "AdminTool.controllerClient is null; this getConsumer() callsite needs a controller "
-              + "context to fetch KME schemas. If this is an admin-only topic (e.g., dump-admin-messages) "
-              + "that doesn't use KafkaMessageEnvelope, we'll add a dedicated bypass in a follow-up PR.");
+      LOGGER.info(
+          "AdminTool.controllerClient is null; using the jar-only KME deserializer. The on-wire vtp "
+              + "header bootstrap still applies. Most callsites without controllerClient (e.g., admin-topic "
+              + "dumps) don't carry KafkaMessageEnvelope and don't need KME schemas.");
+      return PubSubMessageDeserializer.createOptimizedDeserializer();
     }
-    KmeSchemaReader kmeSchemaReader = KmeSchemaReader.fromControllerClient(controllerClient);
-    return PubSubMessageDeserializer.createOptimizedWithSchemaReader(kmeSchemaReader);
+    try {
+      KmeSchemaReader kmeSchemaReader = KmeSchemaReader.fromControllerClient(controllerClient);
+      return PubSubMessageDeserializer.createOptimizedWithSchemaReader(kmeSchemaReader);
+    } catch (Exception e) {
+      LOGGER.warn(
+          "Failed to fetch KME schemas from controller for admin-tool consumer; falling back to the jar-only "
+              + "KME deserializer. The on-wire vtp header bootstrap still applies. Cause: {}",
+          e.toString());
+      return PubSubMessageDeserializer.createOptimizedDeserializer();
+    }
   }
 }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -3971,8 +3971,8 @@ public class AdminTool {
     } catch (Exception e) {
       LOGGER.warn(
           "Failed to fetch KME schemas from controller for admin-tool consumer; falling back to the jar-only "
-              + "KME deserializer. The on-wire vtp header bootstrap still applies. Cause: {}",
-          e.toString());
+              + "KME deserializer. The on-wire vtp header bootstrap still applies.",
+          e);
       return PubSubMessageDeserializer.createOptimizedDeserializer();
     }
   }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -113,6 +113,7 @@ import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pubsub.manager.TopicManagerContext;
 import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import com.linkedin.venice.schema.KmeSchemaReader;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.avro.SchemaCompatibility;
 import com.linkedin.venice.schema.vson.VsonAvroSchemaAdapter;
@@ -3939,11 +3940,33 @@ public class AdminTool {
   private static PubSubConsumerAdapter getConsumer(PubSubClientsFactory pubSubClientsFactory, ConsumerContext context) {
     return pubSubClientsFactory.getConsumerAdapterFactory()
         .create(
-            new PubSubConsumerAdapterContext.Builder()
-                .setPubSubMessageDeserializer(PubSubMessageDeserializer.createOptimizedDeserializer())
+            new PubSubConsumerAdapterContext.Builder().setPubSubMessageDeserializer(buildAdminToolDeserializer())
                 .setPubSubPositionTypeRegistry(context.getPositionTypeRegistry())
                 .setVeniceProperties(context.getVeniceProperties())
                 .setConsumerName("admin-tool-topic-dumper")
                 .build());
+  }
+
+  /**
+   * Build a deserializer whose underlying KME value serializer is backed by a
+   * {@link KmeSchemaReader} populated from the {@code venice_system_store_kafka_message_envelope}
+   * system store via the static {@code controllerClient}.
+   *
+   * <p>First-iteration strict mode: throws when {@code controllerClient} is null (so callers
+   * that don't initialize cluster context first — e.g., admin-message dump paths — are surfaced
+   * during code review). A follow-up PR will soften this with a logged fallback for admin-only
+   * topics that don't carry KME envelopes.
+   *
+   * @throws IllegalStateException if cluster discovery hasn't wired {@code controllerClient}
+   */
+  private static PubSubMessageDeserializer buildAdminToolDeserializer() {
+    if (controllerClient == null) {
+      throw new IllegalStateException(
+          "AdminTool.controllerClient is null; this getConsumer() callsite needs a controller "
+              + "context to fetch KME schemas. If this is an admin-only topic (e.g., dump-admin-messages) "
+              + "that doesn't use KafkaMessageEnvelope, we'll add a dedicated bypass in a follow-up PR.");
+    }
+    KmeSchemaReader kmeSchemaReader = KmeSchemaReader.fromControllerClient(controllerClient);
+    return PubSubMessageDeserializer.createOptimizedWithSchemaReader(kmeSchemaReader);
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputUtils.java
@@ -29,6 +29,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.kafka.clients.CommonClientConfigs;
@@ -38,6 +39,8 @@ import org.apache.logging.log4j.Logger;
 
 public class KafkaInputUtils {
   private static final Logger LOGGER = LogManager.getLogger(KafkaInputUtils.class);
+  private static final AtomicBoolean SCHEMA_READER_DISABLED_WARNED = new AtomicBoolean(false);
+  private static final AtomicBoolean SCHEMA_READER_EMPTY_BROADCAST_WARNED = new AtomicBoolean(false);
   private static Properties sslProps = null;
 
   /**
@@ -142,33 +145,76 @@ public class KafkaInputUtils {
   }
 
   /**
-   * Construct a {@link PubSubMessageDeserializer} whose value serializer is wired with a
-   * {@link KmeSchemaReader} built from the {@code NEWER_KME_SCHEMAS_PREFIX} entries in
-   * {@code properties} (the VPJ driver broadcasts these to executors via Spark/MR conf).
-   *
-   * <p>When {@code SYSTEM_SCHEMA_READER_ENABLED} is false (e.g., older job conf), logs and
-   * returns a jar-only {@link PubSubMessageDeserializer#createDefaultDeserializer} - the caller
-   * still benefits from the on-wire {@code vtp} header bootstrap inside
-   * {@link PubSubMessageDeserializer#deserialize}.
+   * Build a {@link PubSubMessageDeserializer} (non-optimized variant) for paths that fetch a
+   * single record (e.g., dictionary fetch). See {@link #doBuildSchemaAwareDeserializer} for
+   * fallback semantics.
    */
   public static PubSubMessageDeserializer buildSchemaAwareDeserializer(VeniceProperties properties) {
+    return doBuildSchemaAwareDeserializer(properties, /* optimized */ false);
+  }
+
+  /**
+   * Build a {@link PubSubMessageDeserializer} backed by {@link OptimizedKafkaValueSerializer}
+   * (reused decoders) for hot read paths like Spark VPJ record readers. See
+   * {@link #doBuildSchemaAwareDeserializer} for fallback semantics.
+   */
+  public static PubSubMessageDeserializer buildSchemaAwareOptimizedDeserializer(VeniceProperties properties) {
+    return doBuildSchemaAwareDeserializer(properties, /* optimized */ true);
+  }
+
+  /**
+   * Builds a {@link PubSubMessageDeserializer} whose value serializer is wired with a
+   * {@link KmeSchemaReader} populated from the {@code NEWER_KME_SCHEMAS_PREFIX} entries in
+   * {@code properties} (the VPJ driver broadcasts these to executors via Spark/MR conf).
+   *
+   * <p>Graceful fallback path: returns a jar-only deserializer (default or optimized) when
+   * either {@code SYSTEM_SCHEMA_READER_ENABLED} is false or the broadcast schemas are absent.
+   * The on-wire {@code vtp} header bootstrap inside {@link PubSubMessageDeserializer#deserialize}
+   * still applies on the fallback path. Each fallback condition logs at most once per JVM (via
+   * {@link AtomicBoolean} gates) to avoid spamming Spark executor logs on older configs that
+   * construct a new deserializer per partition.
+   */
+  private static PubSubMessageDeserializer doBuildSchemaAwareDeserializer(
+      VeniceProperties properties,
+      boolean optimized) {
     boolean isSchemaReaderEnabled = properties.getBoolean(SYSTEM_SCHEMA_READER_ENABLED, false);
     if (!isSchemaReaderEnabled) {
-      LOGGER.warn(
-          "{} is false; falling back to the jar-only KME deserializer. The on-wire vtp header bootstrap "
-              + "still applies. Set {}=true on the job conf so the VPJ driver broadcasts newer.kme.schemas.* "
-              + "to executors and consumers can resolve unknown KME protocol versions without depending on vtp.",
-          SYSTEM_SCHEMA_READER_ENABLED,
-          SYSTEM_SCHEMA_READER_ENABLED);
-      return PubSubMessageDeserializer.createDefaultDeserializer();
+      if (SCHEMA_READER_DISABLED_WARNED.compareAndSet(false, true)) {
+        LOGGER.warn(
+            "{} is false; falling back to the jar-only KME deserializer. The on-wire vtp header bootstrap "
+                + "still applies. Set {}=true on the job conf so the VPJ driver broadcasts newer.kme.schemas.* "
+                + "to executors and consumers can resolve unknown KME protocol versions without depending on vtp. "
+                + "(This warning is logged once per JVM.)",
+            SYSTEM_SCHEMA_READER_ENABLED,
+            SYSTEM_SCHEMA_READER_ENABLED);
+      }
+      return optimized
+          ? PubSubMessageDeserializer.createOptimizedDeserializer()
+          : PubSubMessageDeserializer.createDefaultDeserializer();
     }
     Properties clipped = properties.clipAndFilterNamespace(NEWER_KME_SCHEMAS_PREFIX).toProperties();
+    if (clipped.isEmpty()) {
+      if (SCHEMA_READER_EMPTY_BROADCAST_WARNED.compareAndSet(false, true)) {
+        LOGGER.warn(
+            "{} is true but no {}* entries are present on the job conf; falling back to the jar-only KME "
+                + "deserializer. The VPJ driver likely failed to populate the broadcast - confirm "
+                + "validateAndFetchNewKafkaMessageEnvelopeSchemas ran successfully against the controller. "
+                + "(This warning is logged once per JVM.)",
+            SYSTEM_SCHEMA_READER_ENABLED,
+            NEWER_KME_SCHEMAS_PREFIX);
+      }
+      return optimized
+          ? PubSubMessageDeserializer.createOptimizedDeserializer()
+          : PubSubMessageDeserializer.createDefaultDeserializer();
+    }
     Map<Integer, String> newerIdToSchemas = new HashMap<>();
     for (Map.Entry<Object, Object> entry: clipped.entrySet()) {
       newerIdToSchemas.put(Integer.parseInt((String) entry.getKey()), (String) entry.getValue());
     }
     SchemaReader schemaReader = new KmeSchemaReader(newerIdToSchemas);
-    return PubSubMessageDeserializer.createWithSchemaReader(schemaReader);
+    return optimized
+        ? PubSubMessageDeserializer.createOptimizedWithSchemaReader(schemaReader)
+        : PubSubMessageDeserializer.createWithSchemaReader(schemaReader);
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputUtils.java
@@ -32,9 +32,12 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
 public class KafkaInputUtils {
+  private static final Logger LOGGER = LogManager.getLogger(KafkaInputUtils.class);
   private static Properties sslProps = null;
 
   /**
@@ -143,21 +146,21 @@ public class KafkaInputUtils {
    * {@link KmeSchemaReader} built from the {@code NEWER_KME_SCHEMAS_PREFIX} entries in
    * {@code properties} (the VPJ driver broadcasts these to executors via Spark/MR conf).
    *
-   * <p>First-iteration strict mode: throws if {@code SYSTEM_SCHEMA_READER_ENABLED} is false or
-   * the broadcast schemas are missing. The intent is to surface every callsite that doesn't
-   * actually carry the schema-reader broadcast through to the consumer. A follow-up PR will
-   * soften this to a logged fallback to the jar-only deserializer.
-   *
-   * @throws IllegalStateException if the caller's job-conf doesn't carry the KME schema-reader broadcast
+   * <p>When {@code SYSTEM_SCHEMA_READER_ENABLED} is false (e.g., older job conf), logs and
+   * returns a jar-only {@link PubSubMessageDeserializer#createDefaultDeserializer} - the caller
+   * still benefits from the on-wire {@code vtp} header bootstrap inside
+   * {@link PubSubMessageDeserializer#deserialize}.
    */
   public static PubSubMessageDeserializer buildSchemaAwareDeserializer(VeniceProperties properties) {
     boolean isSchemaReaderEnabled = properties.getBoolean(SYSTEM_SCHEMA_READER_ENABLED, false);
     if (!isSchemaReaderEnabled) {
-      throw new IllegalStateException(
-          "SYSTEM_SCHEMA_READER_ENABLED is false; this code path requires the KME schema reader. " + "Either set "
-              + SYSTEM_SCHEMA_READER_ENABLED + "=true on the job conf so the VPJ driver "
-              + "broadcasts newer.kme.schemas.* to executors, or wait for the follow-up PR that adds a "
-              + "logged fallback to the jar-only deserializer.");
+      LOGGER.warn(
+          "{} is false; falling back to the jar-only KME deserializer. The on-wire vtp header bootstrap "
+              + "still applies. Set {}=true on the job conf so the VPJ driver broadcasts newer.kme.schemas.* "
+              + "to executors and consumers can resolve unknown KME protocol versions without depending on vtp.",
+          SYSTEM_SCHEMA_READER_ENABLED,
+          SYSTEM_SCHEMA_READER_ENABLED);
+      return PubSubMessageDeserializer.createDefaultDeserializer();
     }
     Properties clipped = properties.clipAndFilterNamespace(NEWER_KME_SCHEMAS_PREFIX).toProperties();
     Map<Integer, String> newerIdToSchemas = new HashMap<>();

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputUtils.java
@@ -15,6 +15,8 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.ssl.SSLConfigurator;
 import com.linkedin.venice.hadoop.ssl.UserCredentialsFactory;
 import com.linkedin.venice.hadoop.utils.HadoopUtils;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.schema.KmeSchemaReader;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
 import com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer;
@@ -105,7 +107,7 @@ public class KafkaInputUtils {
           .stream()
           .collect(Collectors.toMap(e -> Integer.parseInt(e.getKey()), Map.Entry::getValue));
 
-      SchemaReader schemaReader = new KMESchemaReaderForKafkaInputFormat(newerIdToSchemas);
+      SchemaReader schemaReader = new KmeSchemaReader(newerIdToSchemas);
       kafkaValueSerializer.setSchemaReader(schemaReader);
     }
     return kafkaValueSerializer;
@@ -120,11 +122,50 @@ public class KafkaInputUtils {
     if (strategy.equals(CompressionStrategy.ZSTD_WITH_DICT)) {
       Properties props = properties.toProperties();
       props.setProperty(KAFKA_BOOTSTRAP_SERVERS, kafkaUrl);
-      ByteBuffer dict = DictionaryUtils.readDictionaryFromKafka(topic, new VeniceProperties(props));
+      /*
+       * Forward-compat: feed the dictionary fetch a deserializer wired with the same
+       * KmeSchemaReader that getKafkaValueSerializer builds for the actual
+       * record-read path. If the SoP control-message record on the source VT lands without a
+       * vtp header (e.g. a writer regression like the empty-headers DoL stamp), the reader
+       * still resolves an unknown KME protocol version via the controller-broadcast schemas
+       * instead of throwing 'Received Protocol Version N which is not supported'.
+       */
+      PubSubMessageDeserializer deserializer = buildSchemaAwareDeserializer(properties);
+      ByteBuffer dict = DictionaryUtils.readDictionaryFromKafka(topic, new VeniceProperties(props), deserializer);
       return compressorFactory
           .createVersionSpecificCompressorIfNotExist(strategy, topic, ByteUtils.extractByteArray(dict));
     }
     return compressorFactory.getCompressor(strategy);
+  }
+
+  /**
+   * Construct a {@link PubSubMessageDeserializer} whose value serializer is wired with a
+   * {@link KmeSchemaReader} built from the {@code NEWER_KME_SCHEMAS_PREFIX} entries in
+   * {@code properties} (the VPJ driver broadcasts these to executors via Spark/MR conf).
+   *
+   * <p>First-iteration strict mode: throws if {@code SYSTEM_SCHEMA_READER_ENABLED} is false or
+   * the broadcast schemas are missing. The intent is to surface every callsite that doesn't
+   * actually carry the schema-reader broadcast through to the consumer. A follow-up PR will
+   * soften this to a logged fallback to the jar-only deserializer.
+   *
+   * @throws IllegalStateException if the caller's job-conf doesn't carry the KME schema-reader broadcast
+   */
+  public static PubSubMessageDeserializer buildSchemaAwareDeserializer(VeniceProperties properties) {
+    boolean isSchemaReaderEnabled = properties.getBoolean(SYSTEM_SCHEMA_READER_ENABLED, false);
+    if (!isSchemaReaderEnabled) {
+      throw new IllegalStateException(
+          "SYSTEM_SCHEMA_READER_ENABLED is false; this code path requires the KME schema reader. " + "Either set "
+              + SYSTEM_SCHEMA_READER_ENABLED + "=true on the job conf so the VPJ driver "
+              + "broadcasts newer.kme.schemas.* to executors, or wait for the follow-up PR that adds a "
+              + "logged fallback to the jar-only deserializer.");
+    }
+    Properties clipped = properties.clipAndFilterNamespace(NEWER_KME_SCHEMAS_PREFIX).toProperties();
+    Map<Integer, String> newerIdToSchemas = new HashMap<>();
+    for (Map.Entry<Object, Object> entry: clipped.entrySet()) {
+      newerIdToSchemas.put(Integer.parseInt((String) entry.getKey()), (String) entry.getValue());
+    }
+    SchemaReader schemaReader = new KmeSchemaReader(newerIdToSchemas);
+    return PubSubMessageDeserializer.createWithSchemaReader(schemaReader);
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractInputRecordProcessor.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractInputRecordProcessor.java
@@ -17,7 +17,9 @@ import com.linkedin.venice.compression.CompressorFactory;
 import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.VenicePushJob;
+import com.linkedin.venice.hadoop.input.kafka.KafkaInputUtils;
 import com.linkedin.venice.hadoop.input.recordreader.AbstractVeniceRecordReader;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.DictionaryUtils;
 import com.linkedin.venice.utils.TriConsumer;
@@ -326,7 +328,8 @@ public abstract class AbstractInputRecordProcessor<INPUT_KEY, INPUT_VALUE> exten
    * ended up hitting the original function always, added an override for this in {@link TestVeniceAvroMapperClass}.
    */
   protected ByteBuffer readDictionaryFromKafka(String topicName, VeniceProperties props) {
-    return DictionaryUtils.readDictionaryFromKafka(topicName, props);
+    PubSubMessageDeserializer deserializer = KafkaInputUtils.buildSchemaAwareDeserializer(props);
+    return DictionaryUtils.readDictionaryFromKafka(topicName, props, deserializer);
   }
 
   private VeniceCompressor getZstdCompressor(VeniceProperties props) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -50,6 +50,7 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.ViewConfig;
 import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.serialization.DefaultSerializer;
@@ -842,7 +843,8 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
         CompressionStrategy strategy = CompressionStrategy.valueOf(props.getString(COMPRESSION_STRATEGY));
         if (strategy == CompressionStrategy.ZSTD_WITH_DICT) {
           String topicName = props.getString(TOPIC_PROP);
-          ByteBuffer dict = DictionaryUtils.readDictionaryFromKafka(topicName, props);
+          PubSubMessageDeserializer deserializer = KafkaInputUtils.buildSchemaAwareDeserializer(props);
+          ByteBuffer dict = DictionaryUtils.readDictionaryFromKafka(topicName, props, deserializer);
           return compressorFactory.get()
               .createVersionSpecificCompressorIfNotExist(strategy, topicName, ByteUtils.extractByteArray(dict));
         } else {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJob.java
@@ -15,6 +15,7 @@ import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerClientFactory;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.hadoop.input.kafka.KafkaInputUtils;
 import com.linkedin.venice.hadoop.utils.VPJSSLUtils;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
@@ -453,12 +454,13 @@ public class VTConsistencyCheckerJob {
       VeniceProperties props,
       PubSubTopicRepository topicRepository,
       String consumerName) {
+    PubSubMessageDeserializer deserializer = KafkaInputUtils.buildSchemaAwareDeserializer(props);
     return PubSubClientsFactory.createConsumerFactory(props)
         .create(
             new PubSubConsumerAdapterContext.Builder().setPubSubBrokerAddress(props.getString(KAFKA_BOOTSTRAP_SERVERS))
                 .setVeniceProperties(props)
                 .setPubSubTopicRepository(topicRepository)
-                .setPubSubMessageDeserializer(PubSubMessageDeserializer.createDefaultDeserializer())
+                .setPubSubMessageDeserializer(deserializer)
                 .setPubSubPositionTypeRegistry(PubSubPositionTypeRegistry.fromPropertiesOrDefault(props))
                 .setConsumerName(consumerName)
                 .build());

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/input/pubsub/SparkPubSubPartitionReaderFactory.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/input/pubsub/SparkPubSubPartitionReaderFactory.java
@@ -65,12 +65,13 @@ public class SparkPubSubPartitionReaderFactory implements PartitionReaderFactory
 
     /*
      * Reuse the controller-broadcast KME schemas (newer.kme.schemas.*) that the VPJ driver
-     * carries on the Spark conf. Strict mode: throws if SYSTEM_SCHEMA_READER_ENABLED is false
-     * or the broadcast is missing — first-iteration check to surface every Spark path that
-     * isn't actually carrying the schema reader through. Follow-up PR will soften to a logged
-     * fallback.
+     * carries on the Spark conf. Uses the optimized value-serializer variant (reused decoders)
+     * since this is the per-partition Spark record-read hot path. When the broadcast or the
+     * SYSTEM_SCHEMA_READER_ENABLED flag is missing, the helper logs once per JVM and falls
+     * back to a jar-only optimized deserializer; the on-wire vtp header bootstrap still
+     * applies on the fallback path.
      */
-    final PubSubMessageDeserializer deserializer = KafkaInputUtils.buildSchemaAwareDeserializer(configWithSsl);
+    final PubSubMessageDeserializer deserializer = KafkaInputUtils.buildSchemaAwareOptimizedDeserializer(configWithSsl);
 
     // Create consumer adapter with proper context
     final PubSubConsumerAdapterContext consumerContext =

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/input/pubsub/SparkPubSubPartitionReaderFactory.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/input/pubsub/SparkPubSubPartitionReaderFactory.java
@@ -8,6 +8,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURC
 
 import com.linkedin.venice.chunking.ChunkKeyValueTransformer;
 import com.linkedin.venice.chunking.ChunkKeyValueTransformerImpl;
+import com.linkedin.venice.hadoop.input.kafka.KafkaInputUtils;
 import com.linkedin.venice.hadoop.utils.VPJSSLUtils;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
@@ -62,12 +63,21 @@ public class SparkPubSubPartitionReaderFactory implements PartitionReaderFactory
     final String regionName = configWithSsl.getString(KAFKA_INPUT_FABRIC, inputRegionBroker);
     final String consumerName = String.format("raw_kif_%s_%s", inputRegionBroker, topicPartition);
 
+    /*
+     * Reuse the controller-broadcast KME schemas (newer.kme.schemas.*) that the VPJ driver
+     * carries on the Spark conf. Strict mode: throws if SYSTEM_SCHEMA_READER_ENABLED is false
+     * or the broadcast is missing — first-iteration check to surface every Spark path that
+     * isn't actually carrying the schema reader through. Follow-up PR will soften to a logged
+     * fallback.
+     */
+    final PubSubMessageDeserializer deserializer = KafkaInputUtils.buildSchemaAwareDeserializer(configWithSsl);
+
     // Create consumer adapter with proper context
     final PubSubConsumerAdapterContext consumerContext =
         new PubSubConsumerAdapterContext.Builder().setPubSubBrokerAddress(inputRegionBroker)
             .setVeniceProperties(configWithSsl)
             .setPubSubTopicRepository(topicRepository)
-            .setPubSubMessageDeserializer(PubSubMessageDeserializer.createOptimizedDeserializer())
+            .setPubSubMessageDeserializer(deserializer)
             .setPubSubPositionTypeRegistry(PubSubPositionTypeRegistry.fromPropertiesOrDefault(configWithSsl))
             .setConsumerName(consumerName)
             .build();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputUtilsTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputUtilsTest.java
@@ -106,6 +106,54 @@ public class KafkaInputUtilsTest {
     assertNotNull(deserializer.getValueSerializer());
   }
 
+  @Test
+  public void testBuildSchemaAwareOptimizedDeserializerFallsBackWhenSystemSchemaReaderDisabled() {
+    /*
+     * Same fallback semantics as the non-optimized variant: when SYSTEM_SCHEMA_READER_ENABLED
+     * is unset, the optimized helper logs once per JVM and returns a jar-only OPTIMIZED
+     * deserializer (reused decoders) for Spark-style hot read paths.
+     */
+    PubSubMessageDeserializer deserializer =
+        KafkaInputUtils.buildSchemaAwareOptimizedDeserializer(VeniceProperties.empty());
+    assertNotNull(deserializer);
+    assertNotNull(deserializer.getValueSerializer());
+  }
+
+  @Test
+  public void testBuildSchemaAwareOptimizedDeserializerBuildsSchemaAwareWhenEnabled() {
+    /*
+     * When the system flag is on and newer.kme.schemas.* entries are present, the optimized
+     * variant builds a KmeSchemaReader-backed OptimizedKafkaValueSerializer for the Spark hot path.
+     */
+    Properties props = new Properties();
+    props.setProperty(SYSTEM_SCHEMA_READER_ENABLED, "true");
+    int currentVersion = AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersion();
+    props.setProperty(
+        NEWER_KME_SCHEMAS_PREFIX + currentVersion,
+        AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersionSchema().toString());
+
+    PubSubMessageDeserializer deserializer =
+        KafkaInputUtils.buildSchemaAwareOptimizedDeserializer(new VeniceProperties(props));
+    assertNotNull(deserializer);
+    assertNotNull(deserializer.getValueSerializer());
+  }
+
+  @Test
+  public void testBuildSchemaAwareDeserializerFallsBackWhenSystemSchemaReaderEnabledButBroadcastIsEmpty() {
+    /*
+     * Misconfig case: SYSTEM_SCHEMA_READER_ENABLED is true but the VPJ driver failed to
+     * populate the newer.kme.schemas.* broadcast. The helper logs once per JVM and falls
+     * back to the jar-only deserializer (previously this case silently built a useless
+     * SchemaReader with an empty map).
+     */
+    Properties props = new Properties();
+    props.setProperty(SYSTEM_SCHEMA_READER_ENABLED, "true");
+
+    PubSubMessageDeserializer deserializer = KafkaInputUtils.buildSchemaAwareDeserializer(new VeniceProperties(props));
+    assertNotNull(deserializer);
+    assertNotNull(deserializer.getValueSerializer());
+  }
+
   /**
    * Dummy SSLConfigurator for simulating successful SSL config setup.
    */

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputUtilsTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputUtilsTest.java
@@ -3,11 +3,16 @@ package com.linkedin.venice.hadoop.input.kafka;
 import static com.linkedin.venice.ConfigKeys.KAFKA_CONFIG_PREFIX;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KIF_RECORD_READER_KAFKA_CONFIG_PREFIX;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.NEWER_KME_SCHEMAS_PREFIX;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SYSTEM_SCHEMA_READER_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 import com.linkedin.venice.hadoop.ssl.SSLConfigurator;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Properties;
 import org.apache.hadoop.mapred.JobConf;
@@ -69,6 +74,36 @@ public class KafkaInputUtilsTest {
         consumerProps.getString("some.kafka.prop"),
         "value123",
         "Prefixed Kafka property should be merged correctly");
+  }
+
+  @Test
+  public void testBuildSchemaAwareDeserializerFallsBackWhenSystemSchemaReaderDisabled() {
+    /*
+     * Default conf has SYSTEM_SCHEMA_READER_ENABLED unset (false). The helper should log a
+     * warning and return the jar-only default deserializer instead of throwing - the on-wire
+     * vtp header bootstrap still applies for forward-compat reads.
+     */
+    PubSubMessageDeserializer deserializer = KafkaInputUtils.buildSchemaAwareDeserializer(VeniceProperties.empty());
+    assertNotNull(deserializer);
+    assertNotNull(deserializer.getValueSerializer());
+  }
+
+  @Test
+  public void testBuildSchemaAwareDeserializerBuildsSchemaAwareWhenEnabled() {
+    /*
+     * When SYSTEM_SCHEMA_READER_ENABLED is true and the VPJ driver has broadcast the
+     * newer.kme.schemas.* entries, the helper builds a KmeSchemaReader-backed deserializer.
+     */
+    Properties props = new Properties();
+    props.setProperty(SYSTEM_SCHEMA_READER_ENABLED, "true");
+    int currentVersion = AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersion();
+    props.setProperty(
+        NEWER_KME_SCHEMAS_PREFIX + currentVersion,
+        AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersionSchema().toString());
+
+    PubSubMessageDeserializer deserializer = KafkaInputUtils.buildSchemaAwareDeserializer(new VeniceProperties(props));
+    assertNotNull(deserializer);
+    assertNotNull(deserializer.getValueSerializer());
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializer.java
@@ -7,11 +7,13 @@ import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
+import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.serialization.KafkaKeySerializer;
 import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
 import com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer;
 import com.linkedin.venice.utils.pools.LandFillObjectPool;
 import com.linkedin.venice.utils.pools.ObjectPool;
+import java.util.Objects;
 import java.util.function.Supplier;
 import org.apache.avro.Schema;
 import org.apache.logging.log4j.LogManager;
@@ -178,6 +180,39 @@ public class PubSubMessageDeserializer {
   public static PubSubMessageDeserializer createOptimizedDeserializer() {
     return new PubSubMessageDeserializer(
         new OptimizedKafkaValueSerializer(),
+        new LandFillObjectPool<>(KafkaMessageEnvelope::new),
+        new LandFillObjectPool<>(KafkaMessageEnvelope::new));
+  }
+
+  /**
+   * Production-safe factory: builds a deserializer whose {@link KafkaValueSerializer} is wired with
+   * the supplied {@link SchemaReader}, so it can fetch an unknown KME protocol-version schema on
+   * the fly (in addition to the {@code vtp} header fast path). Use this whenever the caller can
+   * reach a controller or a system-store-backed schema source — never assume the {@code vtp}
+   * header will be present on every record. The header-less fallback exists for forward-compat
+   * regressions like a writer that drops the header on a control-message record.
+   */
+  public static PubSubMessageDeserializer createWithSchemaReader(SchemaReader schemaReader) {
+    Objects.requireNonNull(schemaReader, "schemaReader is required — caller must wire a SchemaReader");
+    KafkaValueSerializer valueSerializer = new KafkaValueSerializer();
+    valueSerializer.setSchemaReader(schemaReader);
+    return new PubSubMessageDeserializer(
+        valueSerializer,
+        new LandFillObjectPool<>(KafkaMessageEnvelope::new),
+        new LandFillObjectPool<>(KafkaMessageEnvelope::new));
+  }
+
+  /**
+   * Production-safe optimized variant of {@link #createWithSchemaReader(SchemaReader)} —
+   * uses {@link OptimizedKafkaValueSerializer} (reused decoders) for hot paths like VPJ Spark
+   * record readers and CDC consumers.
+   */
+  public static PubSubMessageDeserializer createOptimizedWithSchemaReader(SchemaReader schemaReader) {
+    Objects.requireNonNull(schemaReader, "schemaReader is required — caller must wire a SchemaReader");
+    OptimizedKafkaValueSerializer valueSerializer = new OptimizedKafkaValueSerializer();
+    valueSerializer.setSchemaReader(schemaReader);
+    return new PubSubMessageDeserializer(
+        valueSerializer,
         new LandFillObjectPool<>(KafkaMessageEnvelope::new),
         new LandFillObjectPool<>(KafkaMessageEnvelope::new));
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/schema/KmeSchemaReader.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/schema/KmeSchemaReader.java
@@ -1,63 +1,54 @@
-package com.linkedin.venice.hadoop.input.kafka;
+package com.linkedin.venice.schema;
 
 import static com.linkedin.venice.schema.SchemaData.INVALID_VALUE_SCHEMA_ID;
 import static com.linkedin.venice.system.store.ControllerClientBackedSystemSchemaInitializer.DEFAULT_KEY_SCHEMA_STR;
 
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.MultiSchemaResponse;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
-import com.linkedin.venice.schema.AvroSchemaParseUtils;
-import com.linkedin.venice.schema.SchemaData;
-import com.linkedin.venice.schema.SchemaEntry;
-import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.Utils;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.avro.Schema;
 
 
 /**
- * A specialized {@link SchemaReader} implementation designed for Kafka input format processing
- * in Hadoop MapReduce jobs. This class provides schema reading capabilities specifically for
- * Kafka Message Envelope (KME) schemas used during data ingestion from Kafka topics.
+ * A {@link SchemaReader} for Kafka Message Envelope (KME) protocol-version schemas. Merges
+ * KME schemas loaded from jar resources with any newer schemas supplied at runtime (e.g.,
+ * fetched from a Venice controller) so a deserializer can resolve a protocol version it does
+ * not statically know.
  *
- * <p>This implementation combines newer KME schemas provided at runtime with schemas loaded
- * from resources to create a comprehensive schema registry for deserializing Kafka messages.
- * It is primarily used by {@link KafkaInputUtils} to configure Kafka value serializers with
- * the appropriate schema reader for processing Venice data stored in Kafka topics.
+ * <p>Use this whenever a code path reads Venice control messages or value envelopes and has a
+ * route to fresher KME schemas than the jar carries — either via {@code newer.kme.schemas.*}
+ * job-conf entries broadcast by the VPJ driver, or via a {@link ControllerClient} pointing at
+ * the {@code venice_system_store_kafka_message_envelope} system store. Hand the resulting
+ * reader to {@link com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer#setSchemaReader}
+ * (e.g., through {@link com.linkedin.venice.pubsub.api.PubSubMessageDeserializer#createWithSchemaReader}).
+ * It defends the consumer against records that arrive without the {@code vtp} bootstrap header.
  *
- * <p>Key features:
- * <ul>
- *   <li>Merges runtime-provided KME schemas with resource-based schemas</li>
- *   <li>Provides thread-safe access to schema data using {@link AtomicReference}</li>
- *   <li>Uses default key schema for Venice system operations</li>
- *   <li>Supports schema evolution by handling multiple schema versions</li>
- * </ul>
+ * <p>Update schemas are not supported — KME has no update schemas.
+ *
+ * <p>Formerly {@code KmeSchemaReaderForKafkaInputFormat} under {@code com.linkedin.venice.hadoop.input.kafka};
+ * moved to venice-common in {@link com.linkedin.venice.schema} so non-VPJ callers (admin tool,
+ * controller, server fallback, CDC) can construct one without taking a build dependency on
+ * venice-push-job.
  */
-public class KMESchemaReaderForKafkaInputFormat implements SchemaReader {
+public class KmeSchemaReader implements SchemaReader {
   private final SchemaData schemas;
   private final Schema keySchema;
 
   /**
-   * Constructs a new KMESchemaReaderForKafkaInputFormat with the provided newer KME schemas.
+   * Build a reader from a map of newer KME schemas (id → schema JSON). The supplied schemas
+   * are merged on top of the schemas baked into this jar's resources, so {@code getValueSchema}
+   * can resolve any protocol version that either side knows about.
    *
-   * <p>This constructor initializes the schema reader by:
-   * <ol>
-   *   <li>Loading all existing KME schemas from resources</li>
-   *   <li>Adding the provided newer schemas to the schema data</li>
-   *   <li>Merging resource-based schemas with the newer schemas</li>
-   *   <li>Setting up the default key schema for Venice operations</li>
-   * </ol>
-   *
-   * <p>The newer schemas take precedence over resource-based schemas when there are
-   * schema ID conflicts, allowing for schema evolution and updates.
-   *
-   * @param newerKmeSchemas A map of schema ID to schema string containing newer KME schemas
-   *                        that should be available for deserialization. Can be empty but not null.
-   * @throws IllegalArgumentException if newerKmeSchemas is null
-   * @throws RuntimeException if there are issues parsing the default key schema
+   * @param newerKmeSchemas id → schema-JSON for schemas newer than what this jar ships; may be empty
+   * @throws IllegalArgumentException if {@code newerKmeSchemas} is null
    */
-  public KMESchemaReaderForKafkaInputFormat(Map<Integer, String> newerKmeSchemas) {
+  public KmeSchemaReader(Map<Integer, String> newerKmeSchemas) {
     Map<Integer, Schema> allSchemasFromResources =
         Utils.getAllSchemasFromResources(AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE);
     this.schemas = new SchemaData(AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getSystemStoreName(), null);
@@ -70,6 +61,29 @@ public class KMESchemaReaderForKafkaInputFormat implements SchemaReader {
     }
 
     this.keySchema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(DEFAULT_KEY_SCHEMA_STR);
+  }
+
+  /**
+   * Fetch all KME schemas from the {@code venice_system_store_kafka_message_envelope} system
+   * store via the supplied {@code controllerClient}, and build a {@link KmeSchemaReader} that
+   * merges them with the schemas baked into the local jar. Used by admin tool, controller-side
+   * topic metadata fetcher, and other code paths that have a {@link ControllerClient} in scope.
+   *
+   * @throws VeniceException if the controller call fails (so the caller can choose to swallow
+   *         the failure and fall back to a jar-only deserializer, or surface it).
+   */
+  public static KmeSchemaReader fromControllerClient(ControllerClient controllerClient) {
+    String kmeSystemStoreName = AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getSystemStoreName();
+    MultiSchemaResponse response = controllerClient.getAllValueSchema(kmeSystemStoreName);
+    if (response.isError()) {
+      throw new VeniceException(
+          "Failed to fetch KME schemas from controller for " + kmeSystemStoreName + ": " + response.getError());
+    }
+    Map<Integer, String> newerKmeSchemas = new HashMap<>();
+    for (MultiSchemaResponse.Schema schema: response.getSchemas()) {
+      newerKmeSchemas.put(schema.getId(), schema.getSchemaStr());
+    }
+    return new KmeSchemaReader(newerKmeSchemas);
   }
 
   /**

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/api/PubSubMessageDeserializerTest.java
@@ -4,7 +4,9 @@ import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_LEADER_
 import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_TRANSPORT_PROTOCOL_HEADER;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.expectThrows;
 
 import com.linkedin.venice.exceptions.VeniceMessageException;
 import com.linkedin.venice.kafka.protocol.GUID;
@@ -15,6 +17,7 @@ import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.serialization.KafkaKeySerializer;
 import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
 import com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer;
@@ -346,6 +349,36 @@ public class PubSubMessageDeserializerTest {
         position,
         null);
     assertEquals(message.getPubSubMessageTime(), producerTimestamp);
+  }
+
+  @Test
+  public void testCreateWithSchemaReaderRequiresNonNull() {
+    NullPointerException npe =
+        expectThrows(NullPointerException.class, () -> PubSubMessageDeserializer.createWithSchemaReader(null));
+    assertNotNull(npe.getMessage());
+  }
+
+  @Test
+  public void testCreateOptimizedWithSchemaReaderRequiresNonNull() {
+    NullPointerException npe =
+        expectThrows(NullPointerException.class, () -> PubSubMessageDeserializer.createOptimizedWithSchemaReader(null));
+    assertNotNull(npe.getMessage());
+  }
+
+  @Test
+  public void testCreateWithSchemaReaderWiresValueSerializer() {
+    SchemaReader schemaReader = mock(SchemaReader.class);
+    PubSubMessageDeserializer deserializer = PubSubMessageDeserializer.createWithSchemaReader(schemaReader);
+    assertNotNull(deserializer);
+    assertNotNull(deserializer.getValueSerializer());
+  }
+
+  @Test
+  public void testCreateOptimizedWithSchemaReaderWiresValueSerializer() {
+    SchemaReader schemaReader = mock(SchemaReader.class);
+    PubSubMessageDeserializer deserializer = PubSubMessageDeserializer.createOptimizedWithSchemaReader(schemaReader);
+    assertNotNull(deserializer);
+    assertNotNull(deserializer.getValueSerializer());
   }
 
   private KafkaMessageEnvelope getDummyValue() {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/schema/KmeSchemaReaderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/schema/KmeSchemaReaderTest.java
@@ -1,0 +1,116 @@
+package com.linkedin.venice.schema;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.MultiSchemaResponse;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.testng.annotations.Test;
+
+
+public class KmeSchemaReaderTest {
+  @Test
+  public void testConstructorMergesNewerSchemasWithJarResources() {
+    /*
+     * Pass an empty newer-schemas map; the reader should still serve the jar-bundled KME schemas
+     * for every protocol version baked into AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.
+     */
+    KmeSchemaReader reader = new KmeSchemaReader(Collections.emptyMap());
+    int currentVersion = AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersion();
+    Schema schema = reader.getValueSchema(currentVersion);
+    assertNotNull(schema);
+    assertEquals(reader.getLatestValueSchemaId().intValue(), currentVersion);
+  }
+
+  @Test
+  public void testConstructorAcceptsNewerSchemas() {
+    /*
+     * The newer-schemas map carries id -> schema-JSON entries that the jar doesn't yet ship.
+     * Use a deep-clone of the latest bundled schema under a synthetic future id so the merge
+     * step doesn't reject duplicate ids.
+     */
+    int currentVersion = AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersion();
+    int futureVersion = currentVersion + 1;
+    String latestSchemaJson =
+        AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersionSchema().toString();
+    Map<Integer, String> newerSchemas = new HashMap<>();
+    newerSchemas.put(futureVersion, latestSchemaJson);
+
+    KmeSchemaReader reader = new KmeSchemaReader(newerSchemas);
+    assertNotNull(reader.getValueSchema(futureVersion));
+    assertNotNull(reader.getValueSchema(currentVersion));
+    assertTrue(reader.getLatestValueSchemaId() >= futureVersion);
+  }
+
+  @Test
+  public void testGetKeySchemaReturnsDefault() {
+    KmeSchemaReader reader = new KmeSchemaReader(Collections.emptyMap());
+    assertNotNull(reader.getKeySchema());
+  }
+
+  @Test
+  public void testGetLatestValueSchemaReturnsHighestId() {
+    KmeSchemaReader reader = new KmeSchemaReader(Collections.emptyMap());
+    Schema latest = reader.getLatestValueSchema();
+    assertNotNull(latest);
+    int latestId = reader.getLatestValueSchemaId();
+    assertEquals(reader.getValueSchema(latestId), latest);
+  }
+
+  @Test
+  public void testUpdateSchemasUnsupported() {
+    KmeSchemaReader reader = new KmeSchemaReader(Collections.emptyMap());
+    assertThrows(VeniceUnsupportedOperationException.class, () -> reader.getUpdateSchema(1));
+    assertThrows(VeniceUnsupportedOperationException.class, reader::getLatestUpdateSchema);
+  }
+
+  @Test
+  public void testCloseIsNoOp() {
+    KmeSchemaReader reader = new KmeSchemaReader(Collections.emptyMap());
+    reader.close();
+  }
+
+  @Test
+  public void testFromControllerClientFetchesAndMergesKmeSchemas() {
+    ControllerClient controllerClient = mock(ControllerClient.class);
+    int currentVersion = AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersion();
+    String latestSchemaJson =
+        AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersionSchema().toString();
+
+    MultiSchemaResponse.Schema schemaEntry = new MultiSchemaResponse.Schema();
+    schemaEntry.setId(currentVersion);
+    schemaEntry.setSchemaStr(latestSchemaJson);
+
+    MultiSchemaResponse response = new MultiSchemaResponse();
+    response.setSchemas(new MultiSchemaResponse.Schema[] { schemaEntry });
+    when(controllerClient.getAllValueSchema(anyString())).thenReturn(response);
+
+    KmeSchemaReader reader = KmeSchemaReader.fromControllerClient(controllerClient);
+    assertNotNull(reader.getValueSchema(currentVersion));
+  }
+
+  @Test
+  public void testFromControllerClientThrowsOnControllerError() {
+    ControllerClient controllerClient = mock(ControllerClient.class);
+    MultiSchemaResponse response = new MultiSchemaResponse();
+    response.setError("simulated controller error");
+    when(controllerClient.getAllValueSchema(anyString())).thenReturn(response);
+
+    VeniceException e =
+        expectThrows(VeniceException.class, () -> KmeSchemaReader.fromControllerClient(controllerClient));
+    assertTrue(e.getMessage().contains("simulated controller error"));
+  }
+}


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to #2808 (DoL stamp `vtp` header fix). Plumbs a KME `SchemaReader` through every production callsite that opens its own `PubSubMessageDeserializer`, so a consumer that lands on a header-less control-message record can still resolve an unknown KME protocol version through a schema reader instead of throwing `Received Protocol Version 'N' which is not supported`. Useful insurance against any future writer regression that drops the `vtp` header.

**Depends on #2808.** Once that lands, this branch will be rebased to drop the writer change (which is the first commit on this branch).

## Consumer-side plumbing

The following production paths now use a `KafkaValueSerializer` whose `setSchemaReader` is wired with a `KmeSchemaReader`, so when the in-memory protocol-version cache misses and `vtp` is unavailable, the serializer fetches the unknown schema through the reader:

| Callsite | Schema source |
|---|---|
| `KafkaInputUtils.getCompressor` (ZSTD_WITH_DICT branch, fetches the SoP dictionary from the source VT) | `newer.kme.schemas.*` broadcast on the VPJ job conf |
| `AbstractInputRecordProcessor.readDictionaryFromKafka` | same broadcast |
| `AbstractPartitionWriter` ZSTD branch | same broadcast |
| `SparkPubSubPartitionReaderFactory.createReader` | same broadcast |
| `VTConsistencyCheckerJob.createConsumer` | same broadcast |
| `AdminTool.getConsumer` | `KmeSchemaReader.fromControllerClient(ControllerClient)` fetches all KME schemas from the `venice_system_store_kafka_message_envelope` system store |
| `StoreIngestionTask.getNewStoreVersionState` (SoP-null fallback path) | reuses the host's `kafkaMessageEnvelopeSchemaReader`, newly plumbed through `StoreIngestionTaskFactory.Builder.setKafkaMessageEnvelopeSchemaReader` |

`VeniceChangelogConsumerImpl` already wires a KME `SchemaReader` (added in #2177) — no change. `TopicMetadataFetcher` constructs a deserializer but never invokes the deserialize path (only uses position/topic-metadata APIs on the underlying consumer) — left as-is.

## Graceful fallback semantics

Where the plumbing exists but the upstream config wasn't actually broadcast, the helpers log a warning and fall back to the jar-only deserializer instead of throwing. The on-wire `vtp` header bootstrap still applies on the fallback path. Specific behaviors:

- `KafkaInputUtils.buildSchemaAwareDeserializer(VeniceProperties)`: if `SYSTEM_SCHEMA_READER_ENABLED` is false (older VPJ job conf), logs a warning and returns `PubSubMessageDeserializer.createDefaultDeserializer()`.
- `AdminTool.buildAdminToolDeserializer()`: if `controllerClient` is null (e.g., admin-message dump that runs before cluster discovery), logs and returns `PubSubMessageDeserializer.createOptimizedDeserializer()`. If the controller fetch itself fails (network, ACL, etc.), the exception is caught and the same fallback is used with a `warn` log.
- `StoreIngestionTask.getNewStoreVersionState` SoP-null branch: if the host's `kafkaMessageEnvelopeSchemaReader` wasn't plumbed through `StoreIngestionTaskFactory.Builder`, logs and uses `createDefaultDeserializer()`.

`PubSubMessageDeserializer.createWithSchemaReader` and `createOptimizedWithSchemaReader` themselves do `Objects.requireNonNull(schemaReader, …)` — that's an API contract.

## Refactor: `KmeSchemaReader` moved to venice-common

`KMESchemaReaderForKafkaInputFormat` lived under `clients/venice-push-job/.../hadoop/input/kafka`. The class was a general `SchemaReader` over KME protocol-version schemas — its name was an artifact of where it lived, not what it did. Moved to `internal/venice-common/.../schema/KmeSchemaReader` so non-VPJ callers (admin tool, server, controller-side code) can construct one without a build dependency on `venice-push-job`. Renamed to `KmeSchemaReader` to follow Java naming conventions for acronyms.

A new `KmeSchemaReader.fromControllerClient(ControllerClient)` static factory pulls all KME schemas from the `venice_system_store_kafka_message_envelope` system store via `controllerClient.getAllValueSchema(…)` and merges them with the schemas baked into the jar's resources. Used by `AdminTool` here.

## Strict-to-graceful iteration

The first iteration of this PR used strict throws (`IllegalStateException`) at the consumer-side fallback points to surface every callsite that hadn't plumbed a `SchemaReader`. CI confirmed the gaps exactly where expected: integration-test VPJ jobs don't set `SYSTEM_SCHEMA_READER_ENABLED=true` by default, and various admin-tool entry points run before cluster discovery has wired `controllerClient`. The follow-up commits soften those throws to logged fallbacks. The `Objects.requireNonNull` on `createWithSchemaReader` / `createOptimizedWithSchemaReader` remains — that's an API contract, not a missing-plumbing concern.

## Related

- **#2808** — the minimal DoL stamp `vtp` header fix this PR builds on. **Merge that first.**
- #2778 added KME schema v14 to the protocol.
- #2780 activated KME v14 on the writer.
- #2762 added vtp header stripping after successful deserialize.
- #2177 wired the KME `SchemaReader` into the CDC changelog consumer.

## Testing Done

New unit tests (all pass locally):

- `KmeSchemaReaderTest` (new file, 8 tests): exercises the constructor merge with empty and non-empty newer-schemas maps; `getKeySchema`, `getValueSchema(id)`, `getLatestValueSchema(Id)`; the update-schema methods that should throw `VeniceUnsupportedOperationException`; `close` is a no-op; `fromControllerClient` happy path with a mocked `ControllerClient` returning a populated `MultiSchemaResponse`; and `fromControllerClient` error path where the response carries an error string.
- `PubSubMessageDeserializerTest` (+4 tests): `createWithSchemaReader(null)` and `createOptimizedWithSchemaReader(null)` both throw `NullPointerException` via `requireNonNull`; both successfully construct a deserializer with a non-null mocked `SchemaReader` and expose a `KafkaValueSerializer`.
- `KafkaInputUtilsTest` (+2 tests): `buildSchemaAwareDeserializer` falls back to a jar-only deserializer when `SYSTEM_SCHEMA_READER_ENABLED` is unset; builds a `SchemaReader`-backed deserializer when the system flag is enabled and `newer.kme.schemas.*` entries are present in the job conf.
- `StoreIngestionTaskTest` (+2 tests): `buildDictionaryFetchDeserializer` returns a `SchemaReader`-backed deserializer when the host plumbed `kafkaMessageEnvelopeSchemaReader`; returns the jar-only fallback (with a warn log) when the SchemaReader wasn't wired.

Existing tests confirmed still passing locally: all `VeniceWriterUnitTest`, `KafkaInputUtilsTest`, `StoreIngestionTaskTest.testGetNewStoreVersionState*`, `PubSubMessageDeserializerTest`.

Compile-clean across `internal:venice-common`, `clients:venice-push-job`, `clients:venice-admin-tool`, `clients:da-vinci-client`, `services:venice-server` (main + test sources).