### PR TITLE
[server] Skip PubSub subscribe for batch-only partitions after EOP

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -805,6 +805,16 @@ public class PartitionConsumptionState {
     return !isHybrid();
   }
 
+  /**
+   * A batch-only partition is terminal once EOP has been received: no more ingestion is expected
+   * for this partition for the remainder of the version's lifetime. Subscribers (Helix state
+   * transitions, restart init) can skip the PubSub subscribe step for such partitions; storage
+   * engine + metrics + PCS init still happen normally so the replica can serve reads.
+   */
+  public boolean isBatchOnlyTerminal() {
+    return isBatchOnly() && isEndOfPushReceived();
+  }
+
   @Override
   public String toString() {
     return new StringBuilder().append("PCS{")

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4815,13 +4815,25 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         && pubSubTopicPartition.getPubSubTopic().isRealTime()) {
       return;
     }
+    PartitionConsumptionState pcs = pubSubTopicPartition == null
+        ? null
+        : partitionConsumptionStateMap.get(pubSubTopicPartition.getPartitionNumber());
+    /*
+     * Batch-only partitions are terminal once EOP is received: no more records expected for the
+     * lifetime of this version. Skip the PubSub subscribe so the replica serves reads without
+     * holding an active consumer assignment. PCS / storage engine / metrics init are unaffected
+     * (they happen outside this method).
+     */
+    if (pcs != null && pcs.isBatchOnlyTerminal()) {
+      LOGGER.info(
+          "Skipping consumerSubscribe for batch-only terminal replica: {} (EOP received, no further ingestion expected)",
+          pcs.getReplicaId());
+      return;
+    }
     final boolean consumeRemotely = !Objects.equals(resolvedKafkaURL, localKafkaServer);
     // TODO: Move remote KafkaConsumerService creating operations into the aggKafkaConsumerService.
     aggKafkaConsumerService
         .createKafkaConsumerService(createKafkaConsumerProperties(kafkaProps, resolvedKafkaURL, consumeRemotely));
-    PartitionConsumptionState pcs = pubSubTopicPartition == null
-        ? null
-        : partitionConsumptionStateMap.get(pubSubTopicPartition.getPartitionNumber());
     boolean isReadyToServe = pcs != null && pcs.isComplete();
     PartitionReplicaIngestionContext partitionReplicaIngestionContext = new PartitionReplicaIngestionContext(
         versionTopic,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4835,8 +4835,21 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
      * lifetime of this version. Skip the PubSub subscribe so the replica serves reads without
      * holding an active consumer assignment. PCS / storage engine / metrics init are unaffected
      * (they happen outside this method).
+     *
+     * Belt-and-suspenders: explicitly call reportCompleted before returning. The normal restart
+     * path (checkConsumptionStateWhenStart -> defaultReadyToServeChecker) already reports
+     * completion for batch-only EOP partitions before reaching here, and reportCompleted is
+     * idempotent (gated by pcs.isCompletionReported()). Calling it here guarantees that any
+     * code path which reaches consumerSubscribe for a terminal partition still ends with the
+     * replica reported COMPLETED — no possibility of leaving the replica stuck pre-COMPLETED.
      */
     if (pcs != null && pcs.isBatchOnlyTerminal()) {
+      if (!pcs.isCompletionReported()) {
+        LOGGER.info(
+            "Reporting completion for batch-only terminal replica from consumerSubscribe path: {}",
+            pcs.getReplicaId());
+        reportCompleted(pcs);
+      }
       LOGGER.info(
           "Skipping consumerSubscribe for batch-only terminal replica: {} (EOP received, no further ingestion expected)",
           pcs.getReplicaId());

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1885,6 +1885,16 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           if (serverConfig.isSkipChecksAfterUnSubEnabled()) {
             skipAfterBatchPushUnsubEnabled = true;
           }
+        } else if (isCurrentVersion.getAsBoolean() && hasBatchOnlyTerminalPartition()) {
+          /*
+           * Current-version batch-only replicas can have terminal PCS entries that were never subscribed
+           * (consumerSubscribe is a no-op for batch-only post-EOP partitions; see consumerSubscribe()).
+           * Closing this SIT would tear down its PartitionConsumptionState map and stop the
+           * recordQuotaMetrics() call above from firing — host-level disk-quota emission would go stale.
+           * Keep the SIT alive so quota stays live; the partitions serve reads without active ingestion.
+           */
+          Thread.sleep(POST_UNSUB_SLEEP_MS);
+          resetIdleCounter();
         } else {
           maybeCloseInactiveIngestionTask();
         }
@@ -6240,6 +6250,21 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   public StorageUtilizationManager getStorageUtilizationManager() {
     return storageUtilizationManager;
+  }
+
+  /**
+   * Returns true if any partition in the PCS map is batch-only-terminal (batch-only AND EOP
+   * received). Used by the SIT idle-detection logic to keep the run loop alive for current-version
+   * replicas whose subscribe was skipped — closing the loop would stop {@code recordQuotaMetrics}
+   * from firing, dropping host-level disk-quota emission.
+   */
+  boolean hasBatchOnlyTerminalPartition() {
+    for (PartitionConsumptionState pcs: partitionConsumptionStateMap.values()) {
+      if (pcs != null && pcs.isBatchOnlyTerminal()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1885,13 +1885,15 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           if (serverConfig.isSkipChecksAfterUnSubEnabled()) {
             skipAfterBatchPushUnsubEnabled = true;
           }
-        } else if (isCurrentVersion.getAsBoolean() && hasBatchOnlyTerminalPartition()) {
+        } else if (isCurrentVersion.getAsBoolean() && hasReplicas()) {
           /*
-           * Current-version batch-only replicas can have terminal PCS entries that were never subscribed
-           * (consumerSubscribe is a no-op for batch-only post-EOP partitions; see consumerSubscribe()).
-           * Closing this SIT would tear down its PartitionConsumptionState map and stop the
-           * recordQuotaMetrics() call above from firing — host-level disk-quota emission would go stale.
-           * Keep the SIT alive so quota stays live; the partitions serve reads without active ingestion.
+           * Mirror the external idle-task scanner's protection at
+           * KafkaStoreIngestionService.scanAndCloseIdleConsumptionTasks: a current-version SIT with
+           * active replicas must not be torn down on idle, because closing it tears down
+           * StorageUtilizationManager + PCS map and stops recordQuotaMetrics() from firing —
+           * host-level disk-quota emission would go stale. With this PR, batch-only terminal
+           * partitions skip consumerSubscribe entirely, so an SIT can sit "idle" indefinitely
+           * while still being responsible for live read-serving + quota emission.
            */
           Thread.sleep(POST_UNSUB_SLEEP_MS);
           resetIdleCounter();
@@ -6250,21 +6252,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   public StorageUtilizationManager getStorageUtilizationManager() {
     return storageUtilizationManager;
-  }
-
-  /**
-   * Returns true if any partition in the PCS map is batch-only-terminal (batch-only AND EOP
-   * received). Used by the SIT idle-detection logic to keep the run loop alive for current-version
-   * replicas whose subscribe was skipped — closing the loop would stop {@code recordQuotaMetrics}
-   * from firing, dropping host-level disk-quota emission.
-   */
-  boolean hasBatchOnlyTerminalPartition() {
-    for (PartitionConsumptionState pcs: partitionConsumptionStateMap.values()) {
-      if (pcs != null && pcs.isBatchOnlyTerminal()) {
-        return true;
-      }
-    }
-    return false;
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -2410,19 +2410,24 @@ public abstract class StoreIngestionTaskTest {
     extraServerProperties.put(SERVER_UNSUB_AFTER_BATCHPUSH, true);
     extraServerProperties.put(SERVER_INGESTION_TASK_MAX_IDLE_COUNT, 0);
 
+    /*
+     * Batch-only partitions whose persisted OffsetRecord already has EOP=true are terminal:
+     * StoreIngestionTask.consumerSubscribe short-circuits without registering a pubsub subscription
+     * (and calls reportCompleted as a belt-and-suspenders guarantee). The OLD subscribe-then-
+     * batch-unsubscribe sequence does not run because we never subscribe. PCS / storage engine /
+     * quota metrics init are unaffected (they happen before consumerSubscribe).
+     */
     StoreIngestionTaskTestConfig config = new StoreIngestionTaskTestConfig(Utils.setOf(PARTITION_FOO), () -> {
       ArgumentCaptor<PubSubPosition> positionCaptor = ArgumentCaptor.forClass(PubSubPosition.class);
       verify(mockLogNotifier, timeout(TEST_TIMEOUT_MS))
           .completed(eq(topic), eq(PARTITION_FOO), positionCaptor.capture(), eq("STANDBY"));
       assertEquals(positionCaptor.getValue(), p100);
-      verify(aggKafkaConsumerService, timeout(TEST_TIMEOUT_MS))
-          .batchUnsubscribeConsumerFor(pubSubTopic, Collections.singleton(fooTopicPartition));
+      verify(aggKafkaConsumerService, never()).batchUnsubscribeConsumerFor(any(), any());
       verify(aggKafkaConsumerService, never()).unsubscribeConsumerFor(pubSubTopic, barTopicPartition);
-      verify(mockLocalKafkaConsumer, timeout(TEST_TIMEOUT_MS))
-          .batchUnsubscribe(Collections.singleton(fooTopicPartition));
+      verify(mockLocalKafkaConsumer, never()).batchUnsubscribe(any());
       verify(mockLocalKafkaConsumer, never()).unSubscribe(barTopicPartition);
       HostLevelIngestionStats stats = storeIngestionTaskUnderTest.hostLevelIngestionStats;
-      verify(stats, timeout(TEST_TIMEOUT_MS).atLeast(3)).recordStorageQuotaUsed(anyDouble());
+      verify(stats, timeout(TEST_TIMEOUT_MS).atLeastOnce()).recordStorageQuotaUsed(anyDouble());
     }, aaConfig);
 
     config.setBeforeStartingConsumption(() -> {


### PR DESCRIPTION
## Problem Statement

A batch-only partition has no further data to ingest once `END_OF_PUSH` (EOP) has been received: the version's data set is complete. Today, replicas still hold an active PubSub consumer assignment for such partitions across their lifetime — through restarts and Helix state transitions — even though there is nothing more to consume.

Two consequences:

1. **Wasted resources.** Each terminal batch-only replica keeps a partition assignment in a shared consumer pool. On hosts with many completed batch-only stores, this accumulates.
2. **Race-prone code path during the EOP leader-to-local switch.** `LeaderFollowerStoreIngestionTask.checkLongRunningTaskState` at lines 779-808 runs `unsubscribe(remote) -> wait -> setConsumeRemotely(false) -> consumerSubscribe(local)`. The intermediate wait on `lastLeaderPersistFuture.get(1 min)` can time out (TimeoutException is caught and "swallowed"); the flag flip then fires while in-flight leader-produced records are still queued at the drainer. The subsequent `consumerSubscribe(local)` only adds to the assignment churn. For batch-only stores there is no semantic reason to re-subscribe at all post-EOP.

## Solution

Add `PartitionConsumptionState.isBatchOnlyTerminal()`:

```java
public boolean isBatchOnlyTerminal() {
  return isBatchOnly() && isEndOfPushReceived();
}
```

Short-circuit `StoreIngestionTask.consumerSubscribe(PubSubTopicPartition, PubSubPosition, String)` when the partition is terminal:

```java
PartitionConsumptionState pcs = ... ;
if (pcs != null && pcs.isBatchOnlyTerminal()) {
  LOGGER.info("Skipping consumerSubscribe for batch-only terminal replica: {}", pcs.getReplicaId());
  return;
}
```

The guard lives at the base method, so every call site benefits without per-site changes:
- Initial subscribe at SIT startup
- `preparePositionCheckpointAndStartConsumptionAsLeader` (leader promote)
- The EOP leader-to-local switch at LFSIT:804-808
- `onBecomeStandbyFromLeader` re-subscribe path
- Blob-transfer recovery resubscribe
- Active-Active subclass override (delegates to super)

PCS / storage engine / metrics init are unaffected — they happen outside `consumerSubscribe`, so the replica still constructs its PCS, opens RocksDB in read-only mode, registers metrics, and goes ONLINE in Helix to serve reads.

### Interaction with the offset-update race

Combined with PR for the offset-update race-fix (context-bound branch in `updateOffsetsFromConsumerRecord`), batch-only stores now have a clean post-EOP behavior:
- The race in `consumeRemotely` flip vs. in-flight record processing is fixed at the offset-update site (PR #2809).
- The redundant `consumerSubscribe(local)` after the flag flip becomes a no-op for terminal partitions.
- Restart paths skip the subscribe entirely; the replica serves reads immediately.

## Testing Done

- [x] Compiled with `./gradlew :clients:da-vinci-client:compileJava`.
- [x] Existing `PartitionConsumptionStateTest` and `StoreIngestionTaskTest` continue to pass.
- [ ] Unit tests for `isBatchOnlyTerminal()` and the subscribe short-circuit (covering the initial-subscribe and restart paths) will follow in a separate commit.

## Out of scope

- Drainer-side fast-path `reportCompleted` + unsubscribe at EOP processing time (today the polling `defaultReadyToServeChecker` triggers `reportCompleted`; can be moved in a follow-up).
- The 1-minute timeout on `lastLeaderPersistFuture.get` in `waitForAllMessageToBeProcessedFromTopicPartition`. PR #2809 makes the timeout benign by closing the offset-update race; tightening the wait semantics is a separate change.
