### PR TITLE
[server] Attach vtp protocol-schema header on DoL stamp segment-start record

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -2540,7 +2540,14 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
           topicPartition.getPartitionNumber(),
           KafkaKey.DOL_STAMP,
           kafkaMessageEnvelope,
-          EmptyPubSubMessageHeaders.SINGLETON,
+          /*
+           * Route through getHeaders so the vtp protocol-schema header is attached on this
+           * segment-start message — DoL stamps always carry segmentNumber=0 + messageSequenceNumber=0
+           * (set in getDoLStampKME above), so needVtpHeader is true. Without this, the DoL stamp
+           * lands on the wire with empty headers, and a forward-compat consumer that hits it as
+           * the first record on a fresh VT has no way to bootstrap an unknown KME schema.
+           */
+          getHeaders(kafkaMessageEnvelope.getProducerMetadata(), false, null, EmptyPubSubMessageHeaders.SINGLETON),
           callback);
     }
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -1,8 +1,10 @@
 package com.linkedin.venice.writer;
 
+import static com.linkedin.venice.message.KafkaKey.DOL_STAMP;
 import static com.linkedin.venice.message.KafkaKey.HEART_BEAT;
 import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.EXECUTION_ID_KEY;
 import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_LEADER_COMPLETION_STATE_HEADER;
+import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_TRANSPORT_PROTOCOL_HEADER;
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_KB;
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 import static com.linkedin.venice.writer.LeaderCompleteState.LEADER_COMPLETED;
@@ -575,6 +577,74 @@ public class VeniceWriterUnitTest {
         assertEquals(leaderCompleteHeader.value()[0], leaderCompleteState.getValue());
       }
     }
+  }
+
+  /**
+   * Regression test for the missing-vtp DoL stamp bug. {@link VeniceWriter#sendDoLStamp} used to
+   * call {@link PubSubProducerAdapter#sendMessage} with {@link EmptyPubSubMessageHeaders#SINGLETON}
+   * directly, bypassing {@code getHeaders} — so a fresh-leader DoL on a brand-new version topic
+   * landed at offset 0 with empty headers. A consumer whose jar predated the current KME protocol
+   * version then had no {@code vtp} bootstrap path and failed with
+   * {@code "Received Protocol Version 'N' which is not supported by KafkaValueSerializer"}.
+   *
+   * <p>The fix routes through {@code getHeaders}, which attaches the protocol-schema header
+   * whenever {@code segmentNumber == 0 && messageSequenceNumber == 0} — both of which are always
+   * true on a DoL stamp (see {@code getDoLStampKME}). This test asserts the header is present
+   * and carries the current KME envelope JSON.
+   */
+  @Test
+  public void testSendDoLStampCarriesVtpHeader() {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    CompletableFuture mockedFuture = mock(CompletableFuture.class);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
+    String stringSchema = "\"string\"";
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
+    String testTopic = "test_vt_v1";
+    VeniceWriterOptions opts = new VeniceWriterOptions.Builder(testTopic).setKeyPayloadSerializer(serializer)
+        .setValuePayloadSerializer(serializer)
+        .setWriteComputePayloadSerializer(serializer)
+        .setPartitioner(new DefaultVenicePartitioner())
+        .setTime(SystemTime.INSTANCE)
+        .setPartitionCount(1)
+        .build();
+    VeniceWriter<Object, Object, Object> writer =
+        new VeniceWriter(opts, new VeniceProperties(new Properties()), mockedProducer);
+
+    PubSubTopicPartition tp = mock(PubSubTopicPartition.class);
+    PubSubTopic topic = mock(PubSubTopic.class);
+    when(topic.getName()).thenReturn(testTopic);
+    when(tp.getPubSubTopic()).thenReturn(topic);
+    when(tp.getPartitionNumber()).thenReturn(0);
+
+    writer.sendDoLStamp(tp, null, 12345L, 0);
+
+    ArgumentCaptor<KafkaKey> keyCap = ArgumentCaptor.forClass(KafkaKey.class);
+    ArgumentCaptor<KafkaMessageEnvelope> kmeCap = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    ArgumentCaptor<PubSubMessageHeaders> headersCap = ArgumentCaptor.forClass(PubSubMessageHeaders.class);
+    verify(mockedProducer)
+        .sendMessage(eq(testTopic), eq(0), keyCap.capture(), kmeCap.capture(), headersCap.capture(), any());
+
+    assertTrue(Arrays.equals(DOL_STAMP.getKey(), keyCap.getValue().getKey()));
+    ProducerMetadata pm = kmeCap.getValue().producerMetadata;
+    assertEquals(pm.segmentNumber, 0);
+    assertEquals(pm.messageSequenceNumber, 0);
+
+    PubSubMessageHeaders headers = headersCap.getValue();
+    PubSubMessageHeader vtp = null;
+    for (PubSubMessageHeader h: headers) {
+      if (VENICE_TRANSPORT_PROTOCOL_HEADER.equals(h.key())) {
+        vtp = h;
+        break;
+      }
+    }
+    assertNotNull(
+        vtp,
+        "DoL stamp must carry vtp header so forward-compat consumers can bootstrap an unknown KME schema");
+    String schemaJson = new String(vtp.value(), StandardCharsets.UTF_8);
+    assertTrue(
+        schemaJson.contains("KafkaMessageEnvelope"),
+        "vtp payload must be the current KME protocol-version schema JSON, got: "
+            + schemaJson.substring(0, Math.min(80, schemaJson.length())));
   }
 
   // Write a unit test for the retry mechanism in VeniceWriter.close(true) method.


### PR DESCRIPTION
## Summary

`VeniceWriter.sendDoLStamp` was passing `EmptyPubSubMessageHeaders.SINGLETON` directly to `producerAdapter.sendMessage`, bypassing the `getHeaders()` helper that attaches the `VENICE_TRANSPORT_PROTOCOL_HEADER` (`vtp`) on a segment-start record. Every DoL stamp therefore landed on the wire with empty headers — and when a `STANDBY → LEADER` transition writes a DoL stamp at offset 0 of a brand-new version topic, a forward-compat consumer whose jar predates the current KME protocol version has no on-record schema to bootstrap with. It throws:

```
com.linkedin.venice.exceptions.VeniceMessageException:
    Received Protocol Version 'N' which is not supported by KafkaValueSerializer.
    The only supported Protocol Versions are: {1,...,N-1}
```

## Root cause

`VeniceWriter.getHeaders(producerMetadata, addLeaderCompleteHeader, leaderCompleteState, extraHeaders)` is the canonical helper that produces per-record `PubSubMessageHeaders`. Its contract:

- If `producerMetadata.segmentNumber == 0 && producerMetadata.messageSequenceNumber == 0` (the first record of a new segment), it attaches the `vtp` header carrying the current KME protocol-schema JSON. The receiving consumer uses that bytes-blob to construct an Avro reader for the writer's protocol version, even if the receiver's jar doesn't know about it.
- Otherwise it returns `extraHeaders` unchanged.

`sendHeartbeat` already routes through `getHeaders(...)` and attaches `vtp` on the first heartbeat of every segment. `sendDoLStamp` did not — it constructed its KME via `getDoLStampKME` (which sets `segmentNumber == 0 && messageSequenceNumber == 0`) and then called `producerAdapter.sendMessage` with `EmptyPubSubMessageHeaders.SINGLETON` instead of routing through `getHeaders`. The DoL stamp's "I should be carrying `vtp`" precondition was always true, but `vtp` was never actually attached.

The bug was latent until KME `v14` was activated (#2780). A consumer running an older jar (only supports `v1..v13`) that reads from offset 0 of a fresh version topic now hits a `v14`-encoded DoL stamp with no headers and no way to bootstrap — the deserialize fails permanently for that consumer until it's upgraded.

## Fix

`VeniceWriter.sendDoLStamp` now routes its `sendMessage` call through:

```java
getHeaders(
    kafkaMessageEnvelope.getProducerMetadata(),
    /* addLeaderCompleteHeader */ false,
    /* leaderCompleteState     */ null,
    EmptyPubSubMessageHeaders.SINGLETON)
```

This is the same pattern `sendHeartbeat` uses. Because DoL stamps always carry `segmentNumber == 0 && messageSequenceNumber == 0` (set inside `getDoLStampKME`), the `needVtpHeader` branch fires and `vtp` is attached. No behavioral change for non-DoL paths.

## Scope

This PR is intentionally minimal — only the writer fix and the regression test. A follow-up PR will add defense-in-depth on the consumer side by plumbing a KME `SchemaReader` through every callsite that opens its own `PubSubMessageDeserializer`, so consumers that land on a header-less record from some other future writer regression can still resolve an unknown protocol version. Splitting these makes the immediate fix easy to review and easy to backport.

## Related

- #2778 added KME schema v14 to the protocol.
- #2780 activated KME v14 on the writer — exposed the latent missing-header bug.
- #2762 added vtp header stripping after successful deserialize (orthogonal — concerns memory retention, not schema bootstrap).
- #2798 is a parallel guard on the heartbeat / SOS emission side.

## Testing Done

- New unit test `VeniceWriterUnitTest.testSendDoLStampCarriesVtpHeader`: captures the headers passed to the producer adapter on a `sendDoLStamp` call and asserts (a) `VENICE_TRANSPORT_PROTOCOL_HEADER` is present, (b) the header bytes parse as the current `KafkaMessageEnvelope` protocol-schema JSON, and (c) the underlying `producerMetadata.segmentNumber == 0 && messageSequenceNumber == 0` (the invariant that drives `needVtpHeader=true` inside `getHeaders`).
- Existing `VeniceWriterUnitTest` tests pass (`testSendHeartbeat`, `testVeniceWriterCloseRetry`, etc.).
- Compile-clean on `internal:venice-common` (main + test sources).