### PR TITLE
WIP [da-vinci][server][controller][router][fc][tc][test] Close async OTel instruments properly with a uniform lifecycle

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -65,12 +65,12 @@ import com.linkedin.venice.serialization.avro.SchemaPresenceChecker;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.stats.TehutiUtils;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
-import java.io.Closeable;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -100,7 +100,7 @@ import org.apache.logging.log4j.Logger;
  * the shared behavior of this class. Regular clients participate in version swaps while version-specific
  * clients subscribe to a fixed version and ignore version swap events.
  */
-public class DaVinciBackend implements Closeable {
+public class DaVinciBackend extends AbstractStatsCloseable {
   private static final Logger LOGGER = LogManager.getLogger(DaVinciBackend.class);
 
   // Client type tracking for version-specific vs regular clients
@@ -189,16 +189,18 @@ public class DaVinciBackend implements Closeable {
           configLoader.getVeniceClusterConfig().getClusterName());
 
       // OTel per-store version gauge
-      storeVersionOtelStats = StoreVersionOtelStats
-          .create(metricsRepository, configLoader.getVeniceClusterConfig().getClusterName(), storeRepository);
+      storeVersionOtelStats = statsCloseables.register(
+          StoreVersionOtelStats
+              .create(metricsRepository, configLoader.getVeniceClusterConfig().getClusterName(), storeRepository));
 
-      rocksDBMemoryStats = backendConfig.isDatabaseMemoryStatsEnabled()
-          ? new RocksDBMemoryStats(
-              metricsRepository,
-              "RocksDBMemoryStats",
-              backendConfig.getRocksDBServerConfig().isRocksDBPlainTableFormatEnabled(),
-              configLoader.getVeniceClusterConfig().getClusterName())
-          : null;
+      rocksDBMemoryStats = statsCloseables.register(
+          backendConfig.isDatabaseMemoryStatsEnabled()
+              ? new RocksDBMemoryStats(
+                  metricsRepository,
+                  "RocksDBMemoryStats",
+                  backendConfig.getRocksDBServerConfig().isRocksDBPlainTableFormatEnabled(),
+                  configLoader.getVeniceClusterConfig().getClusterName())
+              : null);
 
       /**
        * The constructor of {@link #storageService} will take care of unused store/store version cleanup.
@@ -298,8 +300,11 @@ public class DaVinciBackend implements Closeable {
       ingestionService.start();
 
       if (BlobTransferUtils.isBlobTransferManagerEnabled(backendConfig)) {
-        aggVersionedBlobTransferStats =
-            new AggVersionedBlobTransferStats(metricsRepository, storeRepository, configLoader.getVeniceServerConfig());
+        aggVersionedBlobTransferStats = statsCloseables.register(
+            new AggVersionedBlobTransferStats(
+                metricsRepository,
+                storeRepository,
+                configLoader.getVeniceServerConfig()));
         aggBlobTransferStats =
             new AggBlobTransferStats(aggVersionedBlobTransferStats, ingestionService.getHostLevelIngestionStats());
         P2PBlobTransferConfig p2PBlobTransferConfig = new P2PBlobTransferConfig(
@@ -434,9 +439,7 @@ public class DaVinciBackend implements Closeable {
     cacheBackend.ifPresent(
         objectCacheBackend -> storeRepository
             .unregisterStoreDataChangedListener(objectCacheBackend.getCacheInvalidatingStoreChangeListener()));
-    if (storeVersionOtelStats != null) {
-      storeVersionOtelStats.close();
-    }
+    super.close();
     ExecutorService storeBackendCloseExecutor = Executors.newCachedThreadPool(
         new DaemonThreadFactory(
             "DaVinciBackend-StoreBackend-Close",

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -27,6 +27,7 @@ import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.LogContext;
@@ -64,7 +65,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
-public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
+public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V> extends AbstractStatsCloseable
     implements StatefulVeniceChangelogConsumer<K, V>, VeniceChangelogConsumer<K, V> {
   private static final Logger LOGGER = LogManager.getLogger(VeniceChangelogConsumerDaVinciRecordTransformerImpl.class);
   private long START_TIMEOUT_IN_SECONDS = 60;
@@ -184,10 +185,11 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
     }
 
     if (changelogClientConfig.getInnerClientConfig().getMetricsRepository() != null) {
-      this.changeCaptureStats = new BasicConsumerStats(
-          changelogClientConfig.getInnerClientConfig().getMetricsRepository(),
-          "vcc-" + changelogClientConfig.getConsumerName(),
-          storeName);
+      this.changeCaptureStats = statsCloseables.register(
+          new BasicConsumerStats(
+              changelogClientConfig.getInnerClientConfig().getMetricsRepository(),
+              "vcc-" + changelogClientConfig.getConsumerName(),
+              storeName));
     } else {
       changeCaptureStats = null;
     }
@@ -439,12 +441,15 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
     this.resume(Collections.emptySet());
   }
 
+  @Override
   public void close() {
     try {
       this.stop();
     } catch (Exception e) {
       LOGGER.error("Close failed for VeniceChangelogConsumer", e);
       throw new RuntimeException(e);
+    } finally {
+      super.close();
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -57,6 +57,7 @@ import com.linkedin.venice.serialization.StoreDeserializerCache;
 import com.linkedin.venice.serialization.avro.AvroSpecificStoreDeserializerCache;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.store.rocksdb.RocksDBUtils;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.DaemonThreadFactory;
@@ -102,7 +103,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
-public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsumer<K, V> {
+public class VeniceChangelogConsumerImpl<K, V> extends AbstractStatsCloseable implements VeniceChangelogConsumer<K, V> {
   private static final Logger LOGGER = LogManager.getLogger(VeniceChangelogConsumerImpl.class);
   private static final int MAX_SUBSCRIBE_RETRIES = 5;
   private static final String ROCKSDB_BUFFER_FOLDER = "rocksdb-chunk-buffer";
@@ -250,10 +251,11 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     }
 
     if (changelogClientConfig.getInnerClientConfig().getMetricsRepository() != null) {
-      this.changeCaptureStats = new BasicConsumerStats(
-          changelogClientConfig.getInnerClientConfig().getMetricsRepository(),
-          "vcc-" + changelogClientConfig.getConsumerName(),
-          storeName);
+      this.changeCaptureStats = statsCloseables.register(
+          new BasicConsumerStats(
+              changelogClientConfig.getInnerClientConfig().getMetricsRepository(),
+              "vcc-" + changelogClientConfig.getConsumerName(),
+              storeName));
     } else {
       changeCaptureStats = null;
     }
@@ -1169,18 +1171,22 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     LOGGER.info("Closing Changelog Consumer with name: {}", changelogClientConfig.getConsumerName());
     subscriptionLock.writeLock().lock();
     try {
-      this.unsubscribeAll();
-      pubSubConsumer.close();
-      heartbeatReporterThread.interrupt();
-      seekExecutorService.shutdown();
-      compressorFactory.close();
+      try {
+        this.unsubscribeAll();
+        pubSubConsumer.close();
+        heartbeatReporterThread.interrupt();
+        seekExecutorService.shutdown();
+        compressorFactory.close();
 
-      if (rocksDBStorageEngineFactory != null) {
-        rocksDBStorageEngineFactory.close();
+        if (rocksDBStorageEngineFactory != null) {
+          rocksDBStorageEngineFactory.close();
+        }
+
+        veniceChangelogConsumerClientFactory.deregisterClient(changelogClientConfig.getConsumerName());
+        LOGGER.info("Closed Changelog Consumer with name: {}", changelogClientConfig.getConsumerName());
+      } finally {
+        super.close();
       }
-
-      veniceChangelogConsumerClientFactory.deregisterClient(changelogClientConfig.getConsumerName());
-      LOGGER.info("Closed Changelog Consumer with name: {}", changelogClientConfig.getConsumerName());
     } finally {
       subscriptionLock.writeLock().unlock();
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/stats/BasicConsumerStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/stats/BasicConsumerStats.java
@@ -74,7 +74,8 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         BasicConsumerTehutiMetricName.MAX_PARTITION_LAG,
         Collections.singletonList(new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     minimumConsumingVersionMetric = MetricEntityStateBase.create(
         BasicConsumerMetricEntity.CURRENT_CONSUMING_VERSION.getMetricEntity(),
@@ -83,7 +84,8 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         BasicConsumerTehutiMetricName.MINIMUM_CONSUMING_VERSION,
         Collections.singletonList(new Gauge()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     maximumConsumingVersionMetric = MetricEntityStateBase.create(
         BasicConsumerMetricEntity.CURRENT_CONSUMING_VERSION.getMetricEntity(),
@@ -92,7 +94,8 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         BasicConsumerTehutiMetricName.MAXIMUM_CONSUMING_VERSION,
         Collections.singletonList(new Gauge()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     recordsConsumedCountMetric = MetricEntityStateBase.create(
         BasicConsumerMetricEntity.RECORDS_CONSUMED_COUNT.getMetricEntity(),
@@ -101,7 +104,8 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         BasicConsumerTehutiMetricName.RECORDS_CONSUMED,
         Arrays.asList(new Avg(), new Max(), new Rate()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     pollSuccessCountMetric = MetricEntityStateOneEnum.create(
         BasicConsumerMetricEntity.POLL_COUNT.getMetricEntity(),
@@ -110,7 +114,8 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         BasicConsumerTehutiMetricName.POLL_SUCCESS_COUNT,
         Collections.singletonList(new Rate()),
         baseDimensionsMap,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     pollFailCountMetric = MetricEntityStateOneEnum.create(
         BasicConsumerMetricEntity.POLL_COUNT.getMetricEntity(),
@@ -119,7 +124,8 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         BasicConsumerTehutiMetricName.POLL_FAIL_COUNT,
         Collections.singletonList(new Rate()),
         baseDimensionsMap,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     versionSwapSuccessCountMetric = MetricEntityStateOneEnum.create(
         BasicConsumerMetricEntity.VERSION_SWAP_COUNT.getMetricEntity(),
@@ -128,7 +134,8 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         BasicConsumerTehutiMetricName.VERSION_SWAP_SUCCESS_COUNT,
         Collections.singletonList(new Total()),
         baseDimensionsMap,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     versionSwapFailCountMetric = MetricEntityStateOneEnum.create(
         BasicConsumerMetricEntity.VERSION_SWAP_COUNT.getMetricEntity(),
@@ -137,7 +144,8 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         BasicConsumerTehutiMetricName.VERSION_SWAP_FAIL_COUNT,
         Collections.singletonList(new Total()),
         baseDimensionsMap,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     chunkedRecordSuccessCountMetric = MetricEntityStateOneEnum.create(
         BasicConsumerMetricEntity.CHUNKED_RECORD_COUNT.getMetricEntity(),
@@ -146,7 +154,8 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         BasicConsumerTehutiMetricName.CHUNKED_RECORD_SUCCESS_COUNT,
         Collections.singletonList(new Rate()),
         baseDimensionsMap,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     chunkedRecordFailCountMetric = MetricEntityStateOneEnum.create(
         BasicConsumerMetricEntity.CHUNKED_RECORD_COUNT.getMetricEntity(),
@@ -155,7 +164,8 @@ public class BasicConsumerStats extends AbstractVeniceStats {
         BasicConsumerTehutiMetricName.CHUNKED_RECORD_FAIL_COUNT,
         Collections.singletonList(new Rate()),
         baseDimensionsMap,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     /*
      * Record default value for version swap metrics so the UP_DOWN_COUNTER in OTEL will emit a default 0.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -34,6 +34,7 @@ import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.stats.HelixMessageChannelStats;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.status.StatusMessageHandler;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.HelixUtils;
@@ -90,6 +91,8 @@ public class HelixParticipationService extends AbstractVeniceService
   private VeniceOfflinePushMonitorAccessor veniceOfflinePushMonitorAccessor;
   private BlobTransferManager<Void> blobTransferManager;
   private final HeartbeatMonitoringService heartbeatMonitoringService;
+  /** Stats fields owned by this class; drained by {@link #stopInner()}. */
+  private final CompositeCloseable statsCloseables = new CompositeCloseable();
 
   // This is ONLY for testing purpose.
   public ThreadPoolExecutor getLeaderFollowerHelixStateTransitionThreadPool() {
@@ -193,20 +196,22 @@ public class HelixParticipationService extends AbstractVeniceService
         config.getMaxLeaderFollowerStateTransitionThreadNumber(),
         "Venice-L/F-state-transition");
     // register stats that tracks the thread pool
-    ParticipantStateTransitionStats stateTransitionStats = new ParticipantStateTransitionStats(
-        metricsRepository,
-        leaderFollowerHelixStateTransitionThreadPool,
-        "Venice_L/F_ST_thread_pool");
+    ParticipantStateTransitionStats stateTransitionStats = statsCloseables.register(
+        new ParticipantStateTransitionStats(
+            metricsRepository,
+            leaderFollowerHelixStateTransitionThreadPool,
+            "Venice_L/F_ST_thread_pool"));
 
     if (config.getLeaderFollowerThreadPoolStrategy()
         .equals(LeaderFollowerPartitionStateModelFactory.LeaderFollowerThreadPoolStrategy.DUAL_POOL_STRATEGY)) {
       ThreadPoolExecutor futureVersionThreadPool = initHelixStateTransitionThreadPool(
           config.getMaxFutureVersionLeaderFollowerStateTransitionThreadNumber(),
           "venice-L/F-state-transition-future-version");
-      ParticipantStateTransitionStats futureVersionStateTransitionStats = new ParticipantStateTransitionStats(
-          metricsRepository,
-          futureVersionThreadPool,
-          "Venice_L/F_ST_thread_pool_future_version");
+      ParticipantStateTransitionStats futureVersionStateTransitionStats = statsCloseables.register(
+          new ParticipantStateTransitionStats(
+              metricsRepository,
+              futureVersionThreadPool,
+              "Venice_L/F_ST_thread_pool_future_version"));
       leaderFollowerParticipantModelFactory = new LeaderFollowerPartitionStateModelDualPoolFactory(
           ingestionBackend,
           veniceConfigLoader,
@@ -301,6 +306,7 @@ public class HelixParticipationService extends AbstractVeniceService
       zkClient.close();
       LOGGER.info("Closed ZkClient.");
     }
+    statsCloseables.close();
     LOGGER.info("Finished stopping HelixParticipation service.");
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AdaptiveThrottlerSignalService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AdaptiveThrottlerSignalService.java
@@ -7,6 +7,7 @@ import com.linkedin.davinci.stats.AdaptiveThrottlingServiceStats;
 import com.linkedin.davinci.stats.ingestion.heartbeat.AggregatedHeartbeatLagEntry;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.venice.service.AbstractVeniceService;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.throttle.VeniceAdaptiveThrottler;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import io.tehuti.Metric;
@@ -49,6 +50,8 @@ public class AdaptiveThrottlerSignalService extends AbstractVeniceService {
   private boolean nonCurrentLeaderMaxHeartbeatLagSignal = false;
   private boolean nonCurrentFollowerMaxHeartbeatLagSignal = false;
   private final AdaptiveThrottlingServiceStats adaptiveThrottlingServiceStats;
+  /** Stats fields owned by this class; drained by {@link #stopInner()}. */
+  private final CompositeCloseable statsCloseables = new CompositeCloseable();
 
   public AdaptiveThrottlerSignalService(
       VeniceServerConfig veniceServerConfig,
@@ -63,8 +66,8 @@ public class AdaptiveThrottlerSignalService extends AbstractVeniceService {
     this.updateService = Executors.newSingleThreadScheduledExecutor(
         new DaemonThreadFactory("AdaptiveThrottlerSignalService", veniceServerConfig.getLogContext()));
     this.heartbeatMonitoringService = heartbeatMonitoringService;
-    this.adaptiveThrottlingServiceStats =
-        new AdaptiveThrottlingServiceStats(metricsRepository, veniceServerConfig.getClusterName());
+    this.adaptiveThrottlingServiceStats = statsCloseables
+        .register(new AdaptiveThrottlingServiceStats(metricsRepository, veniceServerConfig.getClusterName()));
   }
 
   public void registerThrottler(VeniceAdaptiveThrottler adaptiveIngestionThrottler) {
@@ -171,6 +174,7 @@ public class AdaptiveThrottlerSignalService extends AbstractVeniceService {
   @Override
   public void stopInner() throws Exception {
     updateService.shutdownNow();
+    statsCloseables.close();
   }
 
   List<VeniceAdaptiveThrottler> getThrottlerList() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
@@ -20,6 +20,7 @@ import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pubsub.manager.TopicManagerContext.PubSubPropertiesSupplier;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.stats.ThreadPoolStats;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.RedundantExceptionFilter;
 import com.linkedin.venice.utils.SystemTime;
@@ -83,6 +84,8 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
   private final StuckConsumerRepairStats stuckConsumerStats;
   private final ThreadPoolExecutor crossTpProcessingPool;
   private final ThreadPoolStats crossTpProcessingStats;
+  /** Stats fields owned by this class; drained by {@link #stopInner()}. */
+  private final CompositeCloseable statsCloseables = new CompositeCloseable();
 
   private final static String STUCK_CONSUMER_MSG =
       "Didn't find any suspicious ingestion task, and please contact developers to investigate it further";
@@ -119,7 +122,8 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
     this.kafkaClusterUrlResolver = serverConfig.getKafkaClusterUrlResolver();
     this.metadataRepository = metadataRepository;
     if (serverConfig.isStuckConsumerRepairEnabled()) {
-      this.stuckConsumerStats = new StuckConsumerRepairStats(metricsRepository, serverConfig.getClusterName());
+      this.stuckConsumerStats =
+          statsCloseables.register(new StuckConsumerRepairStats(metricsRepository, serverConfig.getClusterName()));
       this.stuckConsumerRepairExecutorService = Executors.newSingleThreadScheduledExecutor(
           new DaemonThreadFactory(this.getClass().getName() + "-StuckConsumerRepair", serverConfig.getLogContext()));
       int intervalInSeconds = serverConfig.getStuckConsumerRepairIntervalSecond();
@@ -156,7 +160,8 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
           TimeUnit.MILLISECONDS,
           new LinkedBlockingQueue<>(),
           new DaemonThreadFactory("cross-tp-parallel-processing", serverConfig.getLogContext()));
-      this.crossTpProcessingStats = new ThreadPoolStats(metricsRepository, crossTpProcessingPool, "CrossTpProcessing");
+      this.crossTpProcessingStats =
+          statsCloseables.register(new ThreadPoolStats(metricsRepository, crossTpProcessingPool, "CrossTpProcessing"));
       LOGGER.info("Cross-TP parallel processing enabled with shared thread pool size: {}", poolSize);
     } else {
       this.crossTpProcessingPool = null;
@@ -195,6 +200,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
         Thread.currentThread().interrupt();
       }
     }
+    statsCloseables.close();
   }
 
   protected static Runnable getStuckConsumerDetectionAndRepairRunnable(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -86,6 +86,7 @@ import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.stats.ThreadPoolStats;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceIngestionFailureReason;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.system.store.ControllerClientBackedSystemSchemaInitializer;
 import com.linkedin.venice.system.store.MetaStoreWriter;
 import com.linkedin.venice.throttle.EventThrottler;
@@ -213,6 +214,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
   private final Map<String, InternalDaVinciRecordTransformerConfig> storeNameToInternalRecordTransformerConfig =
       new VeniceConcurrentHashMap<>();
   private AggVersionedDaVinciRecordTransformerStats recordTransformerStats = null;
+  /** Stats fields owned by this class; drained by {@link #stopInner()}. */
+  private final CompositeCloseable statsCloseables = new CompositeCloseable();
   private final Set<String> blobTransferDisabledStores = VeniceConcurrentHashMap.newKeySet();
 
   private final PubSubProducerAdapterFactory producerAdapterFactory;
@@ -438,11 +441,12 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         metadataRepo,
         serverConfig.isUnregisterMetricForDeletedStoreEnabled(),
         SystemTime.INSTANCE);
-    AggVersionedDIVStats versionedDIVStats = new AggVersionedDIVStats(
-        metricsRepository,
-        metadataRepo,
-        serverConfig.isUnregisterMetricForDeletedStoreEnabled(),
-        serverConfig.getClusterName());
+    AggVersionedDIVStats versionedDIVStats = statsCloseables.register(
+        new AggVersionedDIVStats(
+            metricsRepository,
+            metadataRepo,
+            serverConfig.isUnregisterMetricForDeletedStoreEnabled(),
+            serverConfig.getClusterName()));
     this.versionedIngestionStats = new AggVersionedIngestionStats(metricsRepository, metadataRepo, serverConfig);
     if (serverConfig.isDedicatedDrainerQueueEnabled()) {
       this.storeBufferService =
@@ -507,10 +511,11 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       this.aaWCWorkLoadProcessingThreadPool = Executors.newFixedThreadPool(
           serverConfig.getAAWCWorkloadParallelProcessingThreadPoolSize(),
           new DaemonThreadFactory("AA_WC_PARALLEL_PROCESSING", serverConfig.getLogContext()));
-      new ThreadPoolStats(
-          metricsRepository,
-          (ThreadPoolExecutor) aaWCWorkLoadProcessingThreadPool,
-          "aa_wc_parallel_processing_thread_pool");
+      statsCloseables.register(
+          new ThreadPoolStats(
+              metricsRepository,
+              (ThreadPoolExecutor) aaWCWorkLoadProcessingThreadPool,
+              "aa_wc_parallel_processing_thread_pool"));
     } else {
       this.aaWCWorkLoadProcessingThreadPool = null;
     }
@@ -524,10 +529,11 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     this.aaWCIngestionStorageLookupThreadPool = Executors.newFixedThreadPool(
         serverConfig.getAaWCIngestionStorageLookupThreadPoolSize(),
         new DaemonThreadFactory("AA_WC_INGESTION_STORAGE_LOOKUP", serverConfig.getLogContext()));
-    new ThreadPoolStats(
-        metricsRepository,
-        (ThreadPoolExecutor) aaWCIngestionStorageLookupThreadPool,
-        "aa_wc_ingestion_storage_lookup_thread_pool");
+    statsCloseables.register(
+        new ThreadPoolStats(
+            metricsRepository,
+            (ThreadPoolExecutor) aaWCIngestionStorageLookupThreadPool,
+            "aa_wc_ingestion_storage_lookup_thread_pool"));
     LOGGER.info(
         "Enabled a thread pool for AA/WC ingestion lookup with {} threads.",
         serverConfig.getAaWCIngestionStorageLookupThreadPoolSize());
@@ -781,6 +787,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     Utils.closeQuietlyWithErrorLogged(storeBufferService);
     Utils.closeQuietlyWithErrorLogged(topicManagerRepository);
     topicLockManager.removeAllLocks();
+
+    statsCloseables.close();
   }
 
   @Override
@@ -1552,8 +1560,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       String storeName,
       DaVinciRecordTransformerConfig recordTransformerConfig) {
     if (recordTransformerStats == null) {
-      recordTransformerStats =
-          new AggVersionedDaVinciRecordTransformerStats(metricsRepository, metadataRepo, serverConfig);
+      recordTransformerStats = statsCloseables
+          .register(new AggVersionedDaVinciRecordTransformerStats(metricsRepository, metadataRepo, serverConfig));
     }
 
     storeNameToInternalRecordTransformerConfig

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -22,6 +22,7 @@ import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.Utils;
@@ -71,6 +72,8 @@ public class StoreBufferService extends AbstractStoreBufferService {
 
   private final RecordHandler leaderRecordHandler;
   private final StoreBufferServiceStats storeBufferServiceStats;
+  /** Stats fields owned by this class; drained by {@link #stopInner}. */
+  private final CompositeCloseable statsCloseables = new CompositeCloseable();
   private final LoadingCache<PubSubTopic, Integer> hashCodeCache;
 
   private final boolean isSorted;
@@ -147,17 +150,18 @@ public class StoreBufferService extends AbstractStoreBufferService {
     }
     this.isSorted = sorted;
     this.leaderRecordHandler = queueLeaderWrites ? this::queueLeaderRecord : StoreBufferService::processRecord;
-    this.storeBufferServiceStats = metricsRepository == null
-        ? Objects.requireNonNull(stats)
-        : new StoreBufferServiceStats(
-            Objects.requireNonNull(metricsRepository),
-            sorted ? "StoreBufferServiceSorted" : "StoreBufferServiceUnsorted",
-            clusterName,
-            sorted,
-            this::getTotalMemoryUsage,
-            this::getTotalRemainingMemory,
-            this::getMaxMemoryUsagePerDrainer,
-            this::getMinMemoryUsagePerDrainer);
+    this.storeBufferServiceStats = statsCloseables.register(
+        metricsRepository == null
+            ? Objects.requireNonNull(stats)
+            : new StoreBufferServiceStats(
+                Objects.requireNonNull(metricsRepository),
+                sorted ? "StoreBufferServiceSorted" : "StoreBufferServiceUnsorted",
+                clusterName,
+                sorted,
+                this::getTotalMemoryUsage,
+                this::getTotalRemainingMemory,
+                this::getMaxMemoryUsagePerDrainer,
+                this::getMinMemoryUsagePerDrainer));
     /*
      * {@link #getDrainerIndexForConsumerRecord} hashes the topic name and partition to determine a drainer. Due to the
      * different naming conventions for RT (_rt) and Separate RT (_rt_sep), different drainers might be assigned while
@@ -384,6 +388,7 @@ public class StoreBufferService extends AbstractStoreBufferService {
       this.executorService.shutdownNow();
       this.executorService.awaitTermination(10, TimeUnit.SECONDS);
     }
+    statsCloseables.close();
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/NativeMetadataRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/NativeMetadataRepository.java
@@ -25,6 +25,7 @@ import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.service.ICProvider;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.utils.RetryUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
@@ -54,7 +55,7 @@ import org.apache.logging.log4j.Logger;
  * stores' metadata. Callers are served by the cache and the cache is refreshed periodically by updating it with methods
  * provided by the implementers.
  */
-public abstract class NativeMetadataRepository
+public abstract class NativeMetadataRepository extends AbstractStatsCloseable
     implements SubscriptionBasedReadOnlyStoreRepository, ReadOnlySchemaRepository, ClusterInfoProvider {
   private static final long DEFAULT_REFRESH_INTERVAL_IN_SECONDS = 60;
   private static final Logger LOGGER = LogManager.getLogger(NativeMetadataRepository.class);
@@ -88,8 +89,8 @@ public abstract class NativeMetadataRepository
         CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS,
         NativeMetadataRepository.DEFAULT_REFRESH_INTERVAL_IN_SECONDS);
     this.clientConfig = clientConfig;
-    this.nativeMetadataRepositoryStats =
-        new NativeMetadataRepositoryStats(clientConfig.getMetricsRepository(), "native_metadata_repository", clock);
+    this.nativeMetadataRepositoryStats = statsCloseables.register(
+        new NativeMetadataRepositoryStats(clientConfig.getMetricsRepository(), "native_metadata_repository", clock));
     this.clock = clock;
   }
 
@@ -392,6 +393,7 @@ public abstract class NativeMetadataRepository
     storeConfigMap.clear();
     schemaMap.clear();
     totalStoreReadQuota.set(0);
+    statsCloseables.close();
   }
 
   /**
@@ -425,7 +427,7 @@ public abstract class NativeMetadataRepository
   protected Store removeStore(String storeName) {
     // Remove the store name from the subscription.
     Store oldStore = subscribedStoreMap.remove(storeName);
-    nativeMetadataRepositoryStats.removeCacheTimestamp(storeName);
+    nativeMetadataRepositoryStats.handleStoreDeleted(storeName);
     if (oldStore != null) {
       totalStoreReadQuota.addAndGet(-oldStore.getReadQuotaInCU());
       notifyStoreDeleted(oldStore);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/NativeMetadataRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/NativeMetadataRepository.java
@@ -374,12 +374,8 @@ public abstract class NativeMetadataRepository extends AbstractStatsCloseable
     LOGGER.debug("Refresh finished for {}", getClass().getSimpleName());
   }
 
-  /**
-   * TODO: we may need to rename this function to be 'close' since this resource should not used any more
-   * after calling this function.
-   */
   @Override
-  public void clear() {
+  public void close() {
     scheduler.shutdown();
     try {
       if (!scheduler.awaitTermination(60, TimeUnit.SECONDS)) {
@@ -394,6 +390,11 @@ public abstract class NativeMetadataRepository extends AbstractStatsCloseable
     schemaMap.clear();
     totalStoreReadQuota.set(0);
     statsCloseables.close();
+  }
+
+  @Override
+  public void clear() {
+    close();
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AbstractVeniceAggVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AbstractVeniceAggVersionedStats.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.stats.StatsSupplier;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
@@ -20,7 +21,7 @@ import org.apache.logging.log4j.Logger;
 
 
 public abstract class AbstractVeniceAggVersionedStats<STATS, STATS_REPORTER extends AbstractVeniceStatsReporter<STATS>>
-    implements StoreDataChangedListener {
+    extends AbstractStatsCloseable implements StoreDataChangedListener {
   private static final Logger LOGGER = LogManager.getLogger(AbstractVeniceAggVersionedStats.class);
 
   private final Supplier<STATS> statsInitiator;
@@ -215,5 +216,16 @@ public abstract class AbstractVeniceAggVersionedStats<STATS, STATS_REPORTER exte
    */
   protected void cleanupVersionResources(String storeName, int version) {
     // no-op by default
+  }
+
+  /**
+   * Unsubscribes from {@link #metadataRepository} first so no further listener callbacks can race
+   * with cleanup, then drains {@code statsCloseables}. Subclasses with additional cleanup should
+   * override and call {@code super.close()}.
+   */
+  @Override
+  public void close() {
+    metadataRepository.unregisterStoreDataChangedListener(this);
+    super.close();
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AdaptiveThrottlingServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AdaptiveThrottlingServiceStats.java
@@ -57,7 +57,8 @@ public class AdaptiveThrottlingServiceStats extends AbstractVeniceStats {
               getTehutiName(type),
               Collections.singletonList(new Rate()),
               dimensionsMap,
-              attributes));
+              attributes,
+              resources));
     }
     this.rateMetrics = Collections.unmodifiableMap(metricMap);
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedBlobTransferStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedBlobTransferStats.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.stats;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
+import com.linkedin.venice.stats.metrics.MetricEntityStateUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
@@ -95,7 +96,7 @@ public class AggVersionedBlobTransferStats
     try {
       super.handleStoreDeleted(storeName);
     } finally {
-      otelStatsMap.remove(storeName);
+      MetricEntityStateUtils.closeQuietly(otelStatsMap.remove(storeName));
     }
   }
 
@@ -206,5 +207,12 @@ public class AggVersionedBlobTransferStats
     recordVersionedAndTotalStat(storeName, version, stats -> stats.recordBlobTransferBytesSent(value));
     // OTel metrics
     getBlobTransferOtelStats(storeName).recordBytesSent(version, value);
+  }
+
+  @Override
+  public void close() {
+    // Unregister metadata listener first so handleStore* can't re-populate the map while we drain.
+    super.close();
+    MetricEntityStateUtils.closeAndClear(otelStatsMap);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
@@ -2,7 +2,6 @@ package com.linkedin.davinci.stats;
 
 import static com.linkedin.davinci.stats.OtelVersionedStatsUtils.classifyVersion;
 import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
-import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
 
 import com.linkedin.venice.exceptions.validation.CorruptDataException;
 import com.linkedin.venice.exceptions.validation.DataValidationException;
@@ -15,15 +14,16 @@ import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceDIVResult;
 import com.linkedin.venice.stats.dimensions.VeniceDIVSeverity;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.stats.metrics.MetricEntityStateOneEnum;
 import com.linkedin.venice.stats.metrics.MetricEntityStateTwoEnums;
+import com.linkedin.venice.stats.metrics.MetricEntityStateUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
@@ -50,23 +50,60 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
 
   /**
-   * Per-store OTel metric state maps. Each map grows lazily via {@code computeIfAbsent} and is bounded
-   * by the number of stores the server is actively ingesting. Entries are removed when a store is
-   * deleted via {@link #handleStoreDeleted(String)}. These maps are OTel-only; Tehuti recording is
-   * handled by the parent class via {@code recordVersionedAndTotalStat}.
+   * Per-store entry map. Each entry bundles the per-store {@link AbstractStatsCloseable#resources}
+   * with lazily-populated wrappers for the four per-store OTel metrics. A single {@code remove()} in
+   * {@link #handleStoreDeleted(String)} closes all wrappers atomically — there is no
+   * cross-map race window where a concurrent record could resurrect parallel entries.
+   *
+   * <p>Map grows lazily via {@code computeIfAbsent} and is bounded by the number of stores the
+   * server is actively ingesting. Each map is OTel-only; Tehuti recording is handled by the parent
+   * class via {@code recordVersionedAndTotalStat}.
    */
-  private final Map<String, MetricEntityStateTwoEnums<VersionRole, VeniceDIVResult>> messageCountPerStore =
-      new VeniceConcurrentHashMap<>();
-  private final Map<String, MetricEntityStateTwoEnums<VersionRole, VeniceDIVSeverity>> offsetRewindCountPerStore =
-      new VeniceConcurrentHashMap<>();
-  private final Map<String, MetricEntityStateOneEnum<VersionRole>> producerFailureCountPerStore =
-      new VeniceConcurrentHashMap<>();
-  private final Map<String, MetricEntityStateOneEnum<VersionRole>> benignProducerFailureCountPerStore =
-      new VeniceConcurrentHashMap<>();
+  private final Map<String, PerStoreEntry> perStore = new VeniceConcurrentHashMap<>();
+
+  /** Per-store state held by {@link #perStore}. */
+  private static final class PerStoreEntry extends AbstractStatsCloseable {
+    final MetricEntityStateTwoEnums<VersionRole, VeniceDIVResult> messageCount;
+    final MetricEntityStateTwoEnums<VersionRole, VeniceDIVSeverity> offsetRewindCount;
+    final MetricEntityStateOneEnum<VersionRole> producerFailureCount;
+    final MetricEntityStateOneEnum<VersionRole> benignProducerFailureCount;
+
+    PerStoreEntry(VeniceOpenTelemetryMetricsRepository otelRepository, Map<VeniceMetricsDimensions, String> dims) {
+      this.messageCount = MetricEntityStateTwoEnums.create(
+          DIVOtelMetricEntity.MESSAGE_COUNT.getMetricEntity(),
+          otelRepository,
+          dims,
+          VersionRole.class,
+          VeniceDIVResult.class,
+          statsCloseables);
+      this.offsetRewindCount = MetricEntityStateTwoEnums.create(
+          DIVOtelMetricEntity.OFFSET_REWIND_COUNT.getMetricEntity(),
+          otelRepository,
+          dims,
+          VersionRole.class,
+          VeniceDIVSeverity.class,
+          statsCloseables);
+      this.producerFailureCount = MetricEntityStateOneEnum.create(
+          DIVOtelMetricEntity.PRODUCER_FAILURE_COUNT.getMetricEntity(),
+          otelRepository,
+          dims,
+          VersionRole.class,
+          statsCloseables);
+      this.benignProducerFailureCount = MetricEntityStateOneEnum.create(
+          DIVOtelMetricEntity.BENIGN_PRODUCER_FAILURE_COUNT.getMetricEntity(),
+          otelRepository,
+          dims,
+          VersionRole.class,
+          statsCloseables);
+    }
+  }
 
   /**
    * Per-store version info for classifying versions as CURRENT, FUTURE, or BACKUP.
-   * Updated via {@link #onVersionInfoUpdated(String, int, int)}.
+   * Updated via {@link #onVersionInfoUpdated(String, int, int)}. This map is intentionally
+   * separate from {@link #perStore}: it stores plain data (no {@link java.io.Closeable}), so it
+   * is not vulnerable to the delete-vs-record resurrection race that motivated bundling the
+   * per-store closeable wrappers into a single entry holder.
    */
   private final Map<String, OtelVersionedStatsUtils.VersionInfo> versionInfoMap = new VeniceConcurrentHashMap<>();
 
@@ -131,20 +168,12 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
 
   public void recordLeaderProducerFailure(String storeName, int version) {
     recordVersionedAndTotalStat(storeName, version, DIVStats::recordLeaderProducerFailure);
-    recordOtelOneEnumMetric(
-        storeName,
-        version,
-        producerFailureCountPerStore,
-        DIVOtelMetricEntity.PRODUCER_FAILURE_COUNT);
+    recordOtelProducerFailureCount(storeName, version, false);
   }
 
   public void recordBenignLeaderProducerFailure(String storeName, int version) {
     recordVersionedAndTotalStat(storeName, version, DIVStats::recordBenignLeaderProducerFailure);
-    recordOtelOneEnumMetric(
-        storeName,
-        version,
-        benignProducerFailureCountPerStore,
-        DIVOtelMetricEntity.BENIGN_PRODUCER_FAILURE_COUNT);
+    recordOtelProducerFailureCount(storeName, version, true);
   }
 
   /** {@link AbstractVeniceAggVersionedStats#addStore(com.linkedin.venice.meta.Store)}
@@ -162,10 +191,7 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
     try {
       super.handleStoreDeleted(storeName);
     } finally {
-      messageCountPerStore.remove(storeName);
-      offsetRewindCountPerStore.remove(storeName);
-      producerFailureCountPerStore.remove(storeName);
-      benignProducerFailureCountPerStore.remove(storeName);
+      MetricEntityStateUtils.closeQuietly(perStore.remove(storeName));
       versionInfoMap.remove(storeName);
     }
   }
@@ -225,10 +251,12 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
 
   // --- OTel recording helpers ---
 
-  private Map<VeniceMetricsDimensions, String> buildStoreDimensionsMap(String storeName) {
-    Map<VeniceMetricsDimensions, String> map = new HashMap<>(baseDimensionsMap);
-    map.put(VENICE_STORE_NAME, OpenTelemetryMetricsSetup.sanitizeStoreName(storeName));
-    return Collections.unmodifiableMap(map);
+  private PerStoreEntry getOrCreateEntry(String storeName) {
+    return perStore.computeIfAbsent(
+        storeName,
+        k -> new PerStoreEntry(
+            otelRepository,
+            OpenTelemetryMetricsSetup.buildStoreDimensionsMap(baseDimensionsMap, k)));
   }
 
   private void recordOtelMessageCount(String storeName, int version, VeniceDIVResult result) {
@@ -236,15 +264,7 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
       return;
     }
     VersionRole role = classifyVersion(version, versionInfoMap.get(storeName));
-    messageCountPerStore.computeIfAbsent(
-        storeName,
-        k -> MetricEntityStateTwoEnums.create(
-            DIVOtelMetricEntity.MESSAGE_COUNT.getMetricEntity(),
-            otelRepository,
-            buildStoreDimensionsMap(k),
-            VersionRole.class,
-            VeniceDIVResult.class))
-        .record(1, role, result);
+    getOrCreateEntry(storeName).messageCount.record(1, role, result);
   }
 
   private void recordOtelOffsetRewindCount(String storeName, int version, VeniceDIVSeverity severity) {
@@ -252,31 +272,23 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
       return;
     }
     VersionRole role = classifyVersion(version, versionInfoMap.get(storeName));
-    offsetRewindCountPerStore.computeIfAbsent(
-        storeName,
-        k -> MetricEntityStateTwoEnums.create(
-            DIVOtelMetricEntity.OFFSET_REWIND_COUNT.getMetricEntity(),
-            otelRepository,
-            buildStoreDimensionsMap(k),
-            VersionRole.class,
-            VeniceDIVSeverity.class))
-        .record(1, role, severity);
+    getOrCreateEntry(storeName).offsetRewindCount.record(1, role, severity);
   }
 
-  private void recordOtelOneEnumMetric(
-      String storeName,
-      int version,
-      Map<String, MetricEntityStateOneEnum<VersionRole>> perStoreMap,
-      DIVOtelMetricEntity metricEntity) {
+  private void recordOtelProducerFailureCount(String storeName, int version, boolean benign) {
     if (!emitOtelMetrics) {
       return;
     }
     VersionRole role = classifyVersion(version, versionInfoMap.get(storeName));
-    perStoreMap
-        .computeIfAbsent(
-            storeName,
-            k -> MetricEntityStateOneEnum
-                .create(metricEntity.getMetricEntity(), otelRepository, buildStoreDimensionsMap(k), VersionRole.class))
-        .record(1, role);
+    PerStoreEntry entry = getOrCreateEntry(storeName);
+    (benign ? entry.benignProducerFailureCount : entry.producerFailureCount).record(1, role);
+  }
+
+  @Override
+  public void close() {
+    // Unregister metadata listener first so handleStore* can't re-populate the maps while we drain.
+    super.close();
+    MetricEntityStateUtils.closeAndClear(perStore);
+    versionInfoMap.clear();
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
@@ -50,18 +50,13 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
 
   /**
-   * Per-store entry map. Each entry bundles the per-store {@link AbstractStatsCloseable#resources}
-   * with lazily-populated wrappers for the four per-store OTel metrics. A single {@code remove()} in
-   * {@link #handleStoreDeleted(String)} closes all wrappers atomically — there is no
-   * cross-map race window where a concurrent record could resurrect parallel entries.
-   *
-   * <p>Map grows lazily via {@code computeIfAbsent} and is bounded by the number of stores the
-   * server is actively ingesting. Each map is OTel-only; Tehuti recording is handled by the parent
-   * class via {@code recordVersionedAndTotalStat}.
+   * Per-store entry bundling the four per-store OTel wrappers; one {@code remove()} in
+   * {@link #handleStoreDeleted} closes them atomically. Bounded by the number of stores ingested.
+   * Tehuti recording stays on the parent via {@code recordVersionedAndTotalStat}.
    */
-  private final Map<String, PerStoreEntry> perStore = new VeniceConcurrentHashMap<>();
+  private final Map<String, PerStoreEntry> perStoreEntryMap = new VeniceConcurrentHashMap<>();
 
-  /** Per-store state held by {@link #perStore}. */
+  /** Per-store state held by {@link #perStoreEntryMap}. */
   private static final class PerStoreEntry extends AbstractStatsCloseable {
     final MetricEntityStateTwoEnums<VersionRole, VeniceDIVResult> messageCount;
     final MetricEntityStateTwoEnums<VersionRole, VeniceDIVSeverity> offsetRewindCount;
@@ -100,10 +95,7 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
 
   /**
    * Per-store version info for classifying versions as CURRENT, FUTURE, or BACKUP.
-   * Updated via {@link #onVersionInfoUpdated(String, int, int)}. This map is intentionally
-   * separate from {@link #perStore}: it stores plain data (no {@link java.io.Closeable}), so it
-   * is not vulnerable to the delete-vs-record resurrection race that motivated bundling the
-   * per-store closeable wrappers into a single entry holder.
+   * Updated via {@link #onVersionInfoUpdated(String, int, int)}.
    */
   private final Map<String, OtelVersionedStatsUtils.VersionInfo> versionInfoMap = new VeniceConcurrentHashMap<>();
 
@@ -191,7 +183,7 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
     try {
       super.handleStoreDeleted(storeName);
     } finally {
-      MetricEntityStateUtils.closeQuietly(perStore.remove(storeName));
+      MetricEntityStateUtils.closeQuietly(perStoreEntryMap.remove(storeName));
       versionInfoMap.remove(storeName);
     }
   }
@@ -252,7 +244,7 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
   // --- OTel recording helpers ---
 
   private PerStoreEntry getOrCreateEntry(String storeName) {
-    return perStore.computeIfAbsent(
+    return perStoreEntryMap.computeIfAbsent(
         storeName,
         k -> new PerStoreEntry(
             otelRepository,
@@ -288,7 +280,7 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
   public void close() {
     // Unregister metadata listener first so handleStore* can't re-populate the maps while we drain.
     super.close();
-    MetricEntityStateUtils.closeAndClear(perStore);
+    MetricEntityStateUtils.closeAndClear(perStoreEntryMap);
     versionInfoMap.clear();
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStats.java
@@ -10,10 +10,11 @@ import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
 import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.dimensions.VeniceRecordTransformerOperation;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.stats.metrics.MetricEntityStateOneEnum;
+import com.linkedin.venice.stats.metrics.MetricEntityStateUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
-import java.util.HashMap;
 import java.util.Map;
 
 
@@ -30,18 +31,34 @@ public class AggVersionedDaVinciRecordTransformerStats
   private final boolean emitOtelMetrics;
 
   /**
-   * Per-store OTel metric state for latency. Bounded by the number of stores on this host.
-   * Entries created lazily inside {@link #recordOtelLatency}, removed in
-   * {@link #handleStoreDeleted(String)}.
+   * Per-store entry map. Each entry bundles the per-store {@link AbstractStatsCloseable#resources}
+   * with the latency and error-count wrappers. A single {@code remove()} in
+   * {@link #handleStoreDeleted(String)} closes both wrappers atomically — there is no
+   * cross-map race window where a concurrent record could resurrect parallel entries.
+   * Bounded by the number of stores on this host.
    */
-  private final Map<String, MetricEntityStateOneEnum<VeniceRecordTransformerOperation>> latencyPerStore =
-      new VeniceConcurrentHashMap<>();
+  private final Map<String, PerStoreEntry> perStore = new VeniceConcurrentHashMap<>();
 
-  /**
-   * Per-store OTel metric state for error count. Same bounding and lifecycle as latencyPerStore.
-   */
-  private final Map<String, MetricEntityStateOneEnum<VeniceRecordTransformerOperation>> errorCountPerStore =
-      new VeniceConcurrentHashMap<>();
+  /** Per-store state held by {@link #perStore}. */
+  private static final class PerStoreEntry extends AbstractStatsCloseable {
+    final MetricEntityStateOneEnum<VeniceRecordTransformerOperation> latency;
+    final MetricEntityStateOneEnum<VeniceRecordTransformerOperation> errorCount;
+
+    PerStoreEntry(VeniceOpenTelemetryMetricsRepository otelRepository, Map<VeniceMetricsDimensions, String> dims) {
+      this.latency = MetricEntityStateOneEnum.create(
+          RECORD_TRANSFORMER_LATENCY.getMetricEntity(),
+          otelRepository,
+          dims,
+          VeniceRecordTransformerOperation.class,
+          statsCloseables);
+      this.errorCount = MetricEntityStateOneEnum.create(
+          RECORD_TRANSFORMER_ERROR_COUNT.getMetricEntity(),
+          otelRepository,
+          dims,
+          VeniceRecordTransformerOperation.class,
+          statsCloseables);
+    }
+  }
 
   public AggVersionedDaVinciRecordTransformerStats(
       MetricsRepository metricsRepository,
@@ -66,8 +83,7 @@ public class AggVersionedDaVinciRecordTransformerStats
     try {
       super.handleStoreDeleted(storeName);
     } finally {
-      latencyPerStore.remove(storeName);
-      errorCountPerStore.remove(storeName);
+      MetricEntityStateUtils.closeQuietly(perStore.remove(storeName));
     }
   }
 
@@ -95,48 +111,38 @@ public class AggVersionedDaVinciRecordTransformerStats
     if (!emitOtelMetrics) {
       return;
     }
-    latencyPerStore.computeIfAbsent(storeName, k -> createPerStoreMetric(k, RECORD_TRANSFORMER_LATENCY))
-        .record(value, operation);
+    getOrCreateEntry(storeName).latency.record(value, operation);
   }
 
   private void recordOtelErrorCount(String storeName, VeniceRecordTransformerOperation operation) {
     if (!emitOtelMetrics) {
       return;
     }
-    errorCountPerStore.computeIfAbsent(storeName, k -> createPerStoreMetric(k, RECORD_TRANSFORMER_ERROR_COUNT))
-        .record(1, operation);
+    getOrCreateEntry(storeName).errorCount.record(1, operation);
+  }
+
+  private PerStoreEntry getOrCreateEntry(String storeName) {
+    return perStore.computeIfAbsent(
+        storeName,
+        k -> new PerStoreEntry(
+            otelRepository,
+            OpenTelemetryMetricsSetup.buildStoreDimensionsMap(baseDimensionsMap, k)));
   }
 
   @VisibleForTesting
-  boolean hasLatencyMetricFor(String storeName) {
-    return latencyPerStore.containsKey(storeName);
+  boolean hasMetricsFor(String storeName) {
+    return perStore.get(storeName) != null;
   }
 
   @VisibleForTesting
-  boolean hasErrorCountMetricFor(String storeName) {
-    return errorCountPerStore.containsKey(storeName);
+  int storeCount() {
+    return perStore.size();
   }
 
-  @VisibleForTesting
-  int latencyStoreCount() {
-    return latencyPerStore.size();
-  }
-
-  @VisibleForTesting
-  int errorCountStoreCount() {
-    return errorCountPerStore.size();
-  }
-
-  private MetricEntityStateOneEnum<VeniceRecordTransformerOperation> createPerStoreMetric(
-      String storeName,
-      DaVinciRecordTransformerOtelMetricEntity metricEntity) {
-    Map<VeniceMetricsDimensions, String> storeDimensionsMap = new HashMap<>(baseDimensionsMap);
-    storeDimensionsMap
-        .put(VeniceMetricsDimensions.VENICE_STORE_NAME, OpenTelemetryMetricsSetup.sanitizeStoreName(storeName));
-    return MetricEntityStateOneEnum.create(
-        metricEntity.getMetricEntity(),
-        otelRepository,
-        storeDimensionsMap,
-        VeniceRecordTransformerOperation.class);
+  @Override
+  public void close() {
+    // Unregister metadata listener first so handleStore* can't re-populate the map while we drain.
+    super.close();
+    MetricEntityStateUtils.closeAndClear(perStore);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStats.java
@@ -30,16 +30,10 @@ public class AggVersionedDaVinciRecordTransformerStats
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
   private final boolean emitOtelMetrics;
 
-  /**
-   * Per-store entry map. Each entry bundles the per-store {@link AbstractStatsCloseable#resources}
-   * with the latency and error-count wrappers. A single {@code remove()} in
-   * {@link #handleStoreDeleted(String)} closes both wrappers atomically — there is no
-   * cross-map race window where a concurrent record could resurrect parallel entries.
-   * Bounded by the number of stores on this host.
-   */
-  private final Map<String, PerStoreEntry> perStore = new VeniceConcurrentHashMap<>();
+  /** Per-store entry bundling latency + error-count wrappers; one {@code remove()} in {@link #handleStoreDeleted} closes them. */
+  private final Map<String, PerStoreEntry> perStoreEntryMap = new VeniceConcurrentHashMap<>();
 
-  /** Per-store state held by {@link #perStore}. */
+  /** Per-store state held by {@link #perStoreEntryMap}. */
   private static final class PerStoreEntry extends AbstractStatsCloseable {
     final MetricEntityStateOneEnum<VeniceRecordTransformerOperation> latency;
     final MetricEntityStateOneEnum<VeniceRecordTransformerOperation> errorCount;
@@ -83,7 +77,7 @@ public class AggVersionedDaVinciRecordTransformerStats
     try {
       super.handleStoreDeleted(storeName);
     } finally {
-      MetricEntityStateUtils.closeQuietly(perStore.remove(storeName));
+      MetricEntityStateUtils.closeQuietly(perStoreEntryMap.remove(storeName));
     }
   }
 
@@ -122,7 +116,7 @@ public class AggVersionedDaVinciRecordTransformerStats
   }
 
   private PerStoreEntry getOrCreateEntry(String storeName) {
-    return perStore.computeIfAbsent(
+    return perStoreEntryMap.computeIfAbsent(
         storeName,
         k -> new PerStoreEntry(
             otelRepository,
@@ -131,18 +125,18 @@ public class AggVersionedDaVinciRecordTransformerStats
 
   @VisibleForTesting
   boolean hasMetricsFor(String storeName) {
-    return perStore.get(storeName) != null;
+    return perStoreEntryMap.get(storeName) != null;
   }
 
   @VisibleForTesting
   int storeCount() {
-    return perStore.size();
+    return perStoreEntryMap.size();
   }
 
   @Override
   public void close() {
     // Unregister metadata listener first so handleStore* can't re-populate the map while we drain.
     super.close();
-    MetricEntityStateUtils.closeAndClear(perStore);
+    MetricEntityStateUtils.closeAndClear(perStoreEntryMap);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/BlobTransferOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/BlobTransferOtelStats.java
@@ -137,5 +137,4 @@ public class BlobTransferOtelStats extends AbstractStatsCloseable {
   public void recordBytesSent(int version, long bytes) {
     bytesSentMetric.record(bytes, OtelVersionedStatsUtils.classifyVersion(version, versionInfo));
   }
-
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/BlobTransferOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/BlobTransferOtelStats.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
 import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.stats.metrics.MetricEntity;
 import com.linkedin.venice.stats.metrics.MetricEntityStateOneEnum;
 import com.linkedin.venice.stats.metrics.MetricEntityStateTwoEnums;
@@ -28,7 +29,7 @@ import java.util.Map;
  * <p>Note: Tehuti metrics are managed separately in {@link BlobTransferStats} and
  * {@link BlobTransferStatsReporter}. This class handles only OTel metrics.
  */
-public class BlobTransferOtelStats {
+public class BlobTransferOtelStats extends AbstractStatsCloseable {
   private final boolean emitOtelMetrics;
 
   private volatile VersionInfo versionInfo = VersionInfo.NON_EXISTING;
@@ -72,18 +73,20 @@ public class BlobTransferOtelStats {
         otelRepository,
         baseDimensionsMap,
         VersionRole.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        statsCloseables);
 
     timeMetric = createOneEnumMetric(TIME.getMetricEntity(), otelRepository, baseDimensionsMap);
     bytesReceivedMetric = createOneEnumMetric(BYTES_RECEIVED.getMetricEntity(), otelRepository, baseDimensionsMap);
     bytesSentMetric = createOneEnumMetric(BYTES_SENT.getMetricEntity(), otelRepository, baseDimensionsMap);
   }
 
-  private static MetricEntityStateOneEnum<VersionRole> createOneEnumMetric(
+  private MetricEntityStateOneEnum<VersionRole> createOneEnumMetric(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
       Map<VeniceMetricsDimensions, String> baseDimensionsMap) {
-    return MetricEntityStateOneEnum.create(metricEntity, otelRepository, baseDimensionsMap, VersionRole.class);
+    return MetricEntityStateOneEnum
+        .create(metricEntity, otelRepository, baseDimensionsMap, VersionRole.class, statsCloseables);
   }
 
   public boolean emitOtelMetrics() {
@@ -134,4 +137,5 @@ public class BlobTransferOtelStats {
   public void recordBytesSent(int version, long bytes) {
     bytesSentMetric.record(bytes, OtelVersionedStatsUtils.classifyVersion(version, versionInfo));
   }
+
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HeartbeatMonitoringServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HeartbeatMonitoringServiceStats.java
@@ -69,7 +69,8 @@ public class HeartbeatMonitoringServiceStats extends AbstractVeniceStats {
         TehutiMetricName.HEARTBEAT_MONITOR_SERVICE_EXCEPTION_COUNT,
         Collections.singletonList(new Count()),
         baseDimensionsMap,
-        VeniceHeartbeatComponent.class);
+        VeniceHeartbeatComponent.class,
+        resources);
 
     this.reporterHeartbeatMetrics = MetricEntityStateOneEnum.create(
         HEARTBEAT_MONITORING_HEARTBEAT_COUNT.getMetricEntity(),
@@ -78,7 +79,8 @@ public class HeartbeatMonitoringServiceStats extends AbstractVeniceStats {
         TehutiMetricName.HEARTBEAT_REPORTER,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        VeniceHeartbeatComponent.class);
+        VeniceHeartbeatComponent.class,
+        resources);
 
     this.loggerHeartbeatMetrics = MetricEntityStateOneEnum.create(
         HEARTBEAT_MONITORING_HEARTBEAT_COUNT.getMetricEntity(),
@@ -87,7 +89,8 @@ public class HeartbeatMonitoringServiceStats extends AbstractVeniceStats {
         TehutiMetricName.HEARTBEAT_LOGGER,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        VeniceHeartbeatComponent.class);
+        VeniceHeartbeatComponent.class,
+        resources);
   }
 
   public void recordHeartbeatExceptionCount(VeniceHeartbeatComponent component) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/KafkaConsumerServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/KafkaConsumerServiceStats.java
@@ -140,7 +140,8 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         TehutiMetricName.BYTES_PER_POLL,
         Arrays.asList(new Min(), new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     pollRecordCountOtel = MetricEntityStateBase.create(
         POLL_RECORD_COUNT.getMetricEntity(),
@@ -149,7 +150,8 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         TehutiMetricName.CONSUMER_POLL_RESULT_NUM,
         Arrays.asList(new Avg(), new Min()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     // Total-only OTel repository: null for per-store instances to avoid registering
     // unused OTel instruments. Total-only metrics are only recorded via aggStats.recordTotal*().
@@ -180,7 +182,8 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         TehutiMetricName.CONSUMER_POLL_REQUEST,
         Collections.singletonList(new LongAdderRateGauge(time)),
         nonStoreDimensionsMap,
-        nonStoreAttributes);
+        nonStoreAttributes,
+        resources);
 
     TehutiSensorRegistrationFunction pollNonEmptyTehutiReg = totalStats == null
         ? this::registerSensorIfAbsent
@@ -192,7 +195,8 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         TehutiMetricName.CONSUMER_POLL_NON_ZERO_RESULT_NUM,
         Collections.singletonList(new LongAdderRateGauge(time)),
         nonStoreDimensionsMap,
-        nonStoreAttributes);
+        nonStoreAttributes,
+        resources);
 
     pollTimeOtel = MetricEntityStateBase.create(
         POLL_TIME.getMetricEntity(),
@@ -201,7 +205,8 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         TehutiMetricName.CONSUMER_POLL_REQUEST_LATENCY,
         Arrays.asList(new Avg(), new Max()),
         nonStoreDimensionsMap,
-        nonStoreAttributes);
+        nonStoreAttributes,
+        resources);
 
     pollErrorCountOtel = MetricEntityStateBase.create(
         POLL_ERROR_COUNT.getMetricEntity(),
@@ -210,7 +215,8 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         TehutiMetricName.CONSUMER_POLL_ERROR,
         Collections.singletonList(new OccurrenceRate()),
         nonStoreDimensionsMap,
-        nonStoreAttributes);
+        nonStoreAttributes,
+        resources);
 
     produceToWriteBufferTimeOtel = MetricEntityStateBase.create(
         PRODUCE_TO_WRITE_BUFFER_TIME.getMetricEntity(),
@@ -219,7 +225,8 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         TehutiMetricName.CONSUMER_RECORDS_PRODUCING_TO_WRITE_BUFFER_LATENCY,
         Arrays.asList(new Avg(), new Max()),
         nonStoreDimensionsMap,
-        nonStoreAttributes);
+        nonStoreAttributes,
+        resources);
 
     topicDetectedDeletedCountOtel = MetricEntityStateBase.create(
         TOPIC_DETECTED_DELETED_COUNT.getMetricEntity(),
@@ -228,7 +235,8 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         TehutiMetricName.DETECTED_DELETED_TOPIC_NUM,
         Collections.singletonList(new Total()),
         nonStoreDimensionsMap,
-        nonStoreAttributes);
+        nonStoreAttributes,
+        resources);
 
     orphanTopicPartitionCountOtel = MetricEntityStateBase.create(
         ORPHAN_TOPIC_PARTITION_COUNT.getMetricEntity(),
@@ -237,7 +245,8 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         TehutiMetricName.DETECTED_NO_RUNNING_INGESTION_TOPIC_PARTITION_NUM,
         Collections.singletonList(new Total()),
         nonStoreDimensionsMap,
-        nonStoreAttributes);
+        nonStoreAttributes,
+        resources);
 
     pollTimeSinceLastSuccessOtel = MetricEntityStateBase.create(
         POLL_TIME_SINCE_LAST_SUCCESS.getMetricEntity(),
@@ -246,7 +255,8 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         TehutiMetricName.IDLE_TIME,
         Collections.singletonList(new Max()),
         nonStoreDimensionsMap,
-        nonStoreAttributes);
+        nonStoreAttributes,
+        resources);
 
     // Shared OTel instrument for subscribe + update_assignment, each with its own Tehuti sensor
     subscribeActionTimeOtel = MetricEntityStateOneEnum.create(
@@ -256,7 +266,8 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         TehutiMetricName.DELEGATE_SUBSCRIBE_LATENCY,
         Arrays.asList(new Avg(), new Max()),
         nonStoreDimensionsMap,
-        VeniceConsumerPoolAction.class);
+        VeniceConsumerPoolAction.class,
+        resources);
 
     updateAssignmentActionTimeOtel = MetricEntityStateOneEnum.create(
         POOL_ACTION_TIME.getMetricEntity(),
@@ -265,7 +276,8 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         TehutiMetricName.UPDATE_CURRENT_ASSIGNMENT_LATENCY,
         Arrays.asList(new Avg(), new Max()),
         nonStoreDimensionsMap,
-        VeniceConsumerPoolAction.class);
+        VeniceConsumerPoolAction.class,
+        resources);
 
     // Tehuti-only async gauge: OTel intentionally omitted because this reads from the same source
     // method (getMaxElapsedTimeMSSinceLastPollInConsumerPool) that also records to the
@@ -282,7 +294,8 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         PARTITION_ASSIGNMENT_COUNT.getMetricEntity(),
         totalOnlyOtelRepo,
         nonStoreDimensionsMap,
-        nonStoreAttributes);
+        nonStoreAttributes,
+        resources);
   }
 
   // Recording methods

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStats.java
@@ -6,13 +6,14 @@ import com.linkedin.venice.stats.AbstractVeniceStats;
 import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
 import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateBase;
+import com.linkedin.venice.stats.metrics.MetricEntityStateUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.opentelemetry.api.common.Attributes;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
 import java.time.Clock;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.DoubleSupplier;
 
@@ -25,20 +26,39 @@ import java.util.function.DoubleSupplier;
  * high watermark at query time via max aggregation.
  *
  * <p>Per-store OTel callbacks are registered lazily on first {@link #updateCacheTimestamp} call
- * and read from the shared {@link #metadataCacheTimestampMapInMs}. When a store is removed,
- * the callback returns {@code NaN} (timestamp absent from the map, store no longer tracked). OTel callbacks cannot be
- * deregistered (SDK limitation), so the per-store entry stays registered until the process exits.
+ * and read from the shared {@link #metadataCacheTimestampMapInMs}. When a store is removed via
+ * {@link #handleStoreDeleted(String)} the OTel callback is deregistered (closed) and the per-store map entry is
+ * dropped so the SDK stops polling the gauge.
  */
 public class NativeMetadataRepositoryStats extends AbstractVeniceStats {
   private final Map<String, Long> metadataCacheTimestampMapInMs = new VeniceConcurrentHashMap<>();
   private final Clock clock;
 
-  // OTel: per-store ASYNC_DOUBLE_GAUGE for staleness. Effectively bounded by the number of
-  // distinct stores seen during the lifetime of the process, since callbacks cannot be deregistered
-  // (entries in this map are not removed when a store is unsubscribed).
+  // OTel: per-store ASYNC_DOUBLE_GAUGE for staleness. Bounded by the number of stores currently subscribed.
+  // Per-store entries are removed and closed in {@link #handleStoreDeleted}, deregistering the callback
+  // from the SDK so it stops polling the gauge.
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
-  private final Map<String, AsyncMetricEntityStateBase> otelPerStore = new VeniceConcurrentHashMap<>();
+  /**
+   * Per-store entry map. Each entry bundles the per-store registry with the async-gauge wrapper
+   * (registered eagerly in the {@link PerStoreEntry} constructor), so a single {@code remove()} in
+   * {@link #handleStoreDeleted(String)} is race-free w.r.t. concurrent recordings.
+   */
+  private final Map<String, PerStoreEntry> perStore = new VeniceConcurrentHashMap<>();
+
+  /** Per-store state held by {@link #perStore}. */
+  private static final class PerStoreEntry extends AbstractStatsCloseable {
+    final AsyncMetricEntityStateBase gauge;
+
+    PerStoreEntry(
+        VeniceOpenTelemetryMetricsRepository otelRepository,
+        Map<VeniceMetricsDimensions, String> dims,
+        Attributes attrs,
+        DoubleSupplier callback) {
+      this.gauge = AsyncMetricEntityStateBase
+          .create(METADATA_CACHE_STALENESS.getMetricEntity(), otelRepository, dims, attrs, callback, statsCloseables);
+    }
+  }
 
   public NativeMetadataRepositoryStats(MetricsRepository metricsRepository, String name, Clock clock) {
     super(metricsRepository, name);
@@ -85,27 +105,37 @@ public class NativeMetadataRepositoryStats extends AbstractVeniceStats {
     registerOtelGaugeIfAbsent(storeName, clusterName);
   }
 
-  public void removeCacheTimestamp(String storeName) {
+  /**
+   * Removes the Tehuti cache-timestamp entry and closes the per-store OTel ASYNC gauge wrapper,
+   * deregistering the SDK callback so it stops polling. Called by the owning
+   * {@code NativeMetadataRepository} from its store-removal path.
+   */
+  public void handleStoreDeleted(String storeName) {
     metadataCacheTimestampMapInMs.remove(storeName);
-    // OTel callback stays registered but returns NaN (timestamp absent from map, store no longer tracked)
+    MetricEntityStateUtils.closeQuietly(perStore.remove(storeName));
+  }
+
+  @Override
+  public void close() {
+    MetricEntityStateUtils.closeAndClear(perStore);
+    super.close();
   }
 
   private void registerOtelGaugeIfAbsent(String storeName, String clusterName) {
     if (otelRepository == null) {
       return;
     }
-    otelPerStore.computeIfAbsent(storeName, k -> {
-      Map<VeniceMetricsDimensions, String> dims = new HashMap<>(baseDimensionsMap);
+    perStore.computeIfAbsent(storeName, k -> {
+      Map<VeniceMetricsDimensions, String> dims =
+          OpenTelemetryMetricsSetup.buildStoreDimensionsMap(baseDimensionsMap, k);
       dims.put(VeniceMetricsDimensions.VENICE_CLUSTER_NAME, clusterName);
-      dims.put(VeniceMetricsDimensions.VENICE_STORE_NAME, OpenTelemetryMetricsSetup.sanitizeStoreName(k));
       Attributes attrs = otelRepository.createAttributes(METADATA_CACHE_STALENESS.getMetricEntity(), dims);
-      // DoubleSupplier callback: returns NaN when store is removed (no timestamp in map),
+      // DoubleSupplier callback returns NaN when store is removed (no timestamp in map),
       // consistent with the Tehuti high-watermark gauge behavior.
-      return AsyncMetricEntityStateBase
-          .create(METADATA_CACHE_STALENESS.getMetricEntity(), otelRepository, dims, attrs, (DoubleSupplier) () -> {
-            Long ts = metadataCacheTimestampMapInMs.get(k);
-            return ts == null ? Double.NaN : (double) (clock.millis() - ts);
-          });
+      return new PerStoreEntry(otelRepository, dims, attrs, () -> {
+        Long ts = metadataCacheTimestampMapInMs.get(k);
+        return ts == null ? Double.NaN : (double) (clock.millis() - ts);
+      });
     });
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStats.java
@@ -34,19 +34,12 @@ public class NativeMetadataRepositoryStats extends AbstractVeniceStats {
   private final Map<String, Long> metadataCacheTimestampMapInMs = new VeniceConcurrentHashMap<>();
   private final Clock clock;
 
-  // OTel: per-store ASYNC_DOUBLE_GAUGE for staleness. Bounded by the number of stores currently subscribed.
-  // Per-store entries are removed and closed in {@link #handleStoreDeleted}, deregistering the callback
-  // from the SDK so it stops polling the gauge.
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
-  /**
-   * Per-store entry map. Each entry bundles the per-store registry with the async-gauge wrapper
-   * (registered eagerly in the {@link PerStoreEntry} constructor), so a single {@code remove()} in
-   * {@link #handleStoreDeleted(String)} is race-free w.r.t. concurrent recordings.
-   */
-  private final Map<String, PerStoreEntry> perStore = new VeniceConcurrentHashMap<>();
+  /** Per-store ASYNC_DOUBLE_GAUGE; entries are closed in {@link #handleStoreDeleted} so the SDK stops polling. */
+  private final Map<String, PerStoreEntry> perStoreEntryMap = new VeniceConcurrentHashMap<>();
 
-  /** Per-store state held by {@link #perStore}. */
+  /** Per-store state held by {@link #perStoreEntryMap}. */
   private static final class PerStoreEntry extends AbstractStatsCloseable {
     final AsyncMetricEntityStateBase gauge;
 
@@ -105,19 +98,15 @@ public class NativeMetadataRepositoryStats extends AbstractVeniceStats {
     registerOtelGaugeIfAbsent(storeName, clusterName);
   }
 
-  /**
-   * Removes the Tehuti cache-timestamp entry and closes the per-store OTel ASYNC gauge wrapper,
-   * deregistering the SDK callback so it stops polling. Called by the owning
-   * {@code NativeMetadataRepository} from its store-removal path.
-   */
+  /** Removes the Tehuti cache-timestamp entry and closes the per-store OTel async-gauge wrapper. */
   public void handleStoreDeleted(String storeName) {
     metadataCacheTimestampMapInMs.remove(storeName);
-    MetricEntityStateUtils.closeQuietly(perStore.remove(storeName));
+    MetricEntityStateUtils.closeQuietly(perStoreEntryMap.remove(storeName));
   }
 
   @Override
   public void close() {
-    MetricEntityStateUtils.closeAndClear(perStore);
+    MetricEntityStateUtils.closeAndClear(perStoreEntryMap);
     super.close();
   }
 
@@ -125,7 +114,7 @@ public class NativeMetadataRepositoryStats extends AbstractVeniceStats {
     if (otelRepository == null) {
       return;
     }
-    perStore.computeIfAbsent(storeName, k -> {
+    perStoreEntryMap.computeIfAbsent(storeName, k -> {
       Map<VeniceMetricsDimensions, String> dims =
           OpenTelemetryMetricsSetup.buildStoreDimensionsMap(baseDimensionsMap, k);
       dims.put(VeniceMetricsDimensions.VENICE_CLUSTER_NAME, clusterName);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStateTransitionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStateTransitionStats.java
@@ -88,17 +88,23 @@ public class ParticipantStateTransitionStats extends ThreadPoolStats {
         otelRepository,
         baseDimensionsMap,
         VeniceHelixFromState.class,
-        VeniceHelixToState.class);
+        VeniceHelixToState.class,
+        resources);
 
     inProgressMetric = MetricEntityStateTwoEnums.create(
         IN_PROGRESS_COUNT.getMetricEntity(),
         otelRepository,
         baseDimensionsMap,
         VeniceHelixFromState.class,
-        VeniceHelixToState.class);
+        VeniceHelixToState.class,
+        resources);
 
-    steadyStateMetric = MetricEntityStateOneEnum
-        .create(STEADY_STATE_COUNT.getMetricEntity(), otelRepository, baseDimensionsMap, VeniceHelixSteadyState.class);
+    steadyStateMetric = MetricEntityStateOneEnum.create(
+        STEADY_STATE_COUNT.getMetricEntity(),
+        otelRepository,
+        baseDimensionsMap,
+        VeniceHelixSteadyState.class,
+        resources);
   }
 
   /**
@@ -151,6 +157,17 @@ public class ParticipantStateTransitionStats extends ThreadPoolStats {
   }
 
   private void recordInProgressOtel(long delta, String fromState, String toState) {
+    // Pre-check nulls so Enum.valueOf doesn't throw NPE (which would surface as a less specific
+    // failure than the IAE for an unknown state). Both null and unknown enum values funnel into
+    // recordFailureMetric for diagnosability.
+    if (fromState == null || toState == null) {
+      if (otelRepository != null) {
+        otelRepository.recordFailureMetric(
+            IN_PROGRESS_COUNT.getMetricEntity(),
+            new IllegalArgumentException("null state: fromState=" + fromState + ", toState=" + toState));
+      }
+      return;
+    }
     try {
       VeniceHelixFromState from = VeniceHelixFromState.valueOf(fromState);
       VeniceHelixToState to = VeniceHelixToState.valueOf(toState);
@@ -168,6 +185,14 @@ public class ParticipantStateTransitionStats extends ThreadPoolStats {
   }
 
   private void recordSteadyStateOtel(long delta, String state) {
+    if (state == null) {
+      if (otelRepository != null) {
+        otelRepository.recordFailureMetric(
+            STEADY_STATE_COUNT.getMetricEntity(),
+            new IllegalArgumentException("null state: state=null"));
+      }
+      return;
+    }
     try {
       VeniceHelixSteadyState steadyState = VeniceHelixSteadyState.valueOf(state);
       steadyStateMetric.record(delta, steadyState);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStoreConsumptionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStoreConsumptionStats.java
@@ -1,7 +1,5 @@
 package com.linkedin.davinci.stats;
 
-import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
-
 import com.linkedin.venice.stats.AbstractVeniceStats;
 import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
 import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
@@ -21,7 +19,6 @@ import io.tehuti.metrics.stats.Max;
 import io.tehuti.metrics.stats.OccurrenceRate;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -83,7 +80,8 @@ public class ParticipantStoreConsumptionStats extends AbstractVeniceStats {
         TehutiMetricName.HEARTBEAT,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     this.failedInitializationMetric = MetricEntityStateBase.create(
         ParticipantStoreConsumptionOtelMetricEntity.FAILED_INITIALIZATION_COUNT.getMetricEntity(),
@@ -92,13 +90,8 @@ public class ParticipantStoreConsumptionStats extends AbstractVeniceStats {
         TehutiMetricName.FAILED_INITIALIZATION,
         Collections.singletonList(new Count()),
         baseDimensionsMap,
-        baseAttributes);
-  }
-
-  private Map<VeniceMetricsDimensions, String> buildStoreDimensionsMap(String storeName) {
-    Map<VeniceMetricsDimensions, String> map = new HashMap<>(baseDimensionsMap);
-    map.put(VENICE_STORE_NAME, storeName);
-    return Collections.unmodifiableMap(map);
+        baseAttributes,
+        resources);
   }
 
   private Attributes buildStoreAttributes(
@@ -113,7 +106,8 @@ public class ParticipantStoreConsumptionStats extends AbstractVeniceStats {
       List<MeasurableStat> tehutiStats,
       String storeName) {
     MetricEntity metricEntity = otelMetric.getMetricEntity();
-    Map<VeniceMetricsDimensions, String> storeDimensionsMap = buildStoreDimensionsMap(storeName);
+    Map<VeniceMetricsDimensions, String> storeDimensionsMap =
+        OpenTelemetryMetricsSetup.buildStoreDimensionsMap(baseDimensionsMap, storeName);
     return MetricEntityStateBase.create(
         metricEntity,
         otelRepository,
@@ -121,7 +115,8 @@ public class ParticipantStoreConsumptionStats extends AbstractVeniceStats {
         tehutiName,
         tehutiStats,
         storeDimensionsMap,
-        buildStoreAttributes(metricEntity, storeDimensionsMap));
+        buildStoreAttributes(metricEntity, storeDimensionsMap),
+        resources);
   }
 
   /**
@@ -150,8 +145,9 @@ public class ParticipantStoreConsumptionStats extends AbstractVeniceStats {
             this::registerSensorIfAbsent,
             TehutiMetricName.KILLED_PUSH_JOBS,
             Collections.singletonList(new Count()),
-            buildStoreDimensionsMap(k),
-            VeniceResponseStatusCategory.class))
+            OpenTelemetryMetricsSetup.buildStoreDimensionsMap(baseDimensionsMap, k),
+            VeniceResponseStatusCategory.class,
+            resources))
         .record(1, VeniceResponseStatusCategory.SUCCESS);
   }
 
@@ -162,8 +158,9 @@ public class ParticipantStoreConsumptionStats extends AbstractVeniceStats {
         k -> MetricEntityStateOneEnum.create(
             ParticipantStoreConsumptionOtelMetricEntity.KILL_PUSH_JOB_COUNT.getMetricEntity(),
             otelRepository,
-            buildStoreDimensionsMap(k),
-            VeniceResponseStatusCategory.class))
+            OpenTelemetryMetricsSetup.buildStoreDimensionsMap(baseDimensionsMap, k),
+            VeniceResponseStatusCategory.class,
+            resources))
         .record(1, VeniceResponseStatusCategory.FAIL);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/RocksDBMemoryStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/RocksDBMemoryStats.java
@@ -249,7 +249,8 @@ public class RocksDBMemoryStats extends AbstractVeniceStats {
         Collections.singletonList(new AsyncGauge((ig, ig2) -> valueSupplier.getAsLong(), sensorName)),
         baseDimensionsMap,
         baseAttributes,
-        valueSupplier);
+        valueSupplier,
+        resources);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetadataServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetadataServiceStats.java
@@ -1,19 +1,18 @@
 package com.linkedin.davinci.stats;
 
-import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
-
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.stats.AbstractVeniceStats;
 import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
 import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.stats.metrics.MetricEntityStateOneEnum;
+import com.linkedin.venice.stats.metrics.MetricEntityStateUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.Rate;
-import java.util.HashMap;
 import java.util.Map;
 
 
@@ -42,12 +41,31 @@ public class ServerMetadataServiceStats extends AbstractVeniceStats {
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
   /**
-   * Per-store OTel metrics. When the requested store does not exist (e.g., {@link VeniceNoStoreException}),
-   * {@link OpenTelemetryMetricsSetup#UNKNOWN_STORE_NAME} is used as a sentinel so that all unknown-store failures
-   * share one metric entry. Cardinality is bounded by stores deployed to this server + the sentinel.
+   * Per-store entry map. Entries live for the process lifetime and are drained on {@link #close()}.
+   *
+   * <p>When the requested store does not exist (e.g., {@link VeniceNoStoreException}),
+   * {@link OpenTelemetryMetricsSetup#UNKNOWN_STORE_NAME} is used as a sentinel so that all
+   * unknown-store failures share one entry. Cardinality is bounded by stores deployed to this
+   * server + the sentinel.
    */
-  private final Map<String, MetricEntityStateOneEnum<VeniceResponseStatusCategory>> perStoreMetrics =
-      new VeniceConcurrentHashMap<>();
+  private final Map<String, PerStoreEntry> perStore = new VeniceConcurrentHashMap<>();
+
+  /** Per-store state held by {@link #perStore}. */
+  private static final class PerStoreEntry extends AbstractStatsCloseable {
+    final MetricEntityStateOneEnum<VeniceResponseStatusCategory> wrapper;
+
+    PerStoreEntry(VeniceOpenTelemetryMetricsRepository otelRepository, Map<VeniceMetricsDimensions, String> dims) {
+      // Uses the 4-arg (OTel-only) create overload intentionally: the 7-arg overload would bind
+      // Tehuti recording to every record() call, but we only want Tehuti on failure, not success.
+      // Tehuti and OTel are therefore recorded in separate steps in recordRequestBasedMetadataFailureCount.
+      this.wrapper = MetricEntityStateOneEnum.create(
+          ServerMetadataOtelMetricEntity.METADATA_REQUEST_COUNT.getMetricEntity(),
+          otelRepository,
+          dims,
+          VeniceResponseStatusCategory.class,
+          statsCloseables);
+    }
+  }
 
   public ServerMetadataServiceStats(MetricsRepository metricsRepository, String clusterName) {
     super(metricsRepository, "ServerMetadataStats");
@@ -62,19 +80,12 @@ public class ServerMetadataServiceStats extends AbstractVeniceStats {
     this.baseDimensionsMap = otelData.getBaseDimensionsMap();
   }
 
-  // Uses the 4-arg (OTel-only) create overload intentionally: the 7-arg overload would bind
-  // Tehuti recording to every record() call, but we only want Tehuti on failure, not success.
-  // Tehuti and OTel are therefore recorded in separate steps in recordRequestBasedMetadataFailureCount.
-  private MetricEntityStateOneEnum<VeniceResponseStatusCategory> getStoreMetrics(String storeName) {
-    return perStoreMetrics.computeIfAbsent(storeName, k -> {
-      Map<VeniceMetricsDimensions, String> dimensionsMap = new HashMap<>(baseDimensionsMap);
-      dimensionsMap.put(VENICE_STORE_NAME, k);
-      return MetricEntityStateOneEnum.create(
-          ServerMetadataOtelMetricEntity.METADATA_REQUEST_COUNT.getMetricEntity(),
-          otelRepository,
-          dimensionsMap,
-          VeniceResponseStatusCategory.class);
-    });
+  private PerStoreEntry getOrCreateEntry(String storeName) {
+    return perStore.computeIfAbsent(
+        storeName,
+        k -> new PerStoreEntry(
+            otelRepository,
+            OpenTelemetryMetricsSetup.buildStoreDimensionsMap(baseDimensionsMap, k)));
   }
 
   public void recordRequestBasedMetadataInvokeCount() {
@@ -83,7 +94,7 @@ public class ServerMetadataServiceStats extends AbstractVeniceStats {
 
   public void recordRequestBasedMetadataSuccessCount(String storeName) {
     if (emitOtelMetrics) {
-      getStoreMetrics(storeName).record(1, VeniceResponseStatusCategory.SUCCESS);
+      getOrCreateEntry(storeName).wrapper.record(1, VeniceResponseStatusCategory.SUCCESS);
     }
   }
 
@@ -97,8 +108,14 @@ public class ServerMetadataServiceStats extends AbstractVeniceStats {
     if (emitOtelMetrics) {
       String metricStoreName =
           (e instanceof VeniceNoStoreException) ? OpenTelemetryMetricsSetup.UNKNOWN_STORE_NAME : storeName;
-      getStoreMetrics(metricStoreName).record(1, VeniceResponseStatusCategory.FAIL);
+      getOrCreateEntry(metricStoreName).wrapper.record(1, VeniceResponseStatusCategory.FAIL);
     }
+  }
+
+  @Override
+  public void close() {
+    MetricEntityStateUtils.closeAndClear(perStore);
+    super.close();
   }
 
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetadataServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetadataServiceStats.java
@@ -41,16 +41,11 @@ public class ServerMetadataServiceStats extends AbstractVeniceStats {
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
   /**
-   * Per-store entry map. Entries live for the process lifetime and are drained on {@link #close()}.
-   *
-   * <p>When the requested store does not exist (e.g., {@link VeniceNoStoreException}),
-   * {@link OpenTelemetryMetricsSetup#UNKNOWN_STORE_NAME} is used as a sentinel so that all
-   * unknown-store failures share one entry. Cardinality is bounded by stores deployed to this
-   * server + the sentinel.
+   * Per-store entry map; process-lifetime, drained on {@link #close()}. Unknown stores share the
+   * {@link OpenTelemetryMetricsSetup#UNKNOWN_STORE_NAME} sentinel.
    */
-  private final Map<String, PerStoreEntry> perStore = new VeniceConcurrentHashMap<>();
+  private final Map<String, PerStoreEntry> perStoreEntryMap = new VeniceConcurrentHashMap<>();
 
-  /** Per-store state held by {@link #perStore}. */
   private static final class PerStoreEntry extends AbstractStatsCloseable {
     final MetricEntityStateOneEnum<VeniceResponseStatusCategory> wrapper;
 
@@ -81,7 +76,7 @@ public class ServerMetadataServiceStats extends AbstractVeniceStats {
   }
 
   private PerStoreEntry getOrCreateEntry(String storeName) {
-    return perStore.computeIfAbsent(
+    return perStoreEntryMap.computeIfAbsent(
         storeName,
         k -> new PerStoreEntry(
             otelRepository,
@@ -114,7 +109,7 @@ public class ServerMetadataServiceStats extends AbstractVeniceStats {
 
   @Override
   public void close() {
-    MetricEntityStateUtils.closeAndClear(perStore);
+    MetricEntityStateUtils.closeAndClear(perStoreEntryMap);
     super.close();
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StorageEngineOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StorageEngineOtelStats.java
@@ -14,12 +14,12 @@ import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
 import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.dimensions.VeniceRecordType;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateOneEnum;
 import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateTwoEnums;
 import com.linkedin.venice.stats.metrics.MetricEntityStateOneEnum;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
-import java.io.Closeable;
 import java.util.Map;
 
 
@@ -37,7 +37,7 @@ import java.util.Map;
  * <p>Tehuti metrics are managed separately by
  * {@link AggVersionedStorageEngineStats.StorageEngineStatsReporter}.
  */
-public class StorageEngineOtelStats implements Closeable {
+public class StorageEngineOtelStats extends AbstractStatsCloseable {
   private final boolean emitOtelMetrics;
 
   /**
@@ -89,7 +89,8 @@ public class StorageEngineOtelStats implements Closeable {
           VeniceRecordType.class,
           VersionRole.class,
           (recordType, role) -> getWrapperForRole(role),
-          (wrapper, recordType, role) -> diskUsage(wrapper, recordType));
+          (wrapper, recordType, role) -> diskUsage(wrapper, recordType),
+          statsCloseables);
 
       this.keyCountMetric = AsyncMetricEntityStateOneEnum.create(
           KEY_COUNT_ESTIMATE.getMetricEntity(),
@@ -97,11 +98,16 @@ public class StorageEngineOtelStats implements Closeable {
           baseDimensionsMap,
           VersionRole.class,
           role -> getWrapperForRole(role),
-          (wrapper, role) -> wrapper.getKeyCountEstimate());
+          (wrapper, role) -> wrapper.getKeyCountEstimate(),
+          statsCloseables);
 
       // RocksDB open failure count: COUNTER with VersionRole dimension
-      this.openFailureMetric = MetricEntityStateOneEnum
-          .create(ROCKSDB_OPEN_FAILURE_COUNT.getMetricEntity(), otelRepository, baseDimensionsMap, VersionRole.class);
+      this.openFailureMetric = MetricEntityStateOneEnum.create(
+          ROCKSDB_OPEN_FAILURE_COUNT.getMetricEntity(),
+          otelRepository,
+          baseDimensionsMap,
+          VersionRole.class,
+          statsCloseables);
     } else {
       this.diskUsageMetrics = null;
       this.keyCountMetric = null;
@@ -188,13 +194,17 @@ public class StorageEngineOtelStats implements Closeable {
   }
 
   /**
-   * Clears internal wrapper references. On subsequent collections each async-gauge's
-   * {@code liveStateResolver} will return {@code null} for every role and no data points will be
-   * emitted. The SDK instruments themselves are NOT deregistered — they remain registered and
-   * are polled until the SDK is shut down.
+   * Closes per-store SDK instruments and releases internal wrapper references. The two async
+   * gauges have their callbacks deregistered (SDK stops polling); the sync counter releases its
+   * wrapper-side memory only (SDK aggregator persists until MeterProvider close).
+   *
+   * <p>Per-store close only — these instruments span all versions of this store. Per-version
+   * cleanup goes through {@link #onVersionRemoved}, which removes the version's wrapper from
+   * {@link #wrappersByVersion} but does NOT close the per-store instruments.
    */
   @Override
   public void close() {
     wrappersByVersion.clear();
+    super.close();
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreBufferServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreBufferServiceStats.java
@@ -19,7 +19,6 @@ import io.tehuti.metrics.stats.Max;
 import io.tehuti.metrics.stats.OccurrenceRate;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.LongSupplier;
@@ -34,6 +33,11 @@ public class StoreBufferServiceStats extends AbstractVeniceStats {
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
   private final Attributes baseAttributes;
+
+  private final AsyncMetricEntityStateBase memoryUsedMetric;
+  private final AsyncMetricEntityStateBase memoryRemainingMetric;
+  private final AsyncMetricEntityStateBase memoryUsedPerWriterMaxMetric;
+  private final AsyncMetricEntityStateBase memoryUsedPerWriterMinMetric;
 
   /**
    * Per-store latency metric states. Bounded by the number of active stores on this server (typically < 100).
@@ -72,31 +76,29 @@ public class StoreBufferServiceStats extends AbstractVeniceStats {
     this.baseAttributes = otelData.getBaseAttributes();
 
     // Memory metrics (#1-4): joint Tehuti+OTel AsyncGauge.
-    // Return values are intentionally discarded — the gauge callback is registered internally
-    // by the Tehuti sensor and OTel SDK during create(). No per-recording state is needed.
-    registerMemoryGauge(
+    memoryUsedMetric = registerMemoryGauge(
         StoreBufferServiceOtelMetricEntity.MEMORY_USED,
         TehutiMetricName.TOTAL_MEMORY_USAGE,
         totalMemoryUsageSupplier);
-    registerMemoryGauge(
+    memoryRemainingMetric = registerMemoryGauge(
         StoreBufferServiceOtelMetricEntity.MEMORY_REMAINING,
         TehutiMetricName.TOTAL_REMAINING_MEMORY,
         totalRemainingMemorySupplier);
-    registerMemoryGauge(
+    memoryUsedPerWriterMaxMetric = registerMemoryGauge(
         StoreBufferServiceOtelMetricEntity.MEMORY_USED_PER_WRITER_MAX,
         TehutiMetricName.MAX_MEMORY_USAGE_PER_WRITER,
         maxMemoryUsagePerDrainerSupplier);
-    registerMemoryGauge(
+    memoryUsedPerWriterMinMetric = registerMemoryGauge(
         StoreBufferServiceOtelMetricEntity.MEMORY_USED_PER_WRITER_MIN,
         TehutiMetricName.MIN_MEMORY_USAGE_PER_WRITER,
         minMemoryUsagePerDrainerSupplier);
   }
 
-  private void registerMemoryGauge(
+  private AsyncMetricEntityStateBase registerMemoryGauge(
       StoreBufferServiceOtelMetricEntity metricEntity,
       TehutiMetricName tehutiName,
       LongSupplier supplier) {
-    AsyncMetricEntityStateBase.create(
+    return AsyncMetricEntityStateBase.create(
         metricEntity.getMetricEntity(),
         otelRepository,
         this::registerSensorIfAbsent,
@@ -104,7 +106,8 @@ public class StoreBufferServiceStats extends AbstractVeniceStats {
         Collections.singletonList(new AsyncGauge((ig, ig2) -> supplier.getAsLong(), tehutiName.getMetricName())),
         baseDimensionsMap,
         baseAttributes,
-        supplier);
+        supplier,
+        resources);
   }
 
   private MetricEntityStateBase createPerStoreState(
@@ -112,12 +115,18 @@ public class StoreBufferServiceStats extends AbstractVeniceStats {
       MetricEntity metricEntity,
       TehutiMetricNameEnum tehutiName,
       List<MeasurableStat> tehutiStats) {
-    Map<VeniceMetricsDimensions, String> dims = new HashMap<>(baseDimensionsMap);
-    dims.put(VeniceMetricsDimensions.VENICE_STORE_NAME, storeName);
-    dims = Collections.unmodifiableMap(dims);
+    Map<VeniceMetricsDimensions, String> dims =
+        OpenTelemetryMetricsSetup.buildStoreDimensionsMap(baseDimensionsMap, storeName);
     Attributes attrs = otelRepository != null ? otelRepository.createAttributes(metricEntity, dims) : null;
-    return MetricEntityStateBase
-        .create(metricEntity, otelRepository, this::registerSensorIfAbsent, tehutiName, tehutiStats, dims, attrs);
+    return MetricEntityStateBase.create(
+        metricEntity,
+        otelRepository,
+        this::registerSensorIfAbsent,
+        tehutiName,
+        tehutiStats,
+        dims,
+        attrs,
+        resources);
   }
 
   private MetricEntityStateBase getOrCreateLatencyState(String storeName) {
@@ -146,5 +155,13 @@ public class StoreBufferServiceStats extends AbstractVeniceStats {
 
   public void recordInternalProcessingError(String storeName) {
     getOrCreateErrorState(storeName).record(1);
+  }
+
+  /** Closes all OTel metric wrappers held by this stats instance, including per-store entries. */
+  @Override
+  public void close() {
+    super.close();
+    latencyPerStore.clear();
+    errorPerStore.clear();
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreVersionOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreVersionOtelStats.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
 import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateBase;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.opentelemetry.api.common.Attributes;
 import io.tehuti.metrics.MetricsRepository;
@@ -33,14 +34,7 @@ import org.apache.logging.log4j.Logger;
  * <p>This class implements {@link StoreDataChangedListener} and should be registered once per process
  * on the metadata repository via {@link #register(ReadOnlyStoreRepository)}. Per-store state is
  * created lazily on first store change and bounded by the number of distinct store names ever
- * observed by the process (entries are not removed on deletion — see cleanup limitation below).
- *
- * <p><b>Cleanup limitation:</b> the OTel SDK does support per-instrument deregistration via
- * {@code ObservableLongGauge.close()}, but the current Venice wrapper
- * ({@link AsyncMetricEntityStateBase}) doesn't surface the SDK instrument handle, so callbacks
- * remain registered until the {@link MetricsRepository} is closed. On store deletion, version
- * info is reset to {@link VersionInfo#NON_EXISTING} rather than removed — see
- * {@link #handleStoreDeleted} for why removing the map entry is unsafe given the current wrapper.
+ * observed by the process. Entries are not removed on deletion — see {@link #handleStoreDeleted}.
  */
 public class StoreVersionOtelStats implements StoreDataChangedListener, Closeable {
   private static final Logger LOGGER = LogManager.getLogger(StoreVersionOtelStats.class);
@@ -51,9 +45,8 @@ public class StoreVersionOtelStats implements StoreDataChangedListener, Closeabl
   private final Map<String, AtomicReference<VersionInfo>> perStoreVersions = new VeniceConcurrentHashMap<>();
 
   /**
-   * Tracks the metadata repository this OTel listener is registered on. Set when
-   * {@link #register} succeeds; null otherwise (OTel disabled or never registered). Used by
-   * {@link #close} to deregister the OTel listener.
+   * The metadata repository this listener is registered on. Set when {@link #register} succeeds;
+   * null otherwise (OTel disabled or never registered). Used by {@link #close} to deregister.
    */
   private ReadOnlyStoreRepository registeredMetadataRepository;
 
@@ -124,7 +117,7 @@ public class StoreVersionOtelStats implements StoreDataChangedListener, Closeabl
     // set() after updates existing entries with the latest data from the ZK event.
     perStoreVersions.computeIfAbsent(storeName, k -> {
       AtomicReference<VersionInfo> newRef = new AtomicReference<>(newInfo);
-      registerOtelGauge(k, newRef);
+      registerOtelGauges(k, newRef);
       return newRef;
     }).set(newInfo);
   }
@@ -136,7 +129,7 @@ public class StoreVersionOtelStats implements StoreDataChangedListener, Closeabl
     VersionInfo newInfo = computeVersionInfo(store);
     perStoreVersions.computeIfAbsent(storeName, k -> {
       AtomicReference<VersionInfo> newRef = new AtomicReference<>(newInfo);
-      registerOtelGauge(k, newRef);
+      registerOtelGauges(k, newRef);
       return newRef;
     });
   }
@@ -149,11 +142,11 @@ public class StoreVersionOtelStats implements StoreDataChangedListener, Closeabl
 
   /**
    * Resets version info to {@link VersionInfo#NON_EXISTING} rather than removing the map entry.
-   * The async-gauge callback closes over the {@link AtomicReference}, which the Venice wrapper
-   * doesn't currently surface for de-registration. Removing the map entry would orphan the live
-   * callback (SDK keeps polling stale data); a subsequent re-create would register a second
-   * callback emitting under the same attributes. Resetting keeps one live callback pointed at
-   * the right state across delete→re-create cycles.
+   * The ASYNC_GAUGE callback closes over the {@link AtomicReference}, so removing the entry would
+   * orphan the SDK-side callback (still polling, with no clean way to deregister it through the
+   * current wrapper). Resetting keeps one live callback pointed at sentinel values
+   * ({@code NON_EXISTING_VERSION}) which dashboards can filter; map cardinality stays bounded by
+   * the host's store count across delete→re-create cycles.
    */
   @Override
   public void handleStoreDeleted(String storeName) {
@@ -166,24 +159,22 @@ public class StoreVersionOtelStats implements StoreDataChangedListener, Closeabl
     }
   }
 
-  /**
-   * Registers two ASYNC_GAUGE callbacks: one for CURRENT and one for FUTURE.
-   * Only these two roles are tracked — backup version number is not tracked.
-   */
-  private void registerOtelGauge(String storeName, AtomicReference<VersionInfo> versionInfoRef) {
-    Map<VeniceMetricsDimensions, String> storeDims = new HashMap<>(baseDimensionsMap);
-    storeDims.put(VeniceMetricsDimensions.VENICE_STORE_NAME, OpenTelemetryMetricsSetup.sanitizeStoreName(storeName));
+  /** Registers ASYNC_GAUGE callbacks for both CURRENT and FUTURE roles for a single store. */
+  private void registerOtelGauges(String storeName, AtomicReference<VersionInfo> versionInfoRef) {
+    Map<VeniceMetricsDimensions, String> storeDims =
+        OpenTelemetryMetricsSetup.buildStoreDimensionsMap(baseDimensionsMap, storeName);
     registerRoleGauge(storeDims, VersionRole.CURRENT, () -> versionInfoRef.get().getCurrentVersion());
     registerRoleGauge(storeDims, VersionRole.FUTURE, () -> versionInfoRef.get().getFutureVersion());
   }
 
-  private void registerRoleGauge(
+  private AsyncMetricEntityStateBase registerRoleGauge(
       Map<VeniceMetricsDimensions, String> storeDims,
       VersionRole role,
       LongSupplier callback) {
     Map<VeniceMetricsDimensions, String> dims = new HashMap<>(storeDims);
     dims.put(VeniceMetricsDimensions.VENICE_VERSION_ROLE, role.getDimensionValue());
     Attributes attrs = otelRepository.createAttributes(STORE_VERSION.getMetricEntity(), dims);
-    AsyncMetricEntityStateBase.create(STORE_VERSION.getMetricEntity(), otelRepository, dims, attrs, callback);
+    return AsyncMetricEntityStateBase
+        .create(STORE_VERSION.getMetricEntity(), otelRepository, dims, attrs, callback, CompositeCloseable.NONE);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StuckConsumerRepairStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StuckConsumerRepairStats.java
@@ -41,7 +41,8 @@ public class StuckConsumerRepairStats extends AbstractVeniceStats {
         TehutiMetricName.STUCK_CONSUMER_FOUND,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     ingestionTaskRepairOtel = MetricEntityStateBase.create(
         STUCK_CONSUMER_TASK_REPAIRED_COUNT.getMetricEntity(),
@@ -50,7 +51,8 @@ public class StuckConsumerRepairStats extends AbstractVeniceStats {
         TehutiMetricName.INGESTION_TASK_REPAIR,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     repairFailureOtel = MetricEntityStateBase.create(
         STUCK_CONSUMER_UNRESOLVED_COUNT.getMetricEntity(),
@@ -59,7 +61,8 @@ public class StuckConsumerRepairStats extends AbstractVeniceStats {
         TehutiMetricName.REPAIR_FAILURE,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
   }
 
   public void recordStuckConsumerFound() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStats.java
@@ -78,6 +78,7 @@ import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.dimensions.VenicePartialUpdateOperation;
 import com.linkedin.venice.stats.dimensions.VeniceRecordType;
 import com.linkedin.venice.stats.dimensions.VeniceRegionLocality;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateOneEnum;
 import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateTwoEnums;
 import com.linkedin.venice.stats.metrics.AsyncMetricResolvers.LiveStateResolverOneEnum;
@@ -100,7 +101,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * OpenTelemetry metrics for ingestion statistics.
  * Note: Tehuti metrics are managed separately in {@link com.linkedin.davinci.stats.IngestionStatsReporter}.
  */
-public class IngestionOtelStats {
+public class IngestionOtelStats extends AbstractStatsCloseable {
   private final boolean emitOtelMetrics;
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
@@ -360,7 +361,8 @@ public class IngestionOtelStats {
         baseDimensionsMap,
         VersionRole.class,
         VeniceIngestionSourceComponent.class,
-        VeniceIngestionDestinationComponent.class);
+        VeniceIngestionDestinationComponent.class,
+        statsCloseables);
 
     // Initialize RT region metric maps
     this.rtRecordsConsumedByRegion = new VeniceConcurrentHashMap<>();
@@ -482,17 +484,24 @@ public class IngestionOtelStats {
   }
 
   /**
-   * Cleans up all per-version state for this store. Call this when the store is being deleted.
-   * After this call each async-gauge's {@code liveStateResolver} returns {@code null} for every
-   * role, so no data points are emitted for this store on subsequent collections. The SDK
-   * instruments themselves are not deregistered (OTel does not support it), so this object is
-   * retained until JVM shutdown — only relevant on store deletion or when no versions remain on
-   * this host.
+   * Cleans up all per-version state for this store and deregisters the SDK callbacks. Call this
+   * when the store is being deleted. After this call:
+   * <ul>
+   *   <li>Async gauges are deregistered (the SDK stops polling them).</li>
+   *   <li>Sync wrapper memory is released; the SDK-side aggregator persists until MeterProvider
+   *       close.</li>
+   *   <li>Per-region wrappers are closed and their map cleared.</li>
+   * </ul>
    */
+  @Override
   public void close() {
     ingestionTasksByVersion.clear();
     pushTimeoutByVersion.clear();
     idleTimeByVersion.clear();
+
+    super.close();
+
+    // Per-region maps: wrappers are closed via the registry above; clear the map references.
     rtRecordsConsumedByRegion.clear();
     rtBytesConsumedByRegion.clear();
   }
@@ -516,14 +525,15 @@ public class IngestionOtelStats {
   // Helper methods
 
   private MetricEntityStateOneEnum<VersionRole> createOneEnumMetric(MetricEntity metricEntity) {
-    return MetricEntityStateOneEnum.create(metricEntity, otelRepository, baseDimensionsMap, VersionRole.class);
+    return MetricEntityStateOneEnum
+        .create(metricEntity, otelRepository, baseDimensionsMap, VersionRole.class, statsCloseables);
   }
 
   private <E extends Enum<E> & VeniceDimensionInterface> MetricEntityStateTwoEnums<VersionRole, E> createTwoEnumMetric(
       MetricEntity metricEntity,
       Class<E> enumClass) {
     return MetricEntityStateTwoEnums
-        .create(metricEntity, otelRepository, baseDimensionsMap, VersionRole.class, enumClass);
+        .create(metricEntity, otelRepository, baseDimensionsMap, VersionRole.class, enumClass, statsCloseables);
   }
 
   /**
@@ -534,8 +544,14 @@ public class IngestionOtelStats {
       MetricEntity metricEntity,
       LiveStateResolverOneEnum<VersionRole, S> liveStateResolver,
       ValueResolverOneEnum<S, VersionRole> valueResolver) {
-    return AsyncMetricEntityStateOneEnum
-        .create(metricEntity, otelRepository, baseDimensionsMap, VersionRole.class, liveStateResolver, valueResolver);
+    return AsyncMetricEntityStateOneEnum.create(
+        metricEntity,
+        otelRepository,
+        baseDimensionsMap,
+        VersionRole.class,
+        liveStateResolver,
+        valueResolver,
+        statsCloseables);
   }
 
   /**
@@ -553,7 +569,8 @@ public class IngestionOtelStats {
         VersionRole.class,
         ReplicaType.class,
         liveStateResolver,
-        valueResolver);
+        valueResolver,
+        statsCloseables);
   }
 
   public boolean emitOtelMetrics() {
@@ -664,7 +681,8 @@ public class IngestionOtelStats {
           otelRepository,
           dims,
           VersionRole.class,
-          VeniceRegionLocality.class);
+          VeniceRegionLocality.class,
+          statsCloseables);
     });
   }
 
@@ -678,7 +696,8 @@ public class IngestionOtelStats {
           otelRepository,
           dims,
           VersionRole.class,
-          VeniceRegionLocality.class);
+          VeniceRegionLocality.class,
+          statsCloseables);
     });
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -21,6 +21,7 @@ import com.linkedin.venice.stats.dimensions.VeniceChunkingStatus;
 import com.linkedin.venice.stats.dimensions.VeniceHeartbeatComponent;
 import com.linkedin.venice.stats.dimensions.VeniceRegionLocality;
 import com.linkedin.venice.stats.dimensions.VeniceStoreWriteType;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.RegionUtils;
 import com.linkedin.venice.utils.Utils;
@@ -83,6 +84,8 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   private final Map<String, Integer> cleanupHeartbeatMap;
   private final HeartbeatVersionedStats versionStatsReporter;
   private final HeartbeatMonitoringServiceStats heartbeatMonitoringServiceStats;
+  /** Stats fields owned by this class; drained by {@link #stopInner}. */
+  private final CompositeCloseable statsCloseables = new CompositeCloseable();
   private final Duration maxWaitForVersionInfo;
   private final CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewRepositoryFuture;
   private final String nodeId;
@@ -119,8 +122,8 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
         leaderHeartbeatTimeStamps,
         followerHeartbeatTimeStamps,
         serverConfig.getClusterName());
-    this.heartbeatMonitoringServiceStats =
-        Objects.requireNonNull(heartbeatMonitoringServiceStats, "heartbeatMonitoringServiceStats cannot be null");
+    this.heartbeatMonitoringServiceStats = statsCloseables.register(
+        Objects.requireNonNull(heartbeatMonitoringServiceStats, "heartbeatMonitoringServiceStats cannot be null"));
     this.customizedViewRepositoryFuture = customizedViewRepositoryFuture;
     this.nodeId = Utils.getHelixNodeIdentifier(serverConfig.getListenerHostname(), serverConfig.getListenerPort());
     this.lagMonitorCleanupCycle = serverConfig.getLagMonitorCleanupCycle();
@@ -390,6 +393,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
     heartbeatReporterThreadIsRunning.set(false);
     reportingThread.interrupt();
     lagCleanupAndLoggingThread.interrupt();
+    statsCloseables.close();
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatOtelStats.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.stats.dimensions.VeniceChunkingStatus;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.dimensions.VeniceRegionLocality;
 import com.linkedin.venice.stats.dimensions.VeniceStoreWriteType;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.stats.metrics.MetricEntityStateFiveEnums;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
@@ -25,7 +26,7 @@ import java.util.Map;
  * OpenTelemetry metrics for heartbeat monitoring.
  * Note: Tehuti metrics are managed separately in {@link HeartbeatStatReporter}.
  */
-public class HeartbeatOtelStats {
+public class HeartbeatOtelStats extends AbstractStatsCloseable {
   private final boolean emitOtelMetrics;
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
@@ -135,7 +136,8 @@ public class HeartbeatOtelStats {
           ReplicaType.class,
           ReplicaState.class,
           VeniceStoreWriteType.class,
-          VeniceChunkingStatus.class);
+          VeniceChunkingStatus.class,
+          statsCloseables);
     });
   }
 
@@ -145,11 +147,14 @@ public class HeartbeatOtelStats {
   }
 
   /**
-   * Clears the per-region metric state map, releasing references to MetricEntityState objects.
-   * Does not deregister OTel instruments from the metrics repository — they will be
-   * cleaned up when the Meter/MeterProvider is closed or the SDK shuts down.
+   * Closes the {@link CompositeCloseable} — releasing wrapper-side state for the sync HISTOGRAM
+   * recorded by this class. The per-region map is then cleared so wrappers become eligible for
+   * GC. The SDK aggregator persists until the MeterProvider is closed; this call only releases
+   * wrapper memory.
    */
+  @Override
   public void close() {
+    super.close();
     metricsByRegion.clear();
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/RecordLevelDelayOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/RecordLevelDelayOtelStats.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.stats.dimensions.VeniceChunkingStatus;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.dimensions.VeniceRegionLocality;
 import com.linkedin.venice.stats.dimensions.VeniceStoreWriteType;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.stats.metrics.MetricEntityStateFiveEnums;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
@@ -35,7 +36,7 @@ import java.util.Map;
  *
  * <p>Note: Tehuti metrics are managed separately in {@link HeartbeatStatReporter}.
  */
-public class RecordLevelDelayOtelStats {
+public class RecordLevelDelayOtelStats extends AbstractStatsCloseable {
   private final boolean emitOtelMetrics;
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
@@ -149,7 +150,8 @@ public class RecordLevelDelayOtelStats {
           ReplicaType.class,
           ReplicaState.class,
           VeniceStoreWriteType.class,
-          VeniceChunkingStatus.class);
+          VeniceChunkingStatus.class,
+          statsCloseables);
     });
   }
 
@@ -159,11 +161,14 @@ public class RecordLevelDelayOtelStats {
   }
 
   /**
-   * Clears the per-region metric state map, releasing references to MetricEntityState objects.
-   * Does not deregister OTel instruments from the metrics repository — they will be
-   * cleaned up when the Meter/MeterProvider is closed or the SDK shuts down.
+   * Closes the {@link CompositeCloseable} — releasing wrapper-side state for the sync HISTOGRAM
+   * recorded by this class. The per-region map is then cleared so wrappers become eligible for
+   * GC. The SDK aggregator persists until the MeterProvider is closed; this call only releases
+   * wrapper memory.
    */
+  @Override
   public void close() {
+    super.close();
     metricsByRegion.clear();
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AdaptiveThrottlingServiceStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AdaptiveThrottlingServiceStatsTest.java
@@ -92,8 +92,8 @@ public class AdaptiveThrottlingServiceStatsTest {
 
   @Test
   public void testNoNpeWhenOtelDisabled() {
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, null)) {
       assertAllMethodsSafe(disabledRepo);
     }
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/AggVersionedDaVinciRecordTransformerStatsOtelTest.java
@@ -16,13 +16,12 @@ import static org.testng.Assert.assertTrue;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
-import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceRecordTransformerOperation;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
 import java.util.Collections;
@@ -48,13 +47,11 @@ public class AggVersionedDaVinciRecordTransformerStatsOtelTest {
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
     asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    metricsRepository = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
-            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
-            .build());
+    metricsRepository = MetricsRepositoryUtils.createOtelEnabledRepository(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        inMemoryMetricReader,
+        asyncGaugeExecutor);
     aggStats = createAggStats(metricsRepository);
   }
 
@@ -171,8 +168,8 @@ public class AggVersionedDaVinciRecordTransformerStatsOtelTest {
         RECORD_TRANSFORMER_ERROR_COUNT.getMetricEntity().getMetricName(),
         TEST_METRIC_PREFIX);
 
-    assertTrue(aggStats.hasErrorCountMetricFor(storeA), "Per-store error map must have an entry for " + storeA);
-    assertTrue(aggStats.hasErrorCountMetricFor(storeB), "Per-store error map must have an entry for " + storeB);
+    assertTrue(aggStats.hasMetricsFor(storeA), "Per-store error map must have an entry for " + storeA);
+    assertTrue(aggStats.hasMetricsFor(storeB), "Per-store error map must have an entry for " + storeB);
   }
 
   @Test
@@ -180,18 +177,15 @@ public class AggVersionedDaVinciRecordTransformerStatsOtelTest {
     long timestamp = System.currentTimeMillis();
     aggStats.recordPutLatency(TEST_STORE_NAME, 1, 10.0, timestamp);
     aggStats.recordPutError(TEST_STORE_NAME, 1, timestamp);
-    assertEquals(aggStats.latencyStoreCount(), 1, "Latency map should have one entry after recording");
-    assertEquals(aggStats.errorCountStoreCount(), 1, "Error map should have one entry after recording");
+    assertEquals(aggStats.storeCount(), 1, "Per-store map should have one entry after recording");
 
     aggStats.handleStoreDeleted(TEST_STORE_NAME);
 
-    assertEquals(aggStats.latencyStoreCount(), 0, "Latency map should be empty after store deletion");
-    assertEquals(aggStats.errorCountStoreCount(), 0, "Error map should be empty after store deletion");
+    assertEquals(aggStats.storeCount(), 0, "Per-store map should be empty after store deletion");
 
     aggStats.recordPutLatency(TEST_STORE_NAME, 1, 25.0, timestamp);
     aggStats.recordPutError(TEST_STORE_NAME, 1, timestamp);
-    assertEquals(aggStats.latencyStoreCount(), 1, "Latency map should have exactly one entry after re-record");
-    assertEquals(aggStats.errorCountStoreCount(), 1, "Error map should have exactly one entry after re-record");
+    assertEquals(aggStats.storeCount(), 1, "Per-store map should have exactly one entry after re-record");
   }
 
   // --- NPE prevention tests ---
@@ -199,11 +193,8 @@ public class AggVersionedDaVinciRecordTransformerStatsOtelTest {
   @Test
   public void testNoNpeWhenOtelDisabled() {
     AsyncGauge.AsyncGaugeExecutor localExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setEmitOtelMetrics(false)
-            .setTehutiMetricConfig(new MetricConfig(localExecutor))
-            .build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, localExecutor)) {
       exerciseAllRecordingPaths(disabledRepo);
     }
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/BlobTransferOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/BlobTransferOtelStatsTest.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
@@ -286,8 +287,8 @@ public class BlobTransferOtelStatsTest {
 
   @Test
   public void testNoNpeWhenOtelDisabled() {
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(METRIC_PREFIX, null)) {
       BlobTransferOtelStats disabledStats = new BlobTransferOtelStats(disabledRepo, TEST_STORE_NAME, CLUSTER_NAME);
       assertFalse(disabledStats.emitOtelMetrics());
       assertAllMethodsSafe(disabledStats);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/DIVStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/DIVStatsOtelTest.java
@@ -27,6 +27,7 @@ import com.linkedin.venice.stats.dimensions.VeniceDIVResult;
 import com.linkedin.venice.stats.dimensions.VeniceDIVSeverity;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import com.linkedin.venice.utils.lazy.Lazy;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
@@ -430,8 +431,8 @@ public class DIVStatsOtelTest {
 
   @Test
   public void testNoNpeWhenOtelDisabled() {
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, null)) {
       exerciseAllRecordingPaths(
           new AggVersionedDIVStats(disabledRepo, createEmptyMockMetadataRepository(), true, TEST_CLUSTER_NAME));
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/KafkaConsumerServiceStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/KafkaConsumerServiceStatsOtelTest.java
@@ -28,13 +28,13 @@ import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceConsumerPoolAction;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import com.linkedin.venice.utils.SystemTime;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.ExponentialHistogramPointData;
 import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.tehuti.Metric;
-import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
 import java.util.Collection;
@@ -71,13 +71,11 @@ public class KafkaConsumerServiceStatsOtelTest {
   public void setUp() {
     asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
     inMemoryMetricReader = InMemoryMetricReader.create();
-    metricsRepository = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
-            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
-            .build());
+    metricsRepository = MetricsRepositoryUtils.createOtelEnabledRepository(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        inMemoryMetricReader,
+        asyncGaugeExecutor);
 
     // Create total stats (totalStats=null means this IS the total instance)
     totalStats = new KafkaConsumerServiceStats(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStatsOtelTest.java
@@ -8,13 +8,12 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertFalse;
 
-import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
 import java.time.Clock;
@@ -42,13 +41,11 @@ public class NativeMetadataRepositoryStatsOtelTest {
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
     asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    metricsRepository = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
-            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
-            .build());
+    metricsRepository = MetricsRepositoryUtils.createOtelEnabledRepository(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        inMemoryMetricReader,
+        asyncGaugeExecutor);
     mockClock = mock(Clock.class);
     doReturn(1000L).when(mockClock).millis();
     stats = new NativeMetadataRepositoryStats(metricsRepository, "test", mockClock);
@@ -100,7 +97,7 @@ public class NativeMetadataRepositoryStatsOtelTest {
     stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 500);
     validateGauge(500, "store-a");
 
-    stats.removeCacheTimestamp("store-a");
+    stats.handleStoreDeleted("store-a");
     // After removal, callback returns NaN (no data). Validate directly since the
     // tolerance-based helper doesn't support NaN comparison (NaN != NaN in IEEE 754).
     validateGaugeAbsent("store-a");
@@ -116,19 +113,16 @@ public class NativeMetadataRepositoryStatsOtelTest {
   }
 
   @Test
-  public void testReAddAfterRemoveReusesCallback() {
+  public void testReAddAfterRemoveRegistersFreshCallback() {
     // First registration: gauge reports a real value.
     stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 500);
     validateGauge(500, "store-a");
 
-    // Removal: callback returns NaN (timestamp absent), no data point emitted.
-    stats.removeCacheTimestamp("store-a");
+    // Removal: the per-store OTel wrapper is closed and the SDK callback is deregistered.
+    stats.handleStoreDeleted("store-a");
     validateGaugeAbsent("store-a");
 
-    // Re-add: the existing OTel callback (registered on the first updateCacheTimestamp)
-    // is reused — computeIfAbsent on otelPerStore is a no-op the second time. The gauge
-    // resumes reporting because the callback re-reads from metadataCacheTimestampMapInMs
-    // dynamically each cycle.
+    // Re-add: a fresh OTel wrapper + callback is registered via computeIfAbsent.
     stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 700);
     validateGauge(300, "store-a");
   }
@@ -136,14 +130,11 @@ public class NativeMetadataRepositoryStatsOtelTest {
   @Test
   public void testNoNpeWhenOtelDisabled() {
     AsyncGauge.AsyncGaugeExecutor dedicatedExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setEmitOtelMetrics(false)
-            .setTehutiMetricConfig(new MetricConfig(dedicatedExecutor))
-            .build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, dedicatedExecutor)) {
       NativeMetadataRepositoryStats stats = new NativeMetadataRepositoryStats(disabledRepo, "test", mockClock);
       stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 500);
-      stats.removeCacheTimestamp("store-a");
+      stats.handleStoreDeleted("store-a");
     }
   }
 
@@ -151,7 +142,7 @@ public class NativeMetadataRepositoryStatsOtelTest {
   public void testNoNpeWhenPlainMetricsRepository() {
     NativeMetadataRepositoryStats stats = new NativeMetadataRepositoryStats(new MetricsRepository(), "test", mockClock);
     stats.updateCacheTimestamp("store-a", TEST_CLUSTER_NAME, 500);
-    stats.removeCacheTimestamp("store-a");
+    stats.handleStoreDeleted("store-a");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/NativeMetadataRepositoryStatsTest.java
@@ -25,9 +25,9 @@ public class NativeMetadataRepositoryStatsTest {
     doReturn(1500L).when(mockClock).millis();
     stats.updateCacheTimestamp(store1, "test-cluster", 1100);
     Assert.assertEquals(stats.getMetadataStalenessHighWatermarkMs(), 500d);
-    stats.removeCacheTimestamp(store2);
+    stats.handleStoreDeleted(store2);
     Assert.assertEquals(stats.getMetadataStalenessHighWatermarkMs(), 400d);
-    stats.removeCacheTimestamp(store1);
+    stats.handleStoreDeleted(store1);
     Assert.assertEquals(stats.getMetadataStalenessHighWatermarkMs(), Double.NaN);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStateTransitionStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStateTransitionStatsOtelTest.java
@@ -16,16 +16,15 @@ import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENIC
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceHelixSteadyState;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
 import java.util.Collection;
@@ -54,13 +53,11 @@ public class ParticipantStateTransitionStatsOtelTest {
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
     asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    metricsRepository = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
-            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
-            .build());
+    metricsRepository = MetricsRepositoryUtils.createOtelEnabledRepository(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        inMemoryMetricReader,
+        asyncGaugeExecutor);
     executor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
     stats = new ParticipantStateTransitionStats(metricsRepository, executor, TEST_POOL_NAME);
   }
@@ -224,11 +221,8 @@ public class ParticipantStateTransitionStatsOtelTest {
   @Test
   public void testNoNpeWhenOtelDisabled() {
     AsyncGauge.AsyncGaugeExecutor dedicatedExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setEmitOtelMetrics(false)
-            .setTehutiMetricConfig(new MetricConfig(dedicatedExecutor))
-            .build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, dedicatedExecutor)) {
       exerciseAllRecordingPaths(disabledRepo);
     }
   }
@@ -265,5 +259,43 @@ public class ParticipantStateTransitionStatsOtelTest {
         .put(VENICE_THREAD_POOL_NAME.getDimensionNameInDefaultFormat(), TEST_POOL_NAME)
         .put(VENICE_HELIX_STATE.getDimensionNameInDefaultFormat(), state.toLowerCase())
         .build();
+  }
+
+  // --- Lifecycle test ---
+
+  @Test
+  public void testCloseIsIdempotentAndPostCloseRecordIsNoOp() {
+    // Record once so the in-progress wrapper is created on the SDK side, then close.
+    stats.trackStateTransitionStarted(OFFLINE_STATE, STANDBY_STATE);
+    stats.trackStateTransitionCompleted(OFFLINE_STATE, STANDBY_STATE);
+
+    // Snapshot the data point count for IN_PROGRESS_COUNT prior to close — used to assert no
+    // emission after close.
+    Collection<MetricData> beforeClose = inMemoryMetricReader.collectAllMetrics();
+
+    // close() releases parent ThreadPoolStats resources via try-finally and the subclass's own
+    // CompositeCloseable. A second close() must be a silent no-op (idempotency via CompositeCloseable).
+    stats.close();
+    stats.close();
+
+    // After close, recording is a defined no-op — must not throw and must not emit new OTel data.
+    stats.trackStateTransitionStarted(OFFLINE_STATE, STANDBY_STATE);
+    Collection<MetricData> afterClose = inMemoryMetricReader.collectAllMetrics();
+
+    // Post-close in-progress recording must not have produced an additional data point.
+    long afterIncrement = afterClose.stream()
+        .filter(md -> md.getName().contains(IN_PROGRESS_COUNT.getMetricEntity().getMetricName()))
+        .flatMap(md -> md.getLongSumData().getPoints().stream())
+        .mapToLong(LongPointData::getValue)
+        .sum();
+    long beforeIncrement = beforeClose.stream()
+        .filter(md -> md.getName().contains(IN_PROGRESS_COUNT.getMetricEntity().getMetricName()))
+        .flatMap(md -> md.getLongSumData().getPoints().stream())
+        .mapToLong(LongPointData::getValue)
+        .sum();
+    assertEquals(
+        afterIncrement,
+        beforeIncrement,
+        "Post-close trackStateTransitionStarted must not emit new OTel data points");
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStoreConsumptionStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ParticipantStoreConsumptionStatsTest.java
@@ -121,21 +121,22 @@ public class ParticipantStoreConsumptionStatsTest {
   }
 
   /**
-   * When OTel is enabled, empty store names are rejected by Venice's dimension validation in
-   * {@link com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository}.
-   * Callers must sanitize to {@link com.linkedin.venice.stats.OpenTelemetryMetricsSetup#UNKNOWN_STORE_NAME}
-   * before passing to recording methods.
+   * Empty store names are sanitized to {@link com.linkedin.venice.stats.OpenTelemetryMetricsSetup#UNKNOWN_STORE_NAME}
+   * by the shared {@code buildStoreDimensionsMap} helper, so the recording succeeds and emits under the sentinel
+   * rather than failing dimension validation.
    */
-  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Dimension value cannot be null or empty.*")
-  public void testRecordWithEmptyStoreNameThrowsWhenOtelEnabled() {
+  @Test
+  public void testRecordWithEmptyStoreNameSanitizesToUnknown() {
     stats.recordKillPushJobFailedConsumption("");
+
+    validateCounter(OTEL_FAILED_CONSUMPTION, 1, buildStoreOnlyAttributes(UNKNOWN_STORE_NAME));
   }
 
   /** When OTel is disabled, recording methods tolerate empty store names because dimension validation is skipped. */
   @Test
   public void testRecordWithEmptyStoreNameSafeWhenOtelDisabled() {
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, null)) {
       ParticipantStoreConsumptionStats safeStats =
           new ParticipantStoreConsumptionStats(disabledRepo, TEST_CLUSTER_NAME);
       safeStats.recordKillPushJobFailedConsumption("");
@@ -329,8 +330,8 @@ public class ParticipantStoreConsumptionStatsTest {
 
   @Test
   public void testNoNpeWhenOtelDisabled() {
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, null)) {
       assertAllMethodsSafe(disabledRepo);
     }
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/RocksDBMemoryStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/RocksDBMemoryStatsOtelTest.java
@@ -36,12 +36,18 @@ public class RocksDBMemoryStatsOtelTest {
   private InMemoryMetricReader inMemoryMetricReader;
   private VeniceMetricsRepository metricsRepository;
   private Attributes expectedAttributes;
+  private AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor;
 
   @BeforeMethod
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
-    metricsRepository = MetricsRepositoryUtils
-        .createOtelEnabledRepository(TEST_METRIC_PREFIX, SERVER_METRIC_ENTITIES, inMemoryMetricReader, null);
+    // Dedicated executor so tearDown()'s close() doesn't shut down Tehuti's JVM-wide static singleton.
+    asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
+    metricsRepository = MetricsRepositoryUtils.createOtelEnabledRepository(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        inMemoryMetricReader,
+        asyncGaugeExecutor);
     expectedAttributes =
         Attributes.builder().put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME).build();
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/RocksDBMemoryStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/RocksDBMemoryStatsOtelTest.java
@@ -9,6 +9,7 @@ import static org.testng.Assert.assertTrue;
 import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.tehuti.metrics.MetricConfig;
@@ -39,12 +40,8 @@ public class RocksDBMemoryStatsOtelTest {
   @BeforeMethod
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
-    metricsRepository = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
-            .build());
+    metricsRepository = MetricsRepositoryUtils
+        .createOtelEnabledRepository(TEST_METRIC_PREFIX, SERVER_METRIC_ENTITIES, inMemoryMetricReader, null);
     expectedAttributes =
         Attributes.builder().put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME).build();
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetadataServiceStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetadataServiceStatsOtelTest.java
@@ -130,8 +130,8 @@ public class ServerMetadataServiceStatsOtelTest {
 
   @Test
   public void testNoNpeWhenOtelDisabled() {
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, null)) {
       assertAllMethodsSafeWithRepo(disabledRepo);
     }
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StorageEngineOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StorageEngineOtelStatsTest.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceRecordType;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -351,11 +352,8 @@ public class StorageEngineOtelStatsTest {
 
   @Test
   public void testNoNpeWhenOtelDisabled() {
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(false)
-            .build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(METRIC_PREFIX, null)) {
       exerciseAllRecordingPaths(disabledRepo);
     }
   }
@@ -363,6 +361,38 @@ public class StorageEngineOtelStatsTest {
   @Test
   public void testNoNpeWhenPlainMetricsRepository() {
     exerciseAllRecordingPaths(new MetricsRepository());
+  }
+
+  @Test
+  public void testCloseDeregistersAsyncGaugesAndDropsDataPoints() {
+    AggVersionedStorageEngineStats.StorageEngineStatsWrapper wrapper = new MockWrapper(1000, 200, 50);
+    stats.setStatsWrapper(1, wrapper);
+
+    // Sanity: data points emit pre-close.
+    OpenTelemetryDataTestUtils.validateLongPointDataFromGauge(
+        inMemoryMetricReader,
+        1000,
+        buildDiskUsageAttributes(VersionRole.CURRENT, VeniceRecordType.DATA),
+        DISK_USAGE_METRIC,
+        METRIC_PREFIX);
+
+    stats.close();
+
+    // After close: SDK callbacks deregistered → no data point for either async gauge.
+    assertNull(
+        OpenTelemetryDataTestUtils.getLongPointDataFromGaugeIfPresent(
+            inMemoryMetricReader.collectAllMetrics(),
+            DISK_USAGE_METRIC,
+            METRIC_PREFIX,
+            buildDiskUsageAttributes(VersionRole.CURRENT, VeniceRecordType.DATA)),
+        "Disk usage gauge should be deregistered after close()");
+    assertNull(
+        OpenTelemetryDataTestUtils.getLongPointDataFromGaugeIfPresent(
+            inMemoryMetricReader.collectAllMetrics(),
+            KEY_COUNT_METRIC,
+            METRIC_PREFIX,
+            buildVersionRoleAttributes(VersionRole.CURRENT)),
+        "Key count gauge should be deregistered after close()");
   }
 
   // --- Helper methods ---

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StoreBufferServiceStatsOtelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StoreBufferServiceStatsOtelTest.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
 import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.tehuti.Metric;
@@ -38,13 +39,11 @@ public class StoreBufferServiceStatsOtelTest {
   public void setUp() throws IOException {
     inMemoryMetricReader = InMemoryMetricReader.create();
     asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    metricsRepository = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
-            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
-            .build());
+    metricsRepository = MetricsRepositoryUtils.createOtelEnabledRepository(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        inMemoryMetricReader,
+        asyncGaugeExecutor);
   }
 
   @AfterMethod

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StoreVersionOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StoreVersionOtelStatsTest.java
@@ -19,12 +19,11 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.server.VersionRole;
-import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
 import java.util.Arrays;
@@ -54,13 +53,11 @@ public class StoreVersionOtelStatsTest {
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
     asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    metricsRepository = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
-            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
-            .build());
+    metricsRepository = MetricsRepositoryUtils.createOtelEnabledRepository(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        inMemoryMetricReader,
+        asyncGaugeExecutor);
     stats = new StoreVersionOtelStats(metricsRepository, TEST_CLUSTER_NAME);
   }
 
@@ -111,17 +108,20 @@ public class StoreVersionOtelStatsTest {
   }
 
   @Test
-  public void testStoreDeletedResetsToNonExistingVersion() {
+  public void testStoreDeletedResetsToNonExisting() {
     Store store = createMockStore(TEST_STORE_NAME, 5, createVersion(5, VersionStatus.ONLINE));
     stats.handleStoreChanged(store);
     validateGauge(5, TEST_STORE_NAME, VersionRole.CURRENT);
 
-    // Deletion resets versions to NON_EXISTING_VERSION (state kept for callback reuse)
+    // Deletion resets the AtomicReference to NON_EXISTING. The ASYNC_GAUGE callback keeps polling
+    // but emits NON_EXISTING_VERSION so dashboards can filter deleted stores. The per-store map
+    // entry is intentionally NOT removed — see Javadoc on handleStoreDeleted.
     stats.handleStoreDeleted(TEST_STORE_NAME);
     validateGauge(NON_EXISTING_VERSION, TEST_STORE_NAME, VersionRole.CURRENT);
     validateGauge(NON_EXISTING_VERSION, TEST_STORE_NAME, VersionRole.FUTURE);
 
-    // Re-creation reuses the existing callback — no duplicate registration
+    // A subsequent store change repopulates the same AtomicReference; the original callback
+    // observes the new value, so re-creation works without registering a fresh callback.
     Store reCreated = createMockStore(TEST_STORE_NAME, 8, createVersion(8, VersionStatus.ONLINE));
     stats.handleStoreChanged(reCreated);
     validateGauge(8, TEST_STORE_NAME, VersionRole.CURRENT);
@@ -130,11 +130,8 @@ public class StoreVersionOtelStatsTest {
   @Test
   public void testNoNpeWhenOtelDisabled() {
     AsyncGauge.AsyncGaugeExecutor dedicatedExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setEmitOtelMetrics(false)
-            .setTehutiMetricConfig(new MetricConfig(dedicatedExecutor))
-            .build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, dedicatedExecutor)) {
       StoreVersionOtelStats disabledStats = new StoreVersionOtelStats(disabledRepo, TEST_CLUSTER_NAME);
       Store store = createMockStore(TEST_STORE_NAME, 1, createVersion(1, VersionStatus.ONLINE));
       disabledStats.handleStoreChanged(store);
@@ -300,11 +297,8 @@ public class StoreVersionOtelStatsTest {
     // When OTel is disabled, registering the listener would only add no-op dispatch overhead
     // for every store create/change/delete event. Verify the optimization holds.
     AsyncGauge.AsyncGaugeExecutor dedicatedExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setEmitOtelMetrics(false)
-            .setTehutiMetricConfig(new MetricConfig(dedicatedExecutor))
-            .build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, dedicatedExecutor)) {
       ReadOnlyStoreRepository mockRepo = mock(ReadOnlyStoreRepository.class);
       StoreVersionOtelStats.create(disabledRepo, TEST_CLUSTER_NAME, mockRepo);
       verify(mockRepo, never()).registerStoreDataChangedListener(any());
@@ -332,11 +326,8 @@ public class StoreVersionOtelStatsTest {
     // When OTel is disabled, register() never registered the listener, so close() must not
     // call unregisterStoreDataChangedListener.
     AsyncGauge.AsyncGaugeExecutor dedicatedExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setEmitOtelMetrics(false)
-            .setTehutiMetricConfig(new MetricConfig(dedicatedExecutor))
-            .build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, dedicatedExecutor)) {
       ReadOnlyStoreRepository mockRepo = mock(ReadOnlyStoreRepository.class);
       StoreVersionOtelStats created = StoreVersionOtelStats.create(disabledRepo, TEST_CLUSTER_NAME, mockRepo);
       created.close();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StuckConsumerRepairStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/StuckConsumerRepairStatsTest.java
@@ -5,12 +5,11 @@ import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENIC
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
 import org.testng.annotations.AfterMethod;
@@ -34,13 +33,11 @@ public class StuckConsumerRepairStatsTest {
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
     asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    metricsRepository = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
-            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
-            .build());
+    metricsRepository = MetricsRepositoryUtils.createOtelEnabledRepository(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        inMemoryMetricReader,
+        asyncGaugeExecutor);
     stats = new StuckConsumerRepairStats(metricsRepository, TEST_CLUSTER_NAME);
   }
 
@@ -120,11 +117,8 @@ public class StuckConsumerRepairStatsTest {
   @Test
   public void testNoNpeWhenOtelDisabled() {
     AsyncGauge.AsyncGaugeExecutor localExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setEmitOtelMetrics(false)
-            .setTehutiMetricConfig(new MetricConfig(localExecutor))
-            .build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, localExecutor)) {
       exerciseAllRecordingPaths(disabledRepo);
     }
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/RecordLevelDelayOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/RecordLevelDelayOtelStatsTest.java
@@ -484,14 +484,16 @@ public class RecordLevelDelayOtelStatsTest {
   }
 
   /**
-   * Verifies that close() clears the per-region metric state and that recording
-   * after close() re-creates metric state and continues to work.
+   * Verifies that {@code close()} is final: pre-close recordings emit but any post-close
+   * recording is silently dropped (the per-region wrappers register with the closed
+   * {@code CompositeCloseable} and are immediately retired). Version info is retained — only
+   * wrapper resources are released.
    */
   @Test
-  public void testCloseAndReuse() {
+  public void testCloseDropsPostCloseRecordings() {
     recordLevelDelayOtelStats.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
 
-    // Record a metric, then close
+    // Pre-close recording emits.
     recordWithDefaultLabels(
         recordLevelDelayOtelStats,
         CURRENT_VERSION,
@@ -501,11 +503,11 @@ public class RecordLevelDelayOtelStatsTest {
         100L);
     recordLevelDelayOtelStats.close();
 
-    // Version info should still be intact (close only clears metric state, not version info)
+    // Version info survives close (only metric wrappers are released).
     assertEquals(recordLevelDelayOtelStats.getVersionInfo().getCurrentVersion(), CURRENT_VERSION);
     assertEquals(recordLevelDelayOtelStats.getVersionInfo().getFutureVersion(), FUTURE_VERSION);
 
-    // Recording after close should re-create metric state and work
+    // Post-close recording is silently dropped.
     recordWithDefaultLabels(
         recordLevelDelayOtelStats,
         CURRENT_VERSION,
@@ -514,17 +516,16 @@ public class RecordLevelDelayOtelStatsTest {
         ReplicaState.READY_TO_SERVE,
         200L);
 
-    // The histogram should have both the pre-close and post-close values since OTel
-    // accumulates across the metric reader's collection cycle
+    // Histogram reflects only the pre-close value.
     validateRecordMetric(
         REGION_US_WEST,
         VersionRole.CURRENT,
         ReplicaType.LEADER,
         ReplicaState.READY_TO_SERVE,
         100.0,
-        200.0,
-        300.0,
-        2);
+        100.0,
+        100.0,
+        1);
   }
 
   // ==================================================================================

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.meta.RetryManager;
 import com.linkedin.venice.read.RequestType;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.utils.BatchGetConfigUtils;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.ExceptionUtils;
@@ -60,6 +61,8 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
   private final RetryManager multiKeyLongTailRetryManager;
   private final TreeMap<Integer, Integer> batchGetLongTailRetryThresholdMap;
   private final TreeMap<Integer, Integer> computeLongTailRetryThresholdMap;
+  /** Closeable resources owned by this class; drained by {@link #close()}. */
+  private final CompositeCloseable statsCloseables = new CompositeCloseable();
 
   public RetriableAvroGenericStoreClient(
       InternalAvroStoreClient<K, V> delegate,
@@ -70,23 +73,25 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
         clientConfig.getLongTailRetryThresholdForSingleGetInMicroSeconds();
     this.timeoutProcessor = timeoutProcessor;
 
-    this.singleKeyLongTailRetryManager = new RetryManager(
-        clientConfig.getClusterStats().getMetricsRepository(),
-        SINGLE_KEY_LONG_TAIL_RETRY_STATS_PREFIX + clientConfig.getStoreName(),
-        clientConfig.getLongTailRetryBudgetEnforcementWindowInMs(),
-        clientConfig.getRetryBudgetPercentage(),
-        retryManagerExecutorService,
-        clientConfig.getStoreName(),
-        RequestType.SINGLE_GET);
+    this.singleKeyLongTailRetryManager = statsCloseables.register(
+        new RetryManager(
+            clientConfig.getClusterStats().getMetricsRepository(),
+            SINGLE_KEY_LONG_TAIL_RETRY_STATS_PREFIX + clientConfig.getStoreName(),
+            clientConfig.getLongTailRetryBudgetEnforcementWindowInMs(),
+            clientConfig.getRetryBudgetPercentage(),
+            retryManagerExecutorService,
+            clientConfig.getStoreName(),
+            RequestType.SINGLE_GET));
 
-    this.multiKeyLongTailRetryManager = new RetryManager(
-        clientConfig.getClusterStats().getMetricsRepository(),
-        MULTI_KEY_LONG_TAIL_RETRY_STATS_PREFIX + clientConfig.getStoreName(),
-        clientConfig.getLongTailRetryBudgetEnforcementWindowInMs(),
-        clientConfig.getRetryBudgetPercentage(),
-        retryManagerExecutorService,
-        clientConfig.getStoreName(),
-        RequestType.MULTI_GET);
+    this.multiKeyLongTailRetryManager = statsCloseables.register(
+        new RetryManager(
+            clientConfig.getClusterStats().getMetricsRepository(),
+            MULTI_KEY_LONG_TAIL_RETRY_STATS_PREFIX + clientConfig.getStoreName(),
+            clientConfig.getLongTailRetryBudgetEnforcementWindowInMs(),
+            clientConfig.getRetryBudgetPercentage(),
+            retryManagerExecutorService,
+            clientConfig.getStoreName(),
+            RequestType.MULTI_GET));
 
     // Store the fixed threshold for batch get
     this.longTailRetryThresholdForBatchGetInMicroSeconds =
@@ -300,6 +305,7 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
   @Override
   public void close() {
     retryManagerExecutorService.shutdownNow();
+    statsCloseables.close();
     super.close();
   }
 

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -25,6 +25,7 @@ import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.stats.dimensions.HttpResponseStatusCodeCategory;
 import com.linkedin.venice.stats.dimensions.HttpResponseStatusEnum;
 import com.linkedin.venice.stats.dimensions.RejectionReason;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.utils.LatencyUtils;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.tehuti.metrics.MetricsRepository;
@@ -39,6 +40,8 @@ import org.apache.avro.Schema;
  * This class is in charge of all the metric emissions per request.
  */
 public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient<K, V> {
+  /** Stats fields owned by this class; drained by {@link #close()}. */
+  private final CompositeCloseable statsCloseables = new CompositeCloseable();
   private final FastClientStats clientStatsForSingleGet;
   private final FastClientStats clientStatsForStreamingBatchGet;
   private final FastClientStats clientStatsForStreamingCompute;
@@ -48,12 +51,29 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
 
   public StatsAvroGenericStoreClient(InternalAvroStoreClient<K, V> delegate, ClientConfig clientConfig) {
     super(delegate, clientConfig);
-    this.clientStatsForSingleGet = clientConfig.getStats(RequestType.SINGLE_GET);
-    this.clientStatsForStreamingBatchGet = clientConfig.getStats(RequestType.MULTI_GET_STREAMING);
-    this.clientStatsForStreamingCompute = clientConfig.getStats(RequestType.COMPUTE_STREAMING);
-    this.clusterStats = clientConfig.getClusterStats();
+    this.clientStatsForSingleGet = statsCloseables.register(clientConfig.getStats(RequestType.SINGLE_GET));
+    this.clientStatsForStreamingBatchGet =
+        statsCloseables.register(clientConfig.getStats(RequestType.MULTI_GET_STREAMING));
+    this.clientStatsForStreamingCompute =
+        statsCloseables.register(clientConfig.getStats(RequestType.COMPUTE_STREAMING));
+    this.clusterStats = statsCloseables.register(clientConfig.getClusterStats());
     this.metricsRepository = clientConfig.getMetricsRepository();
+    // {@link #clusterRouteStats} is intentionally NOT registered: it is a process-wide singleton retrieved via
+    // {@link ClusterRouteStats#getInstance(String)} and may be shared by other live clients of the same store.
+    // Closing it here would wipe the shared {@code perRouteStatMap} for those clients, causing recording from
+    // their existing {@link ClusterRouteStats.RouteStats} field references to silently no-op. The per-route SDK
+    // instruments leak only at process shutdown, which is acceptable given the singleton's process-lifetime
+    // semantics.
     this.clusterRouteStats = ClusterRouteStats.getInstance(clientConfig.getStoreName());
+  }
+
+  @Override
+  public void close() {
+    try {
+      super.close();
+    } finally {
+      statsCloseables.close();
+    }
   }
 
   @Override

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/AbstractClientRoutingStrategy.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/AbstractClientRoutingStrategy.java
@@ -2,11 +2,12 @@ package com.linkedin.venice.fastclient.meta;
 
 import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
 import com.linkedin.venice.fastclient.RequestContext;
+import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 
 
-public class AbstractClientRoutingStrategy {
+public class AbstractClientRoutingStrategy implements Closeable {
   public String getReplicas(long requestId, int groupId, List<String> replicas) {
     throw new VeniceUnsupportedOperationException("getReplicas");
   }
@@ -27,5 +28,14 @@ public class AbstractClientRoutingStrategy {
   public boolean trackRequest(RequestContext requestContext) {
     // Do nothing by default
     return false;
+  }
+
+  /**
+   * Default no-op close. Subclasses that own {@link Closeable} stats (e.g.
+   * {@link HelixGroupRoutingStrategy#helixGroupStats}) must override to release them.
+   */
+  @Override
+  public void close() {
+    // no-op default
   }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/AbstractStoreMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/AbstractStoreMetadata.java
@@ -63,7 +63,10 @@ public abstract class AbstractStoreMetadata implements StoreMetadata {
   }
 
   public void setRoutingStrategy(ClientRoutingStrategyType strategyType) {
+    AbstractClientRoutingStrategy previous = this.routingStrategy;
     this.routingStrategy = getRoutingStrategy(strategyType);
+    // Close the previous strategy so any Closeable state it owns (e.g. HelixGroupStats) deregisters.
+    Utils.closeQuietlyWithErrorLogged(previous);
     LOGGER.info(
         "Switched to the following routing strategy: {} for store: {} and the new strategy: {}",
         strategyType,
@@ -75,7 +78,9 @@ public abstract class AbstractStoreMetadata implements StoreMetadata {
    * For testing only.
    */
   public void setRoutingStrategy(AbstractClientRoutingStrategy routingStrategy) {
+    AbstractClientRoutingStrategy previous = this.routingStrategy;
     this.routingStrategy = routingStrategy;
+    Utils.closeQuietlyWithErrorLogged(previous);
   }
 
   @Override
@@ -129,6 +134,10 @@ public abstract class AbstractStoreMetadata implements StoreMetadata {
   @Override
   public void close() throws IOException {
     Utils.closeQuietlyWithErrorLogged(instanceHealthMonitor);
+    // Close the routing strategy so any owned stats (e.g. HelixGroupRoutingStrategy.helixGroupStats) deregister
+    // their OTel async callbacks. The default {@link AbstractClientRoutingStrategy#close()} is a no-op for
+    // strategies that don't own Closeable state.
+    Utils.closeQuietlyWithErrorLogged(routingStrategy);
   }
 
   public VeniceCompressor getCompressor(

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/HelixGroupRoutingStrategy.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/HelixGroupRoutingStrategy.java
@@ -5,7 +5,9 @@ import com.linkedin.venice.fastclient.RequestContext;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.stats.routing.HelixGroupStats;
 import com.linkedin.venice.utils.LatencyUtils;
+import com.linkedin.venice.utils.Utils;
 import io.tehuti.metrics.MetricsRepository;
+import java.io.Closeable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -108,5 +110,14 @@ public class HelixGroupRoutingStrategy extends AbstractClientRoutingStrategy {
       helixGroupStats.recordGroupResponseWaitingTime(groupId, LatencyUtils.getElapsedTimeFromNSToMS(startTimeInNS));
     });
     return true;
+  }
+
+  /**
+   * Closes the {@link HelixGroupStats} owned by this routing strategy so its OTel async callbacks deregister.
+   * Called from {@link AbstractStoreMetadata#close()} via the parent's {@link Closeable} contract.
+   */
+  @Override
+  public void close() {
+    Utils.closeQuietlyWithErrorLogged(helixGroupStats);
   }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/ClusterRouteStats.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/ClusterRouteStats.java
@@ -37,6 +37,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
+/**
+ * Process-wide singleton holder of {@link RouteStats} for a given store. Retrieved via
+ * {@link #getInstance(String)} and shared across every {@link com.linkedin.venice.fastclient.StatsAvroGenericStoreClient}
+ * for that store. The per-route map is therefore process-lifetime — it is intentionally never drained by client
+ * close paths, since closing it would wipe the shared map for any other live client of the same store. The
+ * {@link RouteStats#close()} method exists for parity with the wrapper-Closeable contract used elsewhere, but
+ * production callers are expected to leave per-route entries alive for the JVM lifetime; SDK instruments here are
+ * released at process shutdown via {@link com.linkedin.venice.stats.VeniceMetricsRepository#close()}.
+ */
 public class ClusterRouteStats {
   private static final Logger LOGGER = LogManager.getLogger(ClusterRouteStats.class);
 
@@ -144,7 +153,8 @@ public class ClusterRouteStats {
           RouteTehutiMetricName.PENDING_REQUEST_COUNT,
           Arrays.asList(new Avg(), new Max()),
           baseDimensionsMap,
-          baseAttributes);
+          baseAttributes,
+          resources);
 
       // Initialize OpenTelemetry metric for rejection ratio using ROUTE_REQUEST_REJECTION_RATIO
       this.rejectionRatio = MetricEntityStateOneEnum.create(
@@ -154,7 +164,8 @@ public class ClusterRouteStats {
           RouteTehutiMetricName.REJECTION_RATIO,
           Arrays.asList(new Avg(), new Max()),
           baseDimensionsMap,
-          RejectionReason.class);
+          RejectionReason.class,
+          resources);
 
       // Initialize OpenTelemetry metric for healthy request count using ROUTE_CALL_COUNT
       this.healthyRequestCount = MetricEntityStateThreeEnums.create(
@@ -166,7 +177,8 @@ public class ClusterRouteStats {
           baseDimensionsMap,
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
 
       // Initialize OpenTelemetry metric for quota exceeded request count using ROUTE_CALL_COUNT
       this.quotaExceededRequestCount = MetricEntityStateThreeEnums.create(
@@ -178,7 +190,8 @@ public class ClusterRouteStats {
           baseDimensionsMap,
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
 
       // Initialize OpenTelemetry metric for internal server error request count using ROUTE_CALL_COUNT
       this.internalServerErrorRequestCount = MetricEntityStateThreeEnums.create(
@@ -190,7 +203,8 @@ public class ClusterRouteStats {
           baseDimensionsMap,
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
 
       // Initialize OpenTelemetry metric for leaked request count using ROUTE_CALL_COUNT
       this.leakedRequestCount = MetricEntityStateThreeEnums.create(
@@ -202,7 +216,8 @@ public class ClusterRouteStats {
           baseDimensionsMap,
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
 
       // Initialize OpenTelemetry metric for service unavailable request count using ROUTE_CALL_COUNT
       this.serviceUnavailableRequestCount = MetricEntityStateThreeEnums.create(
@@ -214,7 +229,8 @@ public class ClusterRouteStats {
           baseDimensionsMap,
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
 
       // Initialize OpenTelemetry metric for other error request count using ROUTE_CALL_COUNT
       this.otherErrorRequestCount = MetricEntityStateThreeEnums.create(
@@ -226,7 +242,8 @@ public class ClusterRouteStats {
           baseDimensionsMap,
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
 
       // Initialize OpenTelemetry metric for response waiting time using ROUTE_CALL_TIME
       this.responseWaitingTime = MetricEntityStateThreeEnums.create(
@@ -239,7 +256,8 @@ public class ClusterRouteStats {
           baseDimensionsMap,
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
     }
 
     public void recordRequest() {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/ClusterStats.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/ClusterStats.java
@@ -77,7 +77,8 @@ public class ClusterStats extends AbstractVeniceStats {
         ClusterTehutiMetricName.VERSION_UPDATE_FAILURE,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     this.currentVersionNumber = AsyncMetricEntityStateBase.create(
         STORE_VERSION_CURRENT.getMetricEntity(),
@@ -90,7 +91,8 @@ public class ClusterStats extends AbstractVeniceStats {
                 ClusterTehutiMetricName.CURRENT_VERSION.getMetricName())),
         baseDimensionsMap,
         baseAttributes,
-        this.currentVersion::get);
+        this.currentVersion::get,
+        resources);
 
     // Initialize OTel metrics for instance error counts
     this.blockedInstanceErrorCount = MetricEntityStateOneEnum.create(
@@ -100,7 +102,8 @@ public class ClusterStats extends AbstractVeniceStats {
         ClusterTehutiMetricName.BLOCKED_INSTANCE_COUNT,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        InstanceErrorType.class);
+        InstanceErrorType.class,
+        resources);
 
     this.unhealthyInstanceErrorCount = MetricEntityStateOneEnum.create(
         INSTANCE_ERROR_COUNT.getMetricEntity(),
@@ -109,7 +112,8 @@ public class ClusterStats extends AbstractVeniceStats {
         ClusterTehutiMetricName.UNHEALTHY_INSTANCE_COUNT,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        InstanceErrorType.class);
+        InstanceErrorType.class,
+        resources);
 
     this.overloadedInstanceErrorCount = MetricEntityStateOneEnum.create(
         INSTANCE_ERROR_COUNT.getMetricEntity(),
@@ -118,7 +122,8 @@ public class ClusterStats extends AbstractVeniceStats {
         ClusterTehutiMetricName.OVERLOADED_INSTANCE_COUNT,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        InstanceErrorType.class);
+        InstanceErrorType.class,
+        resources);
   }
 
   public void recordBlockedInstanceCount(int count) {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/FastClientStats.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/FastClientStats.java
@@ -114,7 +114,8 @@ public class FastClientStats extends ClientStats {
         FastClientTehutiMetricName.NO_AVAILABLE_REPLICA_REQUEST_COUNT,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        RejectionReason.class);
+        RejectionReason.class,
+        resources);
 
     this.rejectedRequestCountByLoadController = MetricEntityStateOneEnum.create(
         FastClientMetricEntity.REQUEST_REJECTION_COUNT.getMetricEntity(),
@@ -123,7 +124,8 @@ public class FastClientStats extends ClientStats {
         FastClientTehutiMetricName.REJECTED_REQUEST_COUNT_BY_LOAD_CONTROLLER,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        RejectionReason.class);
+        RejectionReason.class,
+        resources);
 
     this.rejectionRatio = MetricEntityStateOneEnum.create(
         FastClientMetricEntity.REQUEST_REJECTION_RATIO.getMetricEntity(),
@@ -132,7 +134,8 @@ public class FastClientStats extends ClientStats {
         FastClientTehutiMetricName.REJECTION_RATIO,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        RejectionReason.class);
+        RejectionReason.class,
+        resources);
 
     this.longTailRetry = MetricEntityStateOneEnum.create(
         RETRY_CALL_COUNT.getMetricEntity(),
@@ -141,7 +144,8 @@ public class FastClientStats extends ClientStats {
         FastClientTehutiMetricName.LONG_TAIL_RETRY_REQUEST,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        RequestRetryType.class);
+        RequestRetryType.class,
+        resources);
     this.errorRetry = MetricEntityStateOneEnum.create(
         RETRY_CALL_COUNT.getMetricEntity(),
         otelRepository,
@@ -149,7 +153,8 @@ public class FastClientStats extends ClientStats {
         FastClientTehutiMetricName.ERROR_RETRY_REQUEST,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        RequestRetryType.class);
+        RequestRetryType.class,
+        resources);
 
     this.retryRequestWin = MetricEntityStateBase.create(
         RETRY_REQUEST_WIN_COUNT.getMetricEntity(),
@@ -158,7 +163,8 @@ public class FastClientStats extends ClientStats {
         FastClientTehutiMetricName.RETRY_REQUEST_WIN,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        getBaseAttributes());
+        getBaseAttributes(),
+        resources);
 
     // OTel: fanout_size (MIN_MAX_COUNT_SUM_AGGREGATIONS) with dimensions: venice.store.name, venice.request.method,
     // venice.request.fanout_type
@@ -169,7 +175,8 @@ public class FastClientStats extends ClientStats {
         FastClientTehutiMetricName.RETRY_FANOUT_SIZE,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        RequestFanoutType.class);
+        RequestFanoutType.class,
+        resources);
 
     this.originalFanoutSize = MetricEntityStateOneEnum.create(
         REQUEST_FANOUT_COUNT.getMetricEntity(),
@@ -178,7 +185,8 @@ public class FastClientStats extends ClientStats {
         FastClientTehutiMetricName.FANOUT_SIZE,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        RequestFanoutType.class);
+        RequestFanoutType.class,
+        resources);
 
     Map<VeniceMetricsDimensions, String> metadataStalenessDims = null;
     Attributes metadataStalenessAttrs = null;
@@ -212,7 +220,8 @@ public class FastClientStats extends ClientStats {
                 FastClientTehutiMetricName.METADATA_STALENESS_HIGH_WATERMARK_MS.getMetricName())),
         metadataStalenessDims,
         metadataStalenessAttrs,
-        () -> this.cacheTimeStampInMs == 0 ? 0 : (System.currentTimeMillis() - this.cacheTimeStampInMs));
+        () -> this.cacheTimeStampInMs == 0 ? 0 : (System.currentTimeMillis() - this.cacheTimeStampInMs),
+        resources);
   }
 
   @Override

--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/PartitionedProducerExecutor.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/PartitionedProducerExecutor.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.producer;
 
 import com.linkedin.venice.stats.ThreadPoolStats;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.ArrayList;
@@ -52,7 +53,7 @@ import org.apache.logging.log4j.Logger;
  *   <li>workerCount>0, callbackThreadCount>0: Full async - parallel workers + callback isolation</li>
  * </ul>
  */
-public class PartitionedProducerExecutor {
+public class PartitionedProducerExecutor extends AbstractStatsCloseable {
   private static final Logger LOGGER = LogManager.getLogger(PartitionedProducerExecutor.class);
 
   /**
@@ -132,7 +133,8 @@ public class PartitionedProducerExecutor {
             new BlockingRejectionHandler(workerName));
 
         if (metricsRepository != null) {
-          new ThreadPoolStats(metricsRepository, workers[i], storeName + "_producer_worker_" + i);
+          statsCloseables
+              .register(new ThreadPoolStats(metricsRepository, workers[i], storeName + "_producer_worker_" + i));
         }
       }
       LOGGER.info(
@@ -158,7 +160,8 @@ public class PartitionedProducerExecutor {
           new BlockingRejectionHandler(callbackPoolName));
 
       if (metricsRepository != null) {
-        new ThreadPoolStats(metricsRepository, callbackExecutor, storeName + "_producer_callback_pool");
+        statsCloseables
+            .register(new ThreadPoolStats(metricsRepository, callbackExecutor, storeName + "_producer_callback_pool"));
       }
       LOGGER.info(
           "Created callback executor for store {} with {} threads and queue capacity {}",
@@ -295,6 +298,9 @@ public class PartitionedProducerExecutor {
     if (callbackExecutor != null) {
       callbackExecutor.shutdown();
     }
+    // Close every ThreadPoolStats registered at construction (3 ASYNC_GAUGE callbacks per pool) so the SDK
+    // stops polling them after the executor is shut down.
+    statsCloseables.close();
   }
 
   /**
@@ -311,6 +317,7 @@ public class PartitionedProducerExecutor {
     if (callbackExecutor != null) {
       callbackExecutor.shutdownNow();
     }
+    statsCloseables.close();
   }
 
   /**

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/BasicClientStats.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/BasicClientStats.java
@@ -174,7 +174,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
           BasicClientTehutiMetricName.HEALTHY_REQUEST,
           Collections.singletonList(healthyRequestRate),
           baseDimensionsMap,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
       unhealthyRequestMetricForDavinciClient = MetricEntityStateOneEnum.create(
           BasicClientMetricEntity.CALL_COUNT_DVC.getMetricEntity(),
           otelRepository,
@@ -182,7 +183,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
           BasicClientTehutiMetricName.UNHEALTHY_REQUEST,
           Collections.singletonList(new OccurrenceRate()),
           baseDimensionsMap,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
 
       // latency
       healthyLatencyMetricForDavinciClient = MetricEntityStateOneEnum.create(
@@ -196,7 +198,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
                   getName(),
                   getFullMetricName(BasicClientTehutiMetricName.HEALTHY_REQUEST_LATENCY.getMetricName()))),
           baseDimensionsMap,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
       unhealthyLatencyMetricForDavinciClient = MetricEntityStateOneEnum.create(
           BasicClientMetricEntity.CALL_TIME_DVC.getMetricEntity(),
           otelRepository,
@@ -208,7 +211,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
                   getName(),
                   getFullMetricName(BasicClientTehutiMetricName.UNHEALTHY_REQUEST_LATENCY.getMetricName()))),
           baseDimensionsMap,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
 
       healthyRequestMetric = null;
       unhealthyRequestMetric = null;
@@ -222,7 +226,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
           BasicClientTehutiMetricName.REQUEST_KEY_COUNT,
           Arrays.asList(requestKeyCountRate, new Avg(), new Max()),
           baseDimensionsMap,
-          baseAttributes);
+          baseAttributes,
+          resources);
       successResponseKeyCount = MetricEntityStateBase.create(
           BasicClientMetricEntity.RESPONSE_KEY_COUNT_DVC.getMetricEntity(),
           otelRepository,
@@ -230,7 +235,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
           BasicClientTehutiMetricName.SUCCESS_REQUEST_KEY_COUNT,
           Arrays.asList(successRequestKeyCountRate, new Avg(), new Max()),
           baseDimensionsMap,
-          baseAttributes);
+          baseAttributes,
+          resources);
     } else {
       healthyRequestMetric = MetricEntityStateThreeEnums.create(
           BasicClientMetricEntity.CALL_COUNT.getMetricEntity(),
@@ -241,7 +247,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
           baseDimensionsMap,
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
       unhealthyRequestMetric = MetricEntityStateThreeEnums.create(
           BasicClientMetricEntity.CALL_COUNT.getMetricEntity(),
           otelRepository,
@@ -251,7 +258,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
           baseDimensionsMap,
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
       // latency
       healthyLatencyMetric = MetricEntityStateFourEnums.create(
           BasicClientMetricEntity.CALL_TIME.getMetricEntity(),
@@ -267,7 +275,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
           VeniceResponseStatusCategory.class,
-          VeniceRequestKeyCountBucket.class);
+          VeniceRequestKeyCountBucket.class,
+          resources);
       unhealthyLatencyMetric = MetricEntityStateFourEnums.create(
           BasicClientMetricEntity.CALL_TIME.getMetricEntity(),
           otelRepository,
@@ -282,7 +291,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
           VeniceResponseStatusCategory.class,
-          VeniceRequestKeyCountBucket.class);
+          VeniceRequestKeyCountBucket.class,
+          resources);
       healthyRequestMetricForDavinciClient = null;
       unhealthyRequestMetricForDavinciClient = null;
       healthyLatencyMetricForDavinciClient = null;
@@ -295,7 +305,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
           BasicClientTehutiMetricName.REQUEST_KEY_COUNT,
           Arrays.asList(requestKeyCountRate, new Avg(), new Max()),
           baseDimensionsMap,
-          baseAttributes);
+          baseAttributes,
+          resources);
       successResponseKeyCount = MetricEntityStateBase.create(
           BasicClientMetricEntity.RESPONSE_KEY_COUNT.getMetricEntity(),
           otelRepository,
@@ -303,7 +314,8 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
           BasicClientTehutiMetricName.SUCCESS_REQUEST_KEY_COUNT,
           Arrays.asList(successRequestKeyCountRate, new Avg(), new Max()),
           baseDimensionsMap,
-          baseAttributes);
+          baseAttributes,
+          resources);
     }
   }
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/ClientStats.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/ClientStats.java
@@ -108,7 +108,8 @@ public class ClientStats extends BasicClientStats {
         ClientTehutiMetricName.REQUEST_RETRY_COUNT,
         Collections.singletonList(requestRetryCountRate),
         baseDimensionsMap,
-        RequestRetryType.class);
+        RequestRetryType.class,
+        resources);
 
     successRequestDuplicateKeyCount = MetricEntityStateOneEnum.create(
         ClientMetricEntity.REQUEST_DUPLICATE_KEY_COUNT.getMetricEntity(),
@@ -117,7 +118,8 @@ public class ClientStats extends BasicClientStats {
         SUCCESS_REQUEST_DUPLICATE_KEY_COUNT,
         Collections.singletonList(new Rate()),
         baseDimensionsMap,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
     /**
      * The time it took to serialize the request, to be sent to the router. This is done in a blocking fashion
      * on the caller's thread.
@@ -129,7 +131,8 @@ public class ClientStats extends BasicClientStats {
         ClientTehutiMetricName.REQUEST_SERIALIZATION_TIME,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     /**
      * The time it took between sending the request to the router and beginning to process the response.
@@ -141,7 +144,8 @@ public class ClientStats extends BasicClientStats {
         ClientTehutiMetricName.REQUEST_SUBMISSION_TO_RESPONSE_HANDLING_TIME,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     /**
      * The total time it took to process the response (deserialization).
@@ -153,7 +157,8 @@ public class ClientStats extends BasicClientStats {
         ClientTehutiMetricName.RESPONSE_DESERIALIZATION_TIME,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     // response decompression time
     responseDecompressionTime = MetricEntityStateBase.create(
@@ -163,7 +168,8 @@ public class ClientStats extends BasicClientStats {
         ClientTehutiMetricName.RESPONSE_DECOMPRESSION_TIME,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     /**
      * Metrics to track the latency of each proportion of results received.
@@ -175,7 +181,8 @@ public class ClientStats extends BasicClientStats {
         ClientTehutiMetricName.RESPONSE_TTFR,
         Collections.singletonList(new Avg()),
         baseDimensionsMap,
-        StreamProgress.class);
+        StreamProgress.class,
+        resources);
     // TT50PR
     batchStreamProgressTimeToReceiveP50thRecord = MetricEntityStateOneEnum.create(
         ClientMetricEntity.RESPONSE_BATCH_STREAM_PROGRESS_TIME.getMetricEntity(),
@@ -184,7 +191,8 @@ public class ClientStats extends BasicClientStats {
         ClientTehutiMetricName.RESPONSE_TT50PR,
         Collections.singletonList(new Avg()),
         baseDimensionsMap,
-        StreamProgress.class);
+        StreamProgress.class,
+        resources);
     // TT90PR
     batchStreamProgressTimeToReceiveP90thRecord = MetricEntityStateOneEnum.create(
         ClientMetricEntity.RESPONSE_BATCH_STREAM_PROGRESS_TIME.getMetricEntity(),
@@ -193,7 +201,8 @@ public class ClientStats extends BasicClientStats {
         ClientTehutiMetricName.RESPONSE_TT90PR,
         Collections.singletonList(new Avg()),
         baseDimensionsMap,
-        StreamProgress.class);
+        StreamProgress.class,
+        resources);
 
     /**
      * Metrics to track the timed-out requests.
@@ -210,7 +219,8 @@ public class ClientStats extends BasicClientStats {
         APP_TIMED_OUT_REQUEST,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     appTimedOutRequestResultRatio = MetricEntityStateBase.create(
         ClientMetricEntity.REQUEST_TIMEOUT_PARTIAL_RESPONSE_RATIO.getMetricEntity(),
@@ -219,7 +229,8 @@ public class ClientStats extends BasicClientStats {
         APP_TIMED_OUT_REQUEST_RESULT_RATIO,
         Arrays.asList(new Avg(), new Min(), new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     clientFutureTimeout = MetricEntityStateBase.create(
         ClientMetricEntity.REQUEST_TIMEOUT_REQUESTED_DURATION.getMetricEntity(),
@@ -228,7 +239,8 @@ public class ClientStats extends BasicClientStats {
         CLIENT_FUTURE_TIMEOUT,
         Arrays.asList(new Avg(), new Min(), new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     /* Metrics relevant to track long tail retry efficacy for batch get*/
     retryKeyCount = MetricEntityStateBase.create(
@@ -238,7 +250,8 @@ public class ClientStats extends BasicClientStats {
         ClientTehutiMetricName.RETRY_REQUEST_KEY_COUNT,
         Arrays.asList(retryRequestKeyCount, new Avg(), new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     retrySuccessKeyCount = MetricEntityStateBase.create(
         ClientMetricEntity.RETRY_RESPONSE_KEY_COUNT.getMetricEntity(),
@@ -247,7 +260,8 @@ public class ClientStats extends BasicClientStats {
         ClientTehutiMetricName.RETRY_REQUEST_SUCCESS_KEY_COUNT,
         Arrays.asList(retryRequestSuccessKeyCount, new Avg(), new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
   }
 
   @Override

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/StatTrackingStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/StatTrackingStoreClient.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.BiFunction;
 import org.apache.avro.Schema;
+import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -113,6 +114,20 @@ public class StatTrackingStoreClient<K, V> extends DelegatingStoreClient<K, V> {
             computeStreamingStats),
         newClusterName,
         LOGGER);
+  }
+
+  @Override
+  public void close() {
+    try {
+      super.close();
+    } finally {
+      IOUtils.closeQuietly(singleGetStats, LOGGER::error);
+      IOUtils.closeQuietly(multiGetStats, LOGGER::error);
+      IOUtils.closeQuietly(multiGetStreamingStats, LOGGER::error);
+      IOUtils.closeQuietly(schemaReaderStats, LOGGER::error);
+      IOUtils.closeQuietly(computeStats, LOGGER::error);
+      IOUtils.closeQuietly(computeStreamingStats, LOGGER::error);
+    }
   }
 
   @Override

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceAggStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceAggStats.java
@@ -73,10 +73,7 @@ public abstract class AbstractVeniceAggStats<T extends AbstractVeniceStats> impl
     return totalStats;
   }
 
-  /**
-   * Closes {@link #totalStats} and every per-store entry in {@link #storeStats}. Subclasses with
-   * additional cleanup should override and call {@code super.close()}.
-   */
+  /** Closes {@link #totalStats} and every per-store entry in {@link #storeStats}. */
   @Override
   public void close() {
     MetricEntityStateUtils.closeQuietly(totalStats);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceAggStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceAggStats.java
@@ -1,11 +1,13 @@
 package com.linkedin.venice.stats;
 
+import com.linkedin.venice.stats.metrics.MetricEntityStateUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
+import java.io.Closeable;
 import java.util.Map;
 
 
-public abstract class AbstractVeniceAggStats<T extends AbstractVeniceStats> {
+public abstract class AbstractVeniceAggStats<T extends AbstractVeniceStats> implements Closeable {
   public final static String STORE_NAME_FOR_TOTAL_STAT = "total";
   protected T totalStats;
   protected final Map<String, T> storeStats = new VeniceConcurrentHashMap<>();
@@ -69,5 +71,16 @@ public abstract class AbstractVeniceAggStats<T extends AbstractVeniceStats> {
 
   public T getTotalStats() {
     return totalStats;
+  }
+
+  /**
+   * Closes {@link #totalStats} and every per-store entry in {@link #storeStats}. Subclasses with
+   * additional cleanup should override and call {@code super.close()}.
+   */
+  @Override
+  public void close() {
+    MetricEntityStateUtils.closeQuietly(totalStats);
+    storeStats.values().forEach(MetricEntityStateUtils::closeQuietly);
+    storeStats.clear();
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceStats.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.stats;
 import static com.linkedin.venice.stats.AbstractVeniceAggStats.STORE_NAME_FOR_TOTAL_STAT;
 
 import com.linkedin.venice.stats.metrics.AsyncMetricEntityState.TehutiSensorRegistrationFunction;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.stats.metrics.MetricEntityState;
 import com.linkedin.venice.stats.metrics.MetricEntityStateBase;
 import com.linkedin.venice.utils.Time;
@@ -20,11 +21,12 @@ import io.tehuti.metrics.stats.Min;
 import io.tehuti.metrics.stats.Percentiles;
 import io.tehuti.metrics.stats.Rate;
 import io.tehuti.metrics.stats.Total;
+import java.io.Closeable;
 import java.util.Map;
 import java.util.function.Supplier;
 
 
-public class AbstractVeniceStats {
+public class AbstractVeniceStats implements Closeable {
   public static final String DELIMITER = "--";
 
   private final MetricsRepository metricsRepository;
@@ -34,6 +36,8 @@ public class AbstractVeniceStats {
   private final boolean isTehutiMetricsEnabled;
   /** A dummy sensor to return when Tehuti metrics are disabled */
   private final Sensor noopSensor;
+  /** Wrappers and other Closeable resources owned by this stats instance; drained by {@link #close()}. */
+  protected final CompositeCloseable resources = new CompositeCloseable();
 
   public AbstractVeniceStats(MetricsRepository metricsRepository, String name) {
     this.metricsRepository = metricsRepository;
@@ -319,5 +323,14 @@ public class AbstractVeniceStats {
 
   protected final MeasurableStat[] avgAndTotal() {
     return new MeasurableStat[] { new Avg(), new Total() };
+  }
+
+  /**
+   * Drains every {@link Closeable} registered into {@link #resources}. Idempotent. Subclasses with
+   * additional cleanup should override and call {@code super.close()}.
+   */
+  @Override
+  public void close() {
+    resources.close();
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceStats.java
@@ -325,10 +325,7 @@ public class AbstractVeniceStats implements Closeable {
     return new MeasurableStat[] { new Avg(), new Total() };
   }
 
-  /**
-   * Drains every {@link Closeable} registered into {@link #resources}. Idempotent. Subclasses with
-   * additional cleanup should override and call {@code super.close()}.
-   */
+  /** Drains every {@link Closeable} registered into {@link #resources}. Idempotent. */
   @Override
   public void close() {
     resources.close();

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/OpenTelemetryMetricsSetup.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/OpenTelemetryMetricsSetup.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.stats;
 
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.stats.dimensions.RequestRetryType;
 import com.linkedin.venice.stats.dimensions.VeniceDimensionInterface;
@@ -30,6 +32,21 @@ public class OpenTelemetryMetricsSetup {
   public static String sanitizeStoreName(String storeName) {
     String trimmed = (storeName == null) ? null : storeName.trim();
     return (trimmed == null || trimmed.isEmpty()) ? UNKNOWN_STORE_NAME : trimmed;
+  }
+
+  /**
+   * Returns a mutable copy of {@code baseDimensionsMap} with the {@code VENICE_STORE_NAME} dimension
+   * set to the sanitized {@code storeName}. Used by per-store stats classes that maintain a
+   * {@code Map<String, ...>} keyed by store name and need to materialise per-store dimensions on
+   * first creation. The returned map is mutable so callers can layer additional per-call
+   * dimensions on top without copying again.
+   */
+  public static Map<VeniceMetricsDimensions, String> buildStoreDimensionsMap(
+      Map<VeniceMetricsDimensions, String> baseDimensionsMap,
+      String storeName) {
+    Map<VeniceMetricsDimensions, String> dims = new HashMap<>(baseDimensionsMap);
+    dims.put(VENICE_STORE_NAME, sanitizeStoreName(storeName));
+    return dims;
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/ThreadPoolStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/ThreadPoolStats.java
@@ -17,6 +17,9 @@ import java.util.concurrent.ThreadPoolExecutor;
 public class ThreadPoolStats extends AbstractVeniceStats {
   private final ThreadPoolExecutor threadPoolExecutor;
 
+  private final AsyncMetricEntityStateBase activeThreadCountMetric;
+  private final AsyncMetricEntityStateBase maxThreadCountMetric;
+  private final AsyncMetricEntityStateBase queueTaskCountMetric;
   private final MetricEntityStateBase queuedTasksCountMetric;
 
   public ThreadPoolStats(MetricsRepository metricsRepository, ThreadPoolExecutor threadPoolExecutor, String name) {
@@ -36,26 +39,29 @@ public class ThreadPoolStats extends AbstractVeniceStats {
         OpenTelemetryMetricsSetup.builder(metricsRepository).setThreadPoolName(name).build();
 
     // OTel async gauges for thread pool metrics
-    AsyncMetricEntityStateBase.create(
+    activeThreadCountMetric = AsyncMetricEntityStateBase.create(
         ThreadPoolOtelMetricEntity.THREAD_POOL_THREAD_ACTIVE_COUNT.getMetricEntity(),
         otelData.getOtelRepository(),
         otelData.getBaseDimensionsMap(),
         otelData.getBaseAttributes(),
-        () -> this.threadPoolExecutor.getActiveCount());
+        () -> this.threadPoolExecutor.getActiveCount(),
+        resources);
 
-    AsyncMetricEntityStateBase.create(
+    maxThreadCountMetric = AsyncMetricEntityStateBase.create(
         ThreadPoolOtelMetricEntity.THREAD_POOL_THREAD_MAX_COUNT.getMetricEntity(),
         otelData.getOtelRepository(),
         otelData.getBaseDimensionsMap(),
         otelData.getBaseAttributes(),
-        () -> this.threadPoolExecutor.getMaximumPoolSize());
+        () -> this.threadPoolExecutor.getMaximumPoolSize(),
+        resources);
 
-    AsyncMetricEntityStateBase.create(
+    queueTaskCountMetric = AsyncMetricEntityStateBase.create(
         ThreadPoolOtelMetricEntity.THREAD_POOL_QUEUE_TASK_COUNT.getMetricEntity(),
         otelData.getOtelRepository(),
         otelData.getBaseDimensionsMap(),
         otelData.getBaseAttributes(),
-        () -> this.threadPoolExecutor.getQueue().size());
+        () -> this.threadPoolExecutor.getQueue().size(),
+        resources);
 
     /**
      * If only registered as Gauge, the metric would show the queue size at the time of the metric collection, which is not
@@ -71,7 +77,8 @@ public class ThreadPoolStats extends AbstractVeniceStats {
         ThreadPoolTehutiMetricNameEnum.QUEUED_TASK_COUNT,
         Arrays.asList(new Avg(), new Max()),
         otelData.getBaseDimensionsMap(),
-        otelData.getBaseAttributes());
+        otelData.getBaseAttributes(),
+        resources);
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceMetricsRepository.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceMetricsRepository.java
@@ -68,9 +68,13 @@ public class VeniceMetricsRepository extends MetricsRepository implements Closea
 
   @Override
   public void close() {
-    super.close();
-    if (openTelemetryMetricsRepository != null) {
-      openTelemetryMetricsRepository.close();
+    try {
+      super.close();
+    } finally {
+      // Shut down OTel even if Tehuti close() throws, so the exporter thread cannot block JVM exit.
+      if (openTelemetryMetricsRepository != null) {
+        openTelemetryMetricsRepository.close();
+      }
     }
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepository.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepository.java
@@ -8,6 +8,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.stats.dimensions.VeniceDimensionInterface;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.stats.metrics.MetricEntity;
 import com.linkedin.venice.stats.metrics.MetricEntityStateGeneric;
 import com.linkedin.venice.stats.metrics.MetricType;
@@ -49,6 +50,7 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import io.opentelemetry.sdk.resources.Resource;
 import io.tehuti.utils.RedundantLogFilter;
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -63,18 +65,20 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
-public class VeniceOpenTelemetryMetricsRepository {
+public class VeniceOpenTelemetryMetricsRepository implements Closeable {
   private static final Logger LOGGER = LogManager.getLogger(VeniceOpenTelemetryMetricsRepository.class);
   public static final RedundantLogFilter REDUNDANT_LOG_FILTER = RedundantLogFilter.getRedundantLogFilter();
   public static final String DEFAULT_METRIC_PREFIX = "venice.";
   /** Custom metric prefix for internal infrastructure counters (yields {@code venice.internal.*}). */
   private static final String INTERNAL_METRIC_PREFIX = "internal";
+  /** Bounded wait for SDK MeterProvider shutdown — long enough for periodic exporters to flush, short enough to not stall JVM exit. */
+  private static final long SHUTDOWN_TIMEOUT_SECONDS = 10;
   private final VeniceMetricsConfig metricsConfig;
 
   /** OpenTelemetry instance: Either created or retrieved from GlobalOpenTelemetry set by the application */
   private final OpenTelemetry openTelemetry;
   /** SdkMeterProvider that is used to create the OpenTelemetry instance */
-  private SdkMeterProvider sdkMeterProvider = null;
+  private volatile SdkMeterProvider sdkMeterProvider = null;
 
   private final boolean emitOpenTelemetryMetrics;
   private final boolean emitTehutiMetrics;
@@ -88,6 +92,12 @@ public class VeniceOpenTelemetryMetricsRepository {
    * dimension for per-metric attribution.
    */
   private MetricEntityStateGeneric recordFailureMetric;
+
+  /**
+   * Owns the lifecycle of internally-bootstrapped metric wrappers (e.g., {@link #recordFailureMetric}).
+   * Closed from {@link #close()} together with the SDK meter provider shutdown.
+   */
+  private final CompositeCloseable resources = new CompositeCloseable();
 
   public VeniceOpenTelemetryMetricsRepository(VeniceMetricsConfig metricsConfig) {
     this.metricsConfig = metricsConfig;
@@ -104,7 +114,7 @@ public class VeniceOpenTelemetryMetricsRepository {
     this.openTelemetry = initializeOpenTelemetry(metricsConfig);
     this.meter = openTelemetry.getMeter(transformMetricName(getMetricPrefix(), metricFormat));
     this.recordFailureMetric = MetricEntityStateGeneric
-        .create(CommonMetricsEntity.METRIC_RECORD_FAILURE.getMetricEntity(), this, Collections.emptyMap());
+        .create(CommonMetricsEntity.METRIC_RECORD_FAILURE.getMetricEntity(), this, Collections.emptyMap(), resources);
   }
 
   /**
@@ -142,7 +152,7 @@ public class VeniceOpenTelemetryMetricsRepository {
       // Create a new Meter with the new prefix
       this.meter = openTelemetry.getMeter(transformMetricName(getMetricPrefix(), metricFormat));
       this.recordFailureMetric = MetricEntityStateGeneric
-          .create(CommonMetricsEntity.METRIC_RECORD_FAILURE.getMetricEntity(), this, Collections.emptyMap());
+          .create(CommonMetricsEntity.METRIC_RECORD_FAILURE.getMetricEntity(), this, Collections.emptyMap(), resources);
     }
     LOGGER.info("Created child VeniceOpenTelemetryMetricsRepository with metric prefix: {}", newMetricPrefix);
   }
@@ -692,10 +702,26 @@ public class VeniceOpenTelemetryMetricsRepository {
     return attributesBuilder.build();
   }
 
+  @Override
   public void close() {
-    if (sdkMeterProvider != null) {
-      sdkMeterProvider.shutdown();
-      sdkMeterProvider = null;
+    try {
+      resources.close();
+    } finally {
+      SdkMeterProvider provider = sdkMeterProvider;
+      if (provider != null) {
+        sdkMeterProvider = null;
+        // shutdown() is async; join with a bounded timeout so exporter failures surface here
+        // rather than racing past in-flight exports.
+        CompletableResultCode shutdownResult = provider.shutdown();
+        shutdownResult.join(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        if (!shutdownResult.isSuccess()) {
+          LOGGER.warn(
+              "OTel SDK MeterProvider shutdown did not complete cleanly within {}s (done={}, success={})",
+              SHUTDOWN_TIMEOUT_SECONDS,
+              shutdownResult.isDone(),
+              shutdownResult.isSuccess());
+        }
+      }
     }
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AbstractStatsCloseable.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AbstractStatsCloseable.java
@@ -1,0 +1,18 @@
+package com.linkedin.venice.stats.metrics;
+
+import java.io.Closeable;
+
+
+/**
+ * Base class for stats holders that own a {@link CompositeCloseable} registry. Subclasses inherit
+ * the {@code statsCloseables} field and a {@link #close()} that drains it. Override {@code close()}
+ * to add extra cleanup; remember to call {@code super.close()} so the registry is drained.
+ */
+public abstract class AbstractStatsCloseable implements Closeable {
+  protected final CompositeCloseable statsCloseables = new CompositeCloseable();
+
+  @Override
+  public void close() {
+    statsCloseables.close();
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityState.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityState.java
@@ -8,6 +8,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.tehuti.metrics.MeasurableStat;
 import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.AsyncGauge;
+import java.io.Closeable;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -42,17 +43,21 @@ import java.util.function.LongSupplier;
  *       different Tehuti sensor.</li>
  * </ul>
  */
-public abstract class AsyncMetricEntityState {
+public abstract class AsyncMetricEntityState implements Closeable {
   private final boolean emitOpenTelemetryMetrics;
   private final boolean emitTehutiMetrics;
   protected final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
   protected final MetricEntity metricEntity;
 
-  /** Otel metric */
-  protected Object otelMetric = null;
-  /** Respective tehuti metric */
-  protected Sensor tehutiSensor = null;
+  /**
+   * The OTel SDK instrument handle. Volatile so that {@link #close()} setting it to {@code null} is
+   * promptly visible to recording threads, and so that recording threads see a consistent snapshot
+   * (read once into a local) when the cast happens.
+   */
+  protected volatile Object otelMetric = null;
+  /** The Tehuti sensor. Volatile for the same reason as {@link #otelMetric}. */
+  protected volatile Sensor tehutiSensor = null;
 
   public AsyncMetricEntityState(
       MetricEntity metricEntity,
@@ -397,5 +402,39 @@ public abstract class AsyncMetricEntityState {
 
   public Object getOtelMetric() {
     return otelMetric;
+  }
+
+  /**
+   * Releases this wrapper's OTel resources. <b>For async wrappers</b> (the OTel instrument is an
+   * {@link AutoCloseable} {@code Observable*Gauge} / {@code Observable*Counter}), this deregisters
+   * the SDK callback so it stops being polled. <b>For sync wrappers</b> ({@code LongCounter},
+   * {@code DoubleHistogram}, {@code LongUpDownCounter}, sync {@code LongGauge}) the SDK-side
+   * instrument and aggregator persist until the MeterProvider is closed; this method only releases
+   * the wrapper-side reference to the SDK instrument and the Tehuti sensor reference. Idempotent.
+   * Best-effort: SDK close exceptions are logged at WARN and swallowed so a misbehaving close
+   * cannot break shutdown.
+   *
+   * <p><b>Behaviour after close:</b> {@code record()} is a silent no-op (both Tehuti and OTel
+   * sides). For {@code ASYNC_COUNTER_FOR_HIGH_PERF_CASES}, any pending un-collected values held in
+   * the per-attribute {@code LongAdder}s are dropped. The Tehuti {@code Sensor} stays registered in
+   * the underlying {@code MetricsRepository}; only the wrapper's reference is released. For sync
+   * counters/histograms, recreating a wrapper for the same {@link MetricEntity} binds to the SDK's
+   * existing aggregator, so values continue to accumulate across close/recreate.
+   *
+   * <p><b>Caller contract:</b> not concurrent-safe with {@code record()} — callers must coordinate
+   * so that close happens after this wrapper is no longer in use. Direct subclasses
+   * (e.g., {@link AsyncMetricEntityStateBase}) may override to also clear cached attribute maps
+   * and other wrapper-side state, calling {@code super.close()} first.
+   */
+  @Override
+  public void close() {
+    // Snapshot the volatile field before the helper call so a second concurrent close() cannot
+    // observe the field non-null in instanceof and then invoke close() on a now-null reference
+    // and emit a misleading "OTel SDK close threw" WARN. Idempotency is preserved: the second
+    // close sees null here and skips the SDK call.
+    Object localInstrument = otelMetric;
+    otelMetric = null;
+    tehutiSensor = null;
+    MetricEntityStateUtils.closeOtelInstrumentQuietly(localInstrument, metricEntity);
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityState.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityState.java
@@ -50,11 +50,7 @@ public abstract class AsyncMetricEntityState implements Closeable {
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
   protected final MetricEntity metricEntity;
 
-  /**
-   * The OTel SDK instrument handle. Volatile so that {@link #close()} setting it to {@code null} is
-   * promptly visible to recording threads, and so that recording threads see a consistent snapshot
-   * (read once into a local) when the cast happens.
-   */
+  /** OTel SDK instrument handle. Volatile so {@link #close()} nulling it is promptly visible to recording threads. */
   protected volatile Object otelMetric = null;
   /** The Tehuti sensor. Volatile for the same reason as {@link #otelMetric}. */
   protected volatile Sensor tehutiSensor = null;
@@ -405,33 +401,15 @@ public abstract class AsyncMetricEntityState implements Closeable {
   }
 
   /**
-   * Releases this wrapper's OTel resources. <b>For async wrappers</b> (the OTel instrument is an
-   * {@link AutoCloseable} {@code Observable*Gauge} / {@code Observable*Counter}), this deregisters
-   * the SDK callback so it stops being polled. <b>For sync wrappers</b> ({@code LongCounter},
-   * {@code DoubleHistogram}, {@code LongUpDownCounter}, sync {@code LongGauge}) the SDK-side
-   * instrument and aggregator persist until the MeterProvider is closed; this method only releases
-   * the wrapper-side reference to the SDK instrument and the Tehuti sensor reference. Idempotent.
-   * Best-effort: SDK close exceptions are logged at WARN and swallowed so a misbehaving close
-   * cannot break shutdown.
-   *
-   * <p><b>Behaviour after close:</b> {@code record()} is a silent no-op (both Tehuti and OTel
-   * sides). For {@code ASYNC_COUNTER_FOR_HIGH_PERF_CASES}, any pending un-collected values held in
-   * the per-attribute {@code LongAdder}s are dropped. The Tehuti {@code Sensor} stays registered in
-   * the underlying {@code MetricsRepository}; only the wrapper's reference is released. For sync
-   * counters/histograms, recreating a wrapper for the same {@link MetricEntity} binds to the SDK's
-   * existing aggregator, so values continue to accumulate across close/recreate.
-   *
-   * <p><b>Caller contract:</b> not concurrent-safe with {@code record()} — callers must coordinate
-   * so that close happens after this wrapper is no longer in use. Direct subclasses
-   * (e.g., {@link AsyncMetricEntityStateBase}) may override to also clear cached attribute maps
-   * and other wrapper-side state, calling {@code super.close()} first.
+   * Releases this wrapper's OTel resources. For async wrappers this deregisters the SDK callback so
+   * it stops being polled; for sync wrappers it only releases the wrapper-side reference (the SDK
+   * aggregator persists until MeterProvider close). Idempotent and best-effort — SDK close
+   * exceptions are logged at WARN and swallowed. Post-close {@code record()} is a silent no-op.
+   * Not concurrent-safe with {@code record()}; callers must coordinate.
    */
   @Override
   public void close() {
-    // Snapshot the volatile field before the helper call so a second concurrent close() cannot
-    // observe the field non-null in instanceof and then invoke close() on a now-null reference
-    // and emit a misleading "OTel SDK close threw" WARN. Idempotency is preserved: the second
-    // close sees null here and skips the SDK call.
+    // Snapshot before the helper call so a concurrent second close() sees null here and skips.
     Object localInstrument = otelMetric;
     otelMetric = null;
     tehutiSensor = null;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateBase.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateBase.java
@@ -77,12 +77,7 @@ public class AsyncMetricEntityStateBase extends AsyncMetricEntityState {
 
   // --- LongSupplier factory methods (for ASYNC_GAUGE) ---
 
-  /**
-   * Factory method for OTel-only ASYNC_GAUGE with LongSupplier callback.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Factory method for OTel-only ASYNC_GAUGE with LongSupplier callback. */
   public static AsyncMetricEntityStateBase create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -102,12 +97,7 @@ public class AsyncMetricEntityStateBase extends AsyncMetricEntityState {
             asyncCallback));
   }
 
-  /**
-   * Factory method for joint Tehuti+OTel ASYNC_GAUGE with LongSupplier callback.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Factory method for joint Tehuti+OTel ASYNC_GAUGE with LongSupplier callback. */
   public static AsyncMetricEntityStateBase create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -132,12 +122,7 @@ public class AsyncMetricEntityStateBase extends AsyncMetricEntityState {
 
   // --- DoubleSupplier factory methods (for ASYNC_DOUBLE_GAUGE) ---
 
-  /**
-   * Factory method for OTel-only ASYNC_DOUBLE_GAUGE with DoubleSupplier callback.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Factory method for OTel-only ASYNC_DOUBLE_GAUGE with DoubleSupplier callback. */
   public static AsyncMetricEntityStateBase create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -157,12 +142,7 @@ public class AsyncMetricEntityStateBase extends AsyncMetricEntityState {
             asyncDoubleCallback));
   }
 
-  /**
-   * Factory method for joint Tehuti+OTel ASYNC_DOUBLE_GAUGE with DoubleSupplier callback.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Factory method for joint Tehuti+OTel ASYNC_DOUBLE_GAUGE with DoubleSupplier callback. */
   public static AsyncMetricEntityStateBase create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateBase.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateBase.java
@@ -71,31 +71,43 @@ public class AsyncMetricEntityStateBase extends AsyncMetricEntityState {
     if (emitOpenTelemetryMetrics()) {
       Validate.notNull(
           baseAttributes,
-          "Base attributes cannot be null for MetricEntityStateBase for metric: " + metricEntity.getMetricName());
+          "Base attributes cannot be null for AsyncMetricEntityStateBase for metric: " + metricEntity.getMetricName());
     }
   }
 
   // --- LongSupplier factory methods (for ASYNC_GAUGE) ---
 
-  /** Factory method for OTel-only ASYNC_GAUGE with LongSupplier callback */
+  /**
+   * Factory method for OTel-only ASYNC_GAUGE with LongSupplier callback.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static AsyncMetricEntityStateBase create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
       Map<VeniceMetricsDimensions, String> baseDimensionsMap,
       Attributes baseAttributes,
-      @Nonnull LongSupplier asyncCallback) {
-    return new AsyncMetricEntityStateBase(
-        metricEntity,
-        otelRepository,
-        null,
-        null,
-        Collections.emptyList(),
-        baseDimensionsMap,
-        baseAttributes,
-        asyncCallback);
+      @Nonnull LongSupplier asyncCallback,
+      CompositeCloseable registry) {
+    return registry.register(
+        new AsyncMetricEntityStateBase(
+            metricEntity,
+            otelRepository,
+            null,
+            null,
+            Collections.emptyList(),
+            baseDimensionsMap,
+            baseAttributes,
+            asyncCallback));
   }
 
-  /** Factory method for joint Tehuti+OTel ASYNC_GAUGE with LongSupplier callback */
+  /**
+   * Factory method for joint Tehuti+OTel ASYNC_GAUGE with LongSupplier callback.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static AsyncMetricEntityStateBase create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -104,39 +116,53 @@ public class AsyncMetricEntityStateBase extends AsyncMetricEntityState {
       List<MeasurableStat> tehutiMetricStats,
       Map<VeniceMetricsDimensions, String> baseDimensionsMap,
       Attributes baseAttributes,
-      @Nonnull LongSupplier asyncCallback) {
-    return new AsyncMetricEntityStateBase(
-        metricEntity,
-        otelRepository,
-        registerTehutiSensorFn,
-        tehutiMetricNameEnum,
-        tehutiMetricStats,
-        baseDimensionsMap,
-        baseAttributes,
-        asyncCallback);
+      @Nonnull LongSupplier asyncCallback,
+      CompositeCloseable registry) {
+    return registry.register(
+        new AsyncMetricEntityStateBase(
+            metricEntity,
+            otelRepository,
+            registerTehutiSensorFn,
+            tehutiMetricNameEnum,
+            tehutiMetricStats,
+            baseDimensionsMap,
+            baseAttributes,
+            asyncCallback));
   }
 
   // --- DoubleSupplier factory methods (for ASYNC_DOUBLE_GAUGE) ---
 
-  /** Factory method for OTel-only ASYNC_DOUBLE_GAUGE with DoubleSupplier callback */
+  /**
+   * Factory method for OTel-only ASYNC_DOUBLE_GAUGE with DoubleSupplier callback.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static AsyncMetricEntityStateBase create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
       Map<VeniceMetricsDimensions, String> baseDimensionsMap,
       Attributes baseAttributes,
-      @Nonnull DoubleSupplier asyncDoubleCallback) {
-    return new AsyncMetricEntityStateBase(
-        metricEntity,
-        otelRepository,
-        null,
-        null,
-        Collections.emptyList(),
-        baseDimensionsMap,
-        baseAttributes,
-        asyncDoubleCallback);
+      @Nonnull DoubleSupplier asyncDoubleCallback,
+      CompositeCloseable registry) {
+    return registry.register(
+        new AsyncMetricEntityStateBase(
+            metricEntity,
+            otelRepository,
+            null,
+            null,
+            Collections.emptyList(),
+            baseDimensionsMap,
+            baseAttributes,
+            asyncDoubleCallback));
   }
 
-  /** Factory method for joint Tehuti+OTel ASYNC_DOUBLE_GAUGE with DoubleSupplier callback */
+  /**
+   * Factory method for joint Tehuti+OTel ASYNC_DOUBLE_GAUGE with DoubleSupplier callback.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static AsyncMetricEntityStateBase create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -145,15 +171,17 @@ public class AsyncMetricEntityStateBase extends AsyncMetricEntityState {
       List<MeasurableStat> tehutiMetricStats,
       Map<VeniceMetricsDimensions, String> baseDimensionsMap,
       Attributes baseAttributes,
-      @Nonnull DoubleSupplier asyncDoubleCallback) {
-    return new AsyncMetricEntityStateBase(
-        metricEntity,
-        otelRepository,
-        registerTehutiSensorFn,
-        tehutiMetricNameEnum,
-        tehutiMetricStats,
-        baseDimensionsMap,
-        baseAttributes,
-        asyncDoubleCallback);
+      @Nonnull DoubleSupplier asyncDoubleCallback,
+      CompositeCloseable registry) {
+    return registry.register(
+        new AsyncMetricEntityStateBase(
+            metricEntity,
+            otelRepository,
+            registerTehutiSensorFn,
+            tehutiMetricNameEnum,
+            tehutiMetricStats,
+            baseDimensionsMap,
+            baseAttributes,
+            asyncDoubleCallback));
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateOneEnum.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateOneEnum.java
@@ -76,8 +76,7 @@ public class AsyncMetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionIn
    *
    * @param <S> the state type returned by {@code liveStateResolver}. Can be any reference type
    *            (wrapper, task, counter, etc.) — the infra never inspects it beyond null-check.
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   * @param registry closes the returned wrapper at shutdown; pass {@link CompositeCloseable#NONE} for tests.
    */
   public static <E extends Enum<E> & VeniceDimensionInterface, S> AsyncMetricEntityStateOneEnum<E> create(
       MetricEntity metricEntity,
@@ -192,17 +191,9 @@ public class AsyncMetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionIn
   }
 
   /**
-   * Deregisters the underlying SDK observable gauge (if registered) and releases the cached
-   * per-enum {@link Attributes} so the wrapper can be GC'd. Idempotent. Best-effort: SDK close
-   * exceptions are logged at WARN and swallowed.
-   *
-   * <p><b>Caller contract:</b> closing this wrapper deregisters the callback for ALL enum values
-   * (the entire multi-emit instrument is retired). Use {@code liveStateResolver} returning
-   * {@code null} for per-combo dormancy; reserve {@code close()} for full retirement of the
-   * wrapper (e.g., process shutdown or removal of the owning per-store/per-version stats class).
-   * Not concurrent-safe with the SDK collection callback in flight; the SDK's {@code close()}
-   * deregisters the callback but does not block in-flight invocations — those use the local
-   * {@code attributesByEnum} captured at registration time, so the field-nulling here is safe.
+   * Deregisters the underlying SDK observable gauge and releases the cached per-enum {@link Attributes}.
+   * Closes the callback for ALL enum values — use {@code liveStateResolver} returning {@code null}
+   * for per-combo dormancy. Idempotent and best-effort.
    */
   @Override
   public void close() {

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateOneEnum.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateOneEnum.java
@@ -6,6 +6,7 @@ import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.metrics.AsyncMetricResolvers.LiveStateResolverOneEnum;
 import com.linkedin.venice.stats.metrics.AsyncMetricResolvers.ValueResolverOneEnum;
 import io.opentelemetry.api.common.Attributes;
+import java.io.Closeable;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.ObjDoubleConsumer;
@@ -36,18 +37,27 @@ import java.util.function.ObjDoubleConsumer;
  * cost is {@code O(|E|)} {@code liveStateResolver} calls plus one {@code measurement.record(...)}
  * per emitted combo.
  */
-public class AsyncMetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionInterface> {
+public class AsyncMetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionInterface> implements Closeable {
   private final boolean emitOpenTelemetryMetrics;
-  /** Precomputed per-enum attributes; {@code null} when OTel is disabled. */
-  private final EnumMap<E, Attributes> attributesByEnum;
-  /** The single SDK instrument; retained so the SDK keeps the callback referenced. */
-  private final Object instrument;
+  private final MetricEntity metricEntity;
+  /**
+   * Precomputed per-enum attributes; {@code null} when OTel is disabled or after {@link #close()}.
+   * Volatile so close()'s nulling is promptly visible.
+   */
+  private volatile EnumMap<E, Attributes> attributesByEnum;
+  /**
+   * The single SDK instrument; retained so the SDK keeps the callback referenced. Nulled by
+   * {@link #close()}. Volatile so close()'s nulling is promptly visible.
+   */
+  private volatile Object instrument;
 
   private AsyncMetricEntityStateOneEnum(
       boolean emitOpenTelemetryMetrics,
+      MetricEntity metricEntity,
       EnumMap<E, Attributes> attributesByEnum,
       Object instrument) {
     this.emitOpenTelemetryMetrics = emitOpenTelemetryMetrics;
+    this.metricEntity = metricEntity;
     this.attributesByEnum = attributesByEnum;
     this.instrument = instrument;
   }
@@ -66,6 +76,8 @@ public class AsyncMetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionIn
    *
    * @param <S> the state type returned by {@code liveStateResolver}. Can be any reference type
    *            (wrapper, task, counter, etc.) — the infra never inspects it beyond null-check.
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
    */
   public static <E extends Enum<E> & VeniceDimensionInterface, S> AsyncMetricEntityStateOneEnum<E> create(
       MetricEntity metricEntity,
@@ -73,7 +85,8 @@ public class AsyncMetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionIn
       Map<VeniceMetricsDimensions, String> baseDimensionsMap,
       Class<E> enumTypeClass,
       LiveStateResolverOneEnum<E, S> liveStateResolver,
-      ValueResolverOneEnum<S, E> valueResolver) {
+      ValueResolverOneEnum<S, E> valueResolver,
+      CompositeCloseable registry) {
     MetricType metricType = metricEntity.getMetricType();
     if (metricType != MetricType.ASYNC_GAUGE && metricType != MetricType.ASYNC_DOUBLE_GAUGE) {
       throw new IllegalArgumentException(
@@ -84,7 +97,7 @@ public class AsyncMetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionIn
     // If OTel is disabled (or no repo supplied), short-circuit
     boolean emitOtel = otelRepository != null && otelRepository.emitOpenTelemetryMetrics();
     if (!emitOtel) {
-      return new AsyncMetricEntityStateOneEnum<>(false, null, null);
+      return registry.register(new AsyncMetricEntityStateOneEnum<>(false, metricEntity, null, null));
     }
 
     /*
@@ -134,7 +147,7 @@ public class AsyncMetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionIn
               (attrs, value) -> measurement.record((long) value, attrs)));
     }
 
-    return new AsyncMetricEntityStateOneEnum<>(true, attributesByEnum, instrument);
+    return registry.register(new AsyncMetricEntityStateOneEnum<>(true, metricEntity, attributesByEnum, instrument));
   }
 
   /**
@@ -176,5 +189,30 @@ public class AsyncMetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionIn
   /** Visible for testing — the underlying SDK instrument handle, or {@code null} if OTel disabled. */
   public Object getInstrument() {
     return instrument;
+  }
+
+  /**
+   * Deregisters the underlying SDK observable gauge (if registered) and releases the cached
+   * per-enum {@link Attributes} so the wrapper can be GC'd. Idempotent. Best-effort: SDK close
+   * exceptions are logged at WARN and swallowed.
+   *
+   * <p><b>Caller contract:</b> closing this wrapper deregisters the callback for ALL enum values
+   * (the entire multi-emit instrument is retired). Use {@code liveStateResolver} returning
+   * {@code null} for per-combo dormancy; reserve {@code close()} for full retirement of the
+   * wrapper (e.g., process shutdown or removal of the owning per-store/per-version stats class).
+   * Not concurrent-safe with the SDK collection callback in flight; the SDK's {@code close()}
+   * deregisters the callback but does not block in-flight invocations — those use the local
+   * {@code attributesByEnum} captured at registration time, so the field-nulling here is safe.
+   */
+  @Override
+  public void close() {
+    // Snapshot the volatile field before the helper call so a second concurrent close() cannot
+    // observe the field non-null in instanceof and then invoke close() on a now-null reference
+    // and emit a misleading "OTel SDK close threw" WARN. Idempotency is preserved: the second
+    // close sees null here and skips the SDK call.
+    Object localInstrument = instrument;
+    instrument = null;
+    attributesByEnum = null;
+    MetricEntityStateUtils.closeOtelInstrumentQuietly(localInstrument, metricEntity);
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateTwoEnums.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateTwoEnums.java
@@ -6,6 +6,7 @@ import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.metrics.AsyncMetricResolvers.LiveStateResolverTwoEnums;
 import com.linkedin.venice.stats.metrics.AsyncMetricResolvers.ValueResolverTwoEnums;
 import io.opentelemetry.api.common.Attributes;
+import java.io.Closeable;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.ObjDoubleConsumer;
@@ -37,18 +38,28 @@ import java.util.function.ObjDoubleConsumer;
  * is {@code O(|E1| × |E2|)} {@code liveStateResolver} calls plus one
  * {@code measurement.record(...)} per emitted pair.
  */
-public class AsyncMetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface> {
+public class AsyncMetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface>
+    implements Closeable {
   private final boolean emitOpenTelemetryMetrics;
-  /** Precomputed per-pair attributes; {@code null} when OTel is disabled. */
-  private final EnumMap<E1, EnumMap<E2, Attributes>> attributesByEnum;
-  /** The single SDK instrument; retained so the SDK keeps the callback referenced. */
-  private final Object instrument;
+  private final MetricEntity metricEntity;
+  /**
+   * Precomputed per-pair attributes; {@code null} when OTel is disabled or after {@link #close()}.
+   * Volatile so close()'s nulling is promptly visible.
+   */
+  private volatile EnumMap<E1, EnumMap<E2, Attributes>> attributesByEnum;
+  /**
+   * The single SDK instrument; retained so the SDK keeps the callback referenced. Nulled by
+   * {@link #close()}. Volatile so close()'s nulling is promptly visible.
+   */
+  private volatile Object instrument;
 
   private AsyncMetricEntityStateTwoEnums(
       boolean emitOpenTelemetryMetrics,
+      MetricEntity metricEntity,
       EnumMap<E1, EnumMap<E2, Attributes>> attributesByEnum,
       Object instrument) {
     this.emitOpenTelemetryMetrics = emitOpenTelemetryMetrics;
+    this.metricEntity = metricEntity;
     this.attributesByEnum = attributesByEnum;
     this.instrument = instrument;
   }
@@ -65,6 +76,8 @@ public class AsyncMetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensio
    *
    * @param <S> the state type returned by {@code liveStateResolver}. Any reference type — the
    *            infra never inspects it beyond null-check.
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
    */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, S> AsyncMetricEntityStateTwoEnums<E1, E2> create(
       MetricEntity metricEntity,
@@ -73,7 +86,8 @@ public class AsyncMetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensio
       Class<E1> enumTypeClass1,
       Class<E2> enumTypeClass2,
       LiveStateResolverTwoEnums<E1, E2, S> liveStateResolver,
-      ValueResolverTwoEnums<S, E1, E2> valueResolver) {
+      ValueResolverTwoEnums<S, E1, E2> valueResolver,
+      CompositeCloseable registry) {
     MetricType metricType = metricEntity.getMetricType();
     if (metricType != MetricType.ASYNC_GAUGE && metricType != MetricType.ASYNC_DOUBLE_GAUGE) {
       throw new IllegalArgumentException(
@@ -84,7 +98,7 @@ public class AsyncMetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensio
     // If OTel is disabled (or no repo supplied), short-circuit
     boolean emitOtel = otelRepository != null && otelRepository.emitOpenTelemetryMetrics();
     if (!emitOtel) {
-      return new AsyncMetricEntityStateTwoEnums<>(false, null, null);
+      return registry.register(new AsyncMetricEntityStateTwoEnums<>(false, metricEntity, null, null));
     }
 
     /*
@@ -140,7 +154,7 @@ public class AsyncMetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensio
               otelRepository,
               (attrs, value) -> measurement.record((long) value, attrs)));
     }
-    return new AsyncMetricEntityStateTwoEnums<>(true, attributesByEnum, instrument);
+    return registry.register(new AsyncMetricEntityStateTwoEnums<>(true, metricEntity, attributesByEnum, instrument));
   }
 
   /**
@@ -186,5 +200,26 @@ public class AsyncMetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensio
   /** Visible for testing — the underlying SDK instrument handle, or {@code null} if OTel disabled. */
   public Object getInstrument() {
     return instrument;
+  }
+
+  /**
+   * Deregisters the underlying SDK observable gauge (if registered) and releases the cached
+   * per-pair {@link Attributes} so the wrapper can be GC'd. Idempotent. Best-effort: SDK close
+   * exceptions are logged at WARN and swallowed.
+   *
+   * <p><b>Caller contract:</b> closing this wrapper deregisters the callback for ALL enum-pair
+   * combinations. Use {@code liveStateResolver} returning {@code null} for per-combo dormancy;
+   * reserve {@code close()} for full retirement of the wrapper.
+   */
+  @Override
+  public void close() {
+    // Snapshot the volatile field before the helper call so a second concurrent close() cannot
+    // observe the field non-null in instanceof and then invoke close() on a now-null reference
+    // and emit a misleading "OTel SDK close threw" WARN. Idempotency is preserved: the second
+    // close sees null here and skips the SDK call.
+    Object localInstrument = instrument;
+    instrument = null;
+    attributesByEnum = null;
+    MetricEntityStateUtils.closeOtelInstrumentQuietly(localInstrument, metricEntity);
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateTwoEnums.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateTwoEnums.java
@@ -76,8 +76,7 @@ public class AsyncMetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensio
    *
    * @param <S> the state type returned by {@code liveStateResolver}. Any reference type — the
    *            infra never inspects it beyond null-check.
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   * @param registry closes the returned wrapper at shutdown; pass {@link CompositeCloseable#NONE} for tests.
    */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, S> AsyncMetricEntityStateTwoEnums<E1, E2> create(
       MetricEntity metricEntity,
@@ -203,20 +202,12 @@ public class AsyncMetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensio
   }
 
   /**
-   * Deregisters the underlying SDK observable gauge (if registered) and releases the cached
-   * per-pair {@link Attributes} so the wrapper can be GC'd. Idempotent. Best-effort: SDK close
-   * exceptions are logged at WARN and swallowed.
-   *
-   * <p><b>Caller contract:</b> closing this wrapper deregisters the callback for ALL enum-pair
-   * combinations. Use {@code liveStateResolver} returning {@code null} for per-combo dormancy;
-   * reserve {@code close()} for full retirement of the wrapper.
+   * Deregisters the underlying SDK observable gauge and releases the cached per-pair {@link Attributes}.
+   * Closes the callback for ALL enum-pair combinations. Idempotent and best-effort.
    */
   @Override
   public void close() {
-    // Snapshot the volatile field before the helper call so a second concurrent close() cannot
-    // observe the field non-null in instanceof and then invoke close() on a now-null reference
-    // and emit a misleading "OTel SDK close threw" WARN. Idempotency is preserved: the second
-    // close sees null here and skips the SDK call.
+    // Snapshot before the helper call so a concurrent second close() sees null here and skips.
     Object localInstrument = instrument;
     instrument = null;
     attributesByEnum = null;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/CompositeCloseable.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/CompositeCloseable.java
@@ -7,33 +7,14 @@ import java.util.List;
 
 
 /**
- * Registry of {@link Closeable} resources owned by a single component. An owner class typically
- * holds one instance as a {@code private final} field and drains it from its shutdown method.
- * Resources register through either:
- * <ul>
- *   <li>the {@code registry} parameter on {@code MetricEntityState*} / {@code AsyncMetricEntityState*}
- *       {@code create()} factories (framework path), or</li>
- *   <li>a direct {@link #register(Closeable)} call (owner-class path; e.g.
- *       {@code statsCloseables.register(new ThreadPoolStats(...))}).</li>
- * </ul>
- *
- * <p>{@link #close()} drains the registry in reverse order of registration. Errors are logged and
- * swallowed by {@link MetricEntityStateUtils#closeQuietly} so a misbehaving wrapper cannot block
- * shutdown. {@link #close()} is idempotent and final: after it returns, subsequent
- * {@link #register(Closeable)} calls close the resource immediately rather than tracking it.
- *
- * <p>{@link #register(Closeable)} and {@link #close()} are safe to call concurrently;
- * registrations are serialised via the internal lock.
- *
- * <p>{@link #NONE} is a no-op sentinel for test or ad-hoc callsites where no lifecycle applies.
- * Production code should always own a real {@link CompositeCloseable}.
+ * Registry of {@link Closeable} resources owned by a single component. {@link #close()} drains in
+ * reverse order via {@link MetricEntityStateUtils#closeQuietly}, is idempotent, and is final:
+ * post-close {@link #register} calls close the resource immediately instead of tracking it.
+ * Both methods are safe to call concurrently. {@link #NONE} is a no-op sentinel for test or
+ * ad-hoc callsites.
  */
 public class CompositeCloseable implements Closeable {
-  /**
-   * No-op sentinel: registers nothing, closes nothing. Test / ad-hoc use only — resources passed
-   * here are not tracked and never closed. Production code should hold a real
-   * {@link CompositeCloseable} (typically a {@code private final} field on the owner class).
-   */
+  /** No-op sentinel: registers nothing, closes nothing. Test / ad-hoc use only. */
   @VisibleForTesting
   public static final CompositeCloseable NONE = new CompositeCloseable() {
     @Override
@@ -50,13 +31,7 @@ public class CompositeCloseable implements Closeable {
   private final List<Closeable> resources = new ArrayList<>();
   private boolean closed = false;
 
-  /**
-   * Registers and returns the resource for fluent assignment.
-   *
-   * <p>If this registry has already been closed, the resource is closed immediately (best-effort)
-   * and the call returns the (now-closed) resource. This prevents post-close registrations from
-   * silently leaking SDK callbacks when shutdown ordering is racy.
-   */
+  /** Registers and returns the resource. Post-close registrations are closed immediately. */
   public <T extends Closeable> T register(T resource) {
     if (resource == null) {
       return null;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/CompositeCloseable.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/CompositeCloseable.java
@@ -1,0 +1,90 @@
+package com.linkedin.venice.stats.metrics;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Registry of {@link Closeable} resources owned by a single component. An owner class typically
+ * holds one instance as a {@code private final} field and drains it from its shutdown method.
+ * Resources register through either:
+ * <ul>
+ *   <li>the {@code registry} parameter on {@code MetricEntityState*} / {@code AsyncMetricEntityState*}
+ *       {@code create()} factories (framework path), or</li>
+ *   <li>a direct {@link #register(Closeable)} call (owner-class path; e.g.
+ *       {@code statsCloseables.register(new ThreadPoolStats(...))}).</li>
+ * </ul>
+ *
+ * <p>{@link #close()} drains the registry in reverse order of registration. Errors are logged and
+ * swallowed by {@link MetricEntityStateUtils#closeQuietly} so a misbehaving wrapper cannot block
+ * shutdown. {@link #close()} is idempotent and final: after it returns, subsequent
+ * {@link #register(Closeable)} calls close the resource immediately rather than tracking it.
+ *
+ * <p>{@link #register(Closeable)} and {@link #close()} are safe to call concurrently;
+ * registrations are serialised via the internal lock.
+ *
+ * <p>{@link #NONE} is a no-op sentinel for test or ad-hoc callsites where no lifecycle applies.
+ * Production code should always own a real {@link CompositeCloseable}.
+ */
+public class CompositeCloseable implements Closeable {
+  /**
+   * No-op sentinel: registers nothing, closes nothing. Test / ad-hoc use only — resources passed
+   * here are not tracked and never closed. Production code should hold a real
+   * {@link CompositeCloseable} (typically a {@code private final} field on the owner class).
+   */
+  @VisibleForTesting
+  public static final CompositeCloseable NONE = new CompositeCloseable() {
+    @Override
+    public <T extends Closeable> T register(T resource) {
+      return resource;
+    }
+
+    @Override
+    public void close() {
+      /* no-op */
+    }
+  };
+
+  private final List<Closeable> resources = new ArrayList<>();
+  private boolean closed = false;
+
+  /**
+   * Registers and returns the resource for fluent assignment.
+   *
+   * <p>If this registry has already been closed, the resource is closed immediately (best-effort)
+   * and the call returns the (now-closed) resource. This prevents post-close registrations from
+   * silently leaking SDK callbacks when shutdown ordering is racy.
+   */
+  public <T extends Closeable> T register(T resource) {
+    if (resource == null) {
+      return null;
+    }
+    synchronized (resources) {
+      if (closed) {
+        MetricEntityStateUtils.closeQuietly(resource);
+        return resource;
+      }
+      resources.add(resource);
+    }
+    return resource;
+  }
+
+  @Override
+  public void close() {
+    Closeable[] snapshot;
+    synchronized (resources) {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      snapshot = resources.toArray(new Closeable[0]);
+      resources.clear();
+    }
+    // Close outside the lock so a slow SDK close doesn't block concurrent register() calls.
+    for (int i = snapshot.length - 1; i >= 0; i--) {
+      MetricEntityStateUtils.closeQuietly(snapshot[i]);
+    }
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityState.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityState.java
@@ -9,11 +9,10 @@ import io.opentelemetry.api.metrics.LongGauge;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import io.tehuti.metrics.MeasurableStat;
+import io.tehuti.metrics.Sensor;
 import java.util.List;
 import java.util.Map;
 import java.util.function.LongSupplier;
-import java.util.function.ObjDoubleConsumer;
-import java.util.function.ObjLongConsumer;
 
 
 /**
@@ -27,9 +26,24 @@ import java.util.function.ObjLongConsumer;
  */
 public abstract class MetricEntityState extends AsyncMetricEntityState {
   private final boolean isObservableCounter;
-  /** define both long and double consumer to avoid unnecessary conversions **/
-  private final ObjDoubleConsumer<MetricAttributesData> otelDoubleRecordingStrategy;
-  private final ObjLongConsumer<MetricAttributesData> otelLongRecordingStrategy;
+  /**
+   * Strategies take the captured OTel instrument as a parameter (rather than reading the
+   * {@code otelMetric} field on every call) so a concurrent {@link #close()} that nulls the field
+   * cannot cause a NPE/CCE inside the lambda. Both long and double variants are defined to avoid
+   * unnecessary conversions.
+   */
+  private final OtelDoubleRecorder otelDoubleRecordingStrategy;
+  private final OtelLongRecorder otelLongRecordingStrategy;
+
+  @FunctionalInterface
+  private interface OtelDoubleRecorder {
+    void record(Object otelInstrument, MetricAttributesData holder, double value);
+  }
+
+  @FunctionalInterface
+  private interface OtelLongRecorder {
+    void record(Object otelInstrument, MetricAttributesData holder, long value);
+  }
 
   public MetricEntityState(
       MetricEntity metricEntity,
@@ -113,41 +127,46 @@ public abstract class MetricEntityState extends AsyncMetricEntityState {
 
   /**
    * Creates the double recording strategy for histogram types that need double precision.
+   * The {@code otelInstrument} parameter is the captured snapshot from {@link #recordOtelMetric}
+   * (read once from the volatile field) so a concurrent {@link #close()} cannot cause an NPE/CCE.
    */
-  private ObjDoubleConsumer<MetricAttributesData> createOtelDoubleRecordingStrategy(MetricType metricType) {
+  private OtelDoubleRecorder createOtelDoubleRecordingStrategy(MetricType metricType) {
     switch (metricType) {
       case HISTOGRAM:
       case MIN_MAX_COUNT_SUM_AGGREGATIONS:
-        return (holder, value) -> ((DoubleHistogram) otelMetric).record(value, holder.getAttributes());
+        return (instrument, holder, value) -> ((DoubleHistogram) instrument).record(value, holder.getAttributes());
       default:
         // For non-histogram types, delegate to long strategy
-        return (holder, value) -> otelLongRecordingStrategy.accept(holder, (long) value);
+        return (instrument, holder, value) -> otelLongRecordingStrategy.record(instrument, holder, (long) value);
     }
   }
 
   /**
    * Creates the long recording strategy for counter/gauge types - avoids unnecessary double conversion.
+   * See {@link #createOtelDoubleRecordingStrategy} for the rationale behind the {@code otelInstrument}
+   * parameter.
    */
-  private ObjLongConsumer<MetricAttributesData> createOtelLongRecordingStrategy(MetricType metricType) {
+  private OtelLongRecorder createOtelLongRecordingStrategy(MetricType metricType) {
     switch (metricType) {
       case ASYNC_COUNTER_FOR_HIGH_PERF_CASES:
-        return (holder, value) -> {
+        return (instrument, holder, value) -> {
           if (value >= 0) {
             holder.add(value);
           }
         };
       case ASYNC_UP_DOWN_COUNTER_FOR_HIGH_PERF_CASES:
-        return (holder, value) -> holder.add(value);
+        return (instrument, holder, value) -> holder.add(value);
       case COUNTER:
-        return (holder, value) -> ((LongCounter) otelMetric).add(value, holder.getAttributes());
+        return (instrument, holder, value) -> ((LongCounter) instrument).add(value, holder.getAttributes());
       case UP_DOWN_COUNTER:
-        return (holder, value) -> ((LongUpDownCounter) otelMetric).add(value, holder.getAttributes());
+        return (instrument, holder, value) -> ((LongUpDownCounter) instrument).add(value, holder.getAttributes());
       case GAUGE:
-        return (holder, value) -> ((LongGauge) otelMetric).set(value, holder.getAttributes());
+        return (instrument, holder, value) -> ((LongGauge) instrument).set(value, holder.getAttributes());
       case HISTOGRAM:
       case MIN_MAX_COUNT_SUM_AGGREGATIONS:
         // Histograms use double, so convert here (rarely called via long path)
-        return (holder, value) -> ((DoubleHistogram) otelMetric).record((double) value, holder.getAttributes());
+        return (instrument, holder, value) -> ((DoubleHistogram) instrument)
+            .record((double) value, holder.getAttributes());
       default:
         throw new IllegalArgumentException("Unsupported metric type: " + metricType);
     }
@@ -156,26 +175,41 @@ public abstract class MetricEntityState extends AsyncMetricEntityState {
   /**
    * Record OTel metrics only. Package-private to prevent external callers from bypassing the unified
    * {@link #record(double, MetricAttributesData)} API, which records to both OTel and Tehuti.
+   *
+   * <p>Reads the volatile {@code otelMetric} field once into a local so the cast inside the strategy
+   * cannot race with {@link #close()} nulling the field.
    */
   void recordOtelMetric(double value, MetricAttributesData holder) {
-    if (otelMetric != null) {
-      otelDoubleRecordingStrategy.accept(holder, value);
+    if (holder == null) {
+      return;
+    }
+    Object localInstrument = otelMetric;
+    if (localInstrument != null) {
+      otelDoubleRecordingStrategy.record(localInstrument, holder, value);
     }
   }
 
   /**
    * Record OTel metrics only. Package-private to prevent external callers from bypassing the unified
    * {@link #record(long, MetricAttributesData)} API, which records to both OTel and Tehuti.
+   *
+   * <p>Reads the volatile {@code otelMetric} field once into a local so the cast inside the strategy
+   * cannot race with {@link #close()} nulling the field.
    */
   void recordOtelMetric(long value, MetricAttributesData holder) {
-    if (otelMetric != null) {
-      otelLongRecordingStrategy.accept(holder, value);
+    if (holder == null) {
+      return;
+    }
+    Object localInstrument = otelMetric;
+    if (localInstrument != null) {
+      otelLongRecordingStrategy.record(localInstrument, holder, value);
     }
   }
 
   void recordTehutiMetric(double value) {
-    if (tehutiSensor != null) {
-      tehutiSensor.record(value);
+    Sensor localSensor = tehutiSensor;
+    if (localSensor != null) {
+      localSensor.record(value);
     }
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityState.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityState.java
@@ -26,12 +26,7 @@ import java.util.function.LongSupplier;
  */
 public abstract class MetricEntityState extends AsyncMetricEntityState {
   private final boolean isObservableCounter;
-  /**
-   * Strategies take the captured OTel instrument as a parameter (rather than reading the
-   * {@code otelMetric} field on every call) so a concurrent {@link #close()} that nulls the field
-   * cannot cause a NPE/CCE inside the lambda. Both long and double variants are defined to avoid
-   * unnecessary conversions.
-   */
+  /** Strategies take the captured OTel instrument as a parameter so a concurrent {@link #close()} cannot NPE the lambda. */
   private final OtelDoubleRecorder otelDoubleRecordingStrategy;
   private final OtelLongRecorder otelLongRecordingStrategy;
 
@@ -127,8 +122,6 @@ public abstract class MetricEntityState extends AsyncMetricEntityState {
 
   /**
    * Creates the double recording strategy for histogram types that need double precision.
-   * The {@code otelInstrument} parameter is the captured snapshot from {@link #recordOtelMetric}
-   * (read once from the volatile field) so a concurrent {@link #close()} cannot cause an NPE/CCE.
    */
   private OtelDoubleRecorder createOtelDoubleRecordingStrategy(MetricType metricType) {
     switch (metricType) {
@@ -143,8 +136,6 @@ public abstract class MetricEntityState extends AsyncMetricEntityState {
 
   /**
    * Creates the long recording strategy for counter/gauge types - avoids unnecessary double conversion.
-   * See {@link #createOtelDoubleRecordingStrategy} for the rationale behind the {@code otelInstrument}
-   * parameter.
    */
   private OtelLongRecorder createOtelLongRecordingStrategy(MetricType metricType) {
     switch (metricType) {
@@ -175,9 +166,6 @@ public abstract class MetricEntityState extends AsyncMetricEntityState {
   /**
    * Record OTel metrics only. Package-private to prevent external callers from bypassing the unified
    * {@link #record(double, MetricAttributesData)} API, which records to both OTel and Tehuti.
-   *
-   * <p>Reads the volatile {@code otelMetric} field once into a local so the cast inside the strategy
-   * cannot race with {@link #close()} nulling the field.
    */
   void recordOtelMetric(double value, MetricAttributesData holder) {
     if (holder == null) {
@@ -192,9 +180,6 @@ public abstract class MetricEntityState extends AsyncMetricEntityState {
   /**
    * Record OTel metrics only. Package-private to prevent external callers from bypassing the unified
    * {@link #record(long, MetricAttributesData)} API, which records to both OTel and Tehuti.
-   *
-   * <p>Reads the volatile {@code otelMetric} field once into a local so the cast inside the strategy
-   * cannot race with {@link #close()} nulling the field.
    */
   void recordOtelMetric(long value, MetricAttributesData holder) {
     if (holder == null) {

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateBase.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateBase.java
@@ -57,16 +57,28 @@ public class MetricEntityStateBase extends MetricEntityState {
     }
   }
 
-  /** Factory method to keep the API consistent with other subclasses like {@link MetricEntityStateOneEnum} */
+  /**
+   * Factory method to keep the API consistent with other subclasses like {@link MetricEntityStateOneEnum}.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static MetricEntityStateBase create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
       Map<VeniceMetricsDimensions, String> baseDimensionsMap,
-      Attributes baseAttributes) {
-    return new MetricEntityStateBase(metricEntity, otelRepository, baseDimensionsMap, baseAttributes);
+      Attributes baseAttributes,
+      CompositeCloseable registry) {
+    return registry
+        .register(new MetricEntityStateBase(metricEntity, otelRepository, baseDimensionsMap, baseAttributes));
   }
 
-  /** Overloaded Factory method for constructor with Tehuti parameters */
+  /**
+   * Overloaded Factory method for constructor with Tehuti parameters.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static MetricEntityStateBase create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -74,15 +86,17 @@ public class MetricEntityStateBase extends MetricEntityState {
       TehutiMetricNameEnum tehutiMetricNameEnum,
       List<MeasurableStat> tehutiMetricStats,
       Map<VeniceMetricsDimensions, String> baseDimensionsMap,
-      Attributes baseAttributes) {
-    return new MetricEntityStateBase(
-        metricEntity,
-        otelRepository,
-        registerTehutiSensorFn,
-        tehutiMetricNameEnum,
-        tehutiMetricStats,
-        baseDimensionsMap,
-        baseAttributes);
+      Attributes baseAttributes,
+      CompositeCloseable registry) {
+    return registry.register(
+        new MetricEntityStateBase(
+            metricEntity,
+            otelRepository,
+            registerTehutiSensorFn,
+            tehutiMetricNameEnum,
+            tehutiMetricStats,
+            baseDimensionsMap,
+            baseAttributes));
   }
 
   public void record(double value) {

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateBase.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateBase.java
@@ -57,12 +57,7 @@ public class MetricEntityStateBase extends MetricEntityState {
     }
   }
 
-  /**
-   * Factory method to keep the API consistent with other subclasses like {@link MetricEntityStateOneEnum}.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Factory method to keep the API consistent with other subclasses like {@link MetricEntityStateOneEnum}. */
   public static MetricEntityStateBase create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -73,12 +68,7 @@ public class MetricEntityStateBase extends MetricEntityState {
         .register(new MetricEntityStateBase(metricEntity, otelRepository, baseDimensionsMap, baseAttributes));
   }
 
-  /**
-   * Overloaded Factory method for constructor with Tehuti parameters.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Overloaded Factory method for constructor with Tehuti parameters. */
   public static MetricEntityStateBase create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateFiveEnums.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateFiveEnums.java
@@ -88,12 +88,7 @@ public class MetricEntityStateFiveEnums<E1 extends Enum<E1> & VeniceDimensionInt
     registerObservableCounterIfNeeded();
   }
 
-  /**
-   * Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E. */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, E3 extends Enum<E3> & VeniceDimensionInterface, E4 extends Enum<E4> & VeniceDimensionInterface, E5 extends Enum<E5> & VeniceDimensionInterface> MetricEntityStateFiveEnums<E1, E2, E3, E4, E5> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -116,12 +111,7 @@ public class MetricEntityStateFiveEnums<E1 extends Enum<E1> & VeniceDimensionInt
             enumTypeClass5));
   }
 
-  /**
-   * Overloaded Factory method for constructor with Tehuti parameters.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Overloaded Factory method for constructor with Tehuti parameters. */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, E3 extends Enum<E3> & VeniceDimensionInterface, E4 extends Enum<E4> & VeniceDimensionInterface, E5 extends Enum<E5> & VeniceDimensionInterface> MetricEntityStateFiveEnums<E1, E2, E3, E4, E5> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateFiveEnums.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateFiveEnums.java
@@ -88,7 +88,12 @@ public class MetricEntityStateFiveEnums<E1 extends Enum<E1> & VeniceDimensionInt
     registerObservableCounterIfNeeded();
   }
 
-  /** Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E */
+  /**
+   * Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, E3 extends Enum<E3> & VeniceDimensionInterface, E4 extends Enum<E4> & VeniceDimensionInterface, E5 extends Enum<E5> & VeniceDimensionInterface> MetricEntityStateFiveEnums<E1, E2, E3, E4, E5> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -97,19 +102,26 @@ public class MetricEntityStateFiveEnums<E1 extends Enum<E1> & VeniceDimensionInt
       Class<E2> enumTypeClass2,
       Class<E3> enumTypeClass3,
       Class<E4> enumTypeClass4,
-      Class<E5> enumTypeClass5) {
-    return new MetricEntityStateFiveEnums<>(
-        metricEntity,
-        otelRepository,
-        baseDimensionsMap,
-        enumTypeClass1,
-        enumTypeClass2,
-        enumTypeClass3,
-        enumTypeClass4,
-        enumTypeClass5);
+      Class<E5> enumTypeClass5,
+      CompositeCloseable registry) {
+    return registry.register(
+        new MetricEntityStateFiveEnums<>(
+            metricEntity,
+            otelRepository,
+            baseDimensionsMap,
+            enumTypeClass1,
+            enumTypeClass2,
+            enumTypeClass3,
+            enumTypeClass4,
+            enumTypeClass5));
   }
 
-  /** Overloaded Factory method for constructor with Tehuti parameters */
+  /**
+   * Overloaded Factory method for constructor with Tehuti parameters.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, E3 extends Enum<E3> & VeniceDimensionInterface, E4 extends Enum<E4> & VeniceDimensionInterface, E5 extends Enum<E5> & VeniceDimensionInterface> MetricEntityStateFiveEnums<E1, E2, E3, E4, E5> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -121,19 +133,21 @@ public class MetricEntityStateFiveEnums<E1 extends Enum<E1> & VeniceDimensionInt
       Class<E2> enumTypeClass2,
       Class<E3> enumTypeClass3,
       Class<E4> enumTypeClass4,
-      Class<E5> enumTypeClass5) {
-    return new MetricEntityStateFiveEnums<>(
-        metricEntity,
-        otelRepository,
-        registerTehutiSensorFn,
-        tehutiMetricNameEnum,
-        tehutiMetricStats,
-        baseDimensionsMap,
-        enumTypeClass1,
-        enumTypeClass2,
-        enumTypeClass3,
-        enumTypeClass4,
-        enumTypeClass5);
+      Class<E5> enumTypeClass5,
+      CompositeCloseable registry) {
+    return registry.register(
+        new MetricEntityStateFiveEnums<>(
+            metricEntity,
+            otelRepository,
+            registerTehutiSensorFn,
+            tehutiMetricNameEnum,
+            tehutiMetricStats,
+            baseDimensionsMap,
+            enumTypeClass1,
+            enumTypeClass2,
+            enumTypeClass3,
+            enumTypeClass4,
+            enumTypeClass5));
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateFourEnums.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateFourEnums.java
@@ -18,6 +18,7 @@ import javax.annotation.Nonnull;
  */
 public class MetricEntityStateFourEnums<E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, E3 extends Enum<E3> & VeniceDimensionInterface, E4 extends Enum<E4> & VeniceDimensionInterface>
     extends MetricEntityState {
+  /** Lazy cache of {@link MetricAttributesData}; nulled in {@link #close()}. */
   private final EnumMap<E1, EnumMap<E2, EnumMap<E3, EnumMap<E4, MetricAttributesData>>>> metricAttributesDataEnumMap;
 
   private final Class<E1> enumTypeClass1;
@@ -82,7 +83,12 @@ public class MetricEntityStateFourEnums<E1 extends Enum<E1> & VeniceDimensionInt
     registerObservableCounterIfNeeded();
   }
 
-  /** Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E */
+  /**
+   * Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, E3 extends Enum<E3> & VeniceDimensionInterface, E4 extends Enum<E4> & VeniceDimensionInterface> MetricEntityStateFourEnums<E1, E2, E3, E4> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -90,18 +96,25 @@ public class MetricEntityStateFourEnums<E1 extends Enum<E1> & VeniceDimensionInt
       Class<E1> enumTypeClass1,
       Class<E2> enumTypeClass2,
       Class<E3> enumTypeClass3,
-      Class<E4> enumTypeClass4) {
-    return new MetricEntityStateFourEnums<>(
-        metricEntity,
-        otelRepository,
-        baseDimensionsMap,
-        enumTypeClass1,
-        enumTypeClass2,
-        enumTypeClass3,
-        enumTypeClass4);
+      Class<E4> enumTypeClass4,
+      CompositeCloseable registry) {
+    return registry.register(
+        new MetricEntityStateFourEnums<>(
+            metricEntity,
+            otelRepository,
+            baseDimensionsMap,
+            enumTypeClass1,
+            enumTypeClass2,
+            enumTypeClass3,
+            enumTypeClass4));
   }
 
-  /** Overloaded Factory method for constructor with Tehuti parameters */
+  /**
+   * Overloaded Factory method for constructor with Tehuti parameters.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, E3 extends Enum<E3> & VeniceDimensionInterface, E4 extends Enum<E4> & VeniceDimensionInterface> MetricEntityStateFourEnums<E1, E2, E3, E4> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -112,18 +125,20 @@ public class MetricEntityStateFourEnums<E1 extends Enum<E1> & VeniceDimensionInt
       Class<E1> enumTypeClass1,
       Class<E2> enumTypeClass2,
       Class<E3> enumTypeClass3,
-      Class<E4> enumTypeClass4) {
-    return new MetricEntityStateFourEnums<>(
-        metricEntity,
-        otelRepository,
-        registerTehutiSensorFn,
-        tehutiMetricNameEnum,
-        tehutiMetricStats,
-        baseDimensionsMap,
-        enumTypeClass1,
-        enumTypeClass2,
-        enumTypeClass3,
-        enumTypeClass4);
+      Class<E4> enumTypeClass4,
+      CompositeCloseable registry) {
+    return registry.register(
+        new MetricEntityStateFourEnums<>(
+            metricEntity,
+            otelRepository,
+            registerTehutiSensorFn,
+            tehutiMetricNameEnum,
+            tehutiMetricStats,
+            baseDimensionsMap,
+            enumTypeClass1,
+            enumTypeClass2,
+            enumTypeClass3,
+            enumTypeClass4));
   }
 
   /**
@@ -150,7 +165,6 @@ public class MetricEntityStateFourEnums<E1 extends Enum<E1> & VeniceDimensionInt
     if (!emitOpenTelemetryMetrics()) {
       return null;
     }
-
     return metricAttributesDataEnumMap.computeIfAbsent(dimension1, k -> {
       validateInputDimension(k);
       return new EnumMap<>(enumTypeClass2);
@@ -195,15 +209,24 @@ public class MetricEntityStateFourEnums<E1 extends Enum<E1> & VeniceDimensionInt
 
   @Override
   protected Iterable<MetricAttributesData> getAllMetricAttributesData() {
-    if (metricAttributesDataEnumMap == null) {
-      return null;
-    }
-
     List<MetricAttributesData> allData = new ArrayList<>();
     for (EnumMap<E2, EnumMap<E3, EnumMap<E4, MetricAttributesData>>> level2Map: metricAttributesDataEnumMap.values()) {
+      if (level2Map == null) {
+        continue;
+      }
       for (EnumMap<E3, EnumMap<E4, MetricAttributesData>> level3Map: level2Map.values()) {
+        if (level3Map == null) {
+          continue;
+        }
         for (EnumMap<E4, MetricAttributesData> level4Map: level3Map.values()) {
-          allData.addAll(level4Map.values());
+          if (level4Map == null) {
+            continue;
+          }
+          for (MetricAttributesData holder: level4Map.values()) {
+            if (holder != null) {
+              allData.add(holder);
+            }
+          }
         }
       }
     }
@@ -214,4 +237,5 @@ public class MetricEntityStateFourEnums<E1 extends Enum<E1> & VeniceDimensionInt
   public EnumMap<E1, EnumMap<E2, EnumMap<E3, EnumMap<E4, MetricAttributesData>>>> getMetricAttributesDataEnumMap() {
     return metricAttributesDataEnumMap;
   }
+
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateFourEnums.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateFourEnums.java
@@ -83,12 +83,7 @@ public class MetricEntityStateFourEnums<E1 extends Enum<E1> & VeniceDimensionInt
     registerObservableCounterIfNeeded();
   }
 
-  /**
-   * Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E. */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, E3 extends Enum<E3> & VeniceDimensionInterface, E4 extends Enum<E4> & VeniceDimensionInterface> MetricEntityStateFourEnums<E1, E2, E3, E4> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -109,12 +104,7 @@ public class MetricEntityStateFourEnums<E1 extends Enum<E1> & VeniceDimensionInt
             enumTypeClass4));
   }
 
-  /**
-   * Overloaded Factory method for constructor with Tehuti parameters.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Overloaded Factory method for constructor with Tehuti parameters. */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, E3 extends Enum<E3> & VeniceDimensionInterface, E4 extends Enum<E4> & VeniceDimensionInterface> MetricEntityStateFourEnums<E1, E2, E3, E4> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateGeneric.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateGeneric.java
@@ -68,12 +68,7 @@ public class MetricEntityStateGeneric extends MetricEntityState {
     }
   }
 
-  /**
-   * Factory method to keep the API consistent with other subclasses like {@link MetricEntityStateOneEnum}.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Factory method to keep the API consistent with other subclasses like {@link MetricEntityStateOneEnum}. */
   public static MetricEntityStateGeneric create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -82,12 +77,7 @@ public class MetricEntityStateGeneric extends MetricEntityState {
     return registry.register(new MetricEntityStateGeneric(metricEntity, otelRepository, baseDimensionsMap));
   }
 
-  /**
-   * Overloaded Factory method for constructor with Tehuti parameters.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Overloaded Factory method for constructor with Tehuti parameters. */
   public static MetricEntityStateGeneric create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateGeneric.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateGeneric.java
@@ -68,29 +68,42 @@ public class MetricEntityStateGeneric extends MetricEntityState {
     }
   }
 
-  /** Factory method to keep the API consistent with other subclasses like {@link MetricEntityStateOneEnum} */
+  /**
+   * Factory method to keep the API consistent with other subclasses like {@link MetricEntityStateOneEnum}.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static MetricEntityStateGeneric create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
-      Map<VeniceMetricsDimensions, String> baseDimensionsMap) {
-    return new MetricEntityStateGeneric(metricEntity, otelRepository, baseDimensionsMap);
+      Map<VeniceMetricsDimensions, String> baseDimensionsMap,
+      CompositeCloseable registry) {
+    return registry.register(new MetricEntityStateGeneric(metricEntity, otelRepository, baseDimensionsMap));
   }
 
-  /** Overloaded Factory method for constructor with Tehuti parameters */
+  /**
+   * Overloaded Factory method for constructor with Tehuti parameters.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static MetricEntityStateGeneric create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
       TehutiSensorRegistrationFunction registerTehutiSensorFn,
       TehutiMetricNameEnum tehutiMetricNameEnum,
       List<MeasurableStat> tehutiMetricStats,
-      Map<VeniceMetricsDimensions, String> baseDimensionsMap) {
-    return new MetricEntityStateGeneric(
-        metricEntity,
-        otelRepository,
-        registerTehutiSensorFn,
-        tehutiMetricNameEnum,
-        tehutiMetricStats,
-        baseDimensionsMap);
+      Map<VeniceMetricsDimensions, String> baseDimensionsMap,
+      CompositeCloseable registry) {
+    return registry.register(
+        new MetricEntityStateGeneric(
+            metricEntity,
+            otelRepository,
+            registerTehutiSensorFn,
+            tehutiMetricNameEnum,
+            tehutiMetricStats,
+            baseDimensionsMap));
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateOneEnum.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateOneEnum.java
@@ -26,6 +26,7 @@ import javax.annotation.Nonnull;
  *
  */
 public class MetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionInterface> extends MetricEntityState {
+  /** Lazy cache of {@link MetricAttributesData}; nulled in {@link #close()}. */
   private final EnumMap<E, MetricAttributesData> metricAttributesDataEnumMap;
   private final Class<E> enumTypeClass;
 
@@ -60,16 +61,28 @@ public class MetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionInterfa
     registerObservableCounterIfNeeded();
   }
 
-  /** Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E */
+  /**
+   * Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static <E extends Enum<E> & VeniceDimensionInterface> MetricEntityStateOneEnum<E> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
       Map<VeniceMetricsDimensions, String> baseDimensionsMap,
-      Class<E> enumTypeClass) {
-    return new MetricEntityStateOneEnum<>(metricEntity, otelRepository, baseDimensionsMap, enumTypeClass);
+      Class<E> enumTypeClass,
+      CompositeCloseable registry) {
+    return registry
+        .register(new MetricEntityStateOneEnum<>(metricEntity, otelRepository, baseDimensionsMap, enumTypeClass));
   }
 
-  /** Overloaded Factory method for constructor with Tehuti parameters */
+  /**
+   * Overloaded Factory method for constructor with Tehuti parameters.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static <E extends Enum<E> & VeniceDimensionInterface> MetricEntityStateOneEnum<E> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -77,15 +90,17 @@ public class MetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionInterfa
       TehutiMetricNameEnum tehutiMetricNameEnum,
       List<MeasurableStat> tehutiMetricStats,
       Map<VeniceMetricsDimensions, String> baseDimensionsMap,
-      Class<E> enumTypeClass) {
-    return new MetricEntityStateOneEnum<>(
-        metricEntity,
-        otelRepository,
-        registerTehutiSensorFn,
-        tehutiMetricNameEnum,
-        tehutiMetricStats,
-        baseDimensionsMap,
-        enumTypeClass);
+      Class<E> enumTypeClass,
+      CompositeCloseable registry) {
+    return registry.register(
+        new MetricEntityStateOneEnum<>(
+            metricEntity,
+            otelRepository,
+            registerTehutiSensorFn,
+            tehutiMetricNameEnum,
+            tehutiMetricStats,
+            baseDimensionsMap,
+            enumTypeClass));
   }
 
   /**
@@ -122,7 +137,6 @@ public class MetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionInterfa
     if (!emitOpenTelemetryMetrics()) {
       return null;
     }
-
     return metricAttributesDataEnumMap.computeIfAbsent(dimension, k -> {
       validateInputDimension(k);
       Attributes attrs = createAttributes(k);
@@ -148,10 +162,13 @@ public class MetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionInterfa
 
   @Override
   protected Iterable<MetricAttributesData> getAllMetricAttributesData() {
-    if (metricAttributesDataEnumMap == null) {
-      return null;
+    List<MetricAttributesData> snapshot = new ArrayList<>(metricAttributesDataEnumMap.size());
+    for (MetricAttributesData holder: metricAttributesDataEnumMap.values()) {
+      if (holder != null) {
+        snapshot.add(holder);
+      }
     }
-    return new ArrayList<>(metricAttributesDataEnumMap.values());
+    return snapshot;
   }
 
   /** visible for testing */

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateOneEnum.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateOneEnum.java
@@ -26,7 +26,7 @@ import javax.annotation.Nonnull;
  *
  */
 public class MetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionInterface> extends MetricEntityState {
-  /** Lazy cache of {@link MetricAttributesData}; nulled in {@link #close()}. */
+  /** Lazy cache of {@link MetricAttributesData}. */
   private final EnumMap<E, MetricAttributesData> metricAttributesDataEnumMap;
   private final Class<E> enumTypeClass;
 
@@ -61,12 +61,7 @@ public class MetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionInterfa
     registerObservableCounterIfNeeded();
   }
 
-  /**
-   * Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E. */
   public static <E extends Enum<E> & VeniceDimensionInterface> MetricEntityStateOneEnum<E> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -77,12 +72,7 @@ public class MetricEntityStateOneEnum<E extends Enum<E> & VeniceDimensionInterfa
         .register(new MetricEntityStateOneEnum<>(metricEntity, otelRepository, baseDimensionsMap, enumTypeClass));
   }
 
-  /**
-   * Overloaded Factory method for constructor with Tehuti parameters.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Overloaded Factory method for constructor with Tehuti parameters. */
   public static <E extends Enum<E> & VeniceDimensionInterface> MetricEntityStateOneEnum<E> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateThreeEnums.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateThreeEnums.java
@@ -72,12 +72,7 @@ public class MetricEntityStateThreeEnums<E1 extends Enum<E1> & VeniceDimensionIn
     registerObservableCounterIfNeeded();
   }
 
-  /**
-   * Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E. */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, E3 extends Enum<E3> & VeniceDimensionInterface> MetricEntityStateThreeEnums<E1, E2, E3> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -96,12 +91,7 @@ public class MetricEntityStateThreeEnums<E1 extends Enum<E1> & VeniceDimensionIn
             enumTypeClass3));
   }
 
-  /**
-   * Overloaded Factory method for constructor with Tehuti parameters.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Overloaded Factory method for constructor with Tehuti parameters. */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, E3 extends Enum<E3> & VeniceDimensionInterface> MetricEntityStateThreeEnums<E1, E2, E3> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateThreeEnums.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateThreeEnums.java
@@ -19,6 +19,7 @@ import javax.annotation.Nonnull;
  */
 public class MetricEntityStateThreeEnums<E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, E3 extends Enum<E3> & VeniceDimensionInterface>
     extends MetricEntityState {
+  /** Lazy cache of {@link MetricAttributesData}; nulled in {@link #close()}. */
   private final EnumMap<E1, EnumMap<E2, EnumMap<E3, MetricAttributesData>>> metricAttributesDataEnumMap;
 
   private final Class<E1> enumTypeClass1;
@@ -71,24 +72,36 @@ public class MetricEntityStateThreeEnums<E1 extends Enum<E1> & VeniceDimensionIn
     registerObservableCounterIfNeeded();
   }
 
-  /** Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E */
+  /**
+   * Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, E3 extends Enum<E3> & VeniceDimensionInterface> MetricEntityStateThreeEnums<E1, E2, E3> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
       Map<VeniceMetricsDimensions, String> baseDimensionsMap,
       Class<E1> enumTypeClass1,
       Class<E2> enumTypeClass2,
-      Class<E3> enumTypeClass3) {
-    return new MetricEntityStateThreeEnums<>(
-        metricEntity,
-        otelRepository,
-        baseDimensionsMap,
-        enumTypeClass1,
-        enumTypeClass2,
-        enumTypeClass3);
+      Class<E3> enumTypeClass3,
+      CompositeCloseable registry) {
+    return registry.register(
+        new MetricEntityStateThreeEnums<>(
+            metricEntity,
+            otelRepository,
+            baseDimensionsMap,
+            enumTypeClass1,
+            enumTypeClass2,
+            enumTypeClass3));
   }
 
-  /** Overloaded Factory method for constructor with Tehuti parameters */
+  /**
+   * Overloaded Factory method for constructor with Tehuti parameters.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface, E3 extends Enum<E3> & VeniceDimensionInterface> MetricEntityStateThreeEnums<E1, E2, E3> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -98,17 +111,19 @@ public class MetricEntityStateThreeEnums<E1 extends Enum<E1> & VeniceDimensionIn
       Map<VeniceMetricsDimensions, String> baseDimensionsMap,
       Class<E1> enumTypeClass1,
       Class<E2> enumTypeClass2,
-      Class<E3> enumTypeClass3) {
-    return new MetricEntityStateThreeEnums<>(
-        metricEntity,
-        otelRepository,
-        registerTehutiSensorFn,
-        tehutiMetricNameEnum,
-        tehutiMetricStats,
-        baseDimensionsMap,
-        enumTypeClass1,
-        enumTypeClass2,
-        enumTypeClass3);
+      Class<E3> enumTypeClass3,
+      CompositeCloseable registry) {
+    return registry.register(
+        new MetricEntityStateThreeEnums<>(
+            metricEntity,
+            otelRepository,
+            registerTehutiSensorFn,
+            tehutiMetricNameEnum,
+            tehutiMetricStats,
+            baseDimensionsMap,
+            enumTypeClass1,
+            enumTypeClass2,
+            enumTypeClass3));
   }
 
   /**
@@ -134,7 +149,6 @@ public class MetricEntityStateThreeEnums<E1 extends Enum<E1> & VeniceDimensionIn
     if (!emitOpenTelemetryMetrics()) {
       return null;
     }
-
     return metricAttributesDataEnumMap.computeIfAbsent(dimension1, k -> {
       validateInputDimension(k);
       return new EnumMap<>(enumTypeClass2);
@@ -175,14 +189,20 @@ public class MetricEntityStateThreeEnums<E1 extends Enum<E1> & VeniceDimensionIn
 
   @Override
   protected Iterable<MetricAttributesData> getAllMetricAttributesData() {
-    if (metricAttributesDataEnumMap == null) {
-      return null;
-    }
-
     List<MetricAttributesData> allData = new ArrayList<>();
     for (EnumMap<E2, EnumMap<E3, MetricAttributesData>> level2Map: metricAttributesDataEnumMap.values()) {
+      if (level2Map == null) {
+        continue;
+      }
       for (EnumMap<E3, MetricAttributesData> level3Map: level2Map.values()) {
-        allData.addAll(level3Map.values());
+        if (level3Map == null) {
+          continue;
+        }
+        for (MetricAttributesData holder: level3Map.values()) {
+          if (holder != null) {
+            allData.add(holder);
+          }
+        }
       }
     }
     return allData;
@@ -192,4 +212,5 @@ public class MetricEntityStateThreeEnums<E1 extends Enum<E1> & VeniceDimensionIn
   public EnumMap<E1, EnumMap<E2, EnumMap<E3, MetricAttributesData>>> getMetricAttributesDataEnumMap() {
     return metricAttributesDataEnumMap;
   }
+
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateTwoEnums.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateTwoEnums.java
@@ -18,6 +18,7 @@ import javax.annotation.Nonnull;
  */
 public class MetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface>
     extends MetricEntityState {
+  /** Lazy cache of {@link MetricAttributesData}; nulled in {@link #close()}. */
   private final EnumMap<E1, EnumMap<E2, MetricAttributesData>> metricAttributesDataEnumMap;
   private final Class<E1> enumTypeClass1;
   private final Class<E2> enumTypeClass2;
@@ -64,22 +65,34 @@ public class MetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensionInte
     registerObservableCounterIfNeeded();
   }
 
-  /** Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E */
+  /**
+   * Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface> MetricEntityStateTwoEnums<E1, E2> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
       Map<VeniceMetricsDimensions, String> baseDimensionsMap,
       Class<E1> enumTypeClass1,
-      Class<E2> enumTypeClass2) {
-    return new MetricEntityStateTwoEnums<>(
-        metricEntity,
-        otelRepository,
-        baseDimensionsMap,
-        enumTypeClass1,
-        enumTypeClass2);
+      Class<E2> enumTypeClass2,
+      CompositeCloseable registry) {
+    return registry.register(
+        new MetricEntityStateTwoEnums<>(
+            metricEntity,
+            otelRepository,
+            baseDimensionsMap,
+            enumTypeClass1,
+            enumTypeClass2));
   }
 
-  /** Overloaded Factory method for constructor with Tehuti parameters */
+  /**
+   * Overloaded Factory method for constructor with Tehuti parameters.
+   *
+   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
+   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
+   */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface> MetricEntityStateTwoEnums<E1, E2> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -88,16 +101,18 @@ public class MetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensionInte
       List<MeasurableStat> tehutiMetricStats,
       Map<VeniceMetricsDimensions, String> baseDimensionsMap,
       Class<E1> enumTypeClass1,
-      Class<E2> enumTypeClass2) {
-    return new MetricEntityStateTwoEnums<>(
-        metricEntity,
-        otelRepository,
-        registerTehutiSensorFn,
-        tehutiMetricNameEnum,
-        tehutiMetricStats,
-        baseDimensionsMap,
-        enumTypeClass1,
-        enumTypeClass2);
+      Class<E2> enumTypeClass2,
+      CompositeCloseable registry) {
+    return registry.register(
+        new MetricEntityStateTwoEnums<>(
+            metricEntity,
+            otelRepository,
+            registerTehutiSensorFn,
+            tehutiMetricNameEnum,
+            tehutiMetricStats,
+            baseDimensionsMap,
+            enumTypeClass1,
+            enumTypeClass2));
   }
 
   /**
@@ -123,7 +138,6 @@ public class MetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensionInte
     if (!emitOpenTelemetryMetrics()) {
       return null;
     }
-
     return metricAttributesDataEnumMap.computeIfAbsent(dimension1, k -> {
       validateInputDimension(k);
       return new EnumMap<>(enumTypeClass2);
@@ -152,13 +166,16 @@ public class MetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensionInte
 
   @Override
   protected Iterable<MetricAttributesData> getAllMetricAttributesData() {
-    if (metricAttributesDataEnumMap == null) {
-      return null;
-    }
-
     List<MetricAttributesData> allData = new ArrayList<>();
     for (EnumMap<E2, MetricAttributesData> level2Map: metricAttributesDataEnumMap.values()) {
-      allData.addAll(level2Map.values());
+      if (level2Map == null) {
+        continue;
+      }
+      for (MetricAttributesData holder: level2Map.values()) {
+        if (holder != null) {
+          allData.add(holder);
+        }
+      }
     }
     return allData;
   }
@@ -167,4 +184,5 @@ public class MetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensionInte
   public EnumMap<E1, EnumMap<E2, MetricAttributesData>> getMetricAttributesDataEnumMap() {
     return metricAttributesDataEnumMap;
   }
+
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateTwoEnums.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateTwoEnums.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
  */
 public class MetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface>
     extends MetricEntityState {
-  /** Lazy cache of {@link MetricAttributesData}; nulled in {@link #close()}. */
+  /** Lazy cache of {@link MetricAttributesData}. */
   private final EnumMap<E1, EnumMap<E2, MetricAttributesData>> metricAttributesDataEnumMap;
   private final Class<E1> enumTypeClass1;
   private final Class<E2> enumTypeClass2;
@@ -65,12 +65,7 @@ public class MetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensionInte
     registerObservableCounterIfNeeded();
   }
 
-  /**
-   * Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Factory method with named parameters to ensure the passed in enumTypeClass are in the same order as E. */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface> MetricEntityStateTwoEnums<E1, E2> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,
@@ -87,12 +82,7 @@ public class MetricEntityStateTwoEnums<E1 extends Enum<E1> & VeniceDimensionInte
             enumTypeClass2));
   }
 
-  /**
-   * Overloaded Factory method for constructor with Tehuti parameters.
-   *
-   * @param registry the {@link CompositeCloseable} that closes the returned wrapper at shutdown.
-   *                 Pass {@link CompositeCloseable#NONE} at test or ad-hoc callsites without lifecycle.
-   */
+  /** Overloaded Factory method for constructor with Tehuti parameters. */
   public static <E1 extends Enum<E1> & VeniceDimensionInterface, E2 extends Enum<E2> & VeniceDimensionInterface> MetricEntityStateTwoEnums<E1, E2> create(
       MetricEntity metricEntity,
       VeniceOpenTelemetryMetricsRepository otelRepository,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateUtils.java
@@ -6,29 +6,16 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
-/**
- * Static helpers for adopters of the {@code MetricEntityState*} / {@code AsyncMetricEntityState*}
- * wrapper hierarchy.
- *
- * <p>Adopters typically hold per-store / per-version maps of wrappers and need to close each entry
- * on store deletion or process shutdown. The wrapper itself may be {@code null} (no-op subclasses
- * leave fields null when OTel is disabled), so a null-safe close helper avoids replicating the
- * boilerplate at every adopter.
- */
+/** Static helpers for closing {@code MetricEntityState*} / {@code AsyncMetricEntityState*} wrappers. */
 public final class MetricEntityStateUtils {
   private static final Logger LOGGER = LogManager.getLogger(MetricEntityStateUtils.class);
 
   private MetricEntityStateUtils() {
-    // Utility class.
   }
 
   /**
-   * Null-safe close. Accepts any {@link Closeable} — covers every metric wrapper type
-   * ({@link AsyncMetricEntityState} subclasses, {@link AsyncMetricEntityStateOneEnum},
-   * {@link AsyncMetricEntityStateTwoEnums}). Catches every {@link Exception} (not just
-   * {@link java.io.IOException}) so a misbehaving wrapper — including a {@code RuntimeException}
-   * from a half-initialised SDK instrument or a double-close — cannot abort an enclosing close
-   * loop (e.g., {@link CompositeCloseable#close()}) and skip subsequent siblings.
+   * Null-safe close. Catches every {@link Exception} so a misbehaving wrapper cannot abort an
+   * enclosing close loop (e.g., {@link CompositeCloseable#close()}) and skip later siblings.
    */
   public static void closeQuietly(Closeable wrapper) {
     if (wrapper == null) {
@@ -42,17 +29,9 @@ public final class MetricEntityStateUtils {
   }
 
   /**
-   * Closes the SDK-side OTel instrument referenced by the async wrapper hierarchy, if it is
-   * {@link AutoCloseable}. Used by {@link AsyncMetricEntityState#close()} and the independent
-   * close() implementations on {@link AsyncMetricEntityStateOneEnum} / {@link AsyncMetricEntityStateTwoEnums}.
-   *
-   * <p>The {@code instrument} is expected to be the snapshot of the wrapper's volatile field
-   * (read once into a local) so a concurrent second close() cannot dereference a now-null reference.
-   * Sync metric instruments are not {@link AutoCloseable} on the SDK side; this method is a no-op
-   * for them.
-   *
-   * <p>Logs SDK close failures at WARN with the metric name and full stack trace and swallows them
-   * so a misbehaving SDK instrument cannot abort an enclosing close loop.
+   * Closes the SDK-side OTel instrument if it is {@link AutoCloseable}. Sync instruments are not
+   * AutoCloseable on the SDK side; this is a no-op for them. Caller should pass the snapshot of
+   * the wrapper's volatile field so a concurrent second close() cannot deref a now-null reference.
    */
   public static void closeOtelInstrumentQuietly(Object instrument, MetricEntity metricEntity) {
     if (instrument instanceof AutoCloseable) {
@@ -64,10 +43,7 @@ public final class MetricEntityStateUtils {
     }
   }
 
-  /**
-   * Closes every value in the map via {@link #closeQuietly} and clears the map. Each value's
-   * close() is exception-isolated so one misbehaving entry cannot prevent siblings from closing.
-   */
+  /** Closes every value in the map via {@link #closeQuietly} and clears the map. */
   public static void closeAndClear(Map<?, ? extends Closeable> map) {
     map.values().forEach(MetricEntityStateUtils::closeQuietly);
     map.clear();

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/metrics/MetricEntityStateUtils.java
@@ -1,0 +1,75 @@
+package com.linkedin.venice.stats.metrics;
+
+import java.io.Closeable;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Static helpers for adopters of the {@code MetricEntityState*} / {@code AsyncMetricEntityState*}
+ * wrapper hierarchy.
+ *
+ * <p>Adopters typically hold per-store / per-version maps of wrappers and need to close each entry
+ * on store deletion or process shutdown. The wrapper itself may be {@code null} (no-op subclasses
+ * leave fields null when OTel is disabled), so a null-safe close helper avoids replicating the
+ * boilerplate at every adopter.
+ */
+public final class MetricEntityStateUtils {
+  private static final Logger LOGGER = LogManager.getLogger(MetricEntityStateUtils.class);
+
+  private MetricEntityStateUtils() {
+    // Utility class.
+  }
+
+  /**
+   * Null-safe close. Accepts any {@link Closeable} — covers every metric wrapper type
+   * ({@link AsyncMetricEntityState} subclasses, {@link AsyncMetricEntityStateOneEnum},
+   * {@link AsyncMetricEntityStateTwoEnums}). Catches every {@link Exception} (not just
+   * {@link java.io.IOException}) so a misbehaving wrapper — including a {@code RuntimeException}
+   * from a half-initialised SDK instrument or a double-close — cannot abort an enclosing close
+   * loop (e.g., {@link CompositeCloseable#close()}) and skip subsequent siblings.
+   */
+  public static void closeQuietly(Closeable wrapper) {
+    if (wrapper == null) {
+      return;
+    }
+    try {
+      wrapper.close();
+    } catch (Exception e) {
+      LOGGER.warn("Close threw for {}", wrapper.getClass().getSimpleName(), e);
+    }
+  }
+
+  /**
+   * Closes the SDK-side OTel instrument referenced by the async wrapper hierarchy, if it is
+   * {@link AutoCloseable}. Used by {@link AsyncMetricEntityState#close()} and the independent
+   * close() implementations on {@link AsyncMetricEntityStateOneEnum} / {@link AsyncMetricEntityStateTwoEnums}.
+   *
+   * <p>The {@code instrument} is expected to be the snapshot of the wrapper's volatile field
+   * (read once into a local) so a concurrent second close() cannot dereference a now-null reference.
+   * Sync metric instruments are not {@link AutoCloseable} on the SDK side; this method is a no-op
+   * for them.
+   *
+   * <p>Logs SDK close failures at WARN with the metric name and full stack trace and swallows them
+   * so a misbehaving SDK instrument cannot abort an enclosing close loop.
+   */
+  public static void closeOtelInstrumentQuietly(Object instrument, MetricEntity metricEntity) {
+    if (instrument instanceof AutoCloseable) {
+      try {
+        ((AutoCloseable) instrument).close();
+      } catch (Exception e) {
+        LOGGER.warn("OTel SDK close threw for metric {}", metricEntity.getMetricName(), e);
+      }
+    }
+  }
+
+  /**
+   * Closes every value in the map via {@link #closeQuietly} and clears the map. Each value's
+   * close() is exception-isolated so one misbehaving entry cannot prevent siblings from closing.
+   */
+  public static void closeAndClear(Map<?, ? extends Closeable> map) {
+    map.values().forEach(MetricEntityStateUtils::closeQuietly);
+    map.clear();
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/routing/HelixGroupStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/routing/HelixGroupStats.java
@@ -26,7 +26,8 @@ public class HelixGroupStats extends AbstractVeniceStats {
   /**
    * Per-Helix-group OTel metric entity states and Tehuti metric references, keyed by group ID. Each map grows
    * lazily via {@code computeIfAbsent} and is bounded by the number of Helix groups configured for the store
-   * (typically 3–5). Entries are not evicted — the maps persist for the lifetime of this stats instance.
+   * (typically 3–5). Entries are not evicted — the maps persist for the lifetime of this stats instance, so
+   * every wrapper registers with the inherited {@code resources} owner and is closed in {@link #close()}.
    * {@code groupResponseWaitingTimeAvgMap} holds Tehuti {@link io.tehuti.metrics.Metric} references; the
    * remaining maps hold OTel {@link MetricEntityStateBase} instances.
    */
@@ -81,7 +82,8 @@ public class HelixGroupStats extends AbstractVeniceStats {
         HelixGroupTehutiMetricName.GROUP_COUNT,
         Collections.singletonList(new Avg()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
   }
 
   public void recordGroupNum(int groupNum) {
@@ -97,7 +99,8 @@ public class HelixGroupStats extends AbstractVeniceStats {
         HelixGroupTehutiMetricDynamicName.of(HelixGroupTehutiMetricName.GROUP_REQUEST, groupId),
         Collections.singletonList(new OccurrenceRate()),
         otelSetup.baseDimensionsMap,
-        otelSetup.baseAttributes);
+        otelSetup.baseAttributes,
+        resources);
   }
 
   public void recordGroupRequest(int groupId) {
@@ -113,7 +116,8 @@ public class HelixGroupStats extends AbstractVeniceStats {
         HelixGroupTehutiMetricDynamicName.of(HelixGroupTehutiMetricName.GROUP_PENDING_REQUEST, groupId),
         Collections.singletonList(new Avg()),
         otelSetup.baseDimensionsMap,
-        otelSetup.baseAttributes);
+        otelSetup.baseAttributes,
+        resources);
   }
 
   public void recordGroupPendingRequest(int groupId, int value) {
@@ -131,7 +135,8 @@ public class HelixGroupStats extends AbstractVeniceStats {
         HelixGroupTehutiMetricDynamicName.of(HelixGroupTehutiMetricName.GROUP_RESPONSE_WAITING_TIME, groupId),
         Collections.singletonList(avgStat),
         otelSetup.baseDimensionsMap,
-        otelSetup.baseAttributes);
+        otelSetup.baseAttributes,
+        resources);
   }
 
   public void recordGroupResponseWaitingTime(int groupId, double responseWaitingTime) {
@@ -155,6 +160,18 @@ public class HelixGroupStats extends AbstractVeniceStats {
       return -1;
     }
     return avgLatency;
+  }
+
+  @Override
+  public void close() {
+    try {
+      super.close();
+    } finally {
+      groupRequestCountMap.clear();
+      groupPendingRequestMap.clear();
+      groupResponseWaitingTimeMap.clear();
+      groupResponseWaitingTimeAvgMap.clear();
+    }
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/metrics/MetricsRepositoryUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/metrics/MetricsRepositoryUtils.java
@@ -4,6 +4,7 @@ import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.VeniceOpenTelemetryMetricNamingFormat;
 import com.linkedin.venice.stats.metrics.MetricEntity;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
@@ -107,6 +108,49 @@ public class MetricsRepositoryUtils {
             .setInitialMetricsMeasurementTimeoutInMs(initialMetricsMeasurementTimeoutMs)
             .setMaxMetricsMeasurementTimeoutInMs(maxMetricsMeasurementTimeoutMs)
             .build());
+  }
+
+  /**
+   * Constructs an OTel-enabled {@link VeniceMetricsRepository} wired to {@code reader} and
+   * {@code executor}. Callers retain ownership of all three resources; closing the repository
+   * cascades to the executor via the configured {@link MetricConfig}.
+   *
+   * <p>The dedicated {@link AsyncGauge.AsyncGaugeExecutor} is required for any test that calls
+   * {@code metricsRepository.close()} (typically in {@code @AfterMethod}) — without it the close
+   * would shut down the static singleton {@code DEFAULT_ASYNC_GAUGE_EXECUTOR} JVM-wide and break
+   * {@link AsyncGauge} measurements in every subsequent test class. When {@code executor} is
+   * {@code null} no {@link MetricConfig} is configured and Tehuti falls back to its defaults.
+   */
+  public static VeniceMetricsRepository createOtelEnabledRepository(
+      String metricPrefix,
+      Collection<MetricEntity> metricEntities,
+      MetricReader reader,
+      AsyncGauge.AsyncGaugeExecutor executor) {
+    VeniceMetricsConfig.Builder builder = new VeniceMetricsConfig.Builder().setMetricPrefix(metricPrefix)
+        .setMetricEntities(metricEntities)
+        .setEmitOtelMetrics(true)
+        .setOtelAdditionalMetricsReader(reader);
+    if (executor != null) {
+      builder.setTehutiMetricConfig(new MetricConfig(executor));
+    }
+    return new VeniceMetricsRepository(builder.build());
+  }
+
+  /**
+   * Constructs an OTel-disabled {@link VeniceMetricsRepository} with a dedicated executor. Used by
+   * {@code testNoNpeWhenOtelDisabled}-style tests that exercise the disabled-OTel code path. When
+   * {@code executor} is {@code null} no {@link MetricConfig} is configured and Tehuti falls back
+   * to its defaults.
+   */
+  public static VeniceMetricsRepository createOtelDisabledRepository(
+      String metricPrefix,
+      AsyncGauge.AsyncGaugeExecutor executor) {
+    VeniceMetricsConfig.Builder builder =
+        new VeniceMetricsConfig.Builder().setMetricPrefix(metricPrefix).setEmitOtelMetrics(false);
+    if (executor != null) {
+      builder.setTehutiMetricConfig(new MetricConfig(executor));
+    }
+    return new VeniceMetricsRepository(builder.build());
   }
 
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/metrics/MetricsRepositoryUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/metrics/MetricsRepositoryUtils.java
@@ -111,15 +111,8 @@ public class MetricsRepositoryUtils {
   }
 
   /**
-   * Constructs an OTel-enabled {@link VeniceMetricsRepository} wired to {@code reader} and
-   * {@code executor}. Callers retain ownership of all three resources; closing the repository
-   * cascades to the executor via the configured {@link MetricConfig}.
-   *
-   * <p>The dedicated {@link AsyncGauge.AsyncGaugeExecutor} is required for any test that calls
-   * {@code metricsRepository.close()} (typically in {@code @AfterMethod}) — without it the close
-   * would shut down the static singleton {@code DEFAULT_ASYNC_GAUGE_EXECUTOR} JVM-wide and break
-   * {@link AsyncGauge} measurements in every subsequent test class. When {@code executor} is
-   * {@code null} no {@link MetricConfig} is configured and Tehuti falls back to its defaults.
+   * Constructs an OTel-enabled repository. Pass a dedicated {@link AsyncGauge.AsyncGaugeExecutor} when the test calls
+   * {@code metricsRepository.close()} — otherwise the close shuts down Tehuti's JVM-wide static executor singleton.
    */
   public static VeniceMetricsRepository createOtelEnabledRepository(
       String metricPrefix,
@@ -136,12 +129,7 @@ public class MetricsRepositoryUtils {
     return new VeniceMetricsRepository(builder.build());
   }
 
-  /**
-   * Constructs an OTel-disabled {@link VeniceMetricsRepository} with a dedicated executor. Used by
-   * {@code testNoNpeWhenOtelDisabled}-style tests that exercise the disabled-OTel code path. When
-   * {@code executor} is {@code null} no {@link MetricConfig} is configured and Tehuti falls back
-   * to its defaults.
-   */
+  /** OTel-disabled variant of {@link #createOtelEnabledRepository}. Same executor caveat applies. */
   public static VeniceMetricsRepository createOtelDisabledRepository(
       String metricPrefix,
       AsyncGauge.AsyncGaugeExecutor executor) {

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsRepositoryTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceMetricsRepositoryTest.java
@@ -13,10 +13,13 @@ import com.linkedin.venice.stats.metrics.MetricType;
 import com.linkedin.venice.stats.metrics.MetricUnit;
 import com.linkedin.venice.utils.DataProviderUtils;
 import io.tehuti.metrics.MetricConfig;
+import io.tehuti.metrics.MetricsReporter;
+import io.tehuti.metrics.TehutiMetric;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
@@ -106,6 +109,58 @@ public class VeniceMetricsRepositoryTest {
     repository.close();
 
     // Verify that close methods are called
+    Mockito.verify(mockOpenTelemetryRepository).close();
+  }
+
+  /**
+   * Regression test for the try-finally contract in {@link VeniceMetricsRepository#close()}: if Tehuti's
+   * {@code super.close()} throws (e.g., a misbehaving reporter), the OTel repository's {@code close()} MUST
+   * still run so the SDK MeterProvider is shut down. Pre-fix (without try-finally) this would leak the OTel
+   * exporter thread and could prevent JVM exit.
+   */
+  @Test
+  public void testCloseRunsOtelCloseEvenIfSuperCloseThrows() {
+    VeniceMetricsConfig mockConfig = Mockito.mock(VeniceMetricsConfig.class);
+    VeniceOpenTelemetryMetricsRepository mockOpenTelemetryRepository =
+        Mockito.mock(VeniceOpenTelemetryMetricsRepository.class);
+    Mockito.when(mockConfig.getTehutiMetricConfig()).thenReturn(new MetricConfig());
+
+    VeniceMetricsRepository repository = new VeniceMetricsRepository(mockConfig, mockOpenTelemetryRepository);
+    // Add a Tehuti reporter that throws on close — this makes super.close() throw, exercising the try-finally.
+    repository.addReporter(new MetricsReporter() {
+      @Override
+      public void init(List<TehutiMetric> metrics) {
+      }
+
+      @Override
+      public void metricChange(TehutiMetric metric) {
+      }
+
+      @Override
+      public void addMetric(TehutiMetric metric) {
+      }
+
+      @Override
+      public void removeMetric(TehutiMetric metric) {
+      }
+
+      @Override
+      public void close() {
+        throw new RuntimeException("simulated Tehuti close failure");
+      }
+
+      @Override
+      public void configure(java.util.Map<String, ?> configs) {
+      }
+    });
+
+    try {
+      repository.close();
+    } catch (RuntimeException expected) {
+      // Expected — close() rethrows after the finally block runs.
+    }
+
+    // The contract: OTel close MUST have been invoked even though super.close() threw.
     Mockito.verify(mockOpenTelemetryRepository).close();
   }
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepositoryTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/VeniceOpenTelemetryMetricsRepositoryTest.java
@@ -23,6 +23,7 @@ import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.metrics.AsyncMetricEntityState;
 import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateBase;
 import com.linkedin.venice.stats.metrics.AsyncMetricEntityStateOneEnum;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.stats.metrics.MetricAttributesData;
 import com.linkedin.venice.stats.metrics.MetricEntity;
 import com.linkedin.venice.stats.metrics.MetricEntityStateBase;
@@ -209,14 +210,24 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
 
       AsyncMetricEntityState metricEntityState;
       if (metricType == MetricType.ASYNC_DOUBLE_GAUGE) {
-        metricEntityState = AsyncMetricEntityStateBase
-            .create(metricEntity, metricsRepository, baseDimensionsMap, baseAttributes, (DoubleSupplier) () -> 10.0);
+        metricEntityState = AsyncMetricEntityStateBase.create(
+            metricEntity,
+            metricsRepository,
+            baseDimensionsMap,
+            baseAttributes,
+            (DoubleSupplier) () -> 10.0,
+            CompositeCloseable.NONE);
       } else if (metricType.isAsyncMetric()) {
-        metricEntityState = AsyncMetricEntityStateBase
-            .create(metricEntity, metricsRepository, baseDimensionsMap, baseAttributes, () -> 10);
+        metricEntityState = AsyncMetricEntityStateBase.create(
+            metricEntity,
+            metricsRepository,
+            baseDimensionsMap,
+            baseAttributes,
+            () -> 10,
+            CompositeCloseable.NONE);
       } else {
-        metricEntityState =
-            MetricEntityStateBase.create(metricEntity, metricsRepository, baseDimensionsMap, baseAttributes);
+        metricEntityState = MetricEntityStateBase
+            .create(metricEntity, metricsRepository, baseDimensionsMap, baseAttributes, CompositeCloseable.NONE);
       }
 
       metricEntityState.setOtelMetric(instrument);
@@ -618,7 +629,8 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
             "histogramMap", // Child has its own instrument maps
             "counterMap",
             "upDownCounterMap",
-            "gaugeMap"));
+            "gaugeMap",
+            "resources")); // Child has its own CompositeCloseable for owned wrappers
 
     // Fields that are expected to be null in child
     Set<String> FIELDS_EXPECTED_NULL_IN_CHILD = new HashSet<>(Arrays.asList("sdkMeterProvider"));
@@ -749,7 +761,8 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
         baseDimensionsMap,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        RequestType.class);
+        RequestType.class,
+        CompositeCloseable.NONE);
   }
 
   /**
@@ -941,7 +954,8 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
         baseDimensionsMap,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        RequestType.class);
+        RequestType.class,
+        CompositeCloseable.NONE);
   }
 
   /**
@@ -1028,7 +1042,8 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
               storeADimensions,
               HttpResponseStatusEnum.class,
               HttpResponseStatusCodeCategory.class,
-              RequestType.class);
+              RequestType.class,
+              CompositeCloseable.NONE);
 
       Map<VeniceMetricsDimensions, String> storeBDimensions = new HashMap<>();
       storeBDimensions.put(VeniceMetricsDimensions.VENICE_STORE_NAME, "store_B");
@@ -1039,7 +1054,8 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
               storeBDimensions,
               HttpResponseStatusEnum.class,
               HttpResponseStatusCodeCategory.class,
-              RequestType.class);
+              RequestType.class,
+              CompositeCloseable.NONE);
 
       // Record data via both states
       stateA.record(100L, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
@@ -1106,7 +1122,8 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
               storeADimensions,
               HttpResponseStatusEnum.class,
               HttpResponseStatusCodeCategory.class,
-              RequestType.class);
+              RequestType.class,
+              CompositeCloseable.NONE);
 
       Map<VeniceMetricsDimensions, String> storeBDimensions = new HashMap<>();
       storeBDimensions.put(VeniceMetricsDimensions.VENICE_STORE_NAME, "store_B");
@@ -1117,7 +1134,8 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
               storeBDimensions,
               HttpResponseStatusEnum.class,
               HttpResponseStatusCodeCategory.class,
-              RequestType.class);
+              RequestType.class,
+              CompositeCloseable.NONE);
 
       // Record data via both states (including negative values for up-down counter)
       stateA.record(50L, HttpResponseStatusEnum.OK, HttpResponseStatusCodeCategory.SUCCESS, RequestType.SINGLE_GET);
@@ -1249,7 +1267,8 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
           baseDimensionsMap,
           VersionRole.class,
           role -> role,
-          (state, role) -> (role.ordinal() + 1) * 10L);
+          (state, role) -> (role.ordinal() + 1) * 10L,
+          CompositeCloseable.NONE);
 
       assertNotNull(metricState);
 
@@ -1302,8 +1321,13 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
       Attributes baseAttributes = otelRepo.createAttributes(metricEntity, baseDimensionsMap);
 
       // Create with a known fractional value (0.75 = 75% usage)
-      AsyncMetricEntityStateBase state = AsyncMetricEntityStateBase
-          .create(metricEntity, otelRepo, baseDimensionsMap, baseAttributes, (DoubleSupplier) () -> 0.75);
+      AsyncMetricEntityStateBase state = AsyncMetricEntityStateBase.create(
+          metricEntity,
+          otelRepo,
+          baseDimensionsMap,
+          baseAttributes,
+          (DoubleSupplier) () -> 0.75,
+          CompositeCloseable.NONE);
       assertNotNull(state);
 
       // Validate the double gauge value is preserved (not truncated to 0)
@@ -1460,7 +1484,8 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
               storeADims,
               HttpResponseStatusEnum.class,
               HttpResponseStatusCodeCategory.class,
-              RequestType.class);
+              RequestType.class,
+              CompositeCloseable.NONE);
 
       Map<VeniceMetricsDimensions, String> storeBDims = new HashMap<>();
       storeBDims.put(VeniceMetricsDimensions.VENICE_STORE_NAME, "store_B");
@@ -1471,7 +1496,8 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
               storeBDims,
               HttpResponseStatusEnum.class,
               HttpResponseStatusCodeCategory.class,
-              RequestType.class);
+              RequestType.class,
+              CompositeCloseable.NONE);
 
       Attributes storeAAttrs = new OpenTelemetryDataTestUtils.OpenTelemetryAttributesBuilder().setStoreName("store_A")
           .setHttpStatus(HttpResponseStatusEnum.OK)
@@ -1633,4 +1659,29 @@ public class VeniceOpenTelemetryMetricsRepositoryTest {
     }
   }
 
+  /**
+   * Regression test for the bounded-join shutdown contract in
+   * {@link VeniceOpenTelemetryMetricsRepository#close()}: close() must complete cleanly when the SDK shutdown
+   * succeeds. The 10s join timeout in the production code prevents an exporter that fails to flush from
+   * blocking JVM exit; this test ensures the happy path returns within the bounded window. (Failure paths —
+   * exporter timeout, async non-success — are difficult to simulate without mocking the SDK, but the happy
+   * path is the load-bearing one.)
+   */
+  @Test(timeOut = 30_000)
+  public void testCloseCompletesCleanlyOnSuccessfulShutdown() {
+    Set<VeniceMetricsDimensions> dims = new HashSet<>();
+    dims.add(VeniceMetricsDimensions.VENICE_REQUEST_METHOD);
+    MetricEntity entity = new MetricEntity("close_test_counter", MetricType.COUNTER, MetricUnit.NUMBER, "d", dims);
+    VeniceMetricsRepository repo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setServiceName("svc")
+            .setMetricPrefix("test_close")
+            .setEmitOtelMetrics(true)
+            .setMetricEntities(Collections.singletonList(entity))
+            .build());
+    VeniceOpenTelemetryMetricsRepository otelRepo = repo.getOpenTelemetryMetricsRepository();
+    assertNotNull(otelRepo, "OTel repository must exist for the bounded-join shutdown to apply");
+    // close() must complete (not throw, not hang). Test timeout is 30s — well above the 10s join.
+    otelRepo.close();
+    repo.close();
+  }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateOneEnumTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateOneEnumTest.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.stats.metrics.MetricEntityStateTest.DimensionE
 import static com.linkedin.venice.stats.metrics.MetricType.ASYNC_GAUGE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -19,7 +20,9 @@ import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.metrics.AsyncMetricResolvers.LiveStateResolverOneEnum;
 import com.linkedin.venice.stats.metrics.AsyncMetricResolvers.ValueResolverOneEnum;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.ObservableDoubleGauge;
 import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+import io.opentelemetry.api.metrics.ObservableLongGauge;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import java.util.EnumMap;
 import java.util.EnumSet;
@@ -55,7 +58,8 @@ public class AsyncMetricEntityStateOneEnumTest extends MetricEntityStateEnumTest
         baseDimensionsMap,
         DimensionEnum1.class,
         e -> e,
-        (state, e) -> 1L);
+        (state, e) -> 1L,
+        CompositeCloseable.NONE);
 
     assertNotNull(metricState);
     assertFalse(metricState.emitOpenTelemetryMetrics());
@@ -71,7 +75,8 @@ public class AsyncMetricEntityStateOneEnumTest extends MetricEntityStateEnumTest
         baseDimensionsMap,
         DimensionEnum1.class,
         e -> e,
-        (state, e) -> 7L);
+        (state, e) -> 7L,
+        CompositeCloseable.NONE);
 
     assertTrue(metricState.emitOpenTelemetryMetrics());
     // Exactly one SDK instrument registered, regardless of |E|.
@@ -98,7 +103,8 @@ public class AsyncMetricEntityStateOneEnumTest extends MetricEntityStateEnumTest
         baseDimensionsMap,
         DimensionEnum1.class,
         liveStateResolver,
-        valueResolver);
+        valueResolver,
+        CompositeCloseable.NONE);
     Consumer<ObservableLongMeasurement> callback = callbackCaptor.getValue();
 
     ObservableLongMeasurement measurement = mock(ObservableLongMeasurement.class);
@@ -131,7 +137,8 @@ public class AsyncMetricEntityStateOneEnumTest extends MetricEntityStateEnumTest
         baseDimensionsMap,
         DimensionEnum1.class,
         liveStateResolver,
-        (state, e) -> 7L);
+        (state, e) -> 7L,
+        CompositeCloseable.NONE);
 
     ObservableLongMeasurement measurement = mock(ObservableLongMeasurement.class);
     // If per-combo isolation is missing, the whole callback throws and this would propagate.
@@ -157,7 +164,8 @@ public class AsyncMetricEntityStateOneEnumTest extends MetricEntityStateEnumTest
         baseDimensionsMap,
         DimensionEnum1.class,
         e -> null, // always dormant
-        valueResolver);
+        valueResolver,
+        CompositeCloseable.NONE);
     callbackCaptor.getValue().accept(mock(ObservableLongMeasurement.class));
 
     verifyNoInteractions(valueResolver);
@@ -176,7 +184,8 @@ public class AsyncMetricEntityStateOneEnumTest extends MetricEntityStateEnumTest
         baseDimensionsMap,
         DimensionEnum1.class,
         liveStateResolver,
-        (state, e) -> 1L);
+        (state, e) -> 1L,
+        CompositeCloseable.NONE);
     Consumer<ObservableLongMeasurement> callback = callbackCaptor.getValue();
 
     // First collection: nothing live, no records emitted.
@@ -213,7 +222,8 @@ public class AsyncMetricEntityStateOneEnumTest extends MetricEntityStateEnumTest
         baseDimensionsMap,
         DimensionEnum1.class,
         e -> e,
-        (state, e) -> 42.9);
+        (state, e) -> 42.9,
+        CompositeCloseable.NONE);
     Consumer<ObservableLongMeasurement> callback = callbackCaptor.getValue();
 
     ObservableLongMeasurement measurement = mock(ObservableLongMeasurement.class);
@@ -233,7 +243,8 @@ public class AsyncMetricEntityStateOneEnumTest extends MetricEntityStateEnumTest
         baseDimensionsMap,
         DimensionEnum1.class,
         e -> e,
-        (state, e) -> 0.75);
+        (state, e) -> 0.75,
+        CompositeCloseable.NONE);
     Consumer<ObservableDoubleMeasurement> callback = callbackCaptor.getValue();
 
     // ASYNC_DOUBLE_GAUGE uses registerObservableDoubleGauge, not the Long variant.
@@ -256,7 +267,8 @@ public class AsyncMetricEntityStateOneEnumTest extends MetricEntityStateEnumTest
         baseDimensionsMap,
         DimensionEnum1.class,
         e -> e,
-        (state, e) -> 1L);
+        (state, e) -> 1L,
+        CompositeCloseable.NONE);
 
     assertFalse(metricState.emitOpenTelemetryMetrics());
     assertNull(metricState.getAttributesByEnum());
@@ -279,7 +291,8 @@ public class AsyncMetricEntityStateOneEnumTest extends MetricEntityStateEnumTest
         baseDimensionsMap,
         DimensionEnum1.class,
         e -> e,
-        (state, e) -> e.ordinal() * 10L);
+        (state, e) -> e.ordinal() * 10L,
+        CompositeCloseable.NONE);
 
     ObservableLongMeasurement measurement = mock(ObservableLongMeasurement.class);
     callbackCaptor.getValue().accept(measurement);
@@ -315,7 +328,8 @@ public class AsyncMetricEntityStateOneEnumTest extends MetricEntityStateEnumTest
             throw new AssertionError("state mismatch for " + e + ": got " + state + ", expected " + stateByEnum.get(e));
           }
           return 1L;
-        });
+        },
+        CompositeCloseable.NONE);
 
     // If any combo crosses state, the valueResolver throws -> callback propagates -> test fails.
     callbackCaptor.getValue().accept(mock(ObservableLongMeasurement.class));
@@ -331,7 +345,99 @@ public class AsyncMetricEntityStateOneEnumTest extends MetricEntityStateEnumTest
         baseDimensionsMap,
         DimensionEnum1.class,
         e -> e,
-        (state, e) -> 1L);
+        (state, e) -> 1L,
+        CompositeCloseable.NONE);
+  }
+
+  @Test
+  public void testCloseDeregistersInstrumentClearsAttributesAndIsIdempotent() throws Exception {
+    ObservableLongGauge mockGauge = mock(ObservableLongGauge.class);
+    when(mockOtelRepository.registerObservableLongGauge(eq(mockMetricEntity), any())).thenReturn(mockGauge);
+
+    AsyncMetricEntityStateOneEnum<DimensionEnum1> state = AsyncMetricEntityStateOneEnum.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        DimensionEnum1.class,
+        e -> e,
+        (s, e) -> 1L,
+        CompositeCloseable.NONE);
+    assertNotNull(state.getInstrument());
+    assertNotNull(state.getAttributesByEnum());
+    assertEquals(state.getAttributesByEnum().size(), DimensionEnum1.values().length);
+
+    state.close();
+    // SDK callback deregistered exactly once.
+    verify(mockGauge, times(1)).close();
+    // Wrapper-side state released.
+    assertNull(state.getInstrument());
+    assertNull(state.getAttributesByEnum());
+
+    state.close();
+    verify(mockGauge, times(1)).close();
+  }
+
+  @Test
+  public void testCloseOnDoubleGaugeDeregistersInstrument() throws Exception {
+    when(mockMetricEntity.getMetricType()).thenReturn(MetricType.ASYNC_DOUBLE_GAUGE);
+    ObservableDoubleGauge mockGauge = mock(ObservableDoubleGauge.class);
+    when(mockOtelRepository.registerObservableDoubleGauge(eq(mockMetricEntity), any())).thenReturn(mockGauge);
+
+    AsyncMetricEntityStateOneEnum<DimensionEnum1> state = AsyncMetricEntityStateOneEnum.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        DimensionEnum1.class,
+        e -> e,
+        (s, e) -> 1.0,
+        CompositeCloseable.NONE);
+
+    state.close();
+    verify(mockGauge, times(1)).close();
+    assertNull(state.getInstrument());
+  }
+
+  @Test
+  public void testCloseWithOtelDisabledIsNoOp() {
+    when(mockOtelRepository.emitOpenTelemetryMetrics()).thenReturn(false);
+
+    AsyncMetricEntityStateOneEnum<DimensionEnum1> state = AsyncMetricEntityStateOneEnum.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        DimensionEnum1.class,
+        e -> e,
+        (s, e) -> 1L,
+        CompositeCloseable.NONE);
+    assertFalse(state.emitOpenTelemetryMetrics());
+    assertNull(state.getInstrument());
+    assertNull(state.getAttributesByEnum());
+
+    // Must not throw on null instrument/attributes.
+    state.close();
+    state.close();
+  }
+
+  @Test
+  public void testCloseSwallowsExceptionFromMisbehavingSdkInstrument() throws Exception {
+    ObservableLongGauge mockGauge = mock(ObservableLongGauge.class);
+    doThrow(new RuntimeException("simulated SDK close failure")).when(mockGauge).close();
+    when(mockOtelRepository.registerObservableLongGauge(eq(mockMetricEntity), any())).thenReturn(mockGauge);
+    when(mockMetricEntity.getMetricName()).thenReturn("test_metric");
+
+    AsyncMetricEntityStateOneEnum<DimensionEnum1> state = AsyncMetricEntityStateOneEnum.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        DimensionEnum1.class,
+        e -> e,
+        (s, e) -> 1L,
+        CompositeCloseable.NONE);
+
+    // Best-effort: the exception is logged at WARN and swallowed.
+    state.close();
+    verify(mockGauge, times(1)).close();
+    assertNull(state.getInstrument());
   }
 
   /** Captures the {@code Consumer<ObservableLongMeasurement>} passed to {@code registerObservableLongGauge}. */

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateTest.java
@@ -10,9 +10,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -99,8 +102,8 @@ public class AsyncMetricEntityStateTest {
     when(mockOtelRepository.createInstrument(mockMetricEntity)).thenReturn(longCounter);
 
     // ASYNC_GAUGE (LongSupplier) without tehuti sensor
-    AsyncMetricEntityState metricEntityState =
-        AsyncMetricEntityStateBase.create(mockMetricEntity, null, baseDimensionsMap, baseAttributes, () -> 0L);
+    AsyncMetricEntityState metricEntityState = AsyncMetricEntityStateBase
+        .create(mockMetricEntity, null, baseDimensionsMap, baseAttributes, () -> 0L, CompositeCloseable.NONE);
     Assert.assertNotNull(metricEntityState);
     Assert.assertNull(metricEntityState.getOtelMetric());
     Assert.assertNull(metricEntityState.getTehutiSensor());
@@ -114,15 +117,21 @@ public class AsyncMetricEntityStateTest {
         singletonList(new AsyncGauge((ignored1, ignored2) -> 0, "test")),
         baseDimensionsMap,
         baseAttributes,
-        () -> 0L);
+        () -> 0L,
+        CompositeCloseable.NONE);
     Assert.assertNotNull(metricEntityState);
     Assert.assertNull(metricEntityState.getOtelMetric());
     Assert.assertNotNull(metricEntityState.getTehutiSensor());
 
     // ASYNC_DOUBLE_GAUGE (DoubleSupplier) without tehuti sensor
     when(mockMetricEntity.getMetricType()).thenReturn(MetricType.ASYNC_DOUBLE_GAUGE);
-    metricEntityState = AsyncMetricEntityStateBase
-        .create(mockMetricEntity, null, baseDimensionsMap, baseAttributes, (DoubleSupplier) () -> 0.75);
+    metricEntityState = AsyncMetricEntityStateBase.create(
+        mockMetricEntity,
+        null,
+        baseDimensionsMap,
+        baseAttributes,
+        (DoubleSupplier) () -> 0.75,
+        CompositeCloseable.NONE);
     Assert.assertNotNull(metricEntityState);
     Assert.assertNull(metricEntityState.getOtelMetric());
     Assert.assertNull(metricEntityState.getTehutiSensor());
@@ -135,8 +144,13 @@ public class AsyncMetricEntityStateTest {
     when(mockOtelRepository.registerObservableLongGauge(any(MetricEntity.class), any())).thenReturn(mockLongGauge);
 
     // ASYNC_GAUGE (LongSupplier) without tehuti sensor
-    AsyncMetricEntityState metricEntityState = AsyncMetricEntityStateBase
-        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes, () -> 0L);
+    AsyncMetricEntityState metricEntityState = AsyncMetricEntityStateBase.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        baseAttributes,
+        () -> 0L,
+        CompositeCloseable.NONE);
     Assert.assertNotNull(metricEntityState);
     Assert.assertNotNull(metricEntityState.getOtelMetric());
     Assert.assertNull(metricEntityState.getTehutiSensor());
@@ -150,7 +164,8 @@ public class AsyncMetricEntityStateTest {
         singletonList(new AsyncGauge((ignored1, ignored2) -> 0, "test")),
         baseDimensionsMap,
         baseAttributes,
-        () -> 0L);
+        () -> 0L,
+        CompositeCloseable.NONE);
     Assert.assertNotNull(metricEntityState);
     Assert.assertNotNull(metricEntityState.getOtelMetric());
     Assert.assertNotNull(metricEntityState.getTehutiSensor());
@@ -160,8 +175,13 @@ public class AsyncMetricEntityStateTest {
     ObservableDoubleGauge mockDoubleGauge = mock(ObservableDoubleGauge.class);
     when(mockOtelRepository.registerObservableDoubleGauge(any(MetricEntity.class), any())).thenReturn(mockDoubleGauge);
 
-    metricEntityState = AsyncMetricEntityStateBase
-        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes, (DoubleSupplier) () -> 0.75);
+    metricEntityState = AsyncMetricEntityStateBase.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        baseAttributes,
+        (DoubleSupplier) () -> 0.75,
+        CompositeCloseable.NONE);
     Assert.assertNotNull(metricEntityState);
     Assert.assertNotNull(metricEntityState.getOtelMetric());
     Assert.assertNull(metricEntityState.getTehutiSensor());
@@ -175,10 +195,75 @@ public class AsyncMetricEntityStateTest {
         singletonList(new AsyncGauge((ignored1, ignored2) -> 0.75, "test")),
         baseDimensionsMap,
         baseAttributes,
-        (DoubleSupplier) () -> 0.75);
+        (DoubleSupplier) () -> 0.75,
+        CompositeCloseable.NONE);
     Assert.assertNotNull(metricEntityState);
     Assert.assertNotNull(metricEntityState.getOtelMetric());
     Assert.assertNotNull(metricEntityState.getTehutiSensor());
+  }
+
+  @Test
+  public void testCloseDeregistersAsyncInstrumentAndIsIdempotent() throws Exception {
+    when(mockMetricEntity.getMetricType()).thenReturn(ASYNC_GAUGE);
+    ObservableLongGauge mockLongGauge = mock(ObservableLongGauge.class);
+    when(mockOtelRepository.registerObservableLongGauge(any(MetricEntity.class), any())).thenReturn(mockLongGauge);
+
+    AsyncMetricEntityState state = AsyncMetricEntityStateBase.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        baseAttributes,
+        () -> 0L,
+        CompositeCloseable.NONE);
+    Assert.assertNotNull(state.getOtelMetric());
+
+    state.close();
+    // SDK callback deregistered exactly once.
+    verify(mockLongGauge, times(1)).close();
+    // Wrapper-side reference released.
+    assertNull(state.getOtelMetric());
+    assertNull(state.getTehutiSensor());
+
+    // Idempotent: a second close is a no-op (no additional close() call on the SDK handle).
+    state.close();
+    verify(mockLongGauge, times(1)).close();
+  }
+
+  @Test
+  public void testCloseSwallowsExceptionFromMisbehavingSdkInstrument() throws Exception {
+    when(mockMetricEntity.getMetricType()).thenReturn(ASYNC_GAUGE);
+    ObservableLongGauge mockLongGauge = mock(ObservableLongGauge.class);
+    Mockito.doThrow(new RuntimeException("simulated SDK close failure")).when(mockLongGauge).close();
+    when(mockOtelRepository.registerObservableLongGauge(any(MetricEntity.class), any())).thenReturn(mockLongGauge);
+
+    AsyncMetricEntityState state = AsyncMetricEntityStateBase.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        baseAttributes,
+        () -> 0L,
+        CompositeCloseable.NONE);
+
+    // Must not propagate; close is best-effort by contract.
+    state.close();
+    assertNull(state.getOtelMetric());
+  }
+
+  @Test
+  public void testCloseOnSyncOtelMetricOnlyClearsWrapperReference() {
+    // Sync metric type (e.g. COUNTER) — the otelMetric is not AutoCloseable, so close() just nulls the field.
+    when(mockMetricEntity.getMetricType()).thenReturn(MetricType.COUNTER);
+    LongCounter mockCounter = mock(LongCounter.class);
+    when(mockOtelRepository.createInstrument(any(MetricEntity.class))).thenReturn(mockCounter);
+
+    AsyncMetricEntityState state = MetricEntityStateBase
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes, CompositeCloseable.NONE);
+    Assert.assertNotNull(state.getOtelMetric());
+
+    state.close();
+    // Wrapper-side reference released; SDK aggregator stays alive (we don't try to close LongCounter — it isn't
+    // AutoCloseable).
+    assertNull(state.getOtelMetric());
   }
 
   @Test
@@ -187,15 +272,25 @@ public class AsyncMetricEntityStateTest {
     // case 1: right values
     baseDimensionsMap.put(VENICE_REQUEST_METHOD, MULTI_GET_STREAMING.getDimensionValue());
     Attributes baseAttributes1 = getBaseAttributes(baseDimensionsMap);
-    AsyncMetricEntityState metricEntityState = AsyncMetricEntityStateBase
-        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes1, () -> 0L);
+    AsyncMetricEntityState metricEntityState = AsyncMetricEntityStateBase.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        baseAttributes1,
+        () -> 0L,
+        CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
 
     // case 2: baseAttributes have different count than baseDimensionsMap
     Attributes baseAttributes2 = Attributes.builder().build();
     try {
-      AsyncMetricEntityStateBase
-          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes2, () -> 0L);
+      AsyncMetricEntityStateBase.create(
+          mockMetricEntity,
+          mockOtelRepository,
+          baseDimensionsMap,
+          baseAttributes2,
+          () -> 0L,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("should have the same size and values"));
@@ -206,8 +301,13 @@ public class AsyncMetricEntityStateTest {
     baseAttributes3Map.put(VENICE_REQUEST_RETRY_TYPE, ERROR_RETRY.getDimensionValue());
     Attributes baseAttributes3 = getBaseAttributes(baseAttributes3Map);
     try {
-      AsyncMetricEntityStateBase
-          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes3, () -> 0L);
+      AsyncMetricEntityStateBase.create(
+          mockMetricEntity,
+          mockOtelRepository,
+          baseDimensionsMap,
+          baseAttributes3,
+          () -> 0L,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("should contain all the keys and same values as in baseDimensionsMap"));
@@ -219,8 +319,13 @@ public class AsyncMetricEntityStateTest {
     baseDimensionsMap.put(VENICE_REQUEST_RETRY_TYPE, ERROR_RETRY.getDimensionValue());
     Attributes baseAttributes4 = getBaseAttributes(baseDimensionsMap);
     try {
-      AsyncMetricEntityStateBase
-          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes4, () -> 0L);
+      AsyncMetricEntityStateBase.create(
+          mockMetricEntity,
+          mockOtelRepository,
+          baseDimensionsMap,
+          baseAttributes4,
+          () -> 0L,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -230,8 +335,13 @@ public class AsyncMetricEntityStateTest {
     baseDimensionsMap.clear();
     Attributes baseAttributes5 = Attributes.builder().build();
     try {
-      AsyncMetricEntityStateBase
-          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes5, () -> 0L);
+      AsyncMetricEntityStateBase.create(
+          mockMetricEntity,
+          mockOtelRepository,
+          baseDimensionsMap,
+          baseAttributes5,
+          () -> 0L,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -242,8 +352,13 @@ public class AsyncMetricEntityStateTest {
     baseDimensionsMap.put(VENICE_REQUEST_RETRY_TYPE, ERROR_RETRY.getDimensionValue());
     Attributes baseAttributes6 = getBaseAttributes(baseDimensionsMap);
     try {
-      AsyncMetricEntityStateBase
-          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes6, () -> 0L);
+      AsyncMetricEntityStateBase.create(
+          mockMetricEntity,
+          mockOtelRepository,
+          baseDimensionsMap,
+          baseAttributes6,
+          () -> 0L,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -256,8 +371,13 @@ public class AsyncMetricEntityStateTest {
     baseDimensionsMap.clear();
     baseDimensionsMap.put(VENICE_REQUEST_METHOD, MULTI_GET_STREAMING.getDimensionValue());
     try {
-      AsyncMetricEntityStateBase
-          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes7, () -> 0L);
+      AsyncMetricEntityStateBase.create(
+          mockMetricEntity,
+          mockOtelRepository,
+          baseDimensionsMap,
+          baseAttributes7,
+          () -> 0L,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("should have the same size and values"));
@@ -268,8 +388,13 @@ public class AsyncMetricEntityStateTest {
     baseDimensionsMap.clear();
     baseDimensionsMap.put(VENICE_REQUEST_METHOD, null);
     try {
-      AsyncMetricEntityStateBase
-          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes8, () -> 0L);
+      AsyncMetricEntityStateBase.create(
+          mockMetricEntity,
+          mockOtelRepository,
+          baseDimensionsMap,
+          baseAttributes8,
+          () -> 0L,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("should contain all the keys and same values as in baseDimensionsMap"));
@@ -280,7 +405,8 @@ public class AsyncMetricEntityStateTest {
     baseDimensionsMap.clear();
     baseDimensionsMap.put(VENICE_REQUEST_METHOD, MULTI_GET_STREAMING.getDimensionValue());
     try {
-      AsyncMetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, null, () -> 0L);
+      AsyncMetricEntityStateBase
+          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, null, () -> 0L, CompositeCloseable.NONE);
     } catch (IllegalArgumentException e) {
       fail("baseAttributes can be null when emitting OTel metrics is disabled");
     }
@@ -289,7 +415,8 @@ public class AsyncMetricEntityStateTest {
 
     // case 10: baseAttributes is null but emitting OTel metrics is enabled. This should throw exception.
     try {
-      AsyncMetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, null, () -> 0L);
+      AsyncMetricEntityStateBase
+          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, null, () -> 0L, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("Base attributes cannot be null"));
@@ -314,7 +441,8 @@ public class AsyncMetricEntityStateTest {
           singletonList(new Count()), // No AsyncGauge in stats
           baseDimensionsMap,
           baseAttributes,
-          () -> 0L);
+          () -> 0L,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(
@@ -340,7 +468,8 @@ public class AsyncMetricEntityStateTest {
           Arrays.asList(new AsyncGauge((ignored, ignored2) -> 0, "test"), new Count()),
           baseDimensionsMap,
           baseAttributes,
-          () -> 0L);
+          () -> 0L,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(
@@ -363,7 +492,8 @@ public class AsyncMetricEntityStateTest {
         Arrays.asList(new AsyncGauge((ignored, ignored2) -> 0, "test")),
         baseDimensionsMap,
         baseAttributes,
-        () -> 0L);
+        () -> 0L,
+        CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
 
     // case 4: MetricType is ASYNC_DOUBLE_GAUGE, but tehuti has Count instead of AsyncGauge
@@ -384,7 +514,8 @@ public class AsyncMetricEntityStateTest {
           singletonList(new Count()),
           baseDimensionsMap,
           baseAttributes,
-          (DoubleSupplier) () -> 0.5);
+          (DoubleSupplier) () -> 0.5,
+          CompositeCloseable.NONE);
       fail("Should throw for ASYNC_DOUBLE_GAUGE with non-AsyncGauge Tehuti stat");
     } catch (IllegalArgumentException e) {
       assertTrue(
@@ -407,7 +538,8 @@ public class AsyncMetricEntityStateTest {
         singletonList(new AsyncGauge((ignored1, ignored2) -> 0, "test")),
         baseDimensionsMap,
         baseAttributes,
-        () -> 0L);
+        () -> 0L,
+        CompositeCloseable.NONE);
 
     assertTrue(metricEntityState.emitTehutiMetrics(), "Should emit Tehuti metrics when enabled");
     assertNotNull(metricEntityState.getTehutiSensor(), "Tehuti sensor should be created when enabled");
@@ -425,7 +557,8 @@ public class AsyncMetricEntityStateTest {
         singletonList(new AsyncGauge((ignored1, ignored2) -> 0, "test")),
         baseDimensionsMap,
         baseAttributes,
-        () -> 0L);
+        () -> 0L,
+        CompositeCloseable.NONE);
 
     assertFalse(metricEntityState.emitTehutiMetrics(), "Should not emit Tehuti metrics when disabled");
     Assert.assertNull(metricEntityState.getTehutiSensor(), "Tehuti sensor should not be created when disabled");
@@ -442,7 +575,8 @@ public class AsyncMetricEntityStateTest {
         singletonList(new AsyncGauge((ignored1, ignored2) -> 0, "test")),
         baseDimensionsMap,
         baseAttributes,
-        () -> 0L);
+        () -> 0L,
+        CompositeCloseable.NONE);
 
     assertTrue(metricEntityState.emitTehutiMetrics(), "Should emit Tehuti metrics when repository is null");
     assertNotNull(
@@ -461,7 +595,8 @@ public class AsyncMetricEntityStateTest {
         singletonList(new AsyncGauge((ignored1, ignored2) -> 0, "test")),
         baseDimensionsMap,
         baseAttributes,
-        () -> 0L);
+        () -> 0L,
+        CompositeCloseable.NONE);
 
     assertFalse(
         metricEntityState.emitTehutiMetrics(),
@@ -482,7 +617,8 @@ public class AsyncMetricEntityStateTest {
         new ArrayList<>(), // Empty stats list
         baseDimensionsMap,
         baseAttributes,
-        () -> 0L);
+        () -> 0L,
+        CompositeCloseable.NONE);
 
     assertFalse(metricEntityState.emitTehutiMetrics(), "Should not emit Tehuti metrics when stats are empty");
     Assert.assertNull(metricEntityState.getTehutiSensor(), "Tehuti sensor should not be created when stats are empty");
@@ -502,7 +638,8 @@ public class AsyncMetricEntityStateTest {
         singletonList(new AsyncGauge((ignored1, ignored2) -> 0, "test")),
         baseDimensionsMap,
         baseAttributes,
-        () -> 0L);
+        () -> 0L,
+        CompositeCloseable.NONE);
 
     assertFalse(metricEntityState.emitOpenTelemetryMetrics(), "OTel metrics should be disabled");
     assertTrue(metricEntityState.emitTehutiMetrics(), "Tehuti metrics should be enabled independently");

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateTwoEnumsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/AsyncMetricEntityStateTwoEnumsTest.java
@@ -5,6 +5,7 @@ import static com.linkedin.venice.stats.metrics.MetricEntityStateTest.DimensionE
 import static com.linkedin.venice.stats.metrics.MetricType.ASYNC_GAUGE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -21,6 +22,7 @@ import com.linkedin.venice.stats.metrics.AsyncMetricResolvers.LiveStateResolverT
 import com.linkedin.venice.stats.metrics.AsyncMetricResolvers.ValueResolverTwoEnums;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+import io.opentelemetry.api.metrics.ObservableLongGauge;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -61,7 +63,8 @@ public class AsyncMetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTes
         DimensionEnum1.class,
         DimensionEnum2.class,
         (e1, e2) -> e1,
-        (state, e1, e2) -> 1L);
+        (state, e1, e2) -> 1L,
+        CompositeCloseable.NONE);
 
     assertNotNull(metricState);
     assertFalse(metricState.emitOpenTelemetryMetrics());
@@ -78,7 +81,8 @@ public class AsyncMetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTes
         DimensionEnum1.class,
         DimensionEnum2.class,
         (e1, e2) -> e1,
-        (state, e1, e2) -> 1L);
+        (state, e1, e2) -> 1L,
+        CompositeCloseable.NONE);
 
     assertTrue(metricState.emitOpenTelemetryMetrics());
     verify(mockOtelRepository, times(1)).registerObservableLongGauge(eq(mockMetricEntity), any());
@@ -111,7 +115,8 @@ public class AsyncMetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTes
         DimensionEnum1.class,
         DimensionEnum2.class,
         liveStateResolver,
-        (state, e1, e2) -> 42L);
+        (state, e1, e2) -> 42L,
+        CompositeCloseable.NONE);
     Consumer<ObservableLongMeasurement> callback = callbackCaptor.getValue();
 
     ObservableLongMeasurement measurement = mock(ObservableLongMeasurement.class);
@@ -142,7 +147,8 @@ public class AsyncMetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTes
         DimensionEnum1.class,
         DimensionEnum2.class,
         liveStateResolver,
-        (state, e1, e2) -> 3L);
+        (state, e1, e2) -> 3L,
+        CompositeCloseable.NONE);
 
     ObservableLongMeasurement measurement = mock(ObservableLongMeasurement.class);
     callbackCaptor.getValue().accept(measurement);
@@ -166,7 +172,8 @@ public class AsyncMetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTes
         DimensionEnum1.class,
         DimensionEnum2.class,
         (e1, e2) -> null, // always dormant
-        valueResolver);
+        valueResolver,
+        CompositeCloseable.NONE);
     callbackCaptor.getValue().accept(mock(ObservableLongMeasurement.class));
 
     verifyNoInteractions(valueResolver);
@@ -186,7 +193,8 @@ public class AsyncMetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTes
         DimensionEnum1.class,
         DimensionEnum2.class,
         liveStateResolver,
-        (state, e1, e2) -> 1L);
+        (state, e1, e2) -> 1L,
+        CompositeCloseable.NONE);
     Consumer<ObservableLongMeasurement> callback = callbackCaptor.getValue();
 
     // First collection: nothing live.
@@ -219,7 +227,8 @@ public class AsyncMetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTes
         DimensionEnum1.class,
         DimensionEnum2.class,
         (e1, e2) -> e1,
-        (state, e1, e2) -> 42.9);
+        (state, e1, e2) -> 42.9,
+        CompositeCloseable.NONE);
     Consumer<ObservableLongMeasurement> callback = callbackCaptor.getValue();
 
     ObservableLongMeasurement measurement = mock(ObservableLongMeasurement.class);
@@ -241,7 +250,8 @@ public class AsyncMetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTes
         DimensionEnum1.class,
         DimensionEnum2.class,
         (e1, e2) -> e1,
-        (state, e1, e2) -> 0.75);
+        (state, e1, e2) -> 0.75,
+        CompositeCloseable.NONE);
     Consumer<ObservableDoubleMeasurement> callback = callbackCaptor.getValue();
 
     verify(mockOtelRepository, times(0)).registerObservableLongGauge(eq(mockMetricEntity), any());
@@ -265,7 +275,8 @@ public class AsyncMetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTes
         DimensionEnum1.class,
         DimensionEnum2.class,
         (e1, e2) -> e1,
-        (state, e1, e2) -> 1L);
+        (state, e1, e2) -> 1L,
+        CompositeCloseable.NONE);
 
     assertFalse(metricState.emitOpenTelemetryMetrics());
     assertNull(metricState.getAttributesByEnum());
@@ -289,7 +300,8 @@ public class AsyncMetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTes
         DimensionEnum1.class,
         DimensionEnum2.class,
         (e1, e2) -> e1,
-        (state, e1, e2) -> e1.ordinal() * 100L + e2.ordinal());
+        (state, e1, e2) -> e1.ordinal() * 100L + e2.ordinal(),
+        CompositeCloseable.NONE);
 
     ObservableLongMeasurement measurement = mock(ObservableLongMeasurement.class);
     callbackCaptor.getValue().accept(measurement);
@@ -332,7 +344,8 @@ public class AsyncMetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTes
                 "state mismatch for (" + e1 + "," + e2 + "): got " + state + ", expected " + expected);
           }
           return 1L;
-        });
+        },
+        CompositeCloseable.NONE);
 
     // If any pair crosses state, the valueResolver throws -> callback propagates -> test fails.
     callbackCaptor.getValue().accept(mock(ObservableLongMeasurement.class));
@@ -349,7 +362,76 @@ public class AsyncMetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTes
         DimensionEnum1.class,
         DimensionEnum2.class,
         (e1, e2) -> e1,
-        (state, e1, e2) -> 1L);
+        (state, e1, e2) -> 1L,
+        CompositeCloseable.NONE);
+  }
+
+  @Test
+  public void testCloseDeregistersInstrumentClearsAttributesAndIsIdempotent() throws Exception {
+    ObservableLongGauge mockGauge = mock(ObservableLongGauge.class);
+    when(mockOtelRepository.registerObservableLongGauge(eq(mockMetricEntity), any())).thenReturn(mockGauge);
+
+    AsyncMetricEntityStateTwoEnums<DimensionEnum1, DimensionEnum2> state = AsyncMetricEntityStateTwoEnums.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        DimensionEnum1.class,
+        DimensionEnum2.class,
+        (e1, e2) -> e1,
+        (s, e1, e2) -> 1L,
+        CompositeCloseable.NONE);
+    assertNotNull(state.getInstrument());
+    assertNotNull(state.getAttributesByEnum());
+
+    state.close();
+    verify(mockGauge, times(1)).close();
+    assertNull(state.getInstrument());
+    assertNull(state.getAttributesByEnum());
+
+    state.close();
+    verify(mockGauge, times(1)).close();
+  }
+
+  @Test
+  public void testCloseWithOtelDisabledIsNoOp() {
+    when(mockOtelRepository.emitOpenTelemetryMetrics()).thenReturn(false);
+
+    AsyncMetricEntityStateTwoEnums<DimensionEnum1, DimensionEnum2> state = AsyncMetricEntityStateTwoEnums.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        DimensionEnum1.class,
+        DimensionEnum2.class,
+        (e1, e2) -> e1,
+        (s, e1, e2) -> 1L,
+        CompositeCloseable.NONE);
+    assertFalse(state.emitOpenTelemetryMetrics());
+
+    state.close();
+    state.close();
+  }
+
+  @Test
+  public void testCloseSwallowsExceptionFromMisbehavingSdkInstrument() throws Exception {
+    ObservableLongGauge mockGauge = mock(ObservableLongGauge.class);
+    doThrow(new RuntimeException("simulated SDK close failure")).when(mockGauge).close();
+    when(mockOtelRepository.registerObservableLongGauge(eq(mockMetricEntity), any())).thenReturn(mockGauge);
+    when(mockMetricEntity.getMetricName()).thenReturn("test_metric");
+
+    AsyncMetricEntityStateTwoEnums<DimensionEnum1, DimensionEnum2> state = AsyncMetricEntityStateTwoEnums.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        DimensionEnum1.class,
+        DimensionEnum2.class,
+        (e1, e2) -> e1,
+        (s, e1, e2) -> 1L,
+        CompositeCloseable.NONE);
+
+    // Best-effort: the exception is logged at WARN and swallowed.
+    state.close();
+    verify(mockGauge, times(1)).close();
+    assertNull(state.getInstrument());
   }
 
   @SuppressWarnings("unchecked")

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/CompositeCloseableTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/CompositeCloseableTest.java
@@ -1,0 +1,289 @@
+package com.linkedin.venice.stats.metrics;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link CompositeCloseable}. The class is a load-bearing piece of the OTel
+ * runtime cleanup framework; ~100 production sites depend on the contract verified here.
+ */
+public class CompositeCloseableTest {
+  /** Records its index when close() is invoked, so tests can verify ordering. */
+  private static final class IndexRecordingCloseable implements Closeable {
+    private final List<Integer> closeOrder;
+    private final int myIndex;
+    private boolean closed = false;
+
+    IndexRecordingCloseable(List<Integer> closeOrder, int myIndex) {
+      this.closeOrder = closeOrder;
+      this.myIndex = myIndex;
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+      closeOrder.add(myIndex);
+    }
+
+    boolean isClosed() {
+      return closed;
+    }
+  }
+
+  private static final class ThrowingCloseable implements Closeable {
+    private final RuntimeException toThrow;
+    boolean closeCalled = false;
+
+    ThrowingCloseable(RuntimeException toThrow) {
+      this.toThrow = toThrow;
+    }
+
+    @Override
+    public void close() {
+      closeCalled = true;
+      throw toThrow;
+    }
+  }
+
+  private static final class CountingCloseable implements Closeable {
+    int closeCount = 0;
+
+    @Override
+    public void close() {
+      closeCount++;
+    }
+  }
+
+  @Test
+  public void testRegisterReturnsResourceForFluentAssignment() {
+    CompositeCloseable resources = new CompositeCloseable();
+    CountingCloseable c = new CountingCloseable();
+    Closeable returned = resources.register(c);
+    assertSame(returned, c, "register() must return the same instance for fluent assignment");
+  }
+
+  @Test
+  public void testRegisterNullIsSilentlyIgnored() {
+    CompositeCloseable resources = new CompositeCloseable();
+    // Must not throw.
+    Closeable returned = resources.register(null);
+    assertNull(returned, "register(null) must return null");
+    resources.close(); // Must not throw despite no resources.
+  }
+
+  @Test
+  public void testCloseInvokesAllRegisteredResourcesInReverseOrder() {
+    CompositeCloseable resources = new CompositeCloseable();
+    List<Integer> closeOrder = new ArrayList<>();
+    IndexRecordingCloseable a = new IndexRecordingCloseable(closeOrder, 0);
+    IndexRecordingCloseable b = new IndexRecordingCloseable(closeOrder, 1);
+    IndexRecordingCloseable c = new IndexRecordingCloseable(closeOrder, 2);
+    resources.register(a);
+    resources.register(b);
+    resources.register(c);
+
+    resources.close();
+
+    assertTrue(a.isClosed());
+    assertTrue(b.isClosed());
+    assertTrue(c.isClosed());
+    assertEquals(closeOrder, Arrays.asList(2, 1, 0), "close() must run in reverse registration order");
+  }
+
+  @Test
+  public void testCloseIsIdempotent() {
+    CompositeCloseable resources = new CompositeCloseable();
+    CountingCloseable c = new CountingCloseable();
+    resources.register(c);
+
+    resources.close();
+    resources.close();
+    resources.close();
+
+    assertEquals(c.closeCount, 1, "Resource must be closed exactly once across multiple close() calls");
+  }
+
+  @Test
+  public void testThrowingCloseableDoesNotAbortIteration() {
+    // Verifies the documented contract: "a misbehaving wrapper cannot block shutdown."
+    // closeQuietly catches Exception, so RuntimeException from one resource must NOT
+    // skip the close() of the others.
+    CompositeCloseable resources = new CompositeCloseable();
+    CountingCloseable before = new CountingCloseable();
+    ThrowingCloseable throwing = new ThrowingCloseable(new IllegalStateException("simulated bad close"));
+    CountingCloseable after = new CountingCloseable();
+    resources.register(before);
+    resources.register(throwing);
+    resources.register(after);
+
+    resources.close();
+
+    assertTrue(throwing.closeCalled, "Throwing resource's close() must have been invoked");
+    // Reverse order: after closes first, then throwing (throws), then before must still close.
+    assertEquals(after.closeCount, 1, "Sibling registered after the throwing resource must still close");
+    assertEquals(before.closeCount, 1, "Sibling registered before the throwing resource must still close");
+  }
+
+  @Test
+  public void testThrowingCloseableHandlesRuntimeExceptionTypes() {
+    // Verifies catch is broad enough for the various runtime exceptions the OTel SDK can
+    // produce: NPE from a half-init instrument, ClassCastException from a wrong cast, etc.
+    CompositeCloseable resources = new CompositeCloseable();
+    resources.register(new ThrowingCloseable(new NullPointerException("simulated NPE")));
+    resources.register(new ThrowingCloseable(new ClassCastException("simulated CCE")));
+    resources.register(new ThrowingCloseable(new IllegalStateException("simulated ISE")));
+
+    // Must not throw; all swallowed by closeQuietly.
+    resources.close();
+  }
+
+  @Test
+  public void testCloseableThatThrowsIOExceptionIsAlsoSwallowed() {
+    CompositeCloseable resources = new CompositeCloseable();
+    resources.register(() -> {
+      throw new IOException("simulated IO failure");
+    });
+    // Must not propagate IOException either.
+    resources.close();
+  }
+
+  @Test
+  public void testRegisterAfterCloseImmediatelyClosesResource() {
+    // After close(), the registry is in a closed state. Subsequent register() must close
+    // the resource immediately rather than tracking it (preventing leaks from racy shutdown
+    // ordering, e.g., a per-store map populated mid-shutdown).
+    CompositeCloseable resources = new CompositeCloseable();
+    resources.close();
+
+    CountingCloseable late = new CountingCloseable();
+    Closeable returned = resources.register(late);
+
+    assertSame(returned, late, "register() after close still returns the resource for assignment");
+    assertEquals(late.closeCount, 1, "Resource registered after close() must be closed immediately");
+  }
+
+  @Test
+  public void testRegisterAfterCloseDoesNotResurrect() {
+    // Calling close() again after a post-close register() must not re-close the resource.
+    CompositeCloseable resources = new CompositeCloseable();
+    resources.close();
+    CountingCloseable late = new CountingCloseable();
+    resources.register(late);
+
+    resources.close();
+
+    assertEquals(late.closeCount, 1, "Resource must not be closed twice on a closed registry");
+  }
+
+  @Test
+  public void testNoneSentinelDoesNotTrack() {
+    // CompositeCloseable.NONE must be a no-op: register() returns the resource without tracking,
+    // close() does nothing. Tests rely on this so passing NONE doesn't accumulate state across
+    // unrelated tests.
+    CountingCloseable c = new CountingCloseable();
+    Closeable returned = CompositeCloseable.NONE.register(c);
+    assertSame(returned, c, "NONE.register() must return the resource");
+
+    CompositeCloseable.NONE.close();
+
+    assertEquals(c.closeCount, 0, "NONE must not track or close the registered resource");
+  }
+
+  @Test
+  public void testNoneIsThreadSafeAndIdempotent() {
+    // Sanity: NONE has no internal state to corrupt, so this is just a smoke test.
+    for (int i = 0; i < 100; i++) {
+      CompositeCloseable.NONE.register(new CountingCloseable());
+      CompositeCloseable.NONE.close();
+    }
+  }
+
+  @Test
+  public void testConcurrentRegisterIsThreadSafe() throws InterruptedException {
+    // Even though the production usage pattern is "register at construction time" (single-threaded),
+    // the contract claims thread safety. Verify by stressing register() from multiple threads.
+    CompositeCloseable resources = new CompositeCloseable();
+    int threadCount = 8;
+    int perThread = 500;
+    AtomicInteger closeCallCount = new AtomicInteger();
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+
+    try {
+      for (int t = 0; t < threadCount; t++) {
+        pool.submit(() -> {
+          start.await();
+          for (int i = 0; i < perThread; i++) {
+            resources.register(closeCallCount::incrementAndGet);
+          }
+          return null;
+        });
+      }
+      start.countDown();
+      pool.shutdown();
+      assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS));
+
+      resources.close();
+
+      assertEquals(
+          closeCallCount.get(),
+          threadCount * perThread,
+          "Every concurrently-registered resource must be closed exactly once");
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  @Test
+  public void testConcurrentRegisterAndCloseDoesNotLeak() throws InterruptedException {
+    // Race: one thread closes while another registers. The closed-flag guard ensures any
+    // resource that races past close() is closed immediately rather than leaking.
+    int rounds = 100;
+    for (int round = 0; round < rounds; round++) {
+      CompositeCloseable resources = new CompositeCloseable();
+      AtomicInteger closeCallCount = new AtomicInteger();
+      CountDownLatch ready = new CountDownLatch(2);
+      CountDownLatch fire = new CountDownLatch(1);
+      ExecutorService pool = Executors.newFixedThreadPool(2);
+
+      pool.submit(() -> {
+        ready.countDown();
+        fire.await();
+        for (int i = 0; i < 100; i++) {
+          resources.register(closeCallCount::incrementAndGet);
+        }
+        return null;
+      });
+      pool.submit(() -> {
+        ready.countDown();
+        fire.await();
+        resources.close();
+        return null;
+      });
+
+      ready.await();
+      fire.countDown();
+      pool.shutdown();
+      assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS));
+
+      // Guarantee: any resource registered before close completed was closed; any registered
+      // after was closed immediately by the post-close guard. Net: closeCount == 100.
+      assertEquals(closeCallCount.get(), 100, "All registered resources must be closed even under register/close race");
+    }
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateFiveEnumsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateFiveEnumsTest.java
@@ -73,7 +73,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
             MetricEntityStateTest.DimensionEnum4.class,
-            MetricEntityStateTest.DimensionEnum5.class);
+            MetricEntityStateTest.DimensionEnum5.class,
+            CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
     assertNull(metricEntityState.getMetricAttributesDataEnumMap());
     for (MetricEntityStateTest.DimensionEnum1 enum1: MetricEntityStateTest.DimensionEnum1.values()) {
@@ -100,7 +101,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
             MetricEntityStateTest.DimensionEnum4.class,
-            MetricEntityStateTest.DimensionEnum5.class);
+            MetricEntityStateTest.DimensionEnum5.class,
+            CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
     assertEquals(metricEntityState.getMetricAttributesDataEnumMap().size(), 0);
   }
@@ -115,7 +117,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
         MetricEntityStateTest.EmptyDimensionEnum.class,
         MetricEntityStateTest.EmptyDimensionEnum.class,
         MetricEntityStateTest.EmptyDimensionEnum.class,
-        MetricEntityStateTest.EmptyDimensionEnum.class);
+        MetricEntityStateTest.EmptyDimensionEnum.class,
+        CompositeCloseable.NONE);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "The input Otel dimension cannot be null.*")
@@ -129,7 +132,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
             MetricEntityStateTest.DimensionEnum4.class,
-            MetricEntityStateTest.DimensionEnum5.class);
+            MetricEntityStateTest.DimensionEnum5.class,
+            CompositeCloseable.NONE);
     metricEntityState.getAttributes(null, null, null, null, null);
   }
 
@@ -143,7 +147,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
         MetricEntityStateTest.DimensionEnum2.class,
         MetricEntityStateTest.DimensionEnum3.class,
         MetricEntityStateTest.DimensionEnum4.class,
-        MetricEntityStateTest.DimensionEnum5.class);
+        MetricEntityStateTest.DimensionEnum5.class,
+        CompositeCloseable.NONE);
     metricEntityState.getAttributes(
         MULTI_GET_STREAMING,
         MULTI_GET_STREAMING,
@@ -172,7 +177,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
         MetricEntityStateTest.DimensionEnum2.class,
         MetricEntityStateTest.DimensionEnum1Duplicate.class, // duplicate
         MetricEntityStateTest.DimensionEnum3.class,
-        MetricEntityStateTest.DimensionEnum4.class);
+        MetricEntityStateTest.DimensionEnum4.class,
+        CompositeCloseable.NONE);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*doesn't match with the required dimensions.*")
@@ -188,7 +194,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
         MetricEntityStateTest.DimensionEnum2.class,
         MetricEntityStateTest.DimensionEnum3.class,
         MetricEntityStateTest.DimensionEnum4.class,
-        MetricEntityStateTest.DimensionEnum5.class);
+        MetricEntityStateTest.DimensionEnum5.class,
+        CompositeCloseable.NONE);
   }
 
   @Test
@@ -202,7 +209,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
             MetricEntityStateTest.DimensionEnum4.class,
-            MetricEntityStateTest.DimensionEnum5.class);
+            MetricEntityStateTest.DimensionEnum5.class,
+            CompositeCloseable.NONE);
 
     // getAttributes will work similarly for all cases as the attributes are either pre created
     // or on demand
@@ -270,7 +278,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
             MetricEntityStateTest.DimensionEnum4.class,
-            MetricEntityStateTest.DimensionEnum5.class);
+            MetricEntityStateTest.DimensionEnum5.class,
+            CompositeCloseable.NONE);
 
     Attributes diag1 = metricEntityState.getAttributes(
         MetricEntityStateTest.DimensionEnum1.DIMENSION_ONE,
@@ -311,7 +320,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
             MetricEntityStateTest.DimensionEnum4.class,
-            MetricEntityStateTest.DimensionEnum5.class);
+            MetricEntityStateTest.DimensionEnum5.class,
+            CompositeCloseable.NONE);
     metricEntityState.record(
         100L,
         DIMENSION_ONE,
@@ -429,7 +439,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
             MetricEntityStateTest.DimensionEnum4.class,
-            MetricEntityStateTest.DimensionEnum5.class);
+            MetricEntityStateTest.DimensionEnum5.class,
+            CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
 
     // case 2: baseDimensionsMap has extra values
@@ -445,7 +456,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
           MetricEntityStateTest.DimensionEnum2.class,
           MetricEntityStateTest.DimensionEnum3.class,
           MetricEntityStateTest.DimensionEnum4.class,
-          MetricEntityStateTest.DimensionEnum5.class);
+          MetricEntityStateTest.DimensionEnum5.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -462,7 +474,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
           MetricEntityStateTest.DimensionEnum2.class,
           MetricEntityStateTest.DimensionEnum3.class,
           MetricEntityStateTest.DimensionEnum4.class,
-          MetricEntityStateTest.DimensionEnum5.class);
+          MetricEntityStateTest.DimensionEnum5.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -480,7 +493,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
           MetricEntityStateTest.DimensionEnum2.class,
           MetricEntityStateTest.DimensionEnum3.class,
           MetricEntityStateTest.DimensionEnum4.class,
-          MetricEntityStateTest.DimensionEnum5.class);
+          MetricEntityStateTest.DimensionEnum5.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -498,7 +512,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
             MetricEntityStateTest.DimensionEnum4.class,
-            MetricEntityStateTest.DimensionEnum5.class);
+            MetricEntityStateTest.DimensionEnum5.class,
+            CompositeCloseable.NONE);
     // Populate the 5-level EnumMap with 2 distinct entries spanning all enum levels
     state.record(
         100L,
@@ -533,7 +548,8 @@ public class MetricEntityStateFiveEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
             MetricEntityStateTest.DimensionEnum4.class,
-            MetricEntityStateTest.DimensionEnum5.class);
+            MetricEntityStateTest.DimensionEnum5.class,
+            CompositeCloseable.NONE);
     assertNull(disabled.getAllMetricAttributesData());
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateFourEnumsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateFourEnumsTest.java
@@ -69,7 +69,8 @@ public class MetricEntityStateFourEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum1.class,
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
-            MetricEntityStateTest.DimensionEnum4.class);
+            MetricEntityStateTest.DimensionEnum4.class,
+            CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
     assertNull(metricEntityState.getMetricAttributesDataEnumMap());
     for (MetricEntityStateTest.DimensionEnum1 enum1: MetricEntityStateTest.DimensionEnum1.values()) {
@@ -93,7 +94,8 @@ public class MetricEntityStateFourEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum1.class,
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
-            MetricEntityStateTest.DimensionEnum4.class);
+            MetricEntityStateTest.DimensionEnum4.class,
+            CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
     assertEquals(metricEntityState.getMetricAttributesDataEnumMap().size(), 0);
   }
@@ -107,7 +109,8 @@ public class MetricEntityStateFourEnumsTest extends MetricEntityStateEnumTestBas
         MetricEntityStateTest.EmptyDimensionEnum.class,
         MetricEntityStateTest.EmptyDimensionEnum.class,
         MetricEntityStateTest.EmptyDimensionEnum.class,
-        MetricEntityStateTest.EmptyDimensionEnum.class);
+        MetricEntityStateTest.EmptyDimensionEnum.class,
+        CompositeCloseable.NONE);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "The input Otel dimension cannot be null.*")
@@ -120,7 +123,8 @@ public class MetricEntityStateFourEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum1.class,
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
-            MetricEntityStateTest.DimensionEnum4.class);
+            MetricEntityStateTest.DimensionEnum4.class,
+            CompositeCloseable.NONE);
     metricEntityState.getAttributes(null, null, null, null);
   }
 
@@ -133,7 +137,8 @@ public class MetricEntityStateFourEnumsTest extends MetricEntityStateEnumTestBas
         MetricEntityStateTest.DimensionEnum1.class,
         MetricEntityStateTest.DimensionEnum2.class,
         MetricEntityStateTest.DimensionEnum3.class,
-        MetricEntityStateTest.DimensionEnum4.class);
+        MetricEntityStateTest.DimensionEnum4.class,
+        CompositeCloseable.NONE);
     metricEntityState.getAttributes(MULTI_GET_STREAMING, MULTI_GET_STREAMING, MULTI_GET_STREAMING, MULTI_GET_STREAMING);
   }
 
@@ -155,7 +160,8 @@ public class MetricEntityStateFourEnumsTest extends MetricEntityStateEnumTestBas
         MetricEntityStateTest.DimensionEnum1.class,
         MetricEntityStateTest.DimensionEnum2.class,
         MetricEntityStateTest.DimensionEnum1Duplicate.class, // duplicate
-        MetricEntityStateTest.DimensionEnum3.class);
+        MetricEntityStateTest.DimensionEnum3.class,
+        CompositeCloseable.NONE);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*doesn't match with the required dimensions.*")
@@ -170,7 +176,8 @@ public class MetricEntityStateFourEnumsTest extends MetricEntityStateEnumTestBas
         MetricEntityStateTest.DimensionEnum1.class,
         MetricEntityStateTest.DimensionEnum2.class,
         MetricEntityStateTest.DimensionEnum3.class,
-        MetricEntityStateTest.DimensionEnum4.class);
+        MetricEntityStateTest.DimensionEnum4.class,
+        CompositeCloseable.NONE);
   }
 
   @Test
@@ -183,7 +190,8 @@ public class MetricEntityStateFourEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum1.class,
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
-            MetricEntityStateTest.DimensionEnum4.class);
+            MetricEntityStateTest.DimensionEnum4.class,
+            CompositeCloseable.NONE);
 
     // getAttributes will work similarly for all cases as the attributes are either pre created
     // or on demand
@@ -240,7 +248,8 @@ public class MetricEntityStateFourEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum1.class,
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
-            MetricEntityStateTest.DimensionEnum4.class);
+            MetricEntityStateTest.DimensionEnum4.class,
+            CompositeCloseable.NONE);
     metricEntityState.record(
         100L,
         DIMENSION_ONE,
@@ -344,7 +353,8 @@ public class MetricEntityStateFourEnumsTest extends MetricEntityStateEnumTestBas
             MetricEntityStateTest.DimensionEnum1.class,
             MetricEntityStateTest.DimensionEnum2.class,
             MetricEntityStateTest.DimensionEnum3.class,
-            MetricEntityStateTest.DimensionEnum4.class);
+            MetricEntityStateTest.DimensionEnum4.class,
+            CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
 
     // case 2: baseDimensionsMap has extra values
@@ -359,7 +369,8 @@ public class MetricEntityStateFourEnumsTest extends MetricEntityStateEnumTestBas
           MetricEntityStateTest.DimensionEnum1.class,
           MetricEntityStateTest.DimensionEnum2.class,
           MetricEntityStateTest.DimensionEnum3.class,
-          MetricEntityStateTest.DimensionEnum4.class);
+          MetricEntityStateTest.DimensionEnum4.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -375,7 +386,8 @@ public class MetricEntityStateFourEnumsTest extends MetricEntityStateEnumTestBas
           MetricEntityStateTest.DimensionEnum1.class,
           MetricEntityStateTest.DimensionEnum2.class,
           MetricEntityStateTest.DimensionEnum3.class,
-          MetricEntityStateTest.DimensionEnum4.class);
+          MetricEntityStateTest.DimensionEnum4.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -392,10 +404,12 @@ public class MetricEntityStateFourEnumsTest extends MetricEntityStateEnumTestBas
           MetricEntityStateTest.DimensionEnum1.class,
           MetricEntityStateTest.DimensionEnum2.class,
           MetricEntityStateTest.DimensionEnum3.class,
-          MetricEntityStateTest.DimensionEnum4.class);
+          MetricEntityStateTest.DimensionEnum4.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
     }
   }
+
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateGenericTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateGenericTest.java
@@ -94,8 +94,8 @@ public class MetricEntityStateGenericTest {
     LongCounter longCounter = mock(LongCounter.class);
     when(mockMetricEntity.getMetricType()).thenReturn(MetricType.COUNTER);
 
-    MetricEntityState metricEntityState =
-        MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap);
+    MetricEntityState metricEntityState = MetricEntityStateGeneric
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, CompositeCloseable.NONE);
     metricEntityState.setOtelMetric(longCounter);
 
     Attributes attributes = Attributes.builder().put("key", "value").build();
@@ -109,8 +109,8 @@ public class MetricEntityStateGenericTest {
     DoubleHistogram doubleHistogram = mock(DoubleHistogram.class);
     when(mockMetricEntity.getMetricType()).thenReturn(HISTOGRAM);
 
-    MetricEntityStateGeneric metricEntityState =
-        MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap);
+    MetricEntityStateGeneric metricEntityState = MetricEntityStateGeneric
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, CompositeCloseable.NONE);
     metricEntityState.setOtelMetric(doubleHistogram);
     metricEntityState.setTehutiSensor(mockSensor);
 
@@ -145,8 +145,8 @@ public class MetricEntityStateGenericTest {
     DoubleHistogram doubleHistogram = mock(DoubleHistogram.class);
     when(mockMetricEntity.getMetricType()).thenReturn(HISTOGRAM);
 
-    MetricEntityStateGeneric metricEntityState =
-        MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap);
+    MetricEntityStateGeneric metricEntityState = MetricEntityStateGeneric
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, CompositeCloseable.NONE);
     metricEntityState.setOtelMetric(doubleHistogram);
     metricEntityState.setTehutiSensor(mockSensor);
 
@@ -190,13 +190,13 @@ public class MetricEntityStateGenericTest {
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*does not support ASYNC_COUNTER_FOR_HIGH_PERF_CASES.*")
   public void testAsyncCounterNotSupported() {
     when(mockMetricEntity.getMetricType()).thenReturn(MetricType.ASYNC_COUNTER_FOR_HIGH_PERF_CASES);
-    MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap);
+    MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, CompositeCloseable.NONE);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*does not support ASYNC_UP_DOWN_COUNTER_FOR_HIGH_PERF_CASES.*")
   public void testAsyncUpDownCounterNotSupported() {
     when(mockMetricEntity.getMetricType()).thenReturn(MetricType.ASYNC_UP_DOWN_COUNTER_FOR_HIGH_PERF_CASES);
-    MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap);
+    MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, CompositeCloseable.NONE);
   }
 
   @Test
@@ -204,8 +204,8 @@ public class MetricEntityStateGenericTest {
     Map<VeniceMetricsDimensions, String> baseDimensionsMap = new HashMap<>();
     // case 1: right values
     baseDimensionsMap.put(VENICE_REQUEST_METHOD, MULTI_GET_STREAMING.getDimensionValue());
-    MetricEntityStateGeneric metricEntityState =
-        MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap);
+    MetricEntityStateGeneric metricEntityState = MetricEntityStateGeneric
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
 
     // case 2: baseDimensionsMap has extra values
@@ -214,7 +214,7 @@ public class MetricEntityStateGenericTest {
     baseDimensionsMap.put(VENICE_REQUEST_RETRY_ABORT_REASON, SLOW_ROUTE.getDimensionValue());
 
     try {
-      MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap);
+      MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("contains invalid dimension"), e.getMessage());
@@ -222,14 +222,15 @@ public class MetricEntityStateGenericTest {
 
     // case 3: baseDimensionsMap has less values
     baseDimensionsMap.clear();
-    metricEntityState = MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap);
+    metricEntityState = MetricEntityStateGeneric
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
 
     // case 4: baseDimensionsMap has same count, but different dimensions
     baseDimensionsMap.clear();
     baseDimensionsMap.put(VENICE_REQUEST_RETRY_ABORT_REASON, SLOW_ROUTE.getDimensionValue());
     try {
-      MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap);
+      MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("contains invalid dimension"), e.getMessage());
@@ -239,7 +240,7 @@ public class MetricEntityStateGenericTest {
     baseDimensionsMap.clear();
     baseDimensionsMap.put(VENICE_REQUEST_METHOD, null);
     try {
-      MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap);
+      MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("contains a null or empty value for dimension"), e.getMessage());
@@ -249,7 +250,7 @@ public class MetricEntityStateGenericTest {
     baseDimensionsMap.clear();
     baseDimensionsMap.put(VENICE_REQUEST_METHOD, "");
     try {
-      MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap);
+      MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("contains a null or empty value for dimension"), e.getMessage());
@@ -261,7 +262,7 @@ public class MetricEntityStateGenericTest {
     baseDimensionsMap.put(VENICE_STORE_NAME, "store1");
     baseDimensionsMap.put(VENICE_CLUSTER_NAME, "cluster1");
     try {
-      MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap);
+      MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("contains all or more dimensions than required"), e.getMessage());
@@ -270,7 +271,7 @@ public class MetricEntityStateGenericTest {
     // case 8: baseDimensionsMap has more keys
     baseDimensionsMap.put(VENICE_REQUEST_RETRY_ABORT_REASON, SLOW_ROUTE.getDimensionValue());
     try {
-      MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap);
+      MetricEntityStateGeneric.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("contains all or more dimensions than required"), e.getMessage());

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateOneEnumTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateOneEnumTest.java
@@ -47,8 +47,12 @@ public class MetricEntityStateOneEnumTest extends MetricEntityStateEnumTestBase 
 
   @Test
   public void testConstructorWithoutOtelRepo() {
-    MetricEntityStateOneEnum<MetricEntityStateTest.DimensionEnum1> metricEntityState = MetricEntityStateOneEnum
-        .create(mockMetricEntity, null, baseDimensionsMap, MetricEntityStateTest.DimensionEnum1.class);
+    MetricEntityStateOneEnum<MetricEntityStateTest.DimensionEnum1> metricEntityState = MetricEntityStateOneEnum.create(
+        mockMetricEntity,
+        null,
+        baseDimensionsMap,
+        MetricEntityStateTest.DimensionEnum1.class,
+        CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
     assertNull(metricEntityState.getMetricAttributesDataEnumMap());
     assertNull(metricEntityState.getAttributes(MetricEntityStateTest.DimensionEnum1.DIMENSION_ONE));
@@ -57,8 +61,12 @@ public class MetricEntityStateOneEnumTest extends MetricEntityStateEnumTestBase 
 
   @Test
   public void testConstructorWithOtelRepo() {
-    MetricEntityStateOneEnum<MetricEntityStateTest.DimensionEnum1> metricEntityState = MetricEntityStateOneEnum
-        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, MetricEntityStateTest.DimensionEnum1.class);
+    MetricEntityStateOneEnum<MetricEntityStateTest.DimensionEnum1> metricEntityState = MetricEntityStateOneEnum.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        MetricEntityStateTest.DimensionEnum1.class,
+        CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
     EnumMap<MetricEntityStateTest.DimensionEnum1, MetricAttributesData> metricAttributesDataEnumMap =
         metricEntityState.getMetricAttributesDataEnumMap();
@@ -71,20 +79,29 @@ public class MetricEntityStateOneEnumTest extends MetricEntityStateEnumTestBase 
         mockMetricEntity,
         mockOtelRepository,
         baseDimensionsMap,
-        MetricEntityStateTest.EmptyDimensionEnum.class);
+        MetricEntityStateTest.EmptyDimensionEnum.class,
+        CompositeCloseable.NONE);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "The input Otel dimension cannot be null.*")
   public void testGetAttributesWithNullDimension() {
-    MetricEntityStateOneEnum<MetricEntityStateTest.DimensionEnum1> metricEntityState = MetricEntityStateOneEnum
-        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, MetricEntityStateTest.DimensionEnum1.class);
+    MetricEntityStateOneEnum<MetricEntityStateTest.DimensionEnum1> metricEntityState = MetricEntityStateOneEnum.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        MetricEntityStateTest.DimensionEnum1.class,
+        CompositeCloseable.NONE);
     metricEntityState.getAttributes(null);
   }
 
   @Test(expectedExceptions = ClassCastException.class)
   public void testGetAttributesWithInvalidDimensionType() {
-    MetricEntityStateOneEnum metricEntityState = MetricEntityStateOneEnum
-        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, MetricEntityStateTest.DimensionEnum1.class);
+    MetricEntityStateOneEnum metricEntityState = MetricEntityStateOneEnum.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        MetricEntityStateTest.DimensionEnum1.class,
+        CompositeCloseable.NONE);
     metricEntityState.getAttributes(MULTI_GET_STREAMING);
   }
 
@@ -93,14 +110,22 @@ public class MetricEntityStateOneEnumTest extends MetricEntityStateEnumTestBase 
     Map<VeniceMetricsDimensions, String> baseDimensionsMap = new HashMap<>();
     baseDimensionsMap.put(VENICE_REQUEST_METHOD, MULTI_GET_STREAMING.getDimensionValue());
     baseDimensionsMap.put(DIMENSION_ONE.getDimensionName(), DIMENSION_ONE.getDimensionValue()); // duplicate
-    MetricEntityStateOneEnum
-        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, MetricEntityStateTest.DimensionEnum1.class);
+    MetricEntityStateOneEnum.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        MetricEntityStateTest.DimensionEnum1.class,
+        CompositeCloseable.NONE);
   }
 
   @Test
   public void testGetAttributesWithValidDimension() {
-    MetricEntityStateOneEnum<MetricEntityStateTest.DimensionEnum1> metricEntityState = MetricEntityStateOneEnum
-        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, MetricEntityStateTest.DimensionEnum1.class);
+    MetricEntityStateOneEnum<MetricEntityStateTest.DimensionEnum1> metricEntityState = MetricEntityStateOneEnum.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        MetricEntityStateTest.DimensionEnum1.class,
+        CompositeCloseable.NONE);
 
     // getAttributes will work similarly for all cases as the attributes are either pre created
     // or on demand
@@ -129,8 +154,12 @@ public class MetricEntityStateOneEnumTest extends MetricEntityStateEnumTestBase 
 
   @Test
   public void testRecordWithValidDimension() {
-    MetricEntityStateOneEnum<MetricEntityStateTest.DimensionEnum1> metricEntityState = MetricEntityStateOneEnum
-        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, MetricEntityStateTest.DimensionEnum1.class);
+    MetricEntityStateOneEnum<MetricEntityStateTest.DimensionEnum1> metricEntityState = MetricEntityStateOneEnum.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        MetricEntityStateTest.DimensionEnum1.class,
+        CompositeCloseable.NONE);
 
     // record attempt 1
     metricEntityState.record(100L, MetricEntityStateTest.DimensionEnum1.DIMENSION_ONE);
@@ -183,8 +212,12 @@ public class MetricEntityStateOneEnumTest extends MetricEntityStateEnumTestBase 
     Map<VeniceMetricsDimensions, String> baseDimensionsMap = new HashMap<>();
     // case 1: right values
     baseDimensionsMap.put(VENICE_REQUEST_METHOD, MULTI_GET_STREAMING.getDimensionValue());
-    MetricEntityStateOneEnum<MetricEntityStateTest.DimensionEnum1> metricEntityState = MetricEntityStateOneEnum
-        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, MetricEntityStateTest.DimensionEnum1.class);
+    MetricEntityStateOneEnum<MetricEntityStateTest.DimensionEnum1> metricEntityState = MetricEntityStateOneEnum.create(
+        mockMetricEntity,
+        mockOtelRepository,
+        baseDimensionsMap,
+        MetricEntityStateTest.DimensionEnum1.class,
+        CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
 
     // case 2: baseDimensionsMap has extra values
@@ -193,8 +226,12 @@ public class MetricEntityStateOneEnumTest extends MetricEntityStateEnumTestBase 
     baseDimensionsMap.put(VENICE_REQUEST_RETRY_ABORT_REASON, SLOW_ROUTE.getDimensionValue());
 
     try {
-      MetricEntityStateOneEnum
-          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, MetricEntityStateTest.DimensionEnum1.class);
+      MetricEntityStateOneEnum.create(
+          mockMetricEntity,
+          mockOtelRepository,
+          baseDimensionsMap,
+          MetricEntityStateTest.DimensionEnum1.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -203,8 +240,12 @@ public class MetricEntityStateOneEnumTest extends MetricEntityStateEnumTestBase 
     // case 3: baseDimensionsMap has less values
     baseDimensionsMap.clear();
     try {
-      MetricEntityStateOneEnum
-          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, MetricEntityStateTest.DimensionEnum1.class);
+      MetricEntityStateOneEnum.create(
+          mockMetricEntity,
+          mockOtelRepository,
+          baseDimensionsMap,
+          MetricEntityStateTest.DimensionEnum1.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -214,8 +255,12 @@ public class MetricEntityStateOneEnumTest extends MetricEntityStateEnumTestBase 
     baseDimensionsMap.clear();
     baseDimensionsMap.put(VENICE_REQUEST_RETRY_ABORT_REASON, SLOW_ROUTE.getDimensionValue());
     try {
-      MetricEntityStateOneEnum
-          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, MetricEntityStateTest.DimensionEnum1.class);
+      MetricEntityStateOneEnum.create(
+          mockMetricEntity,
+          mockOtelRepository,
+          baseDimensionsMap,
+          MetricEntityStateTest.DimensionEnum1.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -225,8 +270,12 @@ public class MetricEntityStateOneEnumTest extends MetricEntityStateEnumTestBase 
     baseDimensionsMap.clear();
     baseDimensionsMap.put(VENICE_REQUEST_METHOD, null);
     try {
-      MetricEntityStateOneEnum
-          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, MetricEntityStateTest.DimensionEnum1.class);
+      MetricEntityStateOneEnum.create(
+          mockMetricEntity,
+          mockOtelRepository,
+          baseDimensionsMap,
+          MetricEntityStateTest.DimensionEnum1.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("contains a null or empty value for dimension"));
@@ -236,11 +285,16 @@ public class MetricEntityStateOneEnumTest extends MetricEntityStateEnumTestBase 
     baseDimensionsMap.clear();
     baseDimensionsMap.put(VENICE_REQUEST_METHOD, "");
     try {
-      MetricEntityStateOneEnum
-          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, MetricEntityStateTest.DimensionEnum1.class);
+      MetricEntityStateOneEnum.create(
+          mockMetricEntity,
+          mockOtelRepository,
+          baseDimensionsMap,
+          MetricEntityStateTest.DimensionEnum1.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("contains a null or empty value for dimension"));
     }
   }
+
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateTest.java
@@ -14,10 +14,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -101,8 +103,8 @@ public class MetricEntityStateTest {
     when(mockOtelRepository.createInstrument(mockMetricEntity)).thenReturn(longCounter);
 
     // without tehuti sensor
-    MetricEntityState metricEntityState =
-        MetricEntityStateBase.create(mockMetricEntity, null, baseDimensionsMap, baseAttributes);
+    MetricEntityState metricEntityState = MetricEntityStateBase
+        .create(mockMetricEntity, null, baseDimensionsMap, baseAttributes, CompositeCloseable.NONE);
     Assert.assertNotNull(metricEntityState);
     Assert.assertNull(metricEntityState.getOtelMetric());
     Assert.assertNull(metricEntityState.getTehutiSensor()); // No Tehuti sensors added
@@ -110,7 +112,8 @@ public class MetricEntityStateTest {
     Assert.assertNull(((MetricEntityStateBase) metricEntityState).getAttributes());
 
     // without tehuti sensor with empty attributes
-    metricEntityState = MetricEntityStateBase.create(mockMetricEntity, null, baseDimensionsMap, null);
+    metricEntityState =
+        MetricEntityStateBase.create(mockMetricEntity, null, baseDimensionsMap, null, CompositeCloseable.NONE);
     Assert.assertNotNull(metricEntityState);
     Assert.assertNull(metricEntityState.getOtelMetric());
     Assert.assertNull(metricEntityState.getTehutiSensor()); // No Tehuti sensors added
@@ -124,7 +127,8 @@ public class MetricEntityStateTest {
         TestTehutiMetricNameEnum.TEST_METRIC,
         singletonList(new Count()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        CompositeCloseable.NONE);
     Assert.assertNotNull(metricEntityState);
     Assert.assertNull(metricEntityState.getOtelMetric());
     Assert.assertNotNull(metricEntityState.getTehutiSensor());
@@ -139,8 +143,8 @@ public class MetricEntityStateTest {
     when(mockOtelRepository.createInstrument(mockMetricEntity)).thenReturn(longCounter);
 
     // without tehuti sensor
-    MetricEntityState metricEntityState =
-        MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes);
+    MetricEntityState metricEntityState = MetricEntityStateBase
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes, CompositeCloseable.NONE);
     Assert.assertNotNull(metricEntityState);
     Assert.assertNotNull(metricEntityState.getOtelMetric());
     Assert.assertNull(metricEntityState.getTehutiSensor()); // No Tehuti sensors added
@@ -148,7 +152,8 @@ public class MetricEntityStateTest {
 
     // without tehuti sensor but with empty attributes
     try {
-      MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, null);
+      MetricEntityStateBase
+          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, null, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().contains("Base attributes cannot be null for MetricEntityStateBase"));
@@ -163,7 +168,8 @@ public class MetricEntityStateTest {
         TestTehutiMetricNameEnum.TEST_METRIC,
         singletonList(new Count()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        CompositeCloseable.NONE);
     Assert.assertNotNull(metricEntityState);
     Assert.assertNotNull(metricEntityState.getOtelMetric());
     Assert.assertNotNull(metricEntityState.getTehutiSensor());
@@ -178,7 +184,8 @@ public class MetricEntityStateTest {
         TestTehutiMetricNameEnum.TEST_METRIC,
         singletonList(new Count()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        CompositeCloseable.NONE);
     Assert.assertNotNull(metricEntityState);
     Assert.assertNotNull(metricEntityState.getOtelMetric());
     Assert.assertNull(metricEntityState.getTehutiSensor());
@@ -191,8 +198,8 @@ public class MetricEntityStateTest {
     DoubleHistogram doubleHistogram = mock(DoubleHistogram.class);
     when(mockMetricEntity.getMetricType()).thenReturn(HISTOGRAM);
 
-    MetricEntityState metricEntityState =
-        MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes);
+    MetricEntityState metricEntityState = MetricEntityStateBase
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes, CompositeCloseable.NONE);
     metricEntityState.setOtelMetric(doubleHistogram);
 
     Attributes attributes = Attributes.builder().put("key", "value").build();
@@ -206,8 +213,8 @@ public class MetricEntityStateTest {
     LongCounter longCounter = mock(LongCounter.class);
     when(mockMetricEntity.getMetricType()).thenReturn(MetricType.COUNTER);
 
-    MetricEntityState metricEntityState =
-        MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes);
+    MetricEntityState metricEntityState = MetricEntityStateBase
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes, CompositeCloseable.NONE);
     metricEntityState.setOtelMetric(longCounter);
 
     Attributes attributes = Attributes.builder().put("key", "value").build();
@@ -221,8 +228,8 @@ public class MetricEntityStateTest {
     LongUpDownCounter longUpDownCounter = mock(LongUpDownCounter.class);
     when(mockMetricEntity.getMetricType()).thenReturn(MetricType.UP_DOWN_COUNTER);
 
-    MetricEntityState metricEntityState =
-        MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes);
+    MetricEntityState metricEntityState = MetricEntityStateBase
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes, CompositeCloseable.NONE);
     metricEntityState.setOtelMetric(longUpDownCounter);
 
     Attributes attributes = Attributes.builder().put("key", "value").build();
@@ -241,8 +248,8 @@ public class MetricEntityStateTest {
     LongGauge longGauge = mock(LongGauge.class);
     when(mockMetricEntity.getMetricType()).thenReturn(MetricType.GAUGE);
 
-    MetricEntityState metricEntityState =
-        MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes);
+    MetricEntityState metricEntityState = MetricEntityStateBase
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes, CompositeCloseable.NONE);
     metricEntityState.setOtelMetric(longGauge);
 
     Attributes attributes = Attributes.builder().put("key", "value").build();
@@ -258,8 +265,8 @@ public class MetricEntityStateTest {
 
   @Test
   public void testRecordTehutiMetric() {
-    MetricEntityState metricEntityState =
-        MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes);
+    MetricEntityState metricEntityState = MetricEntityStateBase
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes, CompositeCloseable.NONE);
     metricEntityState.setTehutiSensor(mockSensor);
     metricEntityState.recordTehutiMetric(15.0);
     verify(mockSensor, times(1)).record(15.0);
@@ -270,8 +277,8 @@ public class MetricEntityStateTest {
     DoubleHistogram doubleHistogram = mock(DoubleHistogram.class);
     when(mockMetricEntity.getMetricType()).thenReturn(HISTOGRAM);
 
-    MetricEntityState metricEntityState =
-        MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes);
+    MetricEntityState metricEntityState = MetricEntityStateBase
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes, CompositeCloseable.NONE);
     metricEntityState.setOtelMetric(doubleHistogram);
     metricEntityState.setTehutiSensor(mockSensor);
 
@@ -298,14 +305,15 @@ public class MetricEntityStateTest {
     // case 1: right values
     baseDimensionsMap.put(VENICE_REQUEST_METHOD, MULTI_GET_STREAMING.getDimensionValue());
     Attributes baseAttributes1 = getBaseAttributes(baseDimensionsMap);
-    MetricEntityState metricEntityState =
-        MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes1);
+    MetricEntityState metricEntityState = MetricEntityStateBase
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes1, CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
 
     // case 2: baseAttributes have different count than baseDimensionsMap
     Attributes baseAttributes2 = Attributes.builder().build();
     try {
-      MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes2);
+      MetricEntityStateBase
+          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes2, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("should have the same size and values"));
@@ -316,7 +324,8 @@ public class MetricEntityStateTest {
     baseAttributes3Map.put(VENICE_REQUEST_RETRY_TYPE, ERROR_RETRY.getDimensionValue());
     Attributes baseAttributes3 = getBaseAttributes(baseAttributes3Map);
     try {
-      MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes3);
+      MetricEntityStateBase
+          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes3, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("should contain all the keys and same values as in baseDimensionsMap"));
@@ -328,7 +337,8 @@ public class MetricEntityStateTest {
     baseDimensionsMap.put(VENICE_REQUEST_RETRY_TYPE, ERROR_RETRY.getDimensionValue());
     Attributes baseAttributes4 = getBaseAttributes(baseDimensionsMap);
     try {
-      MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes4);
+      MetricEntityStateBase
+          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes4, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -338,7 +348,8 @@ public class MetricEntityStateTest {
     baseDimensionsMap.clear();
     Attributes baseAttributes5 = Attributes.builder().build();
     try {
-      MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes5);
+      MetricEntityStateBase
+          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes5, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -349,7 +360,8 @@ public class MetricEntityStateTest {
     baseDimensionsMap.put(VENICE_REQUEST_RETRY_TYPE, ERROR_RETRY.getDimensionValue());
     Attributes baseAttributes6 = getBaseAttributes(baseDimensionsMap);
     try {
-      MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes6);
+      MetricEntityStateBase
+          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes6, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -362,7 +374,8 @@ public class MetricEntityStateTest {
     baseDimensionsMap.clear();
     baseDimensionsMap.put(VENICE_REQUEST_METHOD, MULTI_GET_STREAMING.getDimensionValue());
     try {
-      MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes7);
+      MetricEntityStateBase
+          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes7, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("should have the same size and values"));
@@ -373,7 +386,8 @@ public class MetricEntityStateTest {
     baseDimensionsMap.clear();
     baseDimensionsMap.put(VENICE_REQUEST_METHOD, null);
     try {
-      MetricEntityStateBase.create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes8);
+      MetricEntityStateBase
+          .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes8, CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("should contain all the keys and same values as in baseDimensionsMap"));
@@ -398,7 +412,8 @@ public class MetricEntityStateTest {
           TestTehutiMetricNameEnum.TEST_METRIC,
           singletonList(new AsyncGauge((ignored, ignored2) -> 0, "test")),
           baseDimensionsMap,
-          baseAttributes); // No async callback provided
+          baseAttributes,
+          CompositeCloseable.NONE); // No async callback provided
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(
@@ -421,7 +436,8 @@ public class MetricEntityStateTest {
           TestTehutiMetricNameEnum.TEST_METRIC,
           singletonList(new AsyncGauge((ignored, ignored2) -> 0, "test")),
           baseDimensionsMap,
-          baseAttributes);
+          baseAttributes,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(
@@ -429,6 +445,49 @@ public class MetricEntityStateTest {
               .contains(
                   "Tehuti metric stats contains AsyncGauge, but the otel metric type is not ASYNC_GAUGE/ASYNC_DOUBLE_GAUGE for metric"));
     }
+  }
+
+  @Test
+  public void testRecordAfterCloseIsNoOpOnBase() {
+    DoubleHistogram doubleHistogram = mock(DoubleHistogram.class);
+    when(mockMetricEntity.getMetricType()).thenReturn(HISTOGRAM);
+
+    MetricEntityState metricEntityState = MetricEntityStateBase
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes, CompositeCloseable.NONE);
+    metricEntityState.setOtelMetric(doubleHistogram);
+    metricEntityState.setTehutiSensor(mockSensor);
+
+    Attributes attributes = Attributes.builder().put("key", "value").build();
+    metricEntityState.record(7.0, attributes);
+    verify(doubleHistogram, times(1)).record(7.0, attributes);
+    verify(mockSensor, times(1)).record(7.0);
+
+    metricEntityState.close();
+    assertNull(metricEntityState.getOtelMetric());
+
+    // Post-close: both Tehuti and OTel paths must be silent no-ops.
+    metricEntityState.record(8.0, attributes);
+    metricEntityState.recordOtelMetric(9.0, new MetricAttributesData(attributes));
+    metricEntityState.recordTehutiMetric(10.0);
+    verify(doubleHistogram, never()).record(8.0, attributes);
+    verify(doubleHistogram, never()).record(9.0, attributes);
+    verify(mockSensor, never()).record(8.0);
+    verify(mockSensor, never()).record(10.0);
+  }
+
+  @Test
+  public void testRecordOtelMetricWithNullHolderIsNoOp() {
+    DoubleHistogram doubleHistogram = mock(DoubleHistogram.class);
+    when(mockMetricEntity.getMetricType()).thenReturn(HISTOGRAM);
+
+    MetricEntityState metricEntityState = MetricEntityStateBase
+        .create(mockMetricEntity, mockOtelRepository, baseDimensionsMap, baseAttributes, CompositeCloseable.NONE);
+    metricEntityState.setOtelMetric(doubleHistogram);
+
+    // Holder null guard: must not throw or invoke the SDK.
+    metricEntityState.recordOtelMetric(1.0, null);
+    metricEntityState.recordOtelMetric(2L, null);
+    verify(doubleHistogram, never()).record(any(double.class), any());
   }
 
   private Attributes getBaseAttributes(Map<VeniceMetricsDimensions, String> inputMap) {

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateThreeEnumsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateThreeEnumsTest.java
@@ -75,7 +75,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
             baseDimensionsMap,
             MetricEntityStateTest.DimensionEnum1.class,
             MetricEntityStateTest.DimensionEnum2.class,
-            MetricEntityStateTest.DimensionEnum3.class);
+            MetricEntityStateTest.DimensionEnum3.class,
+            CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
     assertNull(metricEntityState.getMetricAttributesDataEnumMap());
     for (MetricEntityStateTest.DimensionEnum1 enum1: MetricEntityStateTest.DimensionEnum1.values()) {
@@ -96,7 +97,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
             baseDimensionsMap,
             MetricEntityStateTest.DimensionEnum1.class,
             MetricEntityStateTest.DimensionEnum2.class,
-            MetricEntityStateTest.DimensionEnum3.class);
+            MetricEntityStateTest.DimensionEnum3.class,
+            CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
     assertEquals(metricEntityState.getMetricAttributesDataEnumMap().size(), 0);
   }
@@ -109,7 +111,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
         baseDimensionsMap,
         MetricEntityStateTest.EmptyDimensionEnum.class,
         MetricEntityStateTest.EmptyDimensionEnum.class,
-        MetricEntityStateTest.EmptyDimensionEnum.class);
+        MetricEntityStateTest.EmptyDimensionEnum.class,
+        CompositeCloseable.NONE);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "The input Otel dimension cannot be null.*")
@@ -121,7 +124,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
             baseDimensionsMap,
             MetricEntityStateTest.DimensionEnum1.class,
             MetricEntityStateTest.DimensionEnum2.class,
-            MetricEntityStateTest.DimensionEnum3.class);
+            MetricEntityStateTest.DimensionEnum3.class,
+            CompositeCloseable.NONE);
     metricEntityState.getAttributes(null, null, null);
   }
 
@@ -133,7 +137,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
         baseDimensionsMap,
         MetricEntityStateTest.DimensionEnum1.class,
         MetricEntityStateTest.DimensionEnum2.class,
-        MetricEntityStateTest.DimensionEnum3.class);
+        MetricEntityStateTest.DimensionEnum3.class,
+        CompositeCloseable.NONE);
     metricEntityState.getAttributes(MULTI_GET_STREAMING, MULTI_GET_STREAMING, MULTI_GET_STREAMING);
   }
 
@@ -153,7 +158,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
         baseDimensionsMap,
         MetricEntityStateTest.DimensionEnum1.class,
         MetricEntityStateTest.DimensionEnum2.class,
-        MetricEntityStateTest.DimensionEnum1Duplicate.class); // duplicate
+        MetricEntityStateTest.DimensionEnum1Duplicate.class,
+        CompositeCloseable.NONE); // duplicate
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*doesn't match with the required dimensions.*")
@@ -167,7 +173,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
         baseDimensionsMap,
         MetricEntityStateTest.DimensionEnum1.class,
         MetricEntityStateTest.DimensionEnum2.class,
-        MetricEntityStateTest.DimensionEnum3.class);
+        MetricEntityStateTest.DimensionEnum3.class,
+        CompositeCloseable.NONE);
   }
 
   @Test
@@ -179,7 +186,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
             baseDimensionsMap,
             MetricEntityStateTest.DimensionEnum1.class,
             MetricEntityStateTest.DimensionEnum2.class,
-            MetricEntityStateTest.DimensionEnum3.class);
+            MetricEntityStateTest.DimensionEnum3.class,
+            CompositeCloseable.NONE);
 
     // getAttributes will work similarly for all cases as the attributes are either pre created
     // or on demand
@@ -229,7 +237,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
             baseDimensionsMap,
             MetricEntityStateTest.DimensionEnum1.class,
             MetricEntityStateTest.DimensionEnum2.class,
-            MetricEntityStateTest.DimensionEnum3.class);
+            MetricEntityStateTest.DimensionEnum3.class,
+            CompositeCloseable.NONE);
     metricEntityState.record(
         100L,
         DIMENSION_ONE,
@@ -314,7 +323,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
             baseDimensionsMap,
             MetricEntityStateTest.DimensionEnum1.class,
             MetricEntityStateTest.DimensionEnum2.class,
-            MetricEntityStateTest.DimensionEnum3.class);
+            MetricEntityStateTest.DimensionEnum3.class,
+            CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
 
     // case 2: baseDimensionsMap has extra values
@@ -328,7 +338,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
           baseDimensionsMap,
           MetricEntityStateTest.DimensionEnum1.class,
           MetricEntityStateTest.DimensionEnum2.class,
-          MetricEntityStateTest.DimensionEnum3.class);
+          MetricEntityStateTest.DimensionEnum3.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -343,7 +354,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
           baseDimensionsMap,
           MetricEntityStateTest.DimensionEnum1.class,
           MetricEntityStateTest.DimensionEnum2.class,
-          MetricEntityStateTest.DimensionEnum3.class);
+          MetricEntityStateTest.DimensionEnum3.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -359,7 +371,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
           baseDimensionsMap,
           MetricEntityStateTest.DimensionEnum1.class,
           MetricEntityStateTest.DimensionEnum2.class,
-          MetricEntityStateTest.DimensionEnum3.class);
+          MetricEntityStateTest.DimensionEnum3.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -393,7 +406,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
             baseDimensionsMap,
             HttpResponseStatusEnum.class,
             HttpResponseStatusCodeCategory.class,
-            RequestType.class);
+            RequestType.class,
+            CompositeCloseable.NONE);
     for (HttpResponseStatusEnum enum1: HttpResponseStatusEnum.values()) {
       for (HttpResponseStatusCodeCategory enum2: HttpResponseStatusCodeCategory.values()) {
         for (RequestType enum3: RequestType.values()) {
@@ -413,7 +427,8 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
             baseDimensionsMap,
             HttpResponseStatusEnum.class,
             HttpResponseStatusCodeCategory.class,
-            RequestType.class);
+            RequestType.class,
+            CompositeCloseable.NONE);
 
     int writerThreads = 10;
     int readerThreads = 10;
@@ -496,4 +511,5 @@ public class MetricEntityStateThreeEnumsTest extends MetricEntityStateEnumTestBa
       }
     }
   }
+
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateTwoEnumsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricEntityStateTwoEnumsTest.java
@@ -60,7 +60,8 @@ public class MetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTestBase
             null,
             baseDimensionsMap,
             MetricEntityStateTest.DimensionEnum1.class,
-            MetricEntityStateTest.DimensionEnum2.class);
+            MetricEntityStateTest.DimensionEnum2.class,
+            CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
     assertNull(metricEntityState.getMetricAttributesDataEnumMap());
     for (MetricEntityStateTest.DimensionEnum1 enum1: MetricEntityStateTest.DimensionEnum1.values()) {
@@ -78,7 +79,8 @@ public class MetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTestBase
             mockOtelRepository,
             baseDimensionsMap,
             MetricEntityStateTest.DimensionEnum1.class,
-            MetricEntityStateTest.DimensionEnum2.class);
+            MetricEntityStateTest.DimensionEnum2.class,
+            CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
     EnumMap<MetricEntityStateTest.DimensionEnum1, EnumMap<MetricEntityStateTest.DimensionEnum2, MetricAttributesData>> metricAttributesDataEnumMap =
         metricEntityState.getMetricAttributesDataEnumMap();
@@ -92,7 +94,8 @@ public class MetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTestBase
         mockOtelRepository,
         baseDimensionsMap,
         MetricEntityStateTest.EmptyDimensionEnum.class,
-        MetricEntityStateTest.EmptyDimensionEnum.class);
+        MetricEntityStateTest.EmptyDimensionEnum.class,
+        CompositeCloseable.NONE);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "The input Otel dimension cannot be null.*")
@@ -103,7 +106,8 @@ public class MetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTestBase
             mockOtelRepository,
             baseDimensionsMap,
             MetricEntityStateTest.DimensionEnum1.class,
-            MetricEntityStateTest.DimensionEnum2.class);
+            MetricEntityStateTest.DimensionEnum2.class,
+            CompositeCloseable.NONE);
     metricEntityState.getAttributes(null, null);
   }
 
@@ -114,7 +118,8 @@ public class MetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTestBase
         mockOtelRepository,
         baseDimensionsMap,
         MetricEntityStateTest.DimensionEnum1.class,
-        MetricEntityStateTest.DimensionEnum2.class);
+        MetricEntityStateTest.DimensionEnum2.class,
+        CompositeCloseable.NONE);
     metricEntityState.getAttributes(MULTI_GET_STREAMING, MULTI_GET_STREAMING);
   }
 
@@ -132,7 +137,8 @@ public class MetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTestBase
         mockOtelRepository,
         baseDimensionsMap,
         MetricEntityStateTest.DimensionEnum1.class,
-        MetricEntityStateTest.DimensionEnum1Duplicate.class); // duplicate
+        MetricEntityStateTest.DimensionEnum1Duplicate.class,
+        CompositeCloseable.NONE); // duplicate
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*doesn't match with the required dimensions.*")
@@ -145,7 +151,8 @@ public class MetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTestBase
         mockOtelRepository,
         baseDimensionsMap,
         MetricEntityStateTest.DimensionEnum1.class,
-        MetricEntityStateTest.DimensionEnum2.class);
+        MetricEntityStateTest.DimensionEnum2.class,
+        CompositeCloseable.NONE);
   }
 
   @Test
@@ -156,7 +163,8 @@ public class MetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTestBase
             mockOtelRepository,
             baseDimensionsMap,
             MetricEntityStateTest.DimensionEnum1.class,
-            MetricEntityStateTest.DimensionEnum2.class);
+            MetricEntityStateTest.DimensionEnum2.class,
+            CompositeCloseable.NONE);
 
     // getAttributes will work similarly for all cases as the attributes are either pre created
     // or on demand
@@ -197,7 +205,8 @@ public class MetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTestBase
             mockOtelRepository,
             baseDimensionsMap,
             MetricEntityStateTest.DimensionEnum1.class,
-            MetricEntityStateTest.DimensionEnum2.class);
+            MetricEntityStateTest.DimensionEnum2.class,
+            CompositeCloseable.NONE);
     metricEntityState.record(
         100L,
         MetricEntityStateTest.DimensionEnum1.DIMENSION_ONE,
@@ -272,7 +281,8 @@ public class MetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTestBase
             mockOtelRepository,
             baseDimensionsMap,
             MetricEntityStateTest.DimensionEnum1.class,
-            MetricEntityStateTest.DimensionEnum2.class);
+            MetricEntityStateTest.DimensionEnum2.class,
+            CompositeCloseable.NONE);
     assertNotNull(metricEntityState);
 
     // case 2: baseDimensionsMap has extra values
@@ -285,7 +295,8 @@ public class MetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTestBase
           mockOtelRepository,
           baseDimensionsMap,
           MetricEntityStateTest.DimensionEnum1.class,
-          MetricEntityStateTest.DimensionEnum2.class);
+          MetricEntityStateTest.DimensionEnum2.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -299,7 +310,8 @@ public class MetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTestBase
           mockOtelRepository,
           baseDimensionsMap,
           MetricEntityStateTest.DimensionEnum1.class,
-          MetricEntityStateTest.DimensionEnum2.class);
+          MetricEntityStateTest.DimensionEnum2.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
@@ -314,10 +326,12 @@ public class MetricEntityStateTwoEnumsTest extends MetricEntityStateEnumTestBase
           mockOtelRepository,
           baseDimensionsMap,
           MetricEntityStateTest.DimensionEnum1.class,
-          MetricEntityStateTest.DimensionEnum2.class);
+          MetricEntityStateTest.DimensionEnum2.class,
+          CompositeCloseable.NONE);
       fail();
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("doesn't match with the required dimensions"));
     }
   }
+
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricTypeTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/metrics/MetricTypeTest.java
@@ -82,8 +82,12 @@ public class MetricTypeTest {
     InMemoryMetricReader inMemoryMetricReader = InMemoryMetricReader.create();
     VeniceOpenTelemetryMetricsRepository otelMetricsRepository =
         createOtelRepo(metricEntityCounter, inMemoryMetricReader);
-    MetricEntityStateBase metricEntityStateBaseCounter = MetricEntityStateBase
-        .create(metricEntityCounter, otelMetricsRepository, getBaseDimensionsMap(), getBaseAttributes());
+    MetricEntityStateBase metricEntityStateBaseCounter = MetricEntityStateBase.create(
+        metricEntityCounter,
+        otelMetricsRepository,
+        getBaseDimensionsMap(),
+        getBaseAttributes(),
+        CompositeCloseable.NONE);
     int[] values = { 10, 20, 30, 40, 50 };
     for (int value: values) {
       metricEntityStateBaseCounter.record(value);
@@ -112,8 +116,12 @@ public class MetricTypeTest {
     InMemoryMetricReader inMemoryMetricReader = InMemoryMetricReader.create();
     VeniceOpenTelemetryMetricsRepository otelMetricsRepository =
         createOtelRepo(metricEntityCounter, inMemoryMetricReader);
-    MetricEntityStateBase metricEntityStateBaseCounter = MetricEntityStateBase
-        .create(metricEntityCounter, otelMetricsRepository, getBaseDimensionsMap(), getBaseAttributes());
+    MetricEntityStateBase metricEntityStateBaseCounter = MetricEntityStateBase.create(
+        metricEntityCounter,
+        otelMetricsRepository,
+        getBaseDimensionsMap(),
+        getBaseAttributes(),
+        CompositeCloseable.NONE);
 
     int value = 50;
     metricEntityStateBaseCounter.record(value);
@@ -139,8 +147,12 @@ public class MetricTypeTest {
     InMemoryMetricReader inMemoryMetricReader = InMemoryMetricReader.create();
     VeniceOpenTelemetryMetricsRepository otelMetricsRepository =
         createOtelRepo(metricEntityHistogram, inMemoryMetricReader);
-    MetricEntityStateBase metricEntityStateBaseHistogram = MetricEntityStateBase
-        .create(metricEntityHistogram, otelMetricsRepository, getBaseDimensionsMap(), getBaseAttributes());
+    MetricEntityStateBase metricEntityStateBaseHistogram = MetricEntityStateBase.create(
+        metricEntityHistogram,
+        otelMetricsRepository,
+        getBaseDimensionsMap(),
+        getBaseAttributes(),
+        CompositeCloseable.NONE);
     int[] values = { 10, 20, 30, 40, 50 };
     for (int value: values) {
       metricEntityStateBaseHistogram.record(value);
@@ -186,8 +198,12 @@ public class MetricTypeTest {
         DefaultAggregationSelector.getDefault());
     VeniceOpenTelemetryMetricsRepository otelMetricsRepository =
         createOtelRepo(metricEntityGauge, inMemoryMetricReader);
-    MetricEntityStateBase metricEntityStateBaseGauge = MetricEntityStateBase
-        .create(metricEntityGauge, otelMetricsRepository, getBaseDimensionsMap(), getBaseAttributes());
+    MetricEntityStateBase metricEntityStateBaseGauge = MetricEntityStateBase.create(
+        metricEntityGauge,
+        otelMetricsRepository,
+        getBaseDimensionsMap(),
+        getBaseAttributes(),
+        CompositeCloseable.NONE);
     metricEntityStateBaseGauge.record(10L);
     metricEntityStateBaseGauge.record(20L);
     // validate the last recorded value is 20L: Note that the validate method calls collectAllMetrics() which is
@@ -234,8 +250,13 @@ public class MetricTypeTest {
     final long[] gaugeValue = { 100L };
     LongSupplier supplier = () -> gaugeValue[0];
 
-    AsyncMetricEntityStateBase
-        .create(metricEntityAsyncGauge, otelMetricsRepository, getBaseDimensionsMap(), getBaseAttributes(), supplier);
+    AsyncMetricEntityStateBase.create(
+        metricEntityAsyncGauge,
+        otelMetricsRepository,
+        getBaseDimensionsMap(),
+        getBaseAttributes(),
+        supplier,
+        CompositeCloseable.NONE);
 
     Collection<MetricData> metrics = inMemoryMetricReader.collectAllMetrics();
     assertFalse(metrics.isEmpty(), "Metrics should not be empty");

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/RetryManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/RetryManager.java
@@ -3,7 +3,9 @@ package com.linkedin.venice.meta;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.stats.RetryManagerStats;
 import com.linkedin.venice.throttle.TokenBucket;
+import com.linkedin.venice.utils.Utils;
 import io.tehuti.metrics.MetricsRepository;
+import java.io.Closeable;
 import java.time.Clock;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -14,7 +16,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
-public class RetryManager {
+public class RetryManager implements Closeable {
   private static final Logger LOGGER = LogManager.getLogger(RetryManager.class);
   private static final int TOKEN_BUCKET_REFILL_INTERVAL_IN_SECONDS = 1;
   /**
@@ -156,5 +158,11 @@ public class RetryManager {
 
   public TokenBucket getRetryTokenBucket() {
     return retryTokenBucket.get();
+  }
+
+  /** Releases the OTel resources owned by {@link RetryManagerStats}. */
+  @Override
+  public void close() {
+    Utils.closeQuietlyWithErrorLogged(retryManagerStats);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceAggStoreStats.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceAggStoreStats.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.stats;
 
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.StoreDataChangedListener;
+import com.linkedin.venice.utils.Utils;
 import io.tehuti.metrics.MetricsRepository;
 
 
@@ -43,16 +44,19 @@ public class AbstractVeniceAggStoreStats<T extends AbstractVeniceStats> extends 
 
   @Override
   public void handleStoreDeleted(String storeName) {
-    if (isUnregisterMetricForDeletedStoreEnabled) {
-      T stats = super.storeStats.get(storeName);
-      if (stats != null) {
-        stats.unregisterAllSensors();
-      }
+    T stats = super.storeStats.get(storeName);
+    if (stats == null) {
+      return;
     }
+    if (isUnregisterMetricForDeletedStoreEnabled) {
+      stats.unregisterAllSensors();
+    }
+    // OTel close is unconditional — independent of the Tehuti unregister flag.
+    Utils.closeQuietlyWithErrorLogged(stats);
   }
 
   private void registerStoreDataChangedListenerIfRequired(ReadOnlyStoreRepository metadataRepository) {
-    if (isUnregisterMetricForDeletedStoreEnabled) {
+    if (metadataRepository != null) {
       metadataRepository.registerStoreDataChangedListener(this);
     }
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceAggStoreStats.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceAggStoreStats.java
@@ -44,7 +44,9 @@ public class AbstractVeniceAggStoreStats<T extends AbstractVeniceStats> extends 
 
   @Override
   public void handleStoreDeleted(String storeName) {
-    T stats = super.storeStats.get(storeName);
+    // Remove first so a subsequent getStoreStats(storeName) does not return a now-closed instance —
+    // computeIfAbsent inside the parent will recreate fresh stats if the store is re-created later.
+    T stats = super.storeStats.remove(storeName);
     if (stats == null) {
       return;
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/stats/RetryManagerStats.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/stats/RetryManagerStats.java
@@ -72,7 +72,8 @@ public class RetryManagerStats extends AbstractVeniceStats {
         () -> {
           TokenBucket bucket = retryManager.getRetryTokenBucket();
           return bucket == null ? -1 : (long) bucket.getAmortizedRefillPerSecond();
-        });
+        },
+        resources);
 
     this.retriesRemaining = AsyncMetricEntityStateBase.create(
         RETRY_RATE_LIMIT_REMAINING_TOKENS.getMetricEntity(),
@@ -88,7 +89,8 @@ public class RetryManagerStats extends AbstractVeniceStats {
         () -> {
           TokenBucket bucket = retryManager.getRetryTokenBucket();
           return bucket == null ? -1 : bucket.getStaleTokenCount();
-        });
+        },
+        resources);
 
     this.rejectedRetry = MetricEntityStateBase.create(
         RETRY_RATE_LIMIT_REJECTION_COUNT.getMetricEntity(),
@@ -97,7 +99,8 @@ public class RetryManagerStats extends AbstractVeniceStats {
         RetryManagerTehutiMetricName.REJECTED_RETRY,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
   }
 
   public void recordRejectedRetry(int count) {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/RetryManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/RetryManagerTest.java
@@ -253,4 +253,29 @@ public class RetryManagerTest {
         RETRY_RATE_LIMIT_REMAINING_TOKENS.getMetricEntity().getMetricName(),
         ClientType.FAST_CLIENT.getMetricsPrefix());
   }
+
+  /**
+   * Exercises {@link RetryManager#close()} — it must be idempotent and safe to call even when no
+   * {@link RetryManagerStats} was wired in (e.g., disabled retry manager). The close flows through
+   * {@code Utils.closeQuietlyWithErrorLogged}, which tolerates null.
+   */
+  @Test(timeOut = TEST_TIMEOUT_IN_MS)
+  public void testCloseIsSafeWhenDisabled() throws Exception {
+    Clock mockClock = mock(Clock.class);
+    doReturn(System.currentTimeMillis()).when(mockClock).millis();
+    MetricsRepository metricsRepository = MetricsRepositoryUtils.createSingleThreadedMetricsRepository();
+    RetryManager retryManager = new RetryManager(
+        metricsRepository,
+        "test-retry-manager-close",
+        "test-store",
+        null,
+        0,
+        0.1d,
+        mockClock,
+        scheduler);
+    retryManager.close();
+    // Second close must be a silent no-op.
+    retryManager.close();
+    metricsRepository.close();
+  }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/stats/AbstractVeniceAggStoreStatsBranchCoverageTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/stats/AbstractVeniceAggStoreStatsBranchCoverageTest.java
@@ -1,0 +1,97 @@
+package com.linkedin.venice.stats;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertNull;
+
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import io.tehuti.metrics.MetricsRepository;
+import org.testng.annotations.Test;
+
+
+/**
+ * Branch-coverage tests for {@link AbstractVeniceAggStoreStats} — exercises the new
+ * {@code handleStoreDeleted} early-return / unconditional-OTel-close paths and the
+ * {@code registerStoreDataChangedListenerIfRequired} null-guard added in this PR.
+ */
+public class AbstractVeniceAggStoreStatsBranchCoverageTest {
+  private static final String CLUSTER = "test-cluster";
+  private static final String STORE = "test-store";
+
+  /** Minimal concrete stats class so we can instantiate {@code AbstractVeniceAggStoreStats<T>}. */
+  private static class TestStats extends AbstractVeniceStats {
+    TestStats(MetricsRepository metricsRepository, String name) {
+      super(metricsRepository, name);
+    }
+  }
+
+  private static class TestAggStats extends AbstractVeniceAggStoreStats<TestStats> {
+    TestAggStats(
+        MetricsRepository metricsRepository,
+        ReadOnlyStoreRepository metadataRepository,
+        boolean isUnregisterEnabled) {
+      super(CLUSTER, metricsRepository, metadataRepository, isUnregisterEnabled);
+    }
+  }
+
+  @Test
+  public void testRegisterListenerOnConstructionWhenRepoNonNull() {
+    MetricsRepository metrics = new MetricsRepository();
+    ReadOnlyStoreRepository repo = mock(ReadOnlyStoreRepository.class);
+    TestAggStats stats = new TestAggStats(metrics, repo, true);
+    verify(repo).registerStoreDataChangedListener(stats);
+  }
+
+  @Test
+  public void testRegisterListenerSkippedWhenRepoIsNull() {
+    MetricsRepository metrics = new MetricsRepository();
+    // Null repo path — constructor must not NPE and must not attempt registration.
+    new TestAggStats(metrics, null, true);
+    // (No throw == pass for this branch.)
+  }
+
+  @Test
+  public void testHandleStoreDeletedEarlyReturnsWhenStoreUnknown() {
+    MetricsRepository metrics = new MetricsRepository();
+    ReadOnlyStoreRepository repo = mock(ReadOnlyStoreRepository.class);
+    TestAggStats stats = new TestAggStats(metrics, repo, true);
+    // Store was never registered; handleStoreDeleted must short-circuit.
+    stats.handleStoreDeleted("never-seen-store");
+    // No assertion needed beyond "did not throw" — the branch is covered.
+  }
+
+  @Test
+  public void testHandleStoreDeletedUnregistersSensorsWhenEnabled() {
+    MetricsRepository metrics = new MetricsRepository();
+    ReadOnlyStoreRepository repo = mock(ReadOnlyStoreRepository.class);
+    TestAggStats stats = new TestAggStats(metrics, repo, true);
+    TestStats storeStats = spy(new TestStats(metrics, STORE));
+    stats.storeStats.put(STORE, storeStats);
+
+    stats.handleStoreDeleted(STORE);
+
+    verify(storeStats, times(1)).unregisterAllSensors();
+    // Entry must be removed from the map so a re-creation of the same store gets fresh stats
+    // instead of the now-closed instance.
+    assertNull(stats.storeStats.get(STORE));
+  }
+
+  @Test
+  public void testHandleStoreDeletedSkipsUnregisterWhenDisabled() {
+    MetricsRepository metrics = new MetricsRepository();
+    ReadOnlyStoreRepository repo = mock(ReadOnlyStoreRepository.class);
+    TestAggStats stats = new TestAggStats(metrics, repo, false);
+    TestStats storeStats = spy(new TestStats(metrics, STORE));
+    stats.storeStats.put(STORE, storeStats);
+
+    stats.handleStoreDeleted(STORE);
+
+    // Tehuti unregister disabled — sensors stay; OTel close path still runs unconditionally.
+    verify(storeStats, never()).unregisterAllSensors();
+    // Entry is removed regardless of the unregister flag.
+    assertNull(stats.storeStats.get(STORE));
+  }
+}

--- a/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/VeniceOpenTelemetryPerfTest.java
+++ b/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/VeniceOpenTelemetryPerfTest.java
@@ -12,6 +12,7 @@ import com.linkedin.venice.stats.dimensions.HttpResponseStatusCodeCategory;
 import com.linkedin.venice.stats.dimensions.HttpResponseStatusEnum;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.stats.metrics.MetricEntity;
 import com.linkedin.venice.stats.metrics.MetricEntityStateBase;
 import com.linkedin.venice.stats.metrics.MetricEntityStateThreeEnums;
@@ -179,7 +180,8 @@ public class VeniceOpenTelemetryPerfTest {
               baseMetricDimensionsMap,
               HttpResponseStatusEnum.class,
               HttpResponseStatusCodeCategory.class,
-              VeniceResponseStatusCategory.class));
+              VeniceResponseStatusCategory.class,
+              CompositeCloseable.NONE));
     }
     long endTimeInit = System.currentTimeMillis();
 
@@ -237,7 +239,8 @@ public class VeniceOpenTelemetryPerfTest {
             baseDimensions,
             HttpResponseStatusEnum.class,
             HttpResponseStatusCodeCategory.class,
-            VeniceResponseStatusCategory.class);
+            VeniceResponseStatusCategory.class,
+            CompositeCloseable.NONE);
 
     // Create Tehuti-only metric
     MetricsRepository tehutiRepository = new MetricsRepository();
@@ -261,7 +264,8 @@ public class VeniceOpenTelemetryPerfTest {
             baseDimensions,
             HttpResponseStatusEnum.class,
             HttpResponseStatusCodeCategory.class,
-            VeniceResponseStatusCategory.class);
+            VeniceResponseStatusCategory.class,
+            CompositeCloseable.NONE);
 
     LOGGER.info("Starting benchmark with " + formatNumber(numLoops) + " loops...");
 
@@ -330,8 +334,8 @@ public class VeniceOpenTelemetryPerfTest {
         Utils.setOf(VeniceMetricsDimensions.VENICE_STORE_NAME, VeniceMetricsDimensions.VENICE_CLUSTER_NAME));
 
     Attributes baseAttributes = otelRepository.createAttributes(upDownCounterMetric, baseDimensionsMap);
-    MetricEntityStateBase otelUpDownCounter =
-        MetricEntityStateBase.create(upDownCounterMetric, otelRepository, baseDimensionsMap, baseAttributes);
+    MetricEntityStateBase otelUpDownCounter = MetricEntityStateBase
+        .create(upDownCounterMetric, otelRepository, baseDimensionsMap, baseAttributes, CompositeCloseable.NONE);
     AtomicLong atomicCounter = new AtomicLong(0);
 
     LOGGER.info("Starting benchmark with " + formatNumber(numLoops) + " loops...");
@@ -405,7 +409,8 @@ public class VeniceOpenTelemetryPerfTest {
             baseDimensions,
             HttpResponseStatusEnum.class,
             HttpResponseStatusCodeCategory.class,
-            VeniceResponseStatusCategory.class);
+            VeniceResponseStatusCategory.class,
+            CompositeCloseable.NONE);
 
     // Create regular COUNTER metric (direct OTel recording)
     MetricEntity counterEntity = createThreeEnumMetricEntity("test_counter", MetricType.COUNTER, "Test counter");
@@ -416,7 +421,8 @@ public class VeniceOpenTelemetryPerfTest {
             baseDimensions,
             HttpResponseStatusEnum.class,
             HttpResponseStatusCodeCategory.class,
-            VeniceResponseStatusCategory.class);
+            VeniceResponseStatusCategory.class,
+            CompositeCloseable.NONE);
 
     LOGGER.info("Starting benchmark with " + formatNumber(numLoops) + " loops...");
 
@@ -493,7 +499,8 @@ public class VeniceOpenTelemetryPerfTest {
             baseDimensions,
             HttpResponseStatusEnum.class,
             HttpResponseStatusCodeCategory.class,
-            VeniceResponseStatusCategory.class);
+            VeniceResponseStatusCategory.class,
+            CompositeCloseable.NONE);
 
     // Create LongAdderRateGauge with Tehuti
     MetricsRepository tehutiRepository = new MetricsRepository(new MetricConfig());
@@ -598,7 +605,8 @@ public class VeniceOpenTelemetryPerfTest {
             baseDimensions,
             HttpResponseStatusEnum.class,
             HttpResponseStatusCodeCategory.class,
-            VeniceResponseStatusCategory.class);
+            VeniceResponseStatusCategory.class,
+            CompositeCloseable.NONE);
 
     // Create regular COUNTER metric
     MetricEntity counterEntity =
@@ -610,7 +618,8 @@ public class VeniceOpenTelemetryPerfTest {
             baseDimensions,
             HttpResponseStatusEnum.class,
             HttpResponseStatusCodeCategory.class,
-            VeniceResponseStatusCategory.class);
+            VeniceResponseStatusCategory.class,
+            CompositeCloseable.NONE);
 
     // Accumulators for timing (one per thread to avoid contention)
     long[] asyncTimes = new long[numThreads];

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -23,6 +23,7 @@ import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.stats.ThreadPoolStats;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.LogContext;
@@ -92,6 +93,8 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
   private final Map<String, ThreadPoolExecutor> clusterToExecutorMap = new ConcurrentHashMap<>();
   private final Set<String> storesBeingProcessed = ConcurrentHashMap.newKeySet();
   private final Map<String, ThreadPoolStats> clusterToThreadPoolStatsMap = new ConcurrentHashMap<>();
+  /** Stats fields owned by this class; drained by {@link #stopInner()}. */
+  private final CompositeCloseable statsCloseables = new CompositeCloseable();
   private final MetricsRepository metricsRepository;
   private Map<String, StoreLifecycleHooks> storeLifecycleHooksCache = new HashMap<>();
 
@@ -140,6 +143,9 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
         Thread.currentThread().interrupt();
       }
     });
+    Utils.closeQuietlyWithErrorLogged(deferredVersionSwapStats);
+    // Close every per-cluster ThreadPoolStats registered above so its ASYNC_GAUGE callbacks deregister.
+    statsCloseables.close();
   }
 
   private ThreadPoolExecutor getOrCreateExecutorForCluster(String cluster) {
@@ -152,7 +158,8 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
           veniceControllerMultiClusterConfig.getLogContext());
       ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(threadPoolSize, threadFactory);
       String statsName = "DeferredVersionSwap-" + cluster;
-      ThreadPoolStats threadPoolStats = new ThreadPoolStats(metricsRepository, executor, statsName);
+      ThreadPoolStats threadPoolStats =
+          statsCloseables.register(new ThreadPoolStats(metricsRepository, executor, statsName));
       clusterToThreadPoolStatsMap.put(cluster, threadPoolStats);
 
       LOGGER.info("Created thread pool for cluster {} with {} threads", cluster, threadPoolSize);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ErrorPartitionResetTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ErrorPartitionResetTask.java
@@ -14,10 +14,10 @@ import com.linkedin.venice.pushmonitor.OfflinePushStatus;
 import com.linkedin.venice.pushmonitor.PartitionStatus;
 import com.linkedin.venice.pushmonitor.PushMonitor;
 import com.linkedin.venice.pushmonitor.ReplicaStatus;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.utils.HelixUtils;
 import com.linkedin.venice.utils.Utils;
 import io.tehuti.metrics.MetricsRepository;
-import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -39,7 +39,7 @@ import org.apache.logging.log4j.Logger;
  *    shown Leader in EV but actually ERROR in offline push status.</li>
  * </ol>
  */
-public class ErrorPartitionResetTask implements Runnable, Closeable {
+public class ErrorPartitionResetTask extends AbstractStatsCloseable implements Runnable {
   private static final String TASK_ID_FORMAT = ErrorPartitionResetTask.class.getSimpleName() + " [cluster: %s] ";
   /**
    * Tracks auto reset attempts of applicable resources' error partitions. Automatically reset will only apply to
@@ -78,7 +78,7 @@ public class ErrorPartitionResetTask implements Runnable, Closeable {
     this.pushMonitor = pushMonitor;
     this.errorPartitionAutoResetLimit = errorPartitionAutoResetLimit;
     this.processingCycleDelayMs = processingCycleDelayMs;
-    errorPartitionStats = new ErrorPartitionStats(metricsRepository, clusterName);
+    errorPartitionStats = statsCloseables.register(new ErrorPartitionStats(metricsRepository, clusterName));
   }
 
   @Override
@@ -226,5 +226,6 @@ public class ErrorPartitionResetTask implements Runnable, Closeable {
   @Override
   public void close() {
     isRunning.set(false);
+    super.close();
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
@@ -34,6 +34,7 @@ import com.linkedin.venice.pushmonitor.AggPushStatusCleanUpStats;
 import com.linkedin.venice.pushmonitor.LeakedPushStatusCleanUpService;
 import com.linkedin.venice.pushmonitor.PushMonitorDelegator;
 import com.linkedin.venice.stats.HelixMessageChannelStats;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.system.store.MetaStoreWriter;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.locks.AutoCloseableLock;
@@ -57,7 +58,7 @@ import org.apache.logging.log4j.Logger;
  * <p>
  * All resources in this class is dedicated for one Venice cluster.
  */
-public class HelixVeniceClusterResources implements VeniceResource {
+public class HelixVeniceClusterResources extends AbstractStatsCloseable implements VeniceResource {
   private static final Logger LOGGER = LogManager.getLogger(HelixVeniceClusterResources.class);
 
   private final String clusterName;
@@ -230,12 +231,13 @@ public class HelixVeniceClusterResources implements VeniceResource {
         clusterName,
         config.getRefreshAttemptsForZkReconnect(),
         config.getRefreshIntervalForZkReconnectInMs());
-    this.aggPartitionHealthStats = new AggPartitionHealthStats(
-        clusterName,
-        metricsRepository,
-        routingDataRepository,
-        storeMetadataRepository,
-        pushMonitor);
+    this.aggPartitionHealthStats = statsCloseables.register(
+        new AggPartitionHealthStats(
+            clusterName,
+            metricsRepository,
+            routingDataRepository,
+            storeMetadataRepository,
+            pushMonitor));
     this.storeConfigAccessor = new ZkStoreConfigAccessor(zkClient, adapterSerializer, metaStoreWriter);
     this.accessController = accessController;
     if (config.getErrorPartitionAutoResetLimit() > 0) {
@@ -273,7 +275,7 @@ public class HelixVeniceClusterResources implements VeniceResource {
       this.logCompactionService = null;
     }
 
-    veniceAdminStats = new VeniceAdminStats(metricsRepository, "venice-admin-", clusterName);
+    veniceAdminStats = statsCloseables.register(new VeniceAdminStats(metricsRepository, "venice-admin-", clusterName));
     this.storagePersonaRepository =
         new StoragePersonaRepository(clusterName, this.storeMetadataRepository, adapterSerializer, zkClient);
     /**
@@ -358,6 +360,7 @@ public class HelixVeniceClusterResources implements VeniceResource {
     customizedViewRepo.clear();
     routersClusterManager.clear();
     admin.clearInstanceMonitor(clusterName);
+    statsCloseables.close();
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
@@ -360,7 +360,7 @@ public class HelixVeniceClusterResources extends AbstractStatsCloseable implemen
     customizedViewRepo.clear();
     routersClusterManager.clear();
     admin.clearInstanceMonitor(clusterName);
-    statsCloseables.close();
+    /* statsCloseables is NOT drained here — refresh() calls clear(); inherited close() drains it on true retirement. */
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ProtocolVersionAutoDetectionService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ProtocolVersionAutoDetectionService.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.LatencyUtils;
+import com.linkedin.venice.utils.Utils;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -71,6 +72,7 @@ public class ProtocolVersionAutoDetectionService extends AbstractVeniceService {
   public void stopInner() throws Exception {
     stop.set(true);
     executor.shutdownNow();
+    Utils.closeQuietlyWithErrorLogged(stats);
     LOGGER.info("Stopped {}", serviceName);
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -18,6 +18,7 @@ import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.IOException;
@@ -133,6 +134,7 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
     stop.set(true);
     httpAsyncClient.close();
     cleanupThread.interrupt();
+    clusterNameCleanupStatsMap.values().forEach(Utils::closeQuietlyWithErrorLogged);
   }
 
   public static void setWaitTimeDeleteRepushSourceVersion(long waitTime) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerService.java
@@ -28,6 +28,7 @@ import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
 import com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.service.ICProvider;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.system.store.ControllerClientBackedSystemSchemaInitializer;
 import com.linkedin.venice.utils.pools.LandFillObjectPool;
 import io.tehuti.metrics.MetricsRepository;
@@ -54,6 +55,10 @@ public class VeniceControllerService extends AbstractVeniceService {
   private final Map<String, AdminConsumerService> consumerServicesByClusters;
 
   private final BiConsumer<Integer, Schema> newSchemaEncountered;
+
+  private HeartbeatBasedCheckerStats heartbeatBasedCheckerStats;
+  /** Stats fields owned by this class; drained by {@link #stopInner()}. */
+  private final CompositeCloseable statsCloseables = new CompositeCloseable();
 
   public VeniceControllerService(
       VeniceControllerMultiClusterConfig multiClusterConfigs,
@@ -221,11 +226,12 @@ public class VeniceControllerService extends AbstractVeniceService {
       MetricsRepository metricsRepository) {
     if (multiClusterConfigs.getBatchJobHeartbeatEnabled()) {
       LOGGER.info("Batch job heartbeat is enabled. Hence use the heartbeat-based batch job liveness checker.");
+      this.heartbeatBasedCheckerStats = statsCloseables.register(new HeartbeatBasedCheckerStats(metricsRepository));
       return new HeartbeatBasedLingeringStoreVersionChecker(
           multiClusterConfigs.getBatchJobHeartbeatTimeout(),
           multiClusterConfigs.getBatchJobHeartbeatInitialBufferTime(),
           new DefaultLingeringStoreVersionChecker(),
-          new HeartbeatBasedCheckerStats(metricsRepository));
+          heartbeatBasedCheckerStats);
     }
     {
       LOGGER.info("Batch job heartbeat is NOT enabled. Hence use the default batch job liveness checker.");
@@ -271,6 +277,7 @@ public class VeniceControllerService extends AbstractVeniceService {
     // TODO merge or differentiate the difference between close() and stopVeniceController() explicitly.
     admin.stopVeniceController();
     admin.close();
+    statsCloseables.close();
 
     LOGGER.info("Stopped Venice controller.");
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerStateModel.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerStateModel.java
@@ -10,6 +10,7 @@ import com.linkedin.venice.helix.SafeHelixManager;
 import com.linkedin.venice.ingestion.control.RealTimeTopicSwitcher;
 import com.linkedin.venice.meta.ValueSchemaCreatedListener;
 import com.linkedin.venice.utils.DaemonThreadFactory;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.locks.AutoCloseableLock;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.List;
@@ -409,6 +410,8 @@ public class VeniceControllerStateModel extends StateModel {
       clusterResources.stopDeadStoreStatsPreFetchTask();
       clusterResources.stopErrorPartitionResetTask();
       clusterResources.clear();
+      // Drain registered stats closeables on true retirement (after the refresh-safe clear()).
+      Utils.closeQuietlyWithErrorLogged(clusterResources);
       clusterResources = null;
     }
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -9234,6 +9234,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       });
       this.clusterToDegradedDcStatesRepo.clear();
       D2ClientUtils.shutdownClient(this.d2Client);
+      // Close per-cluster stats accumulated in maps that are not bound to AbstractVeniceService instances.
+      this.disabledPartitionStatMap.values().forEach(Utils::closeQuietlyWithErrorLogged);
+      this.pushJobStatusStatsMap.values().forEach(Utils::closeQuietlyWithErrorLogged);
+      this.addVersionLatencyStatsMap.values().forEach(Utils::closeQuietlyWithErrorLogged);
+      this.logCompactionStatsMap.values().forEach(Utils::closeQuietlyWithErrorLogged);
 
       long elapsedTime = System.currentTimeMillis() - closeStartTime;
       long remainingTime = Math.max(1, HELIX_MANAGER_DISCONNECT_TIMEOUT_MS - elapsedTime);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
@@ -20,6 +20,7 @@ import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -152,6 +153,7 @@ public class TopicCleanupService extends AbstractVeniceService {
     // N.B.: The two stop mechanisms below are decomposed for the sake of being able to test them separately.
     stopViaFlag();
     stopViaInterrupt();
+    Utils.closeQuietlyWithErrorLogged(topicCleanupServiceStats);
   }
 
   /** Package-private for tests. */

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -333,6 +333,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
   @Override
   public synchronized void close() throws IOException {
     isRunning.getAndSet(false);
+    Utils.closeQuietlyWithErrorLogged(stats);
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/lingeringjob/HeartbeatBasedCheckerStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/lingeringjob/HeartbeatBasedCheckerStats.java
@@ -36,7 +36,8 @@ public class HeartbeatBasedCheckerStats extends AbstractVeniceStats {
         HeartbeatCheckerTehutiMetricNameEnum.CHECK_JOB_HAS_HEARTBEAT_FAILED,
         Collections.singletonList(new Count()),
         otelData.getBaseDimensionsMap(),
-        otelData.getBaseAttributes());
+        otelData.getBaseAttributes(),
+        resources);
 
     timeoutHeartbeatCheckState = MetricEntityStateBase.create(
         HeartbeatCheckerOtelMetricEntity.BATCH_JOB_HEARTBEAT_TIMEOUT_COUNT.getMetricEntity(),
@@ -45,7 +46,8 @@ public class HeartbeatBasedCheckerStats extends AbstractVeniceStats {
         HeartbeatCheckerTehutiMetricNameEnum.TIMEOUT_HEARTBEAT_CHECK,
         Collections.singletonList(new Count()),
         otelData.getBaseDimensionsMap(),
-        otelData.getBaseAttributes());
+        otelData.getBaseAttributes(),
+        resources);
 
     noTimeoutHeartbeatCheckState = MetricEntityStateBase.create(
         HeartbeatCheckerOtelMetricEntity.BATCH_JOB_HEARTBEAT_ACTIVE_COUNT.getMetricEntity(),
@@ -54,7 +56,8 @@ public class HeartbeatBasedCheckerStats extends AbstractVeniceStats {
         HeartbeatCheckerTehutiMetricNameEnum.NON_TIMEOUT_HEARTBEAT_CHECK,
         Collections.singletonList(new Count()),
         otelData.getBaseDimensionsMap(),
-        otelData.getBaseAttributes());
+        otelData.getBaseAttributes(),
+        resources);
   }
 
   void recordCheckJobHasHeartbeatFailed() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -749,6 +749,8 @@ public class AdminSparkServer extends AbstractVeniceService {
   @Override
   public void stopInner() {
     httpService.stop();
+    statsMap.values().forEach(Utils::closeQuietlyWithErrorLogged);
+    Utils.closeQuietlyWithErrorLogged(nonclusterSpecificStats);
   }
 
   int getPort() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AddVersionLatencyStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AddVersionLatencyStats.java
@@ -97,7 +97,8 @@ public class AddVersionLatencyStats extends AbstractVeniceStats {
                     + AddVersionLatencyTehutiMetricNameEnum.ADD_VERSION_RETIRE_OLD_VERSIONS_LATENCY.getMetricName())),
         baseDimensionsMap,
         AdminMessageType.class,
-        AdminMessageProcessingComponent.class);
+        AdminMessageProcessingComponent.class,
+        resources);
 
     resourceAssignmentWaitMetric = MetricEntityStateTwoEnums.create(
         AddVersionLatencyOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_PHASE_START_TO_END_PROCESSING_TIME_PER_COMPONENT
@@ -114,7 +115,8 @@ public class AddVersionLatencyStats extends AbstractVeniceStats {
                         .getMetricName())),
         baseDimensionsMap,
         AdminMessageType.class,
-        AdminMessageProcessingComponent.class);
+        AdminMessageProcessingComponent.class,
+        resources);
 
     failureHandlingMetric = MetricEntityStateTwoEnums.create(
         AddVersionLatencyOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_PHASE_START_TO_END_PROCESSING_TIME_PER_COMPONENT
@@ -130,7 +132,8 @@ public class AddVersionLatencyStats extends AbstractVeniceStats {
                     + AddVersionLatencyTehutiMetricNameEnum.ADD_VERSION_CREATION_FAILURE_LATENCY.getMetricName())),
         baseDimensionsMap,
         AdminMessageType.class,
-        AdminMessageProcessingComponent.class);
+        AdminMessageProcessingComponent.class,
+        resources);
 
     existingVersionHandlingMetric = MetricEntityStateTwoEnums.create(
         AddVersionLatencyOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_PHASE_START_TO_END_PROCESSING_TIME_PER_COMPONENT
@@ -147,7 +150,8 @@ public class AddVersionLatencyStats extends AbstractVeniceStats {
                         .getMetricName())),
         baseDimensionsMap,
         AdminMessageType.class,
-        AdminMessageProcessingComponent.class);
+        AdminMessageProcessingComponent.class,
+        resources);
 
     startOfPushMetric = MetricEntityStateTwoEnums.create(
         AddVersionLatencyOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_PHASE_START_TO_END_PROCESSING_TIME_PER_COMPONENT
@@ -163,7 +167,8 @@ public class AddVersionLatencyStats extends AbstractVeniceStats {
                     + AddVersionLatencyTehutiMetricNameEnum.ADD_VERSION_START_OF_PUSH_LATENCY.getMetricName())),
         baseDimensionsMap,
         AdminMessageType.class,
-        AdminMessageProcessingComponent.class);
+        AdminMessageProcessingComponent.class,
+        resources);
 
     batchTopicCreationMetric = MetricEntityStateTwoEnums.create(
         AddVersionLatencyOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_PHASE_START_TO_END_PROCESSING_TIME_PER_COMPONENT
@@ -179,7 +184,8 @@ public class AddVersionLatencyStats extends AbstractVeniceStats {
                     + AddVersionLatencyTehutiMetricNameEnum.ADD_VERSION_BATCH_TOPIC_CREATION_LATENCY.getMetricName())),
         baseDimensionsMap,
         AdminMessageType.class,
-        AdminMessageProcessingComponent.class);
+        AdminMessageProcessingComponent.class,
+        resources);
 
     helixResourceCreationMetric = MetricEntityStateTwoEnums.create(
         AddVersionLatencyOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_PHASE_START_TO_END_PROCESSING_TIME_PER_COMPONENT
@@ -196,7 +202,8 @@ public class AddVersionLatencyStats extends AbstractVeniceStats {
                         .getMetricName())),
         baseDimensionsMap,
         AdminMessageType.class,
-        AdminMessageProcessingComponent.class);
+        AdminMessageProcessingComponent.class,
+        resources);
   }
 
   public void recordRetireOldVersionsLatency(long latency) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AdminConsumptionStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AdminConsumptionStats.java
@@ -63,9 +63,15 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
   private final MetricEntityStateOneEnum<AdminMessageType> addVersionProcessLatencyMetric;
 
   /**
-   * Tracks the duration of each batch processing cycle for admin messages. 
+   * Tracks the duration of each batch processing cycle for admin messages.
    */
   private final MetricEntityStateBase cycleTimeMetric;
+
+  /** OTel async gauges. Captured so they can be closed during shutdown. */
+  private final AsyncMetricEntityStateBase pendingAdminMessagesCountMetric;
+  private final AsyncMetricEntityStateBase storesWithPendingAdminMessagesCountMetric;
+  private final AsyncMetricEntityStateBase adminConsumptionOffsetLagMetric;
+  private final AsyncMetricEntityStateBase maxAdminConsumptionOffsetLagMetric;
 
   /**
    * A gauge reporting the total number of pending admin messages remaining in the internal queue at the end of each
@@ -110,7 +116,8 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
         AdminConsumptionTehutiMetricNameEnum.FAILED_ADMIN_MESSAGES,
         Arrays.asList(new Count()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     retriableFailureCountMetric = MetricEntityStateBase.create(
         AdminConsumptionOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_RETRIABLE_FAILURE_COUNT.getMetricEntity(),
@@ -119,7 +126,8 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
         AdminConsumptionTehutiMetricNameEnum.FAILED_RETRIABLE_ADMIN_MESSAGES,
         Arrays.asList(new Count()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     divFailureCountMetric = MetricEntityStateBase.create(
         AdminConsumptionOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_DIV_FAILURE_COUNT.getMetricEntity(),
@@ -128,7 +136,8 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
         AdminConsumptionTehutiMetricNameEnum.ADMIN_MESSAGE_DIV_ERROR_REPORT_COUNT,
         Arrays.asList(new Count()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     futureSchemaCountMetric = MetricEntityStateBase.create(
         AdminConsumptionOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_FUTURE_SCHEMA_COUNT.getMetricEntity(),
@@ -137,7 +146,8 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
         AdminConsumptionTehutiMetricNameEnum.ADMIN_MESSAGES_WITH_FUTURE_PROTOCOL_VERSION_COUNT,
         Arrays.asList(new Count()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     produceToBrokerTimeMetric = MetricEntityStateOneEnum.create(
         AdminConsumptionOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_PHASE_REPLICATION_TO_LOCAL_BROKER_TIME
@@ -147,7 +157,8 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
         AdminConsumptionTehutiMetricNameEnum.ADMIN_MESSAGE_MM_LATENCY_MS,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        AdminMessageType.class);
+        AdminMessageType.class,
+        resources);
 
     brokerToQueueTimeMetric = MetricEntityStateOneEnum.create(
         AdminConsumptionOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_PHASE_BROKER_TO_PROCESSING_QUEUE_TIME
@@ -157,7 +168,8 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
         AdminConsumptionTehutiMetricNameEnum.ADMIN_MESSAGE_DELEGATE_LATENCY_MS,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        AdminMessageType.class);
+        AdminMessageType.class,
+        resources);
 
     queueToStartProcessingTimeMetric = MetricEntityStateOneEnum.create(
         AdminConsumptionOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_PHASE_QUEUE_TO_START_PROCESSING_TIME
@@ -167,7 +179,8 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
         AdminConsumptionTehutiMetricNameEnum.ADMIN_MESSAGE_START_PROCESSING_LATENCY_MS,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        AdminMessageType.class);
+        AdminMessageType.class,
+        resources);
 
     processLatencyMetric = MetricEntityStateOneEnum.create(
         AdminConsumptionOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_PHASE_START_TO_END_PROCESSING_TIME.getMetricEntity(),
@@ -176,7 +189,8 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
         AdminConsumptionTehutiMetricNameEnum.ADMIN_MESSAGE_PROCESS_LATENCY_MS,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        AdminMessageType.class);
+        AdminMessageType.class,
+        resources);
 
     addVersionProcessLatencyMetric = MetricEntityStateOneEnum.create(
         AdminConsumptionOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_PHASE_START_TO_END_PROCESSING_TIME.getMetricEntity(),
@@ -185,7 +199,8 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
         AdminConsumptionTehutiMetricNameEnum.ADMIN_MESSAGE_ADD_VERSION_PROCESS_LATENCY_MS,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        AdminMessageType.class);
+        AdminMessageType.class,
+        resources);
 
     cycleTimeMetric = MetricEntityStateBase.create(
         AdminConsumptionOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_BATCH_PROCESSING_CYCLE_TIME.getMetricEntity(),
@@ -194,9 +209,10 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
         AdminConsumptionTehutiMetricNameEnum.ADMIN_CONSUMPTION_CYCLE_DURATION_MS,
         Arrays.asList(new Avg(), new Min(), new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
-    AsyncMetricEntityStateBase.create(
+    pendingAdminMessagesCountMetric = AsyncMetricEntityStateBase.create(
         AdminConsumptionOtelMetricEntity.ADMIN_CONSUMPTION_MESSAGE_PENDING_COUNT.getMetricEntity(),
         otelRepository,
         this::registerSensorIfAbsent,
@@ -207,9 +223,10 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
                 AdminConsumptionTehutiMetricNameEnum.PENDING_ADMIN_MESSAGES_COUNT.getMetricName())),
         baseDimensionsMap,
         baseAttributes,
-        () -> (long) pendingAdminMessagesCountGauge);
+        () -> (long) pendingAdminMessagesCountGauge,
+        resources);
 
-    AsyncMetricEntityStateBase.create(
+    storesWithPendingAdminMessagesCountMetric = AsyncMetricEntityStateBase.create(
         AdminConsumptionOtelMetricEntity.ADMIN_CONSUMPTION_STORE_PENDING_COUNT.getMetricEntity(),
         otelRepository,
         this::registerSensorIfAbsent,
@@ -220,9 +237,10 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
                 AdminConsumptionTehutiMetricNameEnum.STORES_WITH_PENDING_ADMIN_MESSAGES_COUNT.getMetricName())),
         baseDimensionsMap,
         baseAttributes,
-        () -> (long) storesWithPendingAdminMessagesCountGauge);
+        () -> (long) storesWithPendingAdminMessagesCountGauge,
+        resources);
 
-    AsyncMetricEntityStateBase.create(
+    adminConsumptionOffsetLagMetric = AsyncMetricEntityStateBase.create(
         AdminConsumptionOtelMetricEntity.ADMIN_CONSUMPTION_CONSUMER_OFFSET_LAG.getMetricEntity(),
         otelRepository,
         this::registerSensorIfAbsent,
@@ -233,9 +251,10 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
                 AdminConsumptionTehutiMetricNameEnum.ADMIN_CONSUMPTION_OFFSET_LAG.getMetricName())),
         baseDimensionsMap,
         baseAttributes,
-        () -> this.adminConsumptionOffsetLag);
+        () -> this.adminConsumptionOffsetLag,
+        resources);
 
-    AsyncMetricEntityStateBase.create(
+    maxAdminConsumptionOffsetLagMetric = AsyncMetricEntityStateBase.create(
         AdminConsumptionOtelMetricEntity.ADMIN_CONSUMPTION_CONSUMER_CHECKPOINT_OFFSET_LAG.getMetricEntity(),
         otelRepository,
         this::registerSensorIfAbsent,
@@ -246,7 +265,8 @@ public class AdminConsumptionStats extends AbstractVeniceStats {
                 AdminConsumptionTehutiMetricNameEnum.MAX_ADMIN_CONSUMPTION_OFFSET_LAG.getMetricName())),
         baseDimensionsMap,
         baseAttributes,
-        () -> this.maxAdminConsumptionOffsetLag);
+        () -> this.maxAdminConsumptionOffsetLag,
+        resources);
 
     // Tehuti-only
     adminMessageTotalLatencySensor = registerSensor("admin_message_total_latency_ms", new Avg(), new Max());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/DeferredVersionSwapStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/DeferredVersionSwapStats.java
@@ -49,7 +49,8 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         DeferredVersionSwapTehutiMetricNameEnum.DEFERRED_VERSION_SWAP_ERROR,
         Collections.singletonList(new Count()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     deferredVersionSwapThrowableMetric = MetricEntityStateGeneric.create(
         DeferredVersionSwapOtelMetricEntity.DEFERRED_VERSION_SWAP_PROCESSING_ERROR_COUNT.getMetricEntity(),
@@ -57,7 +58,8 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         DeferredVersionSwapTehutiMetricNameEnum.DEFERRED_VERSION_SWAP_THROWABLE,
         Collections.singletonList(new Count()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     deferredVersionSwapFailedRollForwardMetric = MetricEntityStateGeneric.create(
         DeferredVersionSwapOtelMetricEntity.DEFERRED_VERSION_SWAP_ROLL_FORWARD_FAILURE_COUNT.getMetricEntity(),
@@ -65,7 +67,8 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         DeferredVersionSwapTehutiMetricNameEnum.DEFERRED_VERSION_SWAP_FAILED_ROLL_FORWARD,
         Collections.singletonList(new Count()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     deferredVersionSwapStalledVersionSwapMetric = MetricEntityStateBase.create(
         DeferredVersionSwapOtelMetricEntity.DEFERRED_VERSION_SWAP_STALLED_COUNT.getMetricEntity(),
@@ -74,7 +77,8 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
         DeferredVersionSwapTehutiMetricNameEnum.DEFERRED_VERSION_SWAP_STALLED_VERSION_SWAP,
         Collections.singletonList(new Gauge()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     deferredVersionSwapParentChildStatusMismatchMetric = MetricEntityStateGeneric.create(
         DeferredVersionSwapOtelMetricEntity.DEFERRED_VERSION_SWAP_PARENT_STATUS_MISMATCH_COUNT.getMetricEntity(),
@@ -82,7 +86,8 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         DeferredVersionSwapTehutiMetricNameEnum.DEFERRED_VERSION_SWAP_PARENT_CHILD_STATUS_MISMATCH,
         Collections.singletonList(new Count()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     deferredVersionSwapChildStatusMismatchMetric = MetricEntityStateGeneric.create(
         DeferredVersionSwapOtelMetricEntity.DEFERRED_VERSION_SWAP_CHILD_STATUS_MISMATCH_COUNT.getMetricEntity(),
@@ -90,7 +95,8 @@ public class DeferredVersionSwapStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         DeferredVersionSwapTehutiMetricNameEnum.DEFERRED_VERSION_SWAP_CHILD_STATUS_MISMATCH,
         Collections.singletonList(new Count()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
   }
 
   public void recordDeferredVersionSwapExceptionMetric(String clusterName) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/DisabledPartitionStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/DisabledPartitionStats.java
@@ -38,7 +38,8 @@ public class DisabledPartitionStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         DisabledPartitionTehutiMetricNameEnum.DISABLED_PARTITION_COUNT,
         Collections.singletonList(new Total()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
   }
 
   public void recordDisabledPartition(String storeName) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/ErrorPartitionStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/ErrorPartitionStats.java
@@ -53,7 +53,8 @@ public class ErrorPartitionStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         ErrorPartitionTehutiMetricNameEnum.CURRENT_VERSION_ERROR_PARTITION_RESET_ATTEMPT,
         Collections.singletonList(new Total()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     resetErrorMetric = MetricEntityStateGeneric.create(
         ErrorPartitionOtelMetricEntity.ERROR_PARTITION_RESET_ERROR_COUNT.getMetricEntity(),
@@ -61,7 +62,8 @@ public class ErrorPartitionStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         ErrorPartitionTehutiMetricNameEnum.CURRENT_VERSION_ERROR_PARTITION_RESET_ATTEMPT_ERRORED,
         Collections.singletonList(new Count()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     recoveredMetric = MetricEntityStateGeneric.create(
         ErrorPartitionOtelMetricEntity.ERROR_PARTITION_RESET_RECOVERED_PARTITION_COUNT.getMetricEntity(),
@@ -69,7 +71,8 @@ public class ErrorPartitionStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         ErrorPartitionTehutiMetricNameEnum.CURRENT_VERSION_ERROR_PARTITION_RECOVERED_FROM_RESET,
         Collections.singletonList(new Total()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     unrecoverableMetric = MetricEntityStateGeneric.create(
         ErrorPartitionOtelMetricEntity.ERROR_PARTITION_RESET_UNRECOVERABLE_PARTITION_COUNT.getMetricEntity(),
@@ -77,7 +80,8 @@ public class ErrorPartitionStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         ErrorPartitionTehutiMetricNameEnum.CURRENT_VERSION_ERROR_PARTITION_UNRECOVERABLE_FROM_RESET,
         Collections.singletonList(new Total()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     processingErrorMetric = MetricEntityStateBase.create(
         ErrorPartitionOtelMetricEntity.ERROR_PARTITION_PROCESSING_ERROR_COUNT.getMetricEntity(),
@@ -86,7 +90,8 @@ public class ErrorPartitionStats extends AbstractVeniceStats {
         ErrorPartitionTehutiMetricNameEnum.ERROR_PARTITION_PROCESSING_ERROR,
         Collections.singletonList(new Count()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     processingTimeMetric = MetricEntityStateBase.create(
         ErrorPartitionOtelMetricEntity.ERROR_PARTITION_PROCESSING_TIME.getMetricEntity(),
@@ -95,7 +100,8 @@ public class ErrorPartitionStats extends AbstractVeniceStats {
         ErrorPartitionTehutiMetricNameEnum.ERROR_PARTITION_PROCESSING_TIME,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
   }
 
   public void recordErrorPartitionResetAttempt(double value, String storeName) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/LogCompactionStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/LogCompactionStats.java
@@ -50,7 +50,8 @@ public class LogCompactionStats extends AbstractVeniceStats {
         this::registerSensor,
         ControllerTehutiMetricNameEnum.REPUSH_CALL_COUNT,
         Collections.singletonList(new OccurrenceRate()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     compactionEligibleMetric = MetricEntityStateGeneric.create(
         LogCompactionOtelMetricEntity.STORE_COMPACTION_ELIGIBLE_STATE.getMetricEntity(),
@@ -58,7 +59,8 @@ public class LogCompactionStats extends AbstractVeniceStats {
         this::registerSensor,
         ControllerTehutiMetricNameEnum.COMPACTION_ELIGIBLE_STATE,
         Collections.singletonList(new Gauge()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     storeNominatedForCompactionCountMetric = MetricEntityStateGeneric.create(
         LogCompactionOtelMetricEntity.STORE_COMPACTION_NOMINATED_COUNT.getMetricEntity(),
@@ -66,7 +68,8 @@ public class LogCompactionStats extends AbstractVeniceStats {
         this::registerSensor,
         ControllerTehutiMetricNameEnum.STORE_NOMINATED_FOR_COMPACTION_COUNT,
         Collections.singletonList(new OccurrenceRate()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     storeCompactionTriggeredCountMetric = MetricEntityStateGeneric.create(
         LogCompactionOtelMetricEntity.STORE_COMPACTION_TRIGGERED_COUNT.getMetricEntity(),
@@ -74,7 +77,8 @@ public class LogCompactionStats extends AbstractVeniceStats {
         this::registerSensor,
         ControllerTehutiMetricNameEnum.STORE_COMPACTION_TRIGGERED_COUNT,
         Collections.singletonList(new OccurrenceRate()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
   }
 
   public void recordRepushStoreCall(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/PartitionHealthStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/PartitionHealthStats.java
@@ -66,7 +66,8 @@ public class PartitionHealthStats extends AbstractVeniceStats {
         PartitionHealthTehutiMetricNameEnum.UNDER_REPLICATED_PARTITION,
         Arrays.asList(new Max(), new Gauge()),
         otelData.getBaseDimensionsMap(),
-        otelData.getBaseAttributes());
+        otelData.getBaseAttributes(),
+        resources);
   }
 
   public void recordUnderReplicatePartition(int num) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/ProtocolVersionAutoDetectionStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/ProtocolVersionAutoDetectionStats.java
@@ -44,7 +44,8 @@ public class ProtocolVersionAutoDetectionStats extends AbstractVeniceStats {
         ProtocolVersionAutoDetectionTehutiMetricNameEnum.PROTOCOL_VERSION_AUTO_DETECTION_ERROR,
         Collections.singletonList(new Gauge()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     detectionTimeMetric = MetricEntityStateBase.create(
         ProtocolVersionAutoDetectionOtelMetricEntity.PROTOCOL_VERSION_AUTO_DETECTION_TIME.getMetricEntity(),
@@ -53,7 +54,8 @@ public class ProtocolVersionAutoDetectionStats extends AbstractVeniceStats {
         ProtocolVersionAutoDetectionTehutiMetricNameEnum.PROTOCOL_VERSION_AUTO_DETECTION_LATENCY,
         Collections.singletonList(new Avg()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
   }
 
   public void recordProtocolVersionAutoDetectionErrorSensor(int count) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/PushJobStatusStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/PushJobStatusStats.java
@@ -49,7 +49,8 @@ public class PushJobStatusStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         PushJobTehutiMetricNameEnum.BATCH_PUSH_JOB_SUCCESS,
         Arrays.asList(new Count(), new CountSinceLastMeasurement()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     batchPushFailureDueToUserErrorMetric = MetricEntityStateGeneric.create(
         PushJobOtelMetricEntity.PUSH_JOB_COUNT.getMetricEntity(),
@@ -57,7 +58,8 @@ public class PushJobStatusStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         PushJobTehutiMetricNameEnum.BATCH_PUSH_JOB_FAILED_USER_ERROR,
         Arrays.asList(new Count(), new CountSinceLastMeasurement()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     batchPushFailureDueToNonUserErrorMetric = MetricEntityStateGeneric.create(
         PushJobOtelMetricEntity.PUSH_JOB_COUNT.getMetricEntity(),
@@ -65,7 +67,8 @@ public class PushJobStatusStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         PushJobTehutiMetricNameEnum.BATCH_PUSH_JOB_FAILED_NON_USER_ERROR,
         Arrays.asList(new Count(), new CountSinceLastMeasurement()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     incrementalPushSuccessMetric = MetricEntityStateGeneric.create(
         PushJobOtelMetricEntity.PUSH_JOB_COUNT.getMetricEntity(),
@@ -73,7 +76,8 @@ public class PushJobStatusStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         PushJobTehutiMetricNameEnum.INCREMENTAL_PUSH_JOB_SUCCESS,
         Arrays.asList(new Count(), new CountSinceLastMeasurement()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     incrementalPushFailureDueToUserErrorMetric = MetricEntityStateGeneric.create(
         PushJobOtelMetricEntity.PUSH_JOB_COUNT.getMetricEntity(),
@@ -81,7 +85,8 @@ public class PushJobStatusStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         PushJobTehutiMetricNameEnum.INCREMENTAL_PUSH_JOB_FAILED_USER_ERROR,
         Arrays.asList(new Count(), new CountSinceLastMeasurement()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
 
     incrementalPushFailureDueToNonUserErrorMetric = MetricEntityStateGeneric.create(
         PushJobOtelMetricEntity.PUSH_JOB_COUNT.getMetricEntity(),
@@ -89,7 +94,8 @@ public class PushJobStatusStats extends AbstractVeniceStats {
         this::registerSensorIfAbsent,
         PushJobTehutiMetricNameEnum.INCREMENTAL_PUSH_JOB_FAILED_NON_USER_ERROR,
         Arrays.asList(new Count(), new CountSinceLastMeasurement()),
-        baseDimensionsMap);
+        baseDimensionsMap,
+        resources);
   }
 
   public void recordBatchPushSuccessSensor(String storeName) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/SparkServerStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/SparkServerStats.java
@@ -75,7 +75,8 @@ public class SparkServerStats extends AbstractVeniceStats {
         ControllerTehutiMetricNameEnum.CURRENT_IN_FLIGHT_REQUEST,
         Collections.singletonList(new Total()),
         baseDimensionsMap,
-        ControllerRoute.class);
+        ControllerRoute.class,
+        resources);
 
     successfulRequestCountMetric = MetricEntityStateFourEnums.create(
         SparkServerOtelMetricEntity.CALL_COUNT.getMetricEntity(),
@@ -87,7 +88,8 @@ public class SparkServerStats extends AbstractVeniceStats {
         ControllerRoute.class,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     failedRequestCountMetric = MetricEntityStateFourEnums.create(
         SparkServerOtelMetricEntity.CALL_COUNT.getMetricEntity(),
@@ -99,7 +101,8 @@ public class SparkServerStats extends AbstractVeniceStats {
         ControllerRoute.class,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     successfulRequestLatencyHistogramMetric = MetricEntityStateFourEnums.create(
         SparkServerOtelMetricEntity.CALL_TIME.getMetricEntity(),
@@ -114,7 +117,8 @@ public class SparkServerStats extends AbstractVeniceStats {
         ControllerRoute.class,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     failedRequestLatencyHistogramMetric = MetricEntityStateFourEnums.create(
         SparkServerOtelMetricEntity.CALL_TIME.getMetricEntity(),
@@ -128,7 +132,8 @@ public class SparkServerStats extends AbstractVeniceStats {
         ControllerRoute.class,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/StoreBackupVersionCleanupServiceStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/StoreBackupVersionCleanupServiceStats.java
@@ -42,7 +42,8 @@ public class StoreBackupVersionCleanupServiceStats extends AbstractVeniceStats {
         BackupVersionCleanupTehutiMetricNameEnum.BACKUP_VERSION_CLEANUP_VERSION_MISMATCH,
         Arrays.asList(new OccurrenceRate()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     rolledBackVersionDeletedMetric = MetricEntityStateBase.create(
         BackupVersionCleanupOtelMetricEntity.ROLLED_BACK_VERSION_DELETED_COUNT.getMetricEntity(),
@@ -51,7 +52,8 @@ public class StoreBackupVersionCleanupServiceStats extends AbstractVeniceStats {
         BackupVersionCleanupTehutiMetricNameEnum.ROLLED_BACK_VERSION_DELETED,
         Arrays.asList(new OccurrenceRate()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     rolledBackVersionDeleteErrorMetric = MetricEntityStateBase.create(
         BackupVersionCleanupOtelMetricEntity.ROLLED_BACK_VERSION_DELETE_ERROR_COUNT.getMetricEntity(),
@@ -60,7 +62,8 @@ public class StoreBackupVersionCleanupServiceStats extends AbstractVeniceStats {
         BackupVersionCleanupTehutiMetricNameEnum.ROLLED_BACK_VERSION_DELETE_ERROR,
         Arrays.asList(new OccurrenceRate()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
   }
 
   public void recordBackupVersionMismatch() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/SystemStoreHealthCheckStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/SystemStoreHealthCheckStats.java
@@ -35,6 +35,8 @@ public class SystemStoreHealthCheckStats extends AbstractVeniceStats {
   private final AtomicLong badMetaSystemStoreCounter = new AtomicLong(0);
   private final AtomicLong badPushStatusSystemStoreCounter = new AtomicLong(0);
   private final AtomicLong notRepairableSystemStoreCounter = new AtomicLong(0);
+  private final AsyncMetricEntityStateOneEnum<VeniceSystemStoreType> unhealthyCountMetric;
+  private final AsyncMetricEntityStateBase unrepairableCountMetric;
 
   public SystemStoreHealthCheckStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
@@ -65,7 +67,7 @@ public class SystemStoreHealthCheckStats extends AbstractVeniceStats {
     // OTel async gauge. The liveStateResolver returns the backing AtomicLong for each mapped
     // VeniceSystemStoreType value (null for any future enum additions, which skips emission); the
     // valueResolver reads the current count.
-    AsyncMetricEntityStateOneEnum.create(
+    unhealthyCountMetric = AsyncMetricEntityStateOneEnum.create(
         SystemStoreHealthCheckOtelMetricEntity.SYSTEM_STORE_UNHEALTHY_COUNT.getMetricEntity(),
         otelRepository,
         baseDimensionsMap,
@@ -85,14 +87,16 @@ public class SystemStoreHealthCheckStats extends AbstractVeniceStats {
               return null;
           }
         },
-        (counter, type) -> counter.get());
+        (counter, type) -> counter.get(),
+        resources);
 
-    AsyncMetricEntityStateBase.create(
+    unrepairableCountMetric = AsyncMetricEntityStateBase.create(
         SystemStoreHealthCheckOtelMetricEntity.SYSTEM_STORE_UNREPAIRABLE_COUNT.getMetricEntity(),
         otelRepository,
         baseDimensionsMap,
         baseAttributes,
-        notRepairableSystemStoreCounter::get);
+        notRepairableSystemStoreCounter::get,
+        resources);
   }
 
   public AtomicLong getBadMetaSystemStoreCounter() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/TopicCleanupServiceStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/TopicCleanupServiceStats.java
@@ -46,7 +46,8 @@ public class TopicCleanupServiceStats extends AbstractVeniceStats {
         TopicCleanupTehutiMetricNameEnum.DELETABLE_TOPICS_COUNT,
         Arrays.asList(new Gauge()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     topicsDeletedMetric = MetricEntityStateOneEnum.create(
         TopicCleanupOtelMetricEntity.TOPIC_CLEANUP_DELETED_COUNT.getMetricEntity(),
@@ -55,7 +56,8 @@ public class TopicCleanupServiceStats extends AbstractVeniceStats {
         TopicCleanupTehutiMetricNameEnum.TOPICS_DELETED_RATE,
         Arrays.asList(new Rate()),
         baseDimensionsMap,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     topicDeletionErrorMetric = MetricEntityStateOneEnum.create(
         TopicCleanupOtelMetricEntity.TOPIC_CLEANUP_DELETED_COUNT.getMetricEntity(),
@@ -64,7 +66,8 @@ public class TopicCleanupServiceStats extends AbstractVeniceStats {
         TopicCleanupTehutiMetricNameEnum.TOPIC_DELETION_ERROR_RATE,
         Arrays.asList(new Rate()),
         baseDimensionsMap,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
   }
 
   public void recordDeletableTopicsCount(int deletableTopicsCount) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/VeniceAdminStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/VeniceAdminStats.java
@@ -67,7 +67,8 @@ public class VeniceAdminStats extends AbstractVeniceStats {
         VeniceAdminTehutiMetricNameEnum.UNEXPECTED_TOPIC_ABSENCE_DURING_INCREMENTAL_PUSH_COUNT,
         Arrays.asList(new Count()),
         baseDimensionsMap,
-        PushType.class);
+        PushType.class,
+        resources);
 
     batchPushStartedMetric = MetricEntityStateOneEnum.create(
         VeniceAdminOtelMetricEntity.ADMIN_PUSH_STARTED_COUNT.getMetricEntity(),
@@ -76,7 +77,8 @@ public class VeniceAdminStats extends AbstractVeniceStats {
         VeniceAdminTehutiMetricNameEnum.SUCCESSFULLY_STARTED_USER_BATCH_PUSH_PARENT_ADMIN_COUNT,
         Arrays.asList(new Count()),
         baseDimensionsMap,
-        PushType.class);
+        PushType.class,
+        resources);
 
     incrementalPushStartedMetric = MetricEntityStateOneEnum.create(
         VeniceAdminOtelMetricEntity.ADMIN_PUSH_STARTED_COUNT.getMetricEntity(),
@@ -85,7 +87,8 @@ public class VeniceAdminStats extends AbstractVeniceStats {
         VeniceAdminTehutiMetricNameEnum.SUCCESSFUL_STARTED_USER_INCREMENTAL_PUSH_PARENT_ADMIN_COUNT,
         Arrays.asList(new Count()),
         baseDimensionsMap,
-        PushType.class);
+        PushType.class,
+        resources);
 
     serializationFailureMetric = MetricEntityStateBase.create(
         VeniceAdminOtelMetricEntity.ADMIN_OPERATION_SERIALIZATION_FAILURE_COUNT.getMetricEntity(),
@@ -94,7 +97,8 @@ public class VeniceAdminStats extends AbstractVeniceStats {
         VeniceAdminTehutiMetricNameEnum.FAILED_SERIALIZING_ADMIN_OPERATION_MESSAGE_COUNT,
         Arrays.asList(new Count()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
   }
 
   public void recordUnexpectedTopicAbsenceCount(PushType pushType) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairService.java
@@ -6,6 +6,7 @@ import com.linkedin.venice.controller.VeniceControllerMultiClusterConfig;
 import com.linkedin.venice.controller.VeniceParentHelixAdmin;
 import com.linkedin.venice.controller.stats.SystemStoreHealthCheckStats;
 import com.linkedin.venice.service.AbstractVeniceService;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.Map;
@@ -80,6 +81,7 @@ public class SystemStoreRepairService extends AbstractVeniceService {
     } catch (InterruptedException e) {
       currentThread().interrupt();
     }
+    clusterToSystemStoreHealthCheckStatsMap.values().forEach(Utils::closeQuietlyWithErrorLogged);
     LOGGER.info("SystemStoreRepairService is shutdown.");
   }
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -89,6 +89,7 @@ import com.linkedin.venice.stats.ThreadPoolStats;
 import com.linkedin.venice.stats.VeniceJVMStats;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.ZkClientStatusStats;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.stats.metrics.MetricEntity;
 import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
 import com.linkedin.venice.throttle.EventThrottler;
@@ -164,6 +165,8 @@ public class RouterServer extends AbstractVeniceService {
   private Optional<HelixHybridStoreQuotaRepository> hybridStoreQuotaRepository;
   private ReadOnlyStoreRepository metadataRepository;
   private RouterStats<AggRouterHttpRequestStats> routerStats;
+  /** Stats fields owned by this class; drained by {@link #stopInner()}. */
+  private final CompositeCloseable statsCloseables = new CompositeCloseable();
   private HelixReadOnlyStoreViewConfigRepositoryAdapter storeConfigRepository;
 
   private PushStatusStoreReader pushStatusStoreReader;
@@ -669,7 +672,8 @@ public class RouterServer extends AbstractVeniceService {
           config.getLogContext(),
           responseAggregationQueueCapacity,
           LINKED_BLOCKING_QUEUE);
-      new ThreadPoolStats(metricsRepository, responseAggregationExecutor, "response_aggregation_thread_pool");
+      statsCloseables.register(
+          new ThreadPoolStats(metricsRepository, responseAggregationExecutor, "response_aggregation_thread_pool"));
       LOGGER.info(
           "Response aggregation thread pool enabled with size: {}, queue capacity: {}",
           responseAggregationThreadPoolSize,
@@ -763,7 +767,8 @@ public class RouterServer extends AbstractVeniceService {
             config.getLogContext(),
             config.getResolveQueueCapacity(),
             LINKED_BLOCKING_QUEUE);
-        new ThreadPoolStats(metricsRepository, this.dnsResolveExecutor, "dns_resolution_thread_pool");
+        statsCloseables
+            .register(new ThreadPoolStats(metricsRepository, this.dnsResolveExecutor, "dns_resolution_thread_pool"));
         int resolveThreads = config.getResolveThreads();
         int maxConcurrentSslHandshakes = config.getMaxConcurrentSslHandshakes();
         int clientResolutionRetryAttempts = config.getClientResolutionRetryAttempts();
@@ -986,6 +991,10 @@ public class RouterServer extends AbstractVeniceService {
     if (dnsResolveExecutor != null) {
       dnsResolveExecutor.shutdownNow();
     }
+    Utils.closeQuietlyWithErrorLogged(helixGroupSelector);
+    Utils.closeQuietlyWithErrorLogged(routerStats);
+    Utils.closeQuietlyWithErrorLogged(scatterGatherMode);
+    statsCloseables.close();
   }
 
   public HelixBaseRoutingRepository getRoutingDataRepository() {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceDelegateMode.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceDelegateMode.java
@@ -26,7 +26,9 @@ import com.linkedin.venice.router.stats.RouteHttpStats;
 import com.linkedin.venice.router.stats.RouterStats;
 import com.linkedin.venice.router.throttle.RouterThrottler;
 import com.linkedin.venice.stats.ThreadPoolStats;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.utils.DaemonThreadFactory;
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -61,7 +63,7 @@ import org.apache.logging.log4j.Logger;
  * TODO: maybe we should improve DDS lib to catch all kinds of exception in {@link ScatterGatherMode#scatter} to avoid
  * this potential leaking issue.
  */
-public class VeniceDelegateMode extends ScatterGatherMode {
+public class VeniceDelegateMode extends ScatterGatherMode implements Closeable {
   public static final Logger LOGGER = LogManager.getLogger(VeniceDelegateMode.class);
   /**
    * The following constant defines the threshold for selecting a host based on its average latency.
@@ -113,6 +115,8 @@ public class VeniceDelegateMode extends ScatterGatherMode {
   private final RoutingComputationMode routingComputationMode;
   private final ThreadPoolExecutor parallelRoutingExecutor;
   private final int parallelRoutingChunkSize;
+  /** Stats fields owned by this class; drained by {@link #close()}. */
+  private final CompositeCloseable statsCloseables = new CompositeCloseable();
 
   public VeniceDelegateMode(
       VeniceRouterConfig config,
@@ -157,10 +161,11 @@ public class VeniceDelegateMode extends ScatterGatherMode {
           new LinkedBlockingQueue<>(),
           new DaemonThreadFactory("Venice-Parallel-Routing", config.getLogContext()));
       if (routeHttpRequestStats.getMetricsRepository() != null) {
-        new ThreadPoolStats(
-            routeHttpRequestStats.getMetricsRepository(),
-            parallelRoutingExecutor,
-            "ParallelRoutingExecutor");
+        statsCloseables.register(
+            new ThreadPoolStats(
+                routeHttpRequestStats.getMetricsRepository(),
+                parallelRoutingExecutor,
+                "ParallelRoutingExecutor"));
       }
       LOGGER.info(
           "Venice router parallel routing enabled, with thread pool size: {}, chunk size: {}",
@@ -886,5 +891,10 @@ public class VeniceDelegateMode extends ScatterGatherMode {
       }
       populateHostMap(hostMap, selectedHost, partitionKeys);
     }
+  }
+
+  @Override
+  public void close() {
+    statsCloseables.close();
   }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
@@ -39,6 +39,7 @@ import com.linkedin.venice.router.stats.RouterStats;
 import com.linkedin.venice.router.streaming.VeniceChunkedWriteHandler;
 import com.linkedin.venice.router.utils.VeniceRouterUtils;
 import com.linkedin.venice.streaming.StreamingUtils;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
@@ -151,8 +152,8 @@ public class VenicePathParser implements ExtendedResourcePathParser<VenicePath, 
       @Override
       public void handleStoreDeleted(String storeNameString) {
         StoreName storeName = VenicePathParser.this.nameRepository.getStoreName(storeNameString);
-        routerSingleKeyRetryManagers.remove(storeName);
-        routerMultiKeyRetryManagers.remove(storeName);
+        Utils.closeQuietlyWithErrorLogged(routerSingleKeyRetryManagers.remove(storeName));
+        Utils.closeQuietlyWithErrorLogged(routerMultiKeyRetryManagers.remove(storeName));
         cleanDecompressorMaps(storeName, storeVersionName -> true);
       }
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/routing/helix/HelixGroupSelector.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/routing/helix/HelixGroupSelector.java
@@ -4,7 +4,9 @@ import com.linkedin.alpini.base.concurrency.TimeoutProcessor;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixInstanceConfigRepository;
 import com.linkedin.venice.stats.routing.HelixGroupStats;
+import com.linkedin.venice.utils.Utils;
 import io.tehuti.metrics.MetricsRepository;
+import java.io.Closeable;
 import java.util.concurrent.TimeUnit;
 
 
@@ -13,7 +15,7 @@ import java.util.concurrent.TimeUnit;
  * will delegate all the related API calls to the corresponding objects.
  * Besides that, this class is also in charge of emitting metrics for each Helix Group.
  */
-public class HelixGroupSelector implements HelixGroupSelectionStrategy {
+public class HelixGroupSelector implements HelixGroupSelectionStrategy, Closeable {
   /**
    * The timeout to reset group counter.
    * So far, there is no need to make it very tight, so we will hard-code it to be 10 seconds.
@@ -64,5 +66,10 @@ public class HelixGroupSelector implements HelixGroupSelectionStrategy {
   @Override
   public void finishRequest(long requestId, int groupId, double latency) {
     selectionStrategy.finishRequest(requestId, groupId, latency);
+  }
+
+  @Override
+  public void close() {
+    Utils.closeQuietlyWithErrorLogged(helixGroupStats);
   }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -198,7 +198,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
                 getName(),
                 getFullMetricName(RouterTehutiMetricNameEnum.REQUEST_SIZE.getMetricName()))),
         baseDimensionsMap,
-        MessageType.class);
+        MessageType.class,
+        resources);
 
     healthyRequestMetric = MetricEntityStateThreeEnums.create(
         CALL_COUNT.getMetricEntity(),
@@ -209,7 +210,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         baseDimensionsMap,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     unhealthyRequestMetric = MetricEntityStateThreeEnums.create(
         CALL_COUNT.getMetricEntity(),
@@ -220,7 +222,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         baseDimensionsMap,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     tardyRequestMetric = MetricEntityStateThreeEnums.create(
         CALL_COUNT.getMetricEntity(),
@@ -231,7 +234,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         baseDimensionsMap,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     throttledRequestMetric = MetricEntityStateThreeEnums.create(
         CALL_COUNT.getMetricEntity(),
@@ -242,7 +246,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         baseDimensionsMap,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     badRequestMetric = MetricEntityStateThreeEnums.create(
         CALL_COUNT.getMetricEntity(),
@@ -253,7 +258,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         baseDimensionsMap,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     latencyTehutiSensor = registerSensorWithDetailedPercentiles("latency", new Avg(), new Max(0));
     healthyLatencyMetric = createCallTimeMetric(
@@ -280,7 +286,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         RouterTehutiMetricNameEnum.ERROR_RETRY,
         singletonList(new Count()),
         baseDimensionsMap,
-        RequestRetryType.class);
+        RequestRetryType.class,
+        resources);
     allowedRetryCountMetric = MetricEntityStateBase.create(
         ALLOWED_RETRY_COUNT.getMetricEntity(),
         otelRepository,
@@ -288,7 +295,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         RouterTehutiMetricNameEnum.ALLOWED_RETRY_REQUEST_COUNT,
         singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     disallowedRetryCountMetric = MetricEntityStateBase.create(
         DISALLOWED_RETRY_COUNT.getMetricEntity(),
@@ -297,7 +305,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         RouterTehutiMetricNameEnum.DISALLOWED_RETRY_REQUEST_COUNT,
         singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     retryDelayMetric = MetricEntityStateBase.create(
         RETRY_DELAY.getMetricEntity(),
@@ -306,7 +315,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         RouterTehutiMetricNameEnum.RETRY_DELAY,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     delayConstraintAbortedRetryCountMetric = MetricEntityStateOneEnum.create(
         ABORTED_RETRY_COUNT.getMetricEntity(),
@@ -315,7 +325,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         RouterTehutiMetricNameEnum.DELAY_CONSTRAINT_ABORTED_RETRY_REQUEST,
         singletonList(new Count()),
         baseDimensionsMap,
-        RequestRetryAbortReason.class);
+        RequestRetryAbortReason.class,
+        resources);
 
     slowRouteAbortedRetryCountMetric = MetricEntityStateOneEnum.create(
         ABORTED_RETRY_COUNT.getMetricEntity(),
@@ -324,7 +335,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         RouterTehutiMetricNameEnum.SLOW_ROUTE_ABORTED_RETRY_REQUEST,
         singletonList(new Count()),
         baseDimensionsMap,
-        RequestRetryAbortReason.class);
+        RequestRetryAbortReason.class,
+        resources);
 
     retryRouteLimitAbortedRetryCountMetric = MetricEntityStateOneEnum.create(
         ABORTED_RETRY_COUNT.getMetricEntity(),
@@ -333,7 +345,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         RouterTehutiMetricNameEnum.RETRY_ROUTE_LIMIT_ABORTED_RETRY_REQUEST,
         singletonList(new Count()),
         baseDimensionsMap,
-        RequestRetryAbortReason.class);
+        RequestRetryAbortReason.class,
+        resources);
 
     noAvailableReplicaAbortedRetryCountMetric = MetricEntityStateOneEnum.create(
         ABORTED_RETRY_COUNT.getMetricEntity(),
@@ -342,7 +355,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         RouterTehutiMetricNameEnum.NO_AVAILABLE_REPLICA_ABORTED_RETRY_REQUEST,
         singletonList(new Count()),
         baseDimensionsMap,
-        RequestRetryAbortReason.class);
+        RequestRetryAbortReason.class,
+        resources);
 
     keyCountMetric = MetricEntityStateThreeEnums.create(
         KEY_COUNT.getMetricEntity(),
@@ -350,7 +364,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         baseDimensionsMap,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     errorRetryAttemptTriggeredByPendingRequestCheckSensor =
         registerSensor("error_retry_attempt_triggered_by_pending_request_check", new OccurrenceRate());
@@ -458,7 +473,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
                       getName(),
                       getFullMetricName(RouterTehutiMetricNameEnum.KEY_SIZE_IN_BYTE.getMetricName()))),
           baseDimensionsMap,
-          baseAttributes);
+          baseAttributes,
+          resources);
     } else {
       keySizeMetric = null;
     }
@@ -474,7 +490,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
                 getName(),
                 getFullMetricName(RouterTehutiMetricNameEnum.RESPONSE_SIZE.getMetricName()))),
         baseDimensionsMap,
-        MessageType.class);
+        MessageType.class,
+        resources);
 
     // Initialize the in-flight request counter
     currentInFlightRequest = new AtomicInteger();
@@ -496,7 +513,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
         VeniceResponseStatusCategory.class,
-        VeniceRequestKeyCountBucket.class);
+        VeniceRequestKeyCountBucket.class,
+        resources);
   }
 
   /**

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterStats.java
@@ -8,10 +8,12 @@ import static com.linkedin.venice.read.RequestType.SINGLE_GET;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.read.RequestType;
+import com.linkedin.venice.stats.metrics.MetricEntityStateUtils;
+import java.io.Closeable;
 import java.util.function.Function;
 
 
-public class RouterStats<STAT_TYPE> {
+public class RouterStats<STAT_TYPE> implements Closeable {
   private final STAT_TYPE statsForSingleGet;
   private final STAT_TYPE statsForMultiGet;
   private final STAT_TYPE statsForCompute;
@@ -43,4 +45,22 @@ public class RouterStats<STAT_TYPE> {
     }
   }
 
+  /**
+   * Closes each per-request-type stats instance if it is {@link Closeable}. STAT_TYPE is generic;
+   * non-Closeable parameterisations are no-ops.
+   */
+  @Override
+  public void close() {
+    closeIfCloseable(statsForSingleGet);
+    closeIfCloseable(statsForMultiGet);
+    closeIfCloseable(statsForCompute);
+    closeIfCloseable(statsForMultiGetStreaming);
+    closeIfCloseable(statsForComputeStreaming);
+  }
+
+  private static void closeIfCloseable(Object stats) {
+    if (stats instanceof Closeable) {
+      MetricEntityStateUtils.closeQuietly((Closeable) stats);
+    }
+  }
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceDelegateMode.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceDelegateMode.java
@@ -1257,4 +1257,24 @@ public class TestVeniceDelegateMode {
     // Should select the only available host
     Assert.assertEquals(requests.iterator().next().getHosts().get(0), instance1);
   }
+
+  /**
+   * Exercises {@link VeniceDelegateMode#close()}. The instance owns a {@code statsCloseables}
+   * registry that may be empty (parallel routing disabled) or hold a {@link ThreadPoolStats}
+   * wrapper (parallel routing enabled). Close must drain whatever's there without throwing in
+   * either case, and remain idempotent.
+   */
+  @Test
+  public void testCloseIsIdempotent() {
+    VeniceRouterConfig config = mock(VeniceRouterConfig.class);
+    doReturn(LEAST_LOADED_ROUTING).when(config).getMultiKeyRoutingStrategy();
+    doReturn(RoutingComputationMode.SEQUENTIAL).when(config).getRoutingComputationMode();
+    VeniceDelegateMode scatterMode = new VeniceDelegateMode(
+        config,
+        mock(RouterStats.class),
+        mock(RouteHttpRequestStats.class),
+        mock(RouterStats.class));
+    scatterMode.close();
+    scatterMode.close();
+  }
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/stats/RouterStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/stats/RouterStatsTest.java
@@ -1,0 +1,79 @@
+package com.linkedin.venice.router.stats;
+
+import static com.linkedin.venice.read.RequestType.COMPUTE;
+import static com.linkedin.venice.read.RequestType.COMPUTE_STREAMING;
+import static com.linkedin.venice.read.RequestType.MULTI_GET;
+import static com.linkedin.venice.read.RequestType.MULTI_GET_STREAMING;
+import static com.linkedin.venice.read.RequestType.SINGLE_GET;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.read.RequestType;
+import java.io.Closeable;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.testng.annotations.Test;
+
+
+public class RouterStatsTest {
+  /** Closeable double that records how many times {@link #close()} was invoked. */
+  private static final class CloseableStub implements Closeable {
+    final AtomicInteger closeCount = new AtomicInteger();
+
+    @Override
+    public void close() {
+      closeCount.incrementAndGet();
+    }
+  }
+
+  @Test
+  public void testGetStatsByTypeReturnsPerRequestTypeInstance() {
+    Map<RequestType, CloseableStub> stubs = new EnumMap<>(RequestType.class);
+    for (RequestType type: new RequestType[] { SINGLE_GET, MULTI_GET, COMPUTE, MULTI_GET_STREAMING,
+        COMPUTE_STREAMING }) {
+      stubs.put(type, new CloseableStub());
+    }
+    RouterStats<CloseableStub> stats = new RouterStats<>(stubs::get);
+    for (RequestType type: stubs.keySet()) {
+      assertEquals(stats.getStatsByType(type), stubs.get(type));
+    }
+  }
+
+  @Test
+  public void testCloseClosesEveryCloseableStat() {
+    Map<RequestType, CloseableStub> stubs = new EnumMap<>(RequestType.class);
+    for (RequestType type: new RequestType[] { SINGLE_GET, MULTI_GET, COMPUTE, MULTI_GET_STREAMING,
+        COMPUTE_STREAMING }) {
+      stubs.put(type, new CloseableStub());
+    }
+    RouterStats<CloseableStub> stats = new RouterStats<>(stubs::get);
+    stats.close();
+    for (CloseableStub stub: stubs.values()) {
+      assertEquals(stub.closeCount.get(), 1, "Each per-request-type Closeable should be closed exactly once");
+    }
+  }
+
+  /** Verifies {@code RouterStats#close()} is a silent no-op when {@code STAT_TYPE} is not {@link Closeable}. */
+  @Test
+  public void testCloseSafeForNonCloseableStatType() {
+    RouterStats<String> stats = new RouterStats<>(type -> "stats-for-" + type.name());
+    // Should not throw despite STAT_TYPE not being Closeable.
+    stats.close();
+    assertEquals(stats.getStatsByType(SINGLE_GET), "stats-for-SINGLE_GET");
+  }
+
+  @Test
+  public void testCloseIsIdempotent() {
+    CloseableStub stub = new CloseableStub();
+    RouterStats<CloseableStub> stats = new RouterStats<>(type -> stub);
+    stats.close();
+    stats.close();
+    // Each request-type slot holds the same stub instance, so it's closed once per slot per close() call.
+    // Across two close() calls that's 2 * 5 invocations — the value isn't what matters, only that no exception fires
+    // and the per-Closeable close was attempted.
+    assertTrue(stub.closeCount.get() >= 5, "close() should not throw and should keep delegating on repeat calls");
+    assertFalse(stub.closeCount.get() < 5);
+  }
+}

--- a/services/venice-server/src/main/java/com/linkedin/venice/cleaner/BackupVersionOptimizationService.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/cleaner/BackupVersionOptimizationService.java
@@ -193,6 +193,7 @@ public class BackupVersionOptimizationService extends AbstractVeniceService impl
     stop = true;
     executor.shutdownNow();
     executor.awaitTermination(30, TimeUnit.SECONDS);
+    Utils.closeQuietlyWithErrorLogged(stats);
   }
 
   @Override

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
@@ -26,6 +26,7 @@ import com.linkedin.venice.stats.AggServerQuotaUsageStats;
 import com.linkedin.venice.stats.ServerConnectionStats;
 import com.linkedin.venice.stats.ServerLoadStats;
 import com.linkedin.venice.stats.ThreadPoolStats;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
 import com.linkedin.venice.utils.ReflectUtils;
 import com.linkedin.venice.utils.SslUtils;
 import com.linkedin.venice.utils.Utils;
@@ -38,6 +39,7 @@ import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.tehuti.metrics.MetricsRepository;
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -47,7 +49,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
-public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
+public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> implements Closeable {
+  /** Stats fields owned by this class; drained by {@link #close()}. */
+  private final CompositeCloseable statsCloseables = new CompositeCloseable();
   private static final Logger LOGGER = LogManager.getLogger(HttpChannelInitializer.class);
 
   private final StorageReadRequestHandler requestHandler;
@@ -125,9 +129,10 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
     this.sslFactory = sslFactory;
     this.alpiniSslFactory = sslFactory.isPresent() ? SslUtils.toAlpiniSSLFactory(sslFactory.get()) : null;
     this.sslHandshakeExecutor = sslHandshakeExecutor;
-    this.sslHandshakesThreadPoolStats = sslHandshakeExecutor != null
-        ? new ThreadPoolStats(metricsRepository, sslHandshakeExecutor, "ssl_handshake_thread_pool")
-        : null;
+    this.sslHandshakesThreadPoolStats = statsCloseables.register(
+        sslHandshakeExecutor != null
+            ? new ThreadPoolStats(metricsRepository, sslHandshakeExecutor, "ssl_handshake_thread_pool")
+            : null);
 
     Class<IdentityParser> identityParserClass = ReflectUtils.loadClass(serverConfig.getIdentityParserClassName());
     this.identityParser = ReflectUtils.callConstructor(identityParserClass, new Class[0], new Object[0]);
@@ -150,7 +155,8 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     if (serverConfig.isQuotaEnforcementEnabled()) {
       String nodeId = Utils.getHelixNodeIdentifier(serverConfig.getListenerHostname(), serverConfig.getListenerPort());
-      this.quotaUsageStats = new AggServerQuotaUsageStats(serverConfig.getClusterName(), metricsRepository);
+      this.quotaUsageStats =
+          statsCloseables.register(new AggServerQuotaUsageStats(serverConfig.getClusterName(), metricsRepository));
       this.quotaEnforcer = new ReadQuotaEnforcementHandler(
           serverConfig,
           storeMetadataRepository,
@@ -173,23 +179,30 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
     this.http2PipelineInitializerBuilder = new VeniceHttp2PipelineInitializerBuilder(serverConfig);
 
     if (sslFactory.isPresent()) {
+      ServerConnectionStats serverConnectionStats = statsCloseables.register(
+          new ServerConnectionStats(metricsRepository, "server_connection_stats", serverConfig.getClusterName()));
       this.serverConnectionStatsHandler = new ServerConnectionStatsHandler(
           this.identityParser,
-          new ServerConnectionStats(metricsRepository, "server_connection_stats", serverConfig.getClusterName()),
+          serverConnectionStats,
           serverConfig.getRouterPrincipalName(),
           serverConfig.getLogContext());
     } else {
       this.serverConnectionStatsHandler = null;
     }
     if (serverConfig.isLoadControllerEnabled()) {
-      this.loadControllerHandler = new ServerLoadControllerHandler(
-          serverConfig,
-          new ServerLoadStats(metricsRepository, "server_load", serverConfig.getClusterName()));
+      ServerLoadStats serverLoadStats = statsCloseables
+          .register(new ServerLoadStats(metricsRepository, "server_load", serverConfig.getClusterName()));
+      this.loadControllerHandler = new ServerLoadControllerHandler(serverConfig, serverLoadStats);
       LOGGER.info("Server load controller is enabled");
     } else {
       this.loadControllerHandler = null;
       LOGGER.info("Server load controller is disabled");
     }
+  }
+
+  @Override
+  public void close() {
+    statsCloseables.close();
   }
 
   /*

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
@@ -19,6 +19,8 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.stats.ThreadPoolStats;
+import com.linkedin.venice.stats.metrics.CompositeCloseable;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.ThreadPoolFactory;
 import io.grpc.ServerInterceptor;
 import io.netty.bootstrap.ServerBootstrap;
@@ -60,6 +62,9 @@ public class ListenerService extends AbstractVeniceService {
   private final ThreadPoolExecutor computeExecutor;
   private final ThreadPoolExecutor grpcExecutor;
   private ThreadPoolExecutor sslHandshakeExecutor;
+  private final HttpChannelInitializer channelInitializer;
+  /** Stats fields owned by this class; drained by {@link #stopInner()}. */
+  private final CompositeCloseable statsCloseables = new CompositeCloseable();
 
   // TODO: move netty config to a config file
   private static int nettyBacklogSize = 1000;
@@ -89,13 +94,13 @@ public class ListenerService extends AbstractVeniceService {
         serverConfig.getRestServiceStorageThreadNum(),
         "StorageExecutionThread",
         serverConfig.getDatabaseLookupQueueCapacity());
-    new ThreadPoolStats(metricsRepository, executor, "storage_execution_thread_pool");
+    statsCloseables.register(new ThreadPoolStats(metricsRepository, executor, "storage_execution_thread_pool"));
 
     computeExecutor = createThreadPool(
         serverConfig.getServerComputeThreadNum(),
         "StorageComputeThread",
         serverConfig.getComputeQueueCapacity());
-    new ThreadPoolStats(metricsRepository, computeExecutor, "storage_compute_thread_pool");
+    statsCloseables.register(new ThreadPoolStats(metricsRepository, computeExecutor, "storage_compute_thread_pool"));
 
     if (sslFactory.isPresent() && serverConfig.getSslHandshakeThreadPoolSize() > 0) {
       this.sslHandshakeExecutor = createThreadPool(
@@ -116,7 +121,7 @@ public class ListenerService extends AbstractVeniceService {
         compressorFactory,
         resourceReadUsageTracker);
 
-    HttpChannelInitializer channelInitializer = new HttpChannelInitializer(
+    channelInitializer = new HttpChannelInitializer(
         storeMetadataRepository,
         customizedViewRepository,
         metricsRepository,
@@ -215,6 +220,8 @@ public class ListenerService extends AbstractVeniceService {
       LOGGER.info("Stopping gRPC service on port {}", grpcPort);
       grpcServer.stop();
     }
+    Utils.closeQuietlyWithErrorLogged(channelInitializer);
+    statsCloseables.close();
   }
 
   protected ThreadPoolExecutor createThreadPool(int threadCount, String threadNamePrefix, int capacity) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerReadMetadataRepository.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerReadMetadataRepository.java
@@ -24,7 +24,9 @@ import com.linkedin.venice.systemstore.schemas.StoreMetaValue;
 import com.linkedin.venice.systemstore.schemas.StoreProperties;
 import com.linkedin.venice.systemstore.schemas.StoreValueSchemas;
 import com.linkedin.venice.utils.HelixUtils;
+import com.linkedin.venice.utils.Utils;
 import io.tehuti.metrics.MetricsRepository;
+import java.io.Closeable;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -41,7 +43,7 @@ import org.apache.logging.log4j.Logger;
 /**
  * A wrapper that holds reference for various repositories responsible for constructing metadata responses upon request.
  */
-public class ServerReadMetadataRepository implements ReadMetadataRetriever {
+public class ServerReadMetadataRepository implements ReadMetadataRetriever, Closeable {
   private static final Logger LOGGER = LogManager.getLogger(ServerReadMetadataRepository.class);
   private final String serverCluster;
   private final boolean sslEnabled;
@@ -89,6 +91,11 @@ public class ServerReadMetadataRepository implements ReadMetadataRetriever {
 
     customizedViewFuture.ifPresent(future -> future.thenApply(cv -> this.customizedViewRepository = cv));
     helixInstanceFuture.ifPresent(future -> future.thenApply(helix -> this.helixInstanceConfigRepository = helix));
+  }
+
+  @Override
+  public void close() {
+    Utils.closeQuietlyWithErrorLogged(serverMetadataServiceStats);
   }
 
   /**

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -72,6 +72,7 @@ import com.linkedin.venice.stats.AggRocksDBStats;
 import com.linkedin.venice.stats.BackupVersionOptimizationServiceStats;
 import com.linkedin.venice.stats.DiskHealthStats;
 import com.linkedin.venice.stats.VeniceJVMStats;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
 import com.linkedin.venice.system.store.ControllerClientBackedSystemSchemaInitializer;
 import com.linkedin.venice.utils.CollectionUtils;
 import com.linkedin.venice.utils.Utils;
@@ -97,7 +98,7 @@ import org.apache.logging.log4j.Logger;
  * operations and making sure that it is done in the right order based on their
  * dependencies.
  */
-public class VeniceServer {
+public class VeniceServer extends AbstractStatsCloseable {
   private static final Logger LOGGER = LogManager.getLogger(VeniceServer.class);
 
   private final List<ServiceDiscoveryAnnouncer> serviceDiscoveryAnnouncers;
@@ -129,7 +130,6 @@ public class VeniceServer {
   private VeniceJVMStats jvmStats;
   private ICProvider icProvider;
   StorageEngineBackedCompressorFactory compressorFactory;
-  private StoreVersionOtelStats storeVersionOtelStats;
   private HeartbeatMonitoringService heartbeatMonitoringService;
   private AdaptiveThrottlerSignalService adaptiveThrottlerSignalService;
   private ServerReadMetadataRepository serverReadMetadataRepository;
@@ -332,18 +332,19 @@ public class VeniceServer {
         clusterConfig.getClusterName());
 
     // OTel per-store version gauge
-    storeVersionOtelStats =
-        StoreVersionOtelStats.create(metricsRepository, clusterConfig.getClusterName(), metadataRepo);
+    statsCloseables
+        .register(StoreVersionOtelStats.create(metricsRepository, clusterConfig.getClusterName(), metadataRepo));
 
     boolean plainTableEnabled =
         veniceConfigLoader.getVeniceServerConfig().getRocksDBServerConfig().isRocksDBPlainTableFormatEnabled();
-    RocksDBMemoryStats rocksDBMemoryStats = veniceConfigLoader.getVeniceServerConfig().isDatabaseMemoryStatsEnabled()
-        ? new RocksDBMemoryStats(
-            metricsRepository,
-            "RocksDBMemoryStats",
-            plainTableEnabled,
-            clusterConfig.getClusterName())
-        : null;
+    RocksDBMemoryStats rocksDBMemoryStats = statsCloseables.register(
+        veniceConfigLoader.getVeniceServerConfig().isDatabaseMemoryStatsEnabled()
+            ? new RocksDBMemoryStats(
+                metricsRepository,
+                "RocksDBMemoryStats",
+                plainTableEnabled,
+                clusterConfig.getClusterName())
+            : null);
 
     // Create and add StorageService. storeRepository will be populated by StorageService
     storageService = new StorageService(
@@ -361,7 +362,9 @@ public class VeniceServer {
 
     // Create stats for RocksDB
     storageService.getRocksDBAggregatedStatistics()
-        .ifPresent(stat -> new AggRocksDBStats(serverConfig.getClusterName(), metricsRepository, stat));
+        .ifPresent(
+            stat -> statsCloseables
+                .register(new AggRocksDBStats(serverConfig.getClusterName(), metricsRepository, stat)));
 
     compressorFactory = new StorageEngineBackedCompressorFactory(storageMetadataService);
 
@@ -449,11 +452,12 @@ public class VeniceServer {
         serverConfig.getLogContext());
     services.add(diskHealthCheckService);
     // create stats for disk health check service
-    new DiskHealthStats(
-        metricsRepository,
-        diskHealthCheckService,
-        "disk_health_check_service",
-        clusterConfig.getClusterName());
+    statsCloseables.register(
+        new DiskHealthStats(
+            metricsRepository,
+            diskHealthCheckService,
+            "disk_health_check_service",
+            clusterConfig.getClusterName()));
 
     final Optional<ResourceReadUsageTracker> resourceReadUsageTracker;
     if (serverConfig.isOptimizeDatabaseForBackupVersionEnabled()) {
@@ -479,15 +483,16 @@ public class VeniceServer {
         new StoreValueSchemasCacheService(metadataRepo, schemaRepo, serverConfig.getLogContext());
     services.add(storeValueSchemasCacheService);
 
-    serverReadMetadataRepository = new ServerReadMetadataRepository(
-        clusterConfig.getClusterName(),
-        metricsRepository,
-        metadataRepo,
-        schemaRepo,
-        veniceMetadataRepositoryBuilder.getStoreConfigRepo(),
-        Optional.of(customizedViewFuture),
-        Optional.of(helixInstanceFuture),
-        sslFactory.isPresent());
+    serverReadMetadataRepository = statsCloseables.register(
+        new ServerReadMetadataRepository(
+            clusterConfig.getClusterName(),
+            metricsRepository,
+            metadataRepo,
+            schemaRepo,
+            veniceMetadataRepositoryBuilder.getStoreConfigRepo(),
+            Optional.of(customizedViewFuture),
+            Optional.of(helixInstanceFuture),
+            sslFactory.isPresent()));
 
     // create and add ListenerServer for handling GET requests
     ListenerService listenerService = createListenerService(
@@ -511,7 +516,8 @@ public class VeniceServer {
      * Initialize Blob transfer manager for Service
      */
     if (BlobTransferUtils.isBlobTransferManagerEnabled(serverConfig)) {
-      aggVersionedBlobTransferStats = new AggVersionedBlobTransferStats(metricsRepository, metadataRepo, serverConfig);
+      aggVersionedBlobTransferStats =
+          statsCloseables.register(new AggVersionedBlobTransferStats(metricsRepository, metadataRepo, serverConfig));
       aggBlobTransferStats = new AggBlobTransferStats(
           aggVersionedBlobTransferStats,
           kafkaStoreIngestionService.getHostLevelIngestionStats());
@@ -765,14 +771,7 @@ public class VeniceServer {
       LOGGER.info("All services have been stopped");
       compressorFactory.close();
 
-      if (storeVersionOtelStats != null) {
-        try {
-          storeVersionOtelStats.close();
-        } catch (Exception e) {
-          exceptions.add(e);
-          LOGGER.error("Exception while closing StoreVersionOtelStats", e);
-        }
-      }
+      statsCloseables.close();
 
       try {
         metricsRepository.close();

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStats.java
@@ -33,14 +33,9 @@ public class BackupVersionOptimizationServiceStats extends AbstractVeniceStats {
   private final VeniceOpenTelemetryMetricsRepository otelRepository;
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
 
-  /**
-   * Per-store entries. Two wrappers (success / error) share the OTel instrument and bind to
-   * different Tehuti sensors; both are closed together via the per-store registry.
-   * Bounded by the number of stores on this host.
-   */
-  private final Map<String, PerStoreEntry> perStore = new VeniceConcurrentHashMap<>();
+  /** Per-store success/error wrappers; one OTel instrument, two Tehuti sensors. Bounded by host store count. */
+  private final Map<String, PerStoreEntry> perStoreEntryMap = new VeniceConcurrentHashMap<>();
 
-  /** Per-store state: the inherited {@link AbstractStatsCloseable#resources} plus the success and error wrappers. */
   private static final class PerStoreEntry extends AbstractStatsCloseable {
     final MetricEntityStateOneEnum<VeniceOperationOutcome> success;
     final MetricEntityStateOneEnum<VeniceOperationOutcome> error;
@@ -88,7 +83,7 @@ public class BackupVersionOptimizationServiceStats extends AbstractVeniceStats {
   }
 
   private PerStoreEntry getOrCreateEntry(String storeName) {
-    return perStore.computeIfAbsent(
+    return perStoreEntryMap.computeIfAbsent(
         storeName,
         k -> new PerStoreEntry(
             otelRepository,
@@ -98,7 +93,7 @@ public class BackupVersionOptimizationServiceStats extends AbstractVeniceStats {
 
   @Override
   public void close() {
-    MetricEntityStateUtils.closeAndClear(perStore);
+    MetricEntityStateUtils.closeAndClear(perStoreEntryMap);
     super.close();
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStats.java
@@ -5,13 +5,15 @@ import static com.linkedin.davinci.stats.BackupVersionOptimizationOtelMetricEnti
 import com.linkedin.venice.cleaner.BackupVersionOptimizationService;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.stats.dimensions.VeniceOperationOutcome;
+import com.linkedin.venice.stats.metrics.AbstractStatsCloseable;
+import com.linkedin.venice.stats.metrics.AsyncMetricEntityState.TehutiSensorRegistrationFunction;
 import com.linkedin.venice.stats.metrics.MetricEntityStateOneEnum;
+import com.linkedin.venice.stats.metrics.MetricEntityStateUtils;
 import com.linkedin.venice.stats.metrics.TehutiMetricNameEnum;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.OccurrenceRate;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 
@@ -32,16 +34,41 @@ public class BackupVersionOptimizationServiceStats extends AbstractVeniceStats {
   private final Map<VeniceMetricsDimensions, String> baseDimensionsMap;
 
   /**
-   * Per-store joint Tehuti+OTel metric state maps. Two maps because they bind to different Tehuti sensors
-   * (success vs error) while sharing the same OTel instrument ({@code REOPEN_COUNT}) differentiated
-   * by {@link VeniceOperationOutcome}. Tehuti sensor is registered once (first store) and shared by all
-   * subsequent stores via {@code registerSensorIfAbsent}. Bounded by the number of stores on this host.
-   * When OTel is disabled, {@code otelRepository} is null and OTel recording is a no-op.
+   * Per-store entries. Two wrappers (success / error) share the OTel instrument and bind to
+   * different Tehuti sensors; both are closed together via the per-store registry.
+   * Bounded by the number of stores on this host.
    */
-  private final Map<String, MetricEntityStateOneEnum<VeniceOperationOutcome>> successPerStore =
-      new VeniceConcurrentHashMap<>();
-  private final Map<String, MetricEntityStateOneEnum<VeniceOperationOutcome>> errorPerStore =
-      new VeniceConcurrentHashMap<>();
+  private final Map<String, PerStoreEntry> perStore = new VeniceConcurrentHashMap<>();
+
+  /** Per-store state: the inherited {@link AbstractStatsCloseable#resources} plus the success and error wrappers. */
+  private static final class PerStoreEntry extends AbstractStatsCloseable {
+    final MetricEntityStateOneEnum<VeniceOperationOutcome> success;
+    final MetricEntityStateOneEnum<VeniceOperationOutcome> error;
+
+    PerStoreEntry(
+        VeniceOpenTelemetryMetricsRepository otelRepository,
+        Map<VeniceMetricsDimensions, String> dims,
+        TehutiSensorRegistrationFunction registerTehutiSensorFn) {
+      this.success = MetricEntityStateOneEnum.create(
+          REOPEN_COUNT.getMetricEntity(),
+          otelRepository,
+          registerTehutiSensorFn,
+          TehutiMetricName.BACKUP_VERSION_DATABASE_OPTIMIZATION,
+          Collections.singletonList(new OccurrenceRate()),
+          dims,
+          VeniceOperationOutcome.class,
+          statsCloseables);
+      this.error = MetricEntityStateOneEnum.create(
+          REOPEN_COUNT.getMetricEntity(),
+          otelRepository,
+          registerTehutiSensorFn,
+          TehutiMetricName.BACKUP_VERSION_DATA_OPTIMIZATION_ERROR,
+          Collections.singletonList(new OccurrenceRate()),
+          dims,
+          VeniceOperationOutcome.class,
+          statsCloseables);
+    }
+  }
 
   public BackupVersionOptimizationServiceStats(MetricsRepository metricsRepository, String name, String clusterName) {
     super(metricsRepository, name);
@@ -53,34 +80,25 @@ public class BackupVersionOptimizationServiceStats extends AbstractVeniceStats {
   }
 
   public void recordBackupVersionDatabaseOptimization(String storeName) {
-    getOrCreateMetric(successPerStore, storeName, TehutiMetricName.BACKUP_VERSION_DATABASE_OPTIMIZATION)
-        .record(1, VeniceOperationOutcome.SUCCESS);
+    getOrCreateEntry(storeName).success.record(1, VeniceOperationOutcome.SUCCESS);
   }
 
   public void recordBackupVersionDatabaseOptimizationError(String storeName) {
-    getOrCreateMetric(errorPerStore, storeName, TehutiMetricName.BACKUP_VERSION_DATA_OPTIMIZATION_ERROR)
-        .record(1, VeniceOperationOutcome.FAIL);
+    getOrCreateEntry(storeName).error.record(1, VeniceOperationOutcome.FAIL);
   }
 
-  private MetricEntityStateOneEnum<VeniceOperationOutcome> getOrCreateMetric(
-      Map<String, MetricEntityStateOneEnum<VeniceOperationOutcome>> perStoreMap,
-      String storeName,
-      TehutiMetricName tehutiName) {
-    return perStoreMap.computeIfAbsent(storeName, k -> createPerStoreMetric(k, tehutiName));
+  private PerStoreEntry getOrCreateEntry(String storeName) {
+    return perStore.computeIfAbsent(
+        storeName,
+        k -> new PerStoreEntry(
+            otelRepository,
+            OpenTelemetryMetricsSetup.buildStoreDimensionsMap(baseDimensionsMap, k),
+            this::registerSensorIfAbsent));
   }
 
-  private MetricEntityStateOneEnum<VeniceOperationOutcome> createPerStoreMetric(
-      String storeName,
-      TehutiMetricName tehutiName) {
-    Map<VeniceMetricsDimensions, String> storeDims = new HashMap<>(baseDimensionsMap);
-    storeDims.put(VeniceMetricsDimensions.VENICE_STORE_NAME, OpenTelemetryMetricsSetup.sanitizeStoreName(storeName));
-    return MetricEntityStateOneEnum.create(
-        REOPEN_COUNT.getMetricEntity(),
-        otelRepository,
-        this::registerSensorIfAbsent,
-        tehutiName,
-        Collections.singletonList(new OccurrenceRate()),
-        storeDims,
-        VeniceOperationOutcome.class);
+  @Override
+  public void close() {
+    MetricEntityStateUtils.closeAndClear(perStore);
+    super.close();
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/DiskHealthStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/DiskHealthStats.java
@@ -28,6 +28,8 @@ public class DiskHealthStats extends AbstractVeniceStats {
     DISK_HEALTHY
   }
 
+  private final AsyncMetricEntityStateBase diskHealthMetric;
+
   public DiskHealthStats(
       MetricsRepository metricsRepository,
       DiskHealthCheckService diskHealthCheckService,
@@ -41,7 +43,7 @@ public class DiskHealthStats extends AbstractVeniceStats {
     Attributes baseAttributes = otelData.getBaseAttributes();
 
     LongSupplier healthCallback = () -> diskHealthCheckService.isDiskHealthy() ? 1 : 0;
-    AsyncMetricEntityStateBase.create(
+    diskHealthMetric = AsyncMetricEntityStateBase.create(
         DISK_HEALTH_STATUS.getMetricEntity(),
         otelData.getOtelRepository(),
         this::registerSensorIfAbsent,
@@ -50,6 +52,7 @@ public class DiskHealthStats extends AbstractVeniceStats {
             new AsyncGauge((ig, ig2) -> healthCallback.getAsLong(), TehutiMetricName.DISK_HEALTHY.getMetricName())),
         baseDimensionsMap,
         baseAttributes,
-        healthCallback);
+        healthCallback,
+        resources);
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/RocksDBStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/RocksDBStats.java
@@ -227,7 +227,7 @@ public class RocksDBStats extends AbstractVeniceStats {
             return null;
           }
           return stat;
-        }, (stat, level) -> stat.getTickerCount(GET_HIT_TICKER_BY_LEVEL.get(level)));
+        }, (stat, level) -> stat.getTickerCount(GET_HIT_TICKER_BY_LEVEL.get(level)), resources);
 
     // --- Block Cache Hit Ratio: Tehuti-only (OTel derivable: hit{data} / (hit{data} + sum(miss))) ---
     registerSensorIfAbsent(new AsyncGauge((ig, ig2) -> {
@@ -264,7 +264,8 @@ public class RocksDBStats extends AbstractVeniceStats {
         otelRepository,
         baseDimensionsMap,
         baseAttributes,
-        readAmpOtelCallback);
+        readAmpOtelCallback,
+        resources);
   }
 
   /** Registers a Tehuti-only AsyncGauge for a RocksDB TickerType counter. */
@@ -284,7 +285,7 @@ public class RocksDBStats extends AbstractVeniceStats {
     LongSupplier callback = () -> rocksDBStat != null ? rocksDBStat.getTickerCount(tickerType) : -1;
     registerSensorIfAbsent(new AsyncGauge((ig, ig2) -> callback.getAsLong(), tehutiSensorName));
     AsyncMetricEntityStateBase
-        .create(otelEntity.getMetricEntity(), otelRepository, baseDimensionsMap, baseAttributes, callback);
+        .create(otelEntity.getMetricEntity(), otelRepository, baseDimensionsMap, baseAttributes, callback, resources);
   }
 
   /** Registers an OTel-only AsyncMetricEntityStateOneEnum for per-component block cache metrics. */
@@ -305,7 +306,8 @@ public class RocksDBStats extends AbstractVeniceStats {
           }
           return stat;
         },
-        (stat, component) -> stat.getTickerCount(componentTickers.get(component)));
+        (stat, component) -> stat.getTickerCount(componentTickers.get(component)),
+        resources);
   }
 
   public void setRocksDBStat(Statistics stat) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerConnectionStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerConnectionStats.java
@@ -68,7 +68,8 @@ public class ServerConnectionStats extends AbstractVeniceStats {
         CONNECTION_ACTIVE_COUNT.getMetricEntity(),
         otelRepository,
         baseDimensionsMap,
-        VeniceConnectionSource.class);
+        VeniceConnectionSource.class,
+        resources);
 
     routerRequestCountOtel = MetricEntityStateOneEnum.create(
         CONNECTION_REQUEST_COUNT.getMetricEntity(),
@@ -77,7 +78,8 @@ public class ServerConnectionStats extends AbstractVeniceStats {
         TehutiMetricName.ROUTER_CONNECTION_REQUEST,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        VeniceConnectionSource.class);
+        VeniceConnectionSource.class,
+        resources);
 
     clientRequestCountOtel = MetricEntityStateOneEnum.create(
         CONNECTION_REQUEST_COUNT.getMetricEntity(),
@@ -86,7 +88,8 @@ public class ServerConnectionStats extends AbstractVeniceStats {
         TehutiMetricName.CLIENT_CONNECTION_REQUEST,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        VeniceConnectionSource.class);
+        VeniceConnectionSource.class,
+        resources);
 
     // Tehuti only — OTel total derived at query time
     connectionRequestSensor = registerSensorIfAbsent(CONNECTION_REQUEST, new OccurrenceRate());
@@ -99,7 +102,8 @@ public class ServerConnectionStats extends AbstractVeniceStats {
         TehutiMetricName.NEW_CONNECTION_SETUP_LATENCY,
         Arrays.asList(TehutiUtils.getPercentileStatWithAvgAndMax(getName(), NEW_CONNECTION_SETUP_LATENCY)),
         baseDimensionsMap,
-        VeniceConnectionSource.class);
+        VeniceConnectionSource.class,
+        resources);
   }
 
   public void incrementRouterConnectionCount() {

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
@@ -144,7 +144,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         baseDimensionsMap,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     errorRequestMetric = MetricEntityStateThreeEnums.create(
         READ_CALL_COUNT.getMetricEntity(),
@@ -155,7 +156,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         baseDimensionsMap,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     successRequestRatioSensor = registerSensor(
         "success_request_ratio",
@@ -172,7 +174,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
         VeniceResponseStatusCategory.class,
-        VeniceRequestKeyCountBucket.class);
+        VeniceRequestKeyCountBucket.class,
+        resources);
 
     errorRequestLatencyMetric = MetricEntityStateFourEnums.create(
         READ_CALL_TIME.getMetricEntity(),
@@ -185,7 +188,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
         VeniceResponseStatusCategory.class,
-        VeniceRequestKeyCountBucket.class);
+        VeniceRequestKeyCountBucket.class,
+        resources);
 
     responseSizeMetric = MetricEntityStateThreeEnums.create(
         READ_RESPONSE_SIZE.getMetricEntity(),
@@ -196,7 +200,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         baseDimensionsMap,
         HttpResponseStatusEnum.class,
         HttpResponseStatusCodeCategory.class,
-        VeniceResponseStatusCategory.class);
+        VeniceResponseStatusCategory.class,
+        resources);
 
     storageEngineQueryTimeMetric = MetricEntityStateOneEnum.create(
         STORAGE_ENGINE_QUERY_TIME.getMetricEntity(),
@@ -206,7 +211,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         Arrays.asList(
             TehutiUtils.get99PercentileStatWithAvgAndMax(getName(), getFullMetricName("storage_engine_query_latency"))),
         baseDimensionsMap,
-        VeniceChunkingStatus.class);
+        VeniceChunkingStatus.class,
+        resources);
 
     readComputeQueryTimeMetric = MetricEntityStateBase.create(
         STORAGE_ENGINE_READ_COMPUTE_EXECUTION_TIME.getMetricEntity(),
@@ -217,7 +223,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
             TehutiUtils
                 .getPercentileStatWithAvgAndMax(getName(), getFullMetricName("storage_engine_read_compute_latency"))),
         computeBaseDimensionsMap,
-        computeBaseAttributes);
+        computeBaseAttributes,
+        resources);
 
     databaseLookupLatencyForSmallValueSensor = registerPerStoreAndTotal(
         "storage_engine_query_latency_for_small_value",
@@ -249,7 +256,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         ServerTehutiMetricName.STORAGE_ENGINE_LARGE_VALUE_LOOKUP,
         largeValueLookupStats,
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     // Queue metrics: Tehuti total-only; per-store recording routes to total's Tehuti sensor. OTel records per-store.
     if (totalStats == null) {
@@ -263,10 +271,15 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
                   getName(),
                   getFullMetricName("storage_execution_handler_submission_wait_time"))),
           baseDimensionsMap,
-          baseAttributes);
+          baseAttributes,
+          resources);
     } else {
-      queueWaitTimeMetric = MetricEntityStateBase
-          .create(STORAGE_ENGINE_QUEUE_WAIT_TIME.getMetricEntity(), otelRepository, baseDimensionsMap, baseAttributes);
+      queueWaitTimeMetric = MetricEntityStateBase.create(
+          STORAGE_ENGINE_QUEUE_WAIT_TIME.getMetricEntity(),
+          otelRepository,
+          baseDimensionsMap,
+          baseAttributes,
+          resources);
       // Wire per-store recording to total's Tehuti sensor (replicates old registerOnlyTotalSensor behavior)
       queueWaitTimeMetric.setTehutiSensor(totalStats.queueWaitTimeMetric.getTehutiSensor());
     }
@@ -279,10 +292,15 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
           ServerTehutiMetricName.STORAGE_EXECUTION_QUEUE_LEN,
           Arrays.asList(new Max(), new Avg()),
           baseDimensionsMap,
-          baseAttributes);
+          baseAttributes,
+          resources);
     } else {
-      queueSizeMetric = MetricEntityStateBase
-          .create(STORAGE_ENGINE_QUEUE_SIZE.getMetricEntity(), otelRepository, baseDimensionsMap, baseAttributes);
+      queueSizeMetric = MetricEntityStateBase.create(
+          STORAGE_ENGINE_QUEUE_SIZE.getMetricEntity(),
+          otelRepository,
+          baseDimensionsMap,
+          baseAttributes,
+          resources);
       // Wire per-store recording to total's Tehuti sensor (replicates old registerOnlyTotalSensor behavior)
       queueSizeMetric.setTehutiSensor(totalStats.queueSizeMetric.getTehutiSensor());
     }
@@ -295,13 +313,18 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
           ServerTehutiMetricName.REQUEST_KEY_COUNT,
           Arrays.asList(new Rate(), new OccurrenceRate(), new Avg(), new Max()),
           baseDimensionsMap,
-          baseAttributes);
+          baseAttributes,
+          resources);
     } else {
       // Single-get key count is always 1. Tehuti skips it (no sensor), but OTel intentionally
       // records it so that KPS (keys per second) can be measured accurately from a single metric
       // across all request types without special-casing single-get.
-      requestKeyCountMetric = MetricEntityStateBase
-          .create(READ_REQUEST_KEY_COUNT.getMetricEntity(), otelRepository, baseDimensionsMap, baseAttributes);
+      requestKeyCountMetric = MetricEntityStateBase.create(
+          READ_REQUEST_KEY_COUNT.getMetricEntity(),
+          otelRepository,
+          baseDimensionsMap,
+          baseAttributes,
+          resources);
     }
 
     keyNotFoundMetric = MetricEntityStateBase.create(
@@ -311,7 +334,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         ServerTehutiMetricName.KEY_NOT_FOUND,
         Arrays.asList(new Rate()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     requestSizeMetric = MetricEntityStateBase.create(
         READ_REQUEST_SIZE.getMetricEntity(),
@@ -320,7 +344,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         ServerTehutiMetricName.REQUEST_SIZE_IN_BYTES,
         Arrays.asList(new Avg(), new Min(), new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
 
     readComputeLatencyForSmallValueSensor = registerPerStoreAndTotal(
         "storage_engine_read_compute_latency_for_small_value",
@@ -356,7 +381,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
                 getName(),
                 getFullMetricName("storage_engine_read_compute_deserialization_latency"))),
         computeBaseDimensionsMap,
-        VeniceChunkingStatus.class);
+        VeniceChunkingStatus.class,
+        resources);
 
     serializationTimeMetric = MetricEntityStateBase.create(
         STORAGE_ENGINE_READ_COMPUTE_SERIALIZATION_TIME.getMetricEntity(),
@@ -368,7 +394,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
                 getName(),
                 getFullMetricName("storage_engine_read_compute_serialization_latency"))),
         computeBaseDimensionsMap,
-        computeBaseAttributes);
+        computeBaseAttributes,
+        resources);
 
     // All four compute op metrics share one OTel entity (STORAGE_ENGINE_READ_COMPUTE_EXECUTION_COUNT)
     // differentiated by the VeniceComputeOperationType dimension. Separate fields are needed
@@ -430,7 +457,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
           baseDimensionsMap,
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
 
       requestKeySizeMetric = MetricEntityStateBase.create(
           READ_REQUEST_KEY_SIZE.getMetricEntity(),
@@ -439,7 +467,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
           ServerTehutiMetricName.REQUEST_KEY_SIZE,
           Arrays.asList(keySizeStats),
           baseDimensionsMap,
-          baseAttributes);
+          baseAttributes,
+          resources);
     } else {
       responseValueSizeMetric = MetricEntityStateThreeEnums.create(
           READ_RESPONSE_VALUE_SIZE.getMetricEntity(),
@@ -447,10 +476,15 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
           baseDimensionsMap,
           HttpResponseStatusEnum.class,
           HttpResponseStatusCodeCategory.class,
-          VeniceResponseStatusCategory.class);
+          VeniceResponseStatusCategory.class,
+          resources);
 
-      requestKeySizeMetric = MetricEntityStateBase
-          .create(READ_REQUEST_KEY_SIZE.getMetricEntity(), otelRepository, baseDimensionsMap, baseAttributes);
+      requestKeySizeMetric = MetricEntityStateBase.create(
+          READ_REQUEST_KEY_SIZE.getMetricEntity(),
+          otelRepository,
+          baseDimensionsMap,
+          baseAttributes,
+          resources);
     }
 
     misroutedStoreVersionSensor = registerPerStoreAndTotal(
@@ -466,7 +500,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         ServerTehutiMetricName.FLUSH_LATENCY,
         Arrays.asList(TehutiUtils.getPercentileStat(getName(), getFullMetricName("flush_latency"))),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
   }
 
   /** Registers a Tehuti-only sensor that propagates per-store recordings to the total. */
@@ -496,7 +531,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         tehutiName,
         Arrays.asList(new Avg(), new Total()),
         baseDims,
-        VeniceComputeOperationType.class);
+        VeniceComputeOperationType.class,
+        resources);
   }
 
   public void recordSuccessRequest(

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerLoadStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerLoadStats.java
@@ -57,7 +57,8 @@ public class ServerLoadStats extends AbstractVeniceStats {
         TehutiMetricName.REJECTED_REQUEST,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        VeniceServerLoadRequestOutcome.class);
+        VeniceServerLoadRequestOutcome.class,
+        resources);
 
     acceptedRequestMetric = MetricEntityStateOneEnum.create(
         REQUEST_COUNT.getMetricEntity(),
@@ -66,7 +67,8 @@ public class ServerLoadStats extends AbstractVeniceStats {
         TehutiMetricName.ACCEPTED_REQUEST,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
-        VeniceServerLoadRequestOutcome.class);
+        VeniceServerLoadRequestOutcome.class,
+        resources);
 
     rejectionRatioMetric = MetricEntityStateBase.create(
         REJECTION_RATIO.getMetricEntity(),
@@ -75,7 +77,8 @@ public class ServerLoadStats extends AbstractVeniceStats {
         TehutiMetricName.REJECTION_RATIO,
         Arrays.asList(new Avg(), new Max()),
         baseDimensionsMap,
-        baseAttributes);
+        baseAttributes,
+        resources);
   }
 
   /** Tehuti-only: total request count. OTel derives total from sum(ACCEPTED + REJECTED). */

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerReadQuotaUsageStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerReadQuotaUsageStats.java
@@ -95,6 +95,8 @@ public class ServerReadQuotaUsageStats extends AbstractVeniceStats {
   private final MetricEntityStateTwoEnums<QuotaRequestOutcome, VersionRole> requestCount;
   /** OTel high-perf counter with QuotaRequestOutcome × VersionRole dimensions. */
   private final MetricEntityStateTwoEnums<QuotaRequestOutcome, VersionRole> keyCount;
+  /** Joint Tehuti+OTel async gauge for usage ratio. */
+  private final AsyncMetricEntityStateBase usageRatioMetric;
 
   /** Tehuti-only sensors for rejected QPS/KPS (unversioned Rate) */
   private final Sensor rejectedQPSSensor;
@@ -168,7 +170,7 @@ public class ServerReadQuotaUsageStats extends AbstractVeniceStats {
 
     // --- AsyncDoubleGauge: usage ratio (joint Tehuti + OTel, no VersionRole dimension) ---
     // OTel records the raw ratio as a double (e.g., 0.75 = 75% usage). NaN (uninitialized) maps to 0.0.
-    AsyncMetricEntityStateBase.create(
+    usageRatioMetric = AsyncMetricEntityStateBase.create(
         ServerReadQuotaOtelMetricEntity.READ_QUOTA_USAGE_RATIO.getMetricEntity(),
         otelRepository,
         this::registerSensor,
@@ -182,7 +184,8 @@ public class ServerReadQuotaUsageStats extends AbstractVeniceStats {
         (DoubleSupplier) () -> {
           Double ratio = getReadQuotaUsageRatio();
           return ratio.isNaN() ? 0.0 : ratio;
-        });
+        },
+        resources);
 
     // --- OTel high-perf counters: request.count and key.count with outcome+role dimensions ---
     requestCount = MetricEntityStateTwoEnums.create(
@@ -190,13 +193,15 @@ public class ServerReadQuotaUsageStats extends AbstractVeniceStats {
         otelRepository,
         baseDimensionsMap,
         QuotaRequestOutcome.class,
-        VersionRole.class);
+        VersionRole.class,
+        resources);
     keyCount = MetricEntityStateTwoEnums.create(
         ServerReadQuotaOtelMetricEntity.READ_QUOTA_KEY_COUNT.getMetricEntity(),
         otelRepository,
         baseDimensionsMap,
         QuotaRequestOutcome.class,
-        VersionRole.class);
+        VersionRole.class,
+        resources);
   }
 
   /**

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/BackupVersionOptimizationServiceStatsTest.java
@@ -11,6 +11,7 @@ import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.stats.dimensions.VeniceOperationOutcome;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.tehuti.metrics.MetricConfig;
@@ -38,13 +39,11 @@ public class BackupVersionOptimizationServiceStatsTest {
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
     asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    metricsRepository = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
-            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
-            .build());
+    metricsRepository = MetricsRepositoryUtils.createOtelEnabledRepository(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        inMemoryMetricReader,
+        asyncGaugeExecutor);
     stats = new BackupVersionOptimizationServiceStats(
         metricsRepository,
         "BackupVersionOptimizationService",
@@ -218,11 +217,8 @@ public class BackupVersionOptimizationServiceStatsTest {
   @Test
   public void testNoNpeWhenOtelDisabled() {
     AsyncGauge.AsyncGaugeExecutor localExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setEmitOtelMetrics(false)
-            .setTehutiMetricConfig(new MetricConfig(localExecutor))
-            .build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, localExecutor)) {
       exerciseAllRecordingPaths(disabledRepo);
     }
   }

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/DiskHealthStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/DiskHealthStatsTest.java
@@ -9,9 +9,9 @@ import static org.testng.Assert.assertEquals;
 
 import com.linkedin.davinci.storage.DiskHealthCheckService;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
 import org.testng.annotations.AfterMethod;
@@ -39,13 +39,11 @@ public class DiskHealthStatsTest {
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
     asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    metricsRepository = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
-            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
-            .build());
+    metricsRepository = MetricsRepositoryUtils.createOtelEnabledRepository(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        inMemoryMetricReader,
+        asyncGaugeExecutor);
     mockService = mock(DiskHealthCheckService.class);
     doReturn(true).when(mockService).isDiskHealthy();
     new DiskHealthStats(metricsRepository, mockService, STATS_NAME, TEST_CLUSTER_NAME);
@@ -99,11 +97,8 @@ public class DiskHealthStatsTest {
   @Test
   public void testNoNpeWhenOtelDisabled() {
     AsyncGauge.AsyncGaugeExecutor dedicatedExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setEmitOtelMetrics(false)
-            .setTehutiMetricConfig(new MetricConfig(dedicatedExecutor))
-            .build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, dedicatedExecutor)) {
       new DiskHealthStats(disabledRepo, mockService, STATS_NAME, TEST_CLUSTER_NAME);
     }
   }

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/RocksDBStatsOtelTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/RocksDBStatsOtelTest.java
@@ -27,6 +27,7 @@ import com.linkedin.davinci.stats.RocksDBStatsOtelMetricEntity;
 import com.linkedin.venice.stats.dimensions.VeniceRocksDBBlockCacheComponent;
 import com.linkedin.venice.stats.dimensions.VeniceRocksDBLevel;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
@@ -59,13 +60,11 @@ public class RocksDBStatsOtelTest {
     // executor it was given. Without this, close() in tearDown / try-with-resources would shut
     // down the static singleton DEFAULT_ASYNC_GAUGE_EXECUTOR JVM-wide and break later tests.
     asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    metricsRepository = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
-            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
-            .build());
+    metricsRepository = MetricsRepositoryUtils.createOtelEnabledRepository(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        inMemoryMetricReader,
+        asyncGaugeExecutor);
     mockStats = mock(Statistics.class);
     rocksDBStats = new RocksDBStats(metricsRepository, "rocksdb_stat", TEST_CLUSTER_NAME);
     rocksDBStats.setRocksDBStat(mockStats);

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerLoadStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerLoadStatsTest.java
@@ -11,9 +11,9 @@ import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.stats.dimensions.VeniceServerLoadRequestOutcome;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
-import io.tehuti.metrics.MetricConfig;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
 import org.testng.annotations.AfterMethod;
@@ -37,13 +37,11 @@ public class ServerLoadStatsTest {
   public void setUp() {
     inMemoryMetricReader = InMemoryMetricReader.create();
     asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    metricsRepository = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
-            .setTehutiMetricConfig(new MetricConfig(asyncGaugeExecutor))
-            .build());
+    metricsRepository = MetricsRepositoryUtils.createOtelEnabledRepository(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        inMemoryMetricReader,
+        asyncGaugeExecutor);
     stats = new ServerLoadStats(metricsRepository, "server_load", TEST_CLUSTER_NAME);
   }
 
@@ -221,11 +219,8 @@ public class ServerLoadStatsTest {
   @Test
   public void testNoNpeWhenOtelDisabled() {
     AsyncGauge.AsyncGaugeExecutor localExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
-    try (VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setEmitOtelMetrics(false)
-            .setTehutiMetricConfig(new MetricConfig(localExecutor))
-            .build())) {
+    try (VeniceMetricsRepository disabledRepo =
+        MetricsRepositoryUtils.createOtelDisabledRepository(TEST_METRIC_PREFIX, localExecutor)) {
       exerciseAllRecordingPaths(disabledRepo);
     }
   }

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerReadQuotaUsageStatsOtelTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerReadQuotaUsageStatsOtelTest.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.server.VersionRole;
 import com.linkedin.venice.stats.dimensions.QuotaRequestOutcome;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import com.linkedin.venice.utils.TestMockTime;
+import com.linkedin.venice.utils.metrics.MetricsRepositoryUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -40,12 +41,8 @@ public class ServerReadQuotaUsageStatsOtelTest {
   public void setUp() {
     mockTime = new TestMockTime();
     inMemoryMetricReader = InMemoryMetricReader.create();
-    metricsRepository = new VeniceMetricsRepository(
-        new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX)
-            .setMetricEntities(SERVER_METRIC_ENTITIES)
-            .setEmitOtelMetrics(true)
-            .setOtelAdditionalMetricsReader(inMemoryMetricReader)
-            .build());
+    metricsRepository = MetricsRepositoryUtils
+        .createOtelEnabledRepository(TEST_METRIC_PREFIX, SERVER_METRIC_ENTITIES, inMemoryMetricReader, null);
   }
 
   @AfterMethod

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerReadQuotaUsageStatsOtelTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/ServerReadQuotaUsageStatsOtelTest.java
@@ -36,13 +36,19 @@ public class ServerReadQuotaUsageStatsOtelTest {
   private InMemoryMetricReader inMemoryMetricReader;
   private VeniceMetricsRepository metricsRepository;
   private TestMockTime mockTime;
+  private AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor;
 
   @BeforeMethod
   public void setUp() {
     mockTime = new TestMockTime();
     inMemoryMetricReader = InMemoryMetricReader.create();
-    metricsRepository = MetricsRepositoryUtils
-        .createOtelEnabledRepository(TEST_METRIC_PREFIX, SERVER_METRIC_ENTITIES, inMemoryMetricReader, null);
+    // Dedicated executor so tearDown()'s close() doesn't shut down Tehuti's JVM-wide static singleton.
+    asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
+    metricsRepository = MetricsRepositoryUtils.createOtelEnabledRepository(
+        TEST_METRIC_PREFIX,
+        SERVER_METRIC_ENTITIES,
+        inMemoryMetricReader,
+        asyncGaugeExecutor);
   }
 
   @AfterMethod


### PR DESCRIPTION
## Problem Statement

Stats classes that own ASYNC_GAUGE / ASYNC_COUNTER wrappers had no consistent way to deregister their SDK-side callbacks at shutdown, so the OTel SDK kept polling callbacks for deleted stores or dropped instruments. Each class invented its own ad-hoc close logic (or had none), which made it easy to forget cleanup for new metrics and led to a number of duplicated per-store dimension and test-setup helpers across the codebase.

## Solution

Introduces a single lifecycle primitive for OTel metric wrappers and applies it uniformly across every stats class that owns wrappers.

**Lifecycle primitives (`venice-client-common`)**
- `CompositeCloseable` — idempotent LIFO registry of `Closeable`s.
- `AbstractStatsCloseable` — base class providing a `statsCloseables` field and a default `close()` that drains the registry.
- `MetricEntityStateUtils.closeQuietly` / `closeAndClear` — null-safe close helpers that swallow per-entry exceptions so a misbehaving wrapper cannot abort sibling cleanup.
- `MetricEntityState*` and `AsyncMetricEntityState*` factory methods now accept a `CompositeCloseable` so each wrapper self-registers on creation and is closed (with the SDK callback deregistered) when its owner shuts down.

**Uniform adoption across stats and owner classes**
- `AbstractVeniceAggVersionedStats` extends `AbstractStatsCloseable`; `close()` unregisters the metadata listener first, then drains the registry.
- Per-store `PerStoreEntry` inner classes (`AggVersionedDIVStats`, `AggVersionedDaVinciRecordTransformerStats`, `NativeMetadataRepositoryStats`, etc.) extend `AbstractStatsCloseable` so `handleStoreDeleted` closes the per-store wrappers and deregisters their SDK callbacks.
- `AbstractVeniceService`-based owners (`HelixParticipationService`, `KafkaStoreIngestionService`, `AggKafkaConsumerService`, `AdaptiveThrottlerSignalService`, `StoreBufferService`, `HeartbeatMonitoringService`) own a `statsCloseables` field and drain it from `stopInner` / `clear` / `shutdown`.
- `VeniceServer`, `HelixVeniceClusterResources`, `PartitionedProducerExecutor`, `NativeMetadataRepository`, `ErrorPartitionResetTask`, `DaVinciBackend`, and the two `VeniceChangelogConsumer*` classes extend `AbstractStatsCloseable`.

**Helper consolidation**
- `OpenTelemetryMetricsSetup.buildStoreDimensionsMap(baseDims, storeName)` — single helper that returns a per-store dimensions map with the store name sanitized. Replaces 5 private helpers and 3 inline patterns and fixes a latent issue where some classes did not sanitize empty/null store names.
- `MetricsRepositoryUtils.createOtelEnabledRepository` / `createOtelDisabledRepository` — centralise the OTel test-setup boilerplate (`InMemoryMetricReader` + dedicated `AsyncGaugeExecutor` + builder wiring) used by ~13 test classes.

### Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**. `CompositeCloseable` synchronises register/close on its own monitor; new entries registered after close return as-is without being tracked.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed. `CompositeCloseable` uses `synchronized`; per-store maps remain `VeniceConcurrentHashMap`.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation. Close iterates the snapshot outside the lock.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`). All per-store maps continue to use `VeniceConcurrentHashMap`.
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination. `closeQuietly` catches `Exception` per entry so one failure cannot abort sibling cleanup.

## How was this PR tested?

- [x] New unit tests added. `CompositeCloseableTest` covers the registry semantics (register, close, register-after-close, idempotent close, exception isolation).
- [ ] New integration tests added.
- [x] Modified or extended existing tests. Updated `MetricEntityState*EnumsTest` (including the new `MetricEntityStateFiveEnumsTest`) to pass `CompositeCloseable.NONE` to the new factory signatures; migrated ~13 OTel test classes to use the new `MetricsRepositoryUtils` helpers; updated `ParticipantStoreConsumptionStatsTest` to assert sanitization of empty store names (now records under `UNKNOWN_STORE_NAME` instead of throwing).
- [x] Verified backward compatibility (if applicable). All recording APIs on stats classes are unchanged; only internal lifecycle wiring and the test-utility surface changed.

## Does this PR introduce any user-facing or breaking changes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.

`OpenTelemetryMetricsSetup.buildStoreDimensionsMap` sanitizes the store name (whitespace-trim + null/empty → `unknown_store`). Three classes (`ServerMetadataServiceStats`, `ParticipantStoreConsumptionStats`, `StoreBufferServiceStats`) previously passed the raw store name through. With this change, an empty or null store name no longer triggers OTel dimension validation; the metric emits under the `unknown_store` sentinel instead. This matches the behavior the other per-store stats classes already had and bounds dimension cardinality for unknown stores.
