### PR TITLE
[vpj] Fail VTConsistencyCheckerJob with VeniceException when inconsistencies are found

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJob.java
@@ -230,6 +230,7 @@ public class VTConsistencyCheckerJob {
 
       LongAccumulator partitionsProcessed = spark.sparkContext().longAccumulator("partitionsProcessed");
       LongAccumulator partitionsWithErrors = spark.sparkContext().longAccumulator("partitionsWithErrors");
+      LongAccumulator inconsistenciesFound = spark.sparkContext().longAccumulator("inconsistenciesFound");
 
       Dataset<Row> inconsistencies = spark.createDataset(partitions, Encoders.INT())
           .flatMap(
@@ -239,24 +240,22 @@ public class VTConsistencyCheckerJob {
                   jobProps,
                   numberOfRegions,
                   partitionsProcessed,
-                  partitionsWithErrors),
+                  partitionsWithErrors,
+                  inconsistenciesFound),
               RowEncoder.apply(OUTPUT_SCHEMA));
 
       inconsistencies.write().mode(SaveMode.ErrorIfExists).parquet(outputPath);
 
       LOGGER.info(
-          "VT consistency check complete. topic={} partitions={} processed={} errors={} output={}",
+          "VT consistency check complete. topic={} partitions={} processed={} errors={} inconsistencies={} output={}",
           versionTopic,
           partitionCount,
           partitionsProcessed.value(),
           partitionsWithErrors.value(),
+          inconsistenciesFound.value(),
           outputPath);
 
-      if (partitionsWithErrors.value() > 0) {
-        throw new RuntimeException(
-            partitionsWithErrors.value() + " partition(s) failed during scan of topic " + versionTopic
-                + ". Check executor logs for details.");
-      }
+      throwOnJobFailures(partitionsWithErrors.value(), inconsistenciesFound.value(), versionTopic, outputPath);
     } finally {
       if (spark != null) {
         spark.stop();
@@ -274,7 +273,8 @@ public class VTConsistencyCheckerJob {
       Properties jobProps,
       int numberOfRegions,
       LongAccumulator partitionsProcessed,
-      LongAccumulator partitionsWithErrors) {
+      LongAccumulator partitionsWithErrors,
+      LongAccumulator inconsistenciesFound) {
     int partition = dc0Split.getPartitionNumber();
     String versionTopic = dc0Split.getTopicName();
     try {
@@ -341,6 +341,7 @@ public class VTConsistencyCheckerJob {
             found.size());
 
         partitionsProcessed.add(1);
+        inconsistenciesFound.add(found.size());
         return found.stream().map(inc -> toRow(inc, versionTopic, partition)).iterator();
       } finally {
         Utils.closeQuietlyWithErrorLogged(dc0Consumer);
@@ -503,6 +504,24 @@ public class VTConsistencyCheckerJob {
     p.putAll(allProps);
     p.setProperty(KAFKA_BOOTSTRAP_SERVERS, brokerUrl);
     return new VeniceProperties(p);
+  }
+
+  /** Throws if any partition errored or any inconsistencies were found, failing the upstream DAG step. */
+  static void throwOnJobFailures(
+      long partitionsWithErrors,
+      long inconsistenciesFound,
+      String versionTopic,
+      String outputPath) {
+    if (partitionsWithErrors > 0) {
+      throw new VeniceException(
+          partitionsWithErrors + " partition(s) failed during scan of topic " + versionTopic
+              + ". Check executor logs for details.");
+    }
+    if (inconsistenciesFound > 0) {
+      throw new VeniceException(
+          inconsistenciesFound + " inconsistencies found in topic " + versionTopic + ". See output at " + outputPath
+              + " for forensic details.");
+    }
   }
 
   private static void validateRequiredProps(Properties props) {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/consistency/VTConsistencyCheckerJobTest.java
@@ -291,6 +291,7 @@ public class VTConsistencyCheckerJobTest {
   public void testFindInconsistenciesForPartitionReturnsErrorRowOnException() {
     LongAccumulator partitionsProcessed = mock(LongAccumulator.class);
     LongAccumulator partitionsWithErrors = mock(LongAccumulator.class);
+    LongAccumulator inconsistenciesFound = mock(LongAccumulator.class);
 
     PubSubTopicRepository repo = new PubSubTopicRepository();
     PubSubTopicPartition tp = new PubSubTopicPartitionImpl(repo.getTopic("store_v1"), 3);
@@ -305,7 +306,8 @@ public class VTConsistencyCheckerJobTest {
         new Properties(),
         3,
         partitionsProcessed,
-        partitionsWithErrors);
+        partitionsWithErrors,
+        inconsistenciesFound);
 
     List<Row> rows = collectRows(result);
     assertEquals(rows.size(), 1, "exactly one sentinel ERROR row");
@@ -320,6 +322,44 @@ public class VTConsistencyCheckerJobTest {
 
     verify(partitionsWithErrors).add(1L);
     verify(partitionsProcessed, never()).add(anyLong());
+    verify(inconsistenciesFound, never()).add(anyLong());
+  }
+
+  // ── throwOnJobFailures ─────────────────────────────────────────────────────
+
+  /**
+   * Clean scan: zero partition errors and zero inconsistencies must not throw, so the DAG step
+   * stays green.
+   */
+  @Test
+  public void testThrowOnJobFailuresDoesNotThrowWhenScanIsClean() {
+    VTConsistencyCheckerJob.throwOnJobFailures(0L, 0L, "store_v1", "/tmp/out");
+  }
+
+  /**
+   * Any failed partition must trip the helper before the inconsistency check, since partition
+   * failures imply we cannot trust the inconsistency count.
+   */
+  @Test
+  public void testThrowOnJobFailuresThrowsWhenPartitionsHadErrors() {
+    VeniceException ex = expectThrows(
+        VeniceException.class,
+        () -> VTConsistencyCheckerJob.throwOnJobFailures(2L, 0L, "store_v1", "/tmp/out"));
+    assertTrue(ex.getMessage().contains("2 partition(s) failed"), "message should report partition error count");
+    assertTrue(ex.getMessage().contains("store_v1"), "message should name the topic");
+  }
+
+  /**
+   * The new fail-on-inconsistency contract: a successful scan that found mismatches must still fail the job.
+   */
+  @Test
+  public void testThrowOnJobFailuresThrowsWhenInconsistenciesFound() {
+    VeniceException ex = expectThrows(
+        VeniceException.class,
+        () -> VTConsistencyCheckerJob.throwOnJobFailures(0L, 5L, "store_v1", "/tmp/out"));
+    assertTrue(ex.getMessage().contains("5 inconsistencies found"), "message should report inconsistency count");
+    assertTrue(ex.getMessage().contains("store_v1"), "message should name the topic");
+    assertTrue(ex.getMessage().contains("/tmp/out"), "message should point to the output path");
   }
 
   // ── helpers ────────────────────────────────────────────────────────────────

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVTConsistencyCheckerJob.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVTConsistencyCheckerJob.java
@@ -13,6 +13,8 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_DISCOVER_URL
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 import com.linkedin.venice.annotation.PubSubAgnosticTest;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
@@ -20,6 +22,7 @@ import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.Version;
@@ -101,7 +104,7 @@ public class TestVTConsistencyCheckerJob extends AbstractMultiRegionTest {
    *   <li>Wait for replication to settle</li>
    *   <li>Inject a corrupted record for "corrupt-key" into DC-1's VT with a different value</li>
    *   <li>Write more RT records to advance HW past the injected position</li>
-   *   <li>Run checker — expect exactly one VALUE_MISMATCH for "corrupt-key"</li>
+   *   <li>Run checker — expect it to throw and to record exactly one VALUE_MISMATCH for "corrupt-key" in the output</li>
    * </ol>
    */
   @Test(timeOut = TEST_TIMEOUT)
@@ -243,7 +246,10 @@ public class TestVTConsistencyCheckerJob extends AbstractMultiRegionTest {
         jobProps.setProperty(VTConsistencyCheckerJob.OUTPUT_PATH, outputDir.getAbsolutePath());
         jobProps.setProperty(VTConsistencyCheckerJob.NUMBER_OF_REGIONS, "2");
 
-        VTConsistencyCheckerJob.run(jobProps);
+        VeniceException ex = expectThrows(VeniceException.class, () -> VTConsistencyCheckerJob.run(jobProps));
+        assertTrue(
+            ex.getMessage().contains("inconsistencies found"),
+            "checker should fail with an inconsistency message, got: " + ex.getMessage());
 
         SparkSession reader =
             SparkSession.builder().master("local[*]").appName("TestVTConsistencyCheckerJob-reader").getOrCreate();


### PR DESCRIPTION
## Problem Statement
  - The VT consistency checker is a Spark job that scans two fabrics of an AA store and writes detected inconsistencies that violate eventual consistency promise to a Parquet output.
  - Today the driver always exits successfully — even when the output contains real inconsistencies.
  - Upstream DAGs therefore mark the run as green and silently move on, so genuine cross-colo divergences never page anyone and require manual Parquet inspection to notice.


## Solution
  - Added a Spark LongAccumulator inconsistenciesFound that each executor task increments by the count returned from LilyPadUtils.findInconsistencies, so the driver gets a precise total once the write action completes.
  - After the Parquet write succeeds, the driver throws a VeniceException whose message names the topic, the count, and the output path for forensic follow-up.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
- [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.