### PR TITLE
[server] Fix latestProcessedVtPosition corruption during EOP leader-to-local switch

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1883,8 +1883,24 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       GetLastKnownUpstreamTopicOffset lastKnownUpstreamTopicOffsetSupplier,
       Supplier<String> sourceKafkaUrlSupplier,
       boolean dryRun) {
-    // Only update the metadata if this replica should NOT produce to version topic.
-    if (!shouldProduceToVersionTopic(partitionConsumptionState)) {
+    /*
+     * Dispatch on the record's own provenance, not on the live consumeRemotely flag.
+     *
+     * A non-null leaderProducedRecordContext means this record was produced to local VT by the
+     * leader after consuming it from upstream. Its local-VT position is producedPosition (the
+     * local-broker offset returned by the producer callback), not consumerRecord.getPosition()
+     * (the offset on the upstream/source topic).
+     *
+     * Branching on shouldProduceToVersionTopic (which reads pcs.consumeRemotely() live) is racy:
+     * if the flag flips false between the leader's produce and the drainer's processing of the
+     * same record, the local branch below would capture consumerRecord.getPosition() (the
+     * upstream offset on a different broker, with a different topicId) into
+     * latestProcessedVtPosition.
+     *
+     * updateOffsetsAsRemoteConsumeLeader already handles the chunk-record sub-case
+     * (consumedPosition=EARLIEST) as a no-op via its hasCorrespondingUpstreamMessage check.
+     */
+    if (leaderProducedRecordContext == null) {
       PubSubTopic consumedTopic = consumerRecord.getTopicPartition().getPubSubTopic();
       if (consumedTopic.isRealTime()) {
         // Does this ever happen?

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1884,21 +1884,14 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       Supplier<String> sourceKafkaUrlSupplier,
       boolean dryRun) {
     /*
-     * Dispatch on the record's own provenance, not on the live consumeRemotely flag.
+     * leaderProducedRecordContext != null means this record was produced to local VT by the leader after consuming it
+     * from upstream. Its local-VT position is producedPosition (returned by the producer callback), not
+     * consumerRecord.getPosition() (the offset on the upstream/source topic).
      *
-     * A non-null leaderProducedRecordContext means this record was produced to local VT by the
-     * leader after consuming it from upstream. Its local-VT position is producedPosition (the
-     * local-broker offset returned by the producer callback), not consumerRecord.getPosition()
-     * (the offset on the upstream/source topic).
-     *
-     * Branching on shouldProduceToVersionTopic (which reads pcs.consumeRemotely() live) is racy:
-     * if the flag flips false between the leader's produce and the drainer's processing of the
-     * same record, the local branch below would capture consumerRecord.getPosition() (the
-     * upstream offset on a different broker, with a different topicId) into
+     * Branching on shouldProduceToVersionTopic (which reads pcs.consumeRemotely() live) is racy: if the flag flips
+     * false between the leader's produce and the drainer's processing of the same record, the local branch below would
+     * capture consumerRecord.getPosition() (the upstream offset on a different broker, with a different topicId) into
      * latestProcessedVtPosition.
-     *
-     * updateOffsetsAsRemoteConsumeLeader already handles the chunk-record sub-case
-     * (consumedPosition=EARLIEST) as a no-op via its hasCorrespondingUpstreamMessage check.
      */
     if (leaderProducedRecordContext == null) {
       PubSubTopic consumedTopic = consumerRecord.getTopicPartition().getPubSubTopic();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -3929,4 +3929,86 @@ public class LeaderFollowerStoreIngestionTaskTest {
           "lcs must not propagate: " + description);
     }
   }
+
+  /**
+   * Regression test for the EOP leader-to-local race where a leader-produced record reaches the drainer
+   * after {@code pcs.consumeRemotely()} has flipped to {@code false}.
+   *
+   * Before the fix, {@code updateOffsetsFromConsumerRecord} dispatched on
+   * {@code !shouldProduceToVersionTopic(pcs)} which reads the live {@code consumeRemotely} flag.
+   * With LPRC present but the flag already flipped, the LOCAL branch fired and wrote
+   * {@code consumerRecord.getPosition()} — the upstream-broker offset on a different topicId —
+   * into {@code latestProcessedVtPosition}, corrupting the local VT slot.
+   *
+   * After the fix, dispatch is by {@code leaderProducedRecordContext != null}, which is set at
+   * queue time (consumer thread) and immutable through the drainer hand-off. A flag flip can no
+   * longer redirect the record into the wrong slot.
+   *
+   * Setup: stage the post-flip state (consumeRemotely=false, leaderTopic=versionTopic, leader role).
+   * Invariant: VT update must use {@code lprc.getProducedPosition()} (local-broker offset), never
+   * {@code consumerRecord.getPosition()} (upstream-broker offset).
+   */
+  @Test
+  public void testUpdateOffsetsFromConsumerRecordDispatchesByLeaderProducedContext() throws Exception {
+    setUp();
+
+    PubSubPosition producedPosition = mock(PubSubPosition.class);
+    PubSubPosition consumedPosition = mock(PubSubPosition.class);
+    PubSubPosition upstreamRecordPosition = mock(PubSubPosition.class);
+
+    // Stage the post-flip state: leader consuming local VT, consumeRemotely=false.
+    doReturn(false).when(mockPartitionConsumptionState).consumeRemotely();
+    doReturn(LeaderFollowerStateType.LEADER).when(mockPartitionConsumptionState).getLeaderFollowerState();
+
+    OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
+    PubSubTopic versionTopicRef = leaderFollowerStoreIngestionTask.getVersionTopic();
+    doReturn(versionTopicRef).when(mockOffsetRecord).getLeaderTopic(any());
+    doReturn(mockOffsetRecord).when(mockPartitionConsumptionState).getOffsetRecord();
+
+    // Pre-condition: with consumeRemotely=false and leaderTopic==versionTopic,
+    // shouldProduceToVersionTopic returns false — this is the live-flag state that
+    // would have triggered the old bug.
+    assertFalse(
+        leaderFollowerStoreIngestionTask.shouldProduceToVersionTopic(mockPartitionConsumptionState),
+        "shouldProduceToVersionTopic should return false in the post-flip state");
+
+    // Consumer record from an upstream (remote) source — should NEVER be used to update local VT.
+    DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
+    PubSubTopicPartition sourceTopicPartition = mock(PubSubTopicPartition.class);
+    PubSubTopic sourceTopic = mock(PubSubTopic.class);
+    doReturn(false).when(sourceTopic).isRealTime();
+    doReturn(sourceTopicPartition).when(consumerRecord).getTopicPartition();
+    doReturn(sourceTopic).when(sourceTopicPartition).getPubSubTopic();
+    doReturn(upstreamRecordPosition).when(consumerRecord).getPosition();
+
+    // Leader-produced context — non-null and carrying producedPosition (local) + consumedPosition (upstream).
+    LeaderProducedRecordContext lprc = mock(LeaderProducedRecordContext.class);
+    doReturn(true).when(lprc).hasCorrespondingUpstreamMessage();
+    doReturn(producedPosition).when(lprc).getProducedPosition();
+    doReturn(consumedPosition).when(lprc).getConsumedPosition();
+
+    LeaderFollowerStoreIngestionTask.UpdateVersionTopicOffset vtUpdate =
+        mock(LeaderFollowerStoreIngestionTask.UpdateVersionTopicOffset.class);
+    LeaderFollowerStoreIngestionTask.UpdateUpstreamTopicOffset upstreamUpdate =
+        mock(LeaderFollowerStoreIngestionTask.UpdateUpstreamTopicOffset.class);
+    LeaderFollowerStoreIngestionTask.GetLastKnownUpstreamTopicOffset lastKnownUpstream =
+        mock(LeaderFollowerStoreIngestionTask.GetLastKnownUpstreamTopicOffset.class);
+
+    leaderFollowerStoreIngestionTask.updateOffsetsFromConsumerRecord(
+        mockPartitionConsumptionState,
+        consumerRecord,
+        lprc,
+        vtUpdate,
+        upstreamUpdate,
+        lastKnownUpstream,
+        () -> "remote-broker-url",
+        false);
+
+    // The fix: VT update must use the leader-produced (local) position.
+    verify(vtUpdate, times(1)).apply(producedPosition);
+    // And must NOT use the upstream record's position — that was the bug.
+    verify(vtUpdate, never()).apply(upstreamRecordPosition);
+    // Upstream slot is updated with the consumed (upstream) position.
+    verify(upstreamUpdate, times(1)).apply(eq("remote-broker-url"), eq(versionTopicRef), eq(consumedPosition));
+  }
 }


### PR DESCRIPTION
## Problem Statement

`LeaderFollowerStoreIngestionTask.updateOffsetsFromConsumerRecord` branches on `shouldProduceToVersionTopic(pcs)`, which reads `pcs.consumeRemotely()` live. The flag can flip false (via `setConsumeRemotely(false)` in the EOP leader-to-local switch at `checkLongRunningTaskState`) between the leader's produce callback and the drainer's processing of the same record. When that happens, in-flight leader-produced records that were consumed from an upstream topic fall through to the local branch and write `consumerRecord.getPosition()` (the upstream-broker offset, with a different topicId) into `latestProcessedVtPosition`. The local-VT slot ends up holding a position that belongs to a different physical shard than the local VT.

Downstream effects:
- `TopicManager.getIngestionProgressPercentage` -> `TopicMetadataFetcher.diffPosition` -> `XcConsumerAdapter.positionDifference` fails with `PositionCompareOrDiffException: cannot compare position of different shards` (`PositionUtils.validateSameShard`).
- A subsequent re-subscribe on the local broker carries an upstream-broker `topicId`, triggering topic-id-mismatch fallbacks in downstream adapters.

## Solution

Dispatch on the record's own `leaderProducedRecordContext` instead of on the live `consumeRemotely` flag:

- `context != null` -> record was produced to local VT by the leader after consuming from upstream. Its local-VT position is `producedPosition` (returned by the local producer callback). Goes through `updateOffsetsAsRemoteConsumeLeader`, which already handles the chunk sub-case (`consumedPosition=EARLIEST`) as a no-op via `hasCorrespondingUpstreamMessage`.
- `context == null` -> record was consumed by a follower or by a leader consuming local VT directly. Its local-VT position is `consumerRecord.getPosition()`. Same body as before.

The offset-update decision is now per-record, eliminating the race across the leader-to-local transition (and any other path where the flag and the in-flight record diverge).

### Why this is safe across store types

- Follower: `leaderProducedRecordContext` is always null (drainer-queue insert at `StoreIngestionTask.java:1473-1479` passes `null`). Falls through to the local branch. No change.
- Leader consuming local VT (post-EOP non-NR or non-NR setups): same as follower, context is null. No change.
- Leader-NR (consuming upstream, producing local): `LeaderProducerCallback` queues with a populated context. Goes through `updateOffsetsAsRemoteConsumeLeader`. No change in steady state; the race-prone window during the EOP transition now correctly uses `producedPosition`.
- Active-Active: uses the same `updateOffsetsFromConsumerRecord` via inheritance. Same dispatch.
- Leader-generated chunks: context is non-null but `hasCorrespondingUpstreamMessage=false`. `updateOffsetsAsRemoteConsumeLeader` skips them today via the internal check, unchanged.

## Testing Done

- [x] Compiled with `./gradlew :clients:da-vinci-client:compileJava`.
- [x] Existing `LeaderFollowerStoreIngestionTaskTest` continues to pass.
- [ ] Targeted unit test for the dispatch (covering both the null-context follower path and the non-null-context leader-produce path while `shouldProduceToVersionTopic` returns false) will follow in a separate commit.
