### PR TITLE
[protocol] Stage degradedDatacenters on AdminOperation v100

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -328,7 +328,11 @@ subprojects {
       // Protocol changes should pin the current version via this override and remove the override in a follow-up PR
       // when actually using the new protocol. Example to pin KME to v12 when introducing v13:
       // project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
-      def versionOverrides = []
+      def versionOverrides = [
+          // AdminOperation v100 stages degradedDatacenters on AddVersion.
+          // Pinned to the current active version until the Java wiring lands in a follow-up PR.
+          project(':services:venice-controller').file('src/main/resources/avro/AdminOperation/v99', PathValidation.DIRECTORY)
+      ]
 
       def schemaDirs = [sourceDir]
       sourceDir.eachDir { typeDir ->

--- a/services/venice-controller/src/main/resources/avro/AdminOperation/v100/AdminOperation.avsc
+++ b/services/venice-controller/src/main/resources/avro/AdminOperation/v100/AdminOperation.avsc
@@ -1,0 +1,1339 @@
+{
+  "name": "AdminOperation",
+  "namespace": "com.linkedin.venice.controller.kafka.protocol.admin",
+  "type": "record",
+  "fields": [
+    {
+      "name": "operationType",
+      "doc": "0 => StoreCreation, 1 => ValueSchemaCreation, 2 => PauseStore, 3 => ResumeStore, 4 => KillOfflinePushJob, 5 => DisableStoreRead, 6 => EnableStoreRead, 7=> DeleteAllVersions, 8=> SetStoreOwner, 9=> SetStorePartitionCount, 10=> SetStoreCurrentVersion, 11=> UpdateStore, 12=> DeleteStore, 13=> DeleteOldVersion, 14=> MigrateStore, 15=> AbortMigration, 16=>AddVersion, 17=> DerivedSchemaCreation, 18=>SupersetSchemaCreation, 19=>EnableNativeReplicationForCluster, 20=>MetadataSchemaCreation, 21=>EnableActiveActiveReplicationForCluster, 25=>CreatePersona, 26=>DeletePersona, 27=>UpdatePersona, 28=>RollbackCurrentVersion, 29=>RollforwardCurrentVersion",
+      "type": "int"
+    }, {
+      "name": "executionId",
+      "doc": "ID of a command execution which is used to query the status of this command.",
+      "type": "long",
+      "default": 0
+    }, {
+      "name": "payloadUnion",
+      "doc": "This contains the main payload of the admin operation",
+      "type": [
+        {
+          "name": "StoreCreation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "owner",
+              "type": "string"
+            },
+            {
+              "name": "keySchema",
+              "type": {
+                "type": "record",
+                "name": "SchemaMeta",
+                "fields": [
+                  {"name": "schemaType", "type": "int", "doc": "0 => Avro-1.4, and we can add more if necessary"},
+                  {"name": "definition", "type": "string"}
+                ]
+              }
+            },
+            {
+              "name": "valueSchema",
+              "type": "SchemaMeta"
+            }
+          ]
+        },
+        {
+          "name": "ValueSchemaCreation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "schema",
+              "type": "SchemaMeta"
+            },
+            {
+              "name": "schemaId",
+              "type": "int"
+            },
+            {
+              "name": "doUpdateSupersetSchemaID",
+              "type": "boolean",
+              "doc": "Whether this superset schema ID should be updated to be the value schema ID for this store.",
+              "default": false
+            }
+          ]
+        },
+        {
+          "name": "PauseStore",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "ResumeStore",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "KillOfflinePushJob",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "kafkaTopic",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "DisableStoreRead",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "EnableStoreRead",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "DeleteAllVersions",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "SetStoreOwner",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "owner",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "SetStorePartitionCount",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "partitionNum",
+              "type": "int"
+            }
+          ]
+        },
+        {
+          "name": "SetStoreCurrentVersion",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "currentVersion",
+              "type": "int"
+            }
+          ]
+        },
+        {
+          "name": "UpdateStore",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "owner",
+              "type": "string"
+            },
+            {
+              "name": "partitionNum",
+              "type": "int"
+            },
+            {
+              "name": "currentVersion",
+              "type": "int"
+            },
+            {
+              "name": "enableReads",
+              "type": "boolean"
+            },
+            {
+              "name": "enableWrites",
+              "type": "boolean"
+            },
+            {
+              "name": "storageQuotaInByte",
+              "type": "long",
+              "default": 21474836480
+            },
+            {
+              "name": "readQuotaInCU",
+              "type": "long",
+              "default": 1800
+            },
+            {
+              "name": "hybridStoreConfig",
+              "type": [
+                "null",
+                {
+                  "name": "HybridStoreConfigRecord",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "rewindTimeInSeconds",
+                      "type": "long"
+                    },
+                    {
+                      "name": "offsetLagThresholdToGoOnline",
+                      "type": "long"
+                    },
+                    {
+                      "name": "producerTimestampLagThresholdToGoOnlineInSeconds",
+                      "type": "long",
+                      "default": -1
+                    },
+                    {
+                      "name": "dataReplicationPolicy",
+                      "doc": "Real-time Samza job data replication policy. Using int because Avro Enums are not evolvable 0 => NON_AGGREGATE, 1 => AGGREGATE, 2 => NONE, 3 => ACTIVE_ACTIVE",
+                      "type": "int",
+                      "default": 0
+                    },
+                    {
+                      "name": "bufferReplayPolicy",
+                      "type": "int",
+                      "doc": "Policy that will be used during buffer replay. rewindTimeInSeconds defines the delta. 0 => REWIND_FROM_EOP (replay from 'EOP - rewindTimeInSeconds'), 1 => REWIND_FROM_SOP (replay from 'SOP - rewindTimeInSeconds')",
+                      "default": 0
+                    },
+                    {"name": "realTimeTopicName", "type": "string", "default": "", "doc": "Name of the real time topic this store/version uses"}
+                  ]
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "accessControlled",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "compressionStrategy",
+              "doc": "Using int because Avro Enums are not evolvable",
+              "type": "int",
+              "default": 0
+            },
+            {
+              "name": "chunkingEnabled",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "rmdChunkingEnabled",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "singleGetRouterCacheEnabled",
+              "aliases": ["routerCacheEnabled"],
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "batchGetRouterCacheEnabled",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "batchGetLimit",
+              "doc": "The max key number allowed in batch get request, and Venice will use cluster-level config if the limit (not positive) is not valid",
+              "type": "int",
+              "default": -1
+            },
+            {
+              "name": "numVersionsToPreserve",
+              "doc": "The max number of versions the store should preserve. Venice will use cluster-level config if the number is 0 here.",
+              "type": "int",
+              "default": 0
+            },
+            {
+              "name": "incrementalPushEnabled",
+              "doc": "a flag to see if the store supports incremental push or not",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "separateRealTimeTopicEnabled",
+              "doc": "Flag to see if the store supports separate real-time topic for incremental push.",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "isMigrating",
+              "doc": "Whether or not the store is in the process of migration",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "writeComputationEnabled",
+              "doc": "Whether write-path computation feature is enabled for this store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "replicationMetadataVersionID",
+              "doc": "RMD (Replication metadata) version ID on the store-level. Default -1 means NOT_SET and the cluster-level RMD version ID should be used for stores.",
+              "type": "int",
+              "default":  -1
+            },
+            {
+              "name": "readComputationEnabled",
+              "doc": "Whether read-path computation feature is enabled for this store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "bootstrapToOnlineTimeoutInHours",
+              "doc": "Maximum number of hours allowed for the store to transition from bootstrap to online state",
+              "type": "int",
+              "default": 24
+            },
+            {
+              "name": "leaderFollowerModelEnabled",
+              "doc":  "Whether or not to use leader follower state transition model for upcoming version",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "backupStrategy",
+              "doc":  "Strategies to store backup versions.",
+              "type": "int",
+              "default": 0
+            },
+            {
+              "name": "clientDecompressionEnabled",
+              "type": "boolean",
+              "default": true
+            },
+            {
+              "name": "schemaAutoRegisterFromPushJobEnabled",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "hybridStoreOverheadBypass",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "hybridStoreDiskQuotaEnabled",
+              "doc":  "Whether or not to enable disk storage quota for a hybrid store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "ETLStoreConfig",
+              "type": [
+                "null",
+                {
+                  "name": "ETLStoreConfigRecord",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "etledUserProxyAccount",
+                      "type": ["null", "string"]
+                    },
+                    {
+                      "name": "regularVersionETLEnabled",
+                      "type": "boolean"
+                    },
+                    {
+                      "name": "futureVersionETLEnabled",
+                      "type": "boolean"
+                    },
+                    {
+                      "name": "etlStrategy",
+                      "type": "int",
+                      "default": 1
+                    },
+                    {
+                      "name": "etlActiveFabrics",
+                      "type": ["null", {"type": "array", "items": "string"}],
+                      "default": null,
+                      "doc": "Allowlist of fabric names where ETL onboard/offboard fires. null = fire in every fabric (default behavior). When set, only listed fabrics' child controllers trigger the ExternalETLService."
+                    }
+                  ]
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "partitionerConfig",
+              "type": [
+                "null",
+                {
+                  "name": "PartitionerConfigRecord",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "partitionerClass",
+                      "type": "string"
+                    },
+                    {
+                      "name": "partitionerParams",
+                      "type": {
+                        "type": "map",
+                        "values": "string"
+                      }
+                    },
+                    {
+                      "name": "amplificationFactor",
+                      "type": "int"
+                    }
+                  ]
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "nativeReplicationEnabled",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "pushStreamSourceAddress",
+              "type": ["null", "string"],
+              "default": null
+            },
+            {
+              "name": "largestUsedVersionNumber",
+              "type": ["null", "int"],
+              "default": null
+            },
+            {
+              "name": "largestUsedRTVersionNumber",
+              "type": ["null", "int"],
+              "doc": "Largest used RT version number used by this store. This is used to create real time topic name while creating a new store-version",
+              "default": null
+            },
+            {
+              "name": "incrementalPushPolicy",
+              "doc": "Incremental Push Policy to reconcile with real time pushes. Using int because Avro Enums are not evolvable 0 => PUSH_TO_VERSION_TOPIC, 1 => INCREMENTAL_PUSH_SAME_AS_REAL_TIME",
+              "type": "int",
+              "default": 0
+            },
+            {
+              "name": "backupVersionRetentionMs",
+              "type": "long",
+              "doc": "Backup version retention time after a new version is promoted to the current version, if not specified, Venice will use the configured retention as the default policy",
+              "default": -1
+            },
+            {
+              "name": "replicationFactor",
+              "doc": "number of replica each store version will have",
+              "type": "int",
+              "default": 3
+            },
+            {
+              "name": "migrationDuplicateStore",
+              "doc": "Whether or not the store is a duplicate store in the process of migration",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "nativeReplicationSourceFabric",
+              "doc": "The source fabric to be used when the store is running in Native Replication mode.",
+              "type": ["null", "string"],
+              "default": null
+            },
+            {
+              "name": "activeActiveReplicationEnabled",
+              "doc": "A command option to enable/disable Active/Active replication feature for a store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "disableMetaStore",
+              "doc": "An UpdateStore command option to disable the companion meta system store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "disableDavinciPushStatusStore",
+              "doc": "An UpdateStore command option to disable the companion davinci push status store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "applyTargetVersionFilterForIncPush",
+              "doc": "An UpdateStore command option to enable/disable applying the target version filter for incremental pushes",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "updatedConfigsList",
+              "doc": "The list that contains all updated configs by the UpdateStore command. Most of the fields in UpdateStore are not optional, and changing those fields to Optional (Union) is not a backward compatible change, so we have to add an addition array field to record all updated configs in parent controller.",
+              "type": {
+                "type": "array",
+                "items": "string"
+              },
+              "default": []
+            },
+            {
+              "name": "replicateAllConfigs",
+              "doc": "A flag to indicate whether all store configs in parent cluster will be replicated to child clusters; true by default, so that existing UpdateStore messages in Admin topic will behave the same as before.",
+              "type": "boolean",
+              "default": true
+            },
+            {
+              "name": "regionsFilter",
+              "doc": "A list of regions that will be impacted by the UpdateStore command",
+              "type": ["null", "string"],
+              "default": null
+            },
+            {
+              "name": "storagePersona",
+              "doc": "The name of the StoragePersona to add to the store",
+              "type": ["null", "string"],
+              "default": null
+            },
+            {
+              "name": "views",
+              "doc": "A map of views which describe and configure a downstream view of a venice store. Keys in this map are for convenience of managing configs.",
+              "type": ["null",
+                {
+                  "type":"map",
+                  "java-key-class": "java.lang.String",
+                  "avro.java.string": "String",
+                  "values": {
+                    "name": "StoreViewConfigRecord",
+                    "type": "record",
+                    "doc": "A configuration for a particular view.  This config should inform Venice leaders how to transform and transmit data to destination views.",
+                    "fields": [
+                      {
+                        "name": "viewClassName",
+                        "type": "string",
+                        "doc": "This informs what kind of view we are materializing.  This then informs what kind of parameters are passed to parse this input.  This is expected to be a fully formed class path name for materialization.",
+                        "default": ""
+                      },
+                      {
+                        "name": "viewParameters",
+                        "doc": "Optional parameters to be passed to the given view config.",
+                        "type": ["null",
+                          {
+                            "type": "map",
+                            "java-key-class": "java.lang.String",
+                            "avro.java.string": "String",
+                            "values": { "type": "string", "avro.java.string": "String" }
+                          }
+                        ],
+                        "default": null
+                      }
+                    ]
+                  }
+                }],
+              "default": null
+            },
+            {
+              "name": "latestSuperSetValueSchemaId",
+              "doc": "The schema id for the latest superset schema",
+              "type" : "int",
+              "default": -1
+            },
+            {
+              "name": "storageNodeReadQuotaEnabled",
+              "doc": "Whether storage node read quota is enabled for this store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "compactionEnabled",
+              "doc": "Whether compaction is enabled for this store",
+              "type": "boolean",
+              "default": true
+            },
+            {
+              "name": "compactionThresholdMilliseconds",
+              "doc": "Store-level compaction threshold in milliseconds",
+              "type": "long",
+              "default": -1
+            },
+            {
+              "name": "minCompactionLagSeconds",
+              "doc": "Store-level version topic min compaction lag",
+              "type": "long",
+              "default": -1
+            },
+            {
+              "name": "maxCompactionLagSeconds",
+              "doc": "Store-level version topic max compaction lag",
+              "type": "long",
+              "default": -1
+            },
+            {
+              "name": "maxRecordSizeBytes",
+              "doc": "Store-level maximum size of any record in bytes for batch push jobs",
+              "type": "int",
+              "default": -1
+            },
+            {
+              "name": "maxNearlineRecordSizeBytes",
+              "doc": "Store-level maximum size of any record in bytes for nearline jobs with partial updates",
+              "type": "int",
+              "default": -1
+            },
+            {
+              "name": "unusedSchemaDeletionEnabled",
+              "doc": "Whether unused schema deletion is enabled or not.",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "blobTransferEnabled",
+              "doc": "Flag to indicate if the blob transfer is allowed or not",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "nearlineProducerCompressionEnabled",
+              "doc": "Flag to control whether the producer in Server for nearline workload will enable compression or not",
+              "type": "boolean",
+              "default": true
+            },
+            {
+              "name": "nearlineProducerCountPerWriter",
+              "doc": "How many producers will be used for the nearline producer in Server to improve producing throughput",
+              "type": "int",
+              "default": 1
+            },
+            {
+              "name": "targetSwapRegion",
+              "doc": "Controls what region to swap in the current version during target colo push",
+              "type": ["null","string"],
+              "default": null
+            },
+            {
+              "name": "targetSwapRegionWaitTime",
+              "doc": "Controls how long to wait in minutes before swapping the version on the regions",
+              "type": "int",
+              "default": 60
+            },
+            {
+              "name": "isDaVinciHeartBeatReported",
+              "doc": "Flag to indicate whether DVC is bootstrapping and sending heartbeats",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "globalRtDivEnabled",
+              "doc": "Flag to indicate whether the Global RT DIV feature is on. The DIV will be centralized in the ConsumptionTask, and leaders will periodically replicate the RT DIV to followers via VT.",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "enumSchemaEvolutionAllowed",
+              "doc": "Flag to control whether a certain store is allowed to evolve enum schema since the readers need to use Avro-1.9+",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "storeLifecycleHooks",
+              "doc": "List of store lifecycle hooks",
+              "type": {
+                "type": "array",
+                "items": {
+                  "name": "StoreLifecycleHooksRecord",
+                  "type": "record",
+                  "fields": [
+                    {"name": "storeLifecycleHooksClassName", "type": "string", "doc":  "FQCN of the hook implementation"},
+                    {"name": "storeLifecycleHooksParams", "type": {"type": "map", "values": "string"}, "doc":  "Bag of properties to pass into the hook implementation"}
+                  ]
+                }
+              },
+              "default": []
+            },
+            {
+              "name": "blobTransferInServerEnabled",
+              "doc": "Flag to indicate if the blob transfer is allowed or not in server. Values can be 'NOT_SPECIFIED' as default, 'ENABLED', or 'DISABLED'.",
+              "type": "string",
+              "default": "NOT_SPECIFIED"
+            },
+            {
+              "name": "keyUrnCompressionEnabled",
+              "doc": "Whether key URN compression is enabled for this store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "keyUrnFields",
+              "doc": "List of fields in the key schema that will be eligible for key urn compression",
+              "type": {
+                "type": "array",
+                "items": "string"
+              },
+              "default": []
+            },
+            {
+              "name": "flinkVeniceViewsEnabled",
+              "doc": "Whether this store is enabled to use Flink-based Venice Views",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "throughputQuotaInBytes",
+              "doc": "The maximum throughput measured in bytes that clients can produce into one store. Default -1 means no limit.",
+              "type": "long",
+              "default": -1
+            },
+            {
+              "name": "throughputQuotaInRecords",
+              "doc": "The maximum throughput measured in records that clients can produce into one store. Default -1 means no limit.",
+              "type": "long",
+              "default": -1
+            },
+            {
+              "name": "blobDbEnabled",
+              "doc": "Flag to indicate if the RocksDB BlobDB feature is enabled or not. Values can be 'NOT_SPECIFIED' (default, follows cluster level config), 'ENABLED', or 'DISABLED'.",
+              "type": "string",
+              "default": "NOT_SPECIFIED"
+            },
+            {
+              "name": "previousCurrentVersion",
+              "doc": "Int representing the previous current version before the current version was marked current",
+              "type": "int",
+              "default": -1
+            },
+            {
+              "name": "transientRecordCacheEnabled",
+              "doc": "Whether the bounded hot transient record cache is enabled for this store to retain frequently accessed large records across consumer poll boundaries.",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "mergedValueRmdColumnFamilyEnabled",
+              "doc": "Whether to store value and RMD in a single column family to reduce read amplification during A/A ingestion.",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "ingestionPauseMode",
+              "doc": "Ingestion pause mode. 0 => NOT_PAUSED, 1 => CURRENT_VERSION, 2 => ALL_VERSIONS",
+              "type": "int",
+              "default": 0
+            },
+            {
+              "name": "ingestionPausedRegions",
+              "doc": "List of regions where pause is applied. Empty list means all regions.",
+              "type": {"type": "array", "items": "string"},
+              "default": []
+            },
+            {
+              "name": "targetRegionPromoted",
+              "doc": "Flag set by the parent controller when the target region has promoted the future version to current. Propagated to child controllers so DaVinci clients can resume paused ingestion.",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "storageMode",
+              "doc": "Store-level default storage mode. The controller persists this value on the store record (StoreProperties.storageMode) and also copies it into StoreVersion.storageMode when a new store version is created; existing versions are unaffected. Controls where version data is persisted in addition to (or instead of) Venice local storage. 0 => INTERNAL (default, Venice-only); 1 => DUAL_WRITE (data is written to both Venice local storage and the configured external storage; the specific dual-write implementation -- leader-consumer-pipeline vs Venice Push Job -- is selected by separate server/VPJ configuration); 2 => EXTERNAL (external-storage-only; Venice's data partition becomes NoOp while metadata partitions are still persisted locally for checkpointing).",
+              "type": "int",
+              "default": 0
+            },
+            {
+              "name": "externalStorageReadMode",
+              "doc": "Store-level read routing applied to the store as a whole (not per-version). Controls how clients route reads between Venice local storage and the configured external storage. 0 => VENICE_ONLY (default, reads served from Venice local storage only -- current behavior); 1 => DUAL_MODE_CONSISTENCY_CHECK (the client reads from both Venice and the external storage and verifies/reports divergence; used to validate dual-write correctness before cutover); 2 => DUAL_MODE_EARLY_RETURN (the client issues reads against both Venice and the external storage in parallel and returns the first response, falling back to the slower one on miss); 3 => EXTERNAL_ONLY (reads served from the external storage only, with Venice acting as the metadata/CDC path).",
+              "type": "int",
+              "default": 0
+            }
+          ]
+        },
+        {
+          "name": "DeleteStore",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "largestUsedVersionNumber",
+              "type": "int"
+            }
+          ]
+        },
+        {
+          "name": "DeleteOldVersion",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "versionNum",
+              "type": "int"
+            }
+          ]
+        },
+        {
+          "name": "MigrateStore",
+          "type": "record",
+          "fields": [
+            {
+              "name": "srcClusterName",
+              "type": "string"
+            },
+            {
+              "name": "destClusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "AbortMigration",
+          "type": "record",
+          "fields": [
+            {
+              "name": "srcClusterName",
+              "type": "string"
+            },
+            {
+              "name": "destClusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "AddVersion",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "pushJobId",
+              "type": "string"
+            },
+            {
+              "name": "versionNum",
+              "type": "int"
+            },
+            {
+              "name": "numberOfPartitions",
+              "type": "int"
+            },
+            {
+              "name": "pushType",
+              "doc": "The push type of the new version, 0 => BATCH, 1 => STREAM_REPROCESSING. Previous add version messages will default to BATCH and this is a safe because they were created when BATCH was the only version type",
+              "type": "int",
+              "default": 0
+            },
+            {
+              "name": "pushStreamSourceAddress",
+              "type": ["null", "string"],
+              "default": null
+            },
+            {
+              "name": "rewindTimeInSecondsOverride",
+              "doc": "The overridable rewind time config for this specific version of a hybrid store, and if it is not specified, the new version will use the store-level rewind time config",
+              "type": "long",
+              "default": -1
+            },
+            {
+              "name": "timestampMetadataVersionId",
+              "doc": "The A/A metadata schema version ID that will be used to deserialize metadataPayload.",
+              "type": "int",
+              "default": -1
+            },
+            {
+              "name": "versionSwapDeferred",
+              "doc": "Indicates if swapping this version to current version after push completion should be initiated or not",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "targetedRegions",
+              "doc": "The list of regions that is separated by comma for targeted region push. If set, this admin message should only be consumed by the targeted regions",
+              "type": [
+                "null",
+                {
+                  "type": "array",
+                  "items":  "string"
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "repushSourceVersion",
+              "doc": "Indicates the source version from which a repush version is created",
+              "type": "int",
+              "default": -1
+            },
+            {
+              "name": "currentRTVersionNumber",
+              "type": "int",
+              "doc": "current RT version number that should be used to formulate real time topic name during add version",
+              "default": 0
+            },
+            {
+              "name": "repushTtlSeconds",
+              "type": "int",
+              "doc": "For store version created from repush, indicates the time-to-live in seconds set during the repush",
+              "default": -1
+            },
+            {
+              "name": "degradedDatacenters",
+              "doc": "List of datacenter names marked as degraded at the time of version creation. Child controllers use this in AdminExecutionTask to enforce skipConsumption for degraded DCs even when versionSwapDeferred=true, preventing ghost versions in degraded DCs.",
+              "type": [
+                "null",
+                {
+                  "type": "array",
+                  "items": "string"
+                }
+              ],
+              "default": null
+            }
+          ]
+        },
+        {
+          "name": "DerivedSchemaCreation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "schema",
+              "type": "SchemaMeta"
+            },
+            {
+              "name": "valueSchemaId",
+              "type": "int"
+            },
+            {
+              "name": "derivedSchemaId",
+              "type": "int"
+            }
+          ]
+        },
+        {
+          "name": "SupersetSchemaCreation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "valueSchema",
+              "type": "SchemaMeta"
+            },
+            {
+              "name": "valueSchemaId",
+              "type": "int"
+            },
+            {
+              "name": "supersetSchema",
+              "type": "SchemaMeta"
+            },
+            {
+              "name": "supersetSchemaId",
+              "type": "int"
+            }
+          ]
+        },
+        {
+          "name": "ConfigureNativeReplicationForCluster",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeType",
+              "type": "string"
+            },
+            {
+              "name": "enabled",
+              "type": "boolean"
+            },
+            {
+              "name": "nativeReplicationSourceRegion",
+              "doc": "The source region to be used when the store is running in Native Replication mode.",
+              "type": ["null", "string"],
+              "default": null
+            },
+            {
+              "name": "regionsFilter",
+              "type": ["null", "string"],
+              "default": null
+            }
+          ]
+        },
+        {
+          "name": "MetadataSchemaCreation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "valueSchemaId",
+              "type": "int"
+            },
+            {
+              "name": "metadataSchema",
+              "type": "SchemaMeta"
+            },
+            {
+              "name": "timestampMetadataVersionId",
+              "type": "int",
+              "aliases": ["metadataVersionId"],
+              "default": -1
+            }
+          ]
+        },
+        {
+          "name": "ConfigureActiveActiveReplicationForCluster",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeType",
+              "type": "string"
+            },
+            {
+              "name": "enabled",
+              "type": "boolean"
+            },
+            {
+              "name": "regionsFilter",
+              "type": ["null", "string"],
+              "default": null
+            }
+          ]
+        }, {
+          "name": "ConfigureIncrementalPushForCluster",
+          "doc": "A command to migrate all incremental push stores in a cluster to a specific incremental push policy.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "incrementalPushPolicyToFilter",
+              "doc": "If this batch update command is trying to configure existing incremental push store type, their incremental push policy should also match this filter before the batch update command applies any change to them. Default value is -1, meaning there is no filter.",
+              "type": "int",
+              "default": -1
+            },
+            {
+              "name": "incrementalPushPolicyToApply",
+              "doc": "This field will determine what incremental push policy will be applied to the selected stores. Default value is 1, which is the INCREMENTAL_PUSH_SAME_AS_REAL_TIME policy",
+              "type": "int",
+              "default": 1
+            },
+            {
+              "name": "regionsFilter",
+              "type": ["null", "string"],
+              "default": null
+            }
+          ]
+        }, {
+          "name": "MetaSystemStoreAutoCreationValidation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        }, {
+          "name": "PushStatusSystemStoreAutoCreationValidation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        }, {
+          "name": "CreateStoragePersona",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "quotaNumber",
+              "type": "long"
+            },
+            {
+              "name": "storesToEnforce",
+              "type": {
+                "type": "array",
+                "items": "string",
+                "default": []
+              }
+            },
+            {
+              "name": "owners",
+              "type": {
+                "type": "array",
+                "items": "string",
+                "default": []
+              }
+            }
+          ]
+        }, {
+          "name": "DeleteStoragePersona",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "name",
+              "type": "string"
+            }
+          ]
+        }, {
+          "name": "UpdateStoragePersona",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            }, {
+              "name": "name",
+              "type": "string"
+            }, {
+              "name": "quotaNumber",
+              "type": ["null","long"],
+              "default": null
+            }, {
+              "name": "storesToEnforce",
+              "type": [
+                "null",
+                {
+                  "type": "array",
+                  "items": "string"
+                }
+              ],
+              "default": null
+            }, {
+              "name": "owners",
+              "type": [
+                "null",
+                {
+                  "type": "array",
+                  "items":  "string"
+                }
+              ],
+              "default": null
+            }
+          ]
+        },
+        {
+          "name": "DeleteUnusedValueSchemas",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "schemaIds",
+              "type": {
+                "type": "array",
+                "items": "int",
+                "default": []
+              }
+            }
+          ]
+        },
+        {
+          "name": "RollbackCurrentVersion",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "regionsFilter",
+              "doc": "A list of regions that will be impacted by the RollbackCurrentVersion command",
+              "type": ["null", "string"],
+              "default": null
+            }
+          ]
+        },
+        {
+          "name": "RollForwardCurrentVersion",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "regionsFilter",
+              "doc": "A list of regions that will be impacted by the RollForwardCurrentVersion command",
+              "type": ["null", "string"],
+              "default": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Problem Statement

The degraded-mode batch push feature needs to propagate the set of currently-degraded datacenters from the parent controller to child controllers so that `AdminExecutionTask` on a child controller can decide whether to skip ingestion for its own region. Today, `markDatacenterDegraded` only writes to the parent's local state and produces no admin-topic message, so child controllers never learn about degraded DCs. The `isDegradedDC` check in `AdminExecutionTask` always evaluates to false on a child, which means a degraded DC silently ingests the version anyway when `versionSwapDeferred=true` is set (the auto-conversion path used by degraded-mode pushes).

The selected fix is to embed the degraded-DC set in the AddVersion admin message itself — atomic with version creation and consistent with how other version-creation parameters (e.g., `targetedRegions`, `versionSwapDeferred`) flow from parent to child.

## Solution

Stage a new `degradedDatacenters` field on the `AddVersion` record in a new `AdminOperation` schema version (v100). Following the established pattern (see #2806, #2814), this PR introduces the schema only; Java wiring (parent populates the field, `AdminExecutionTask` reads it) will land in a follow-up PR.

- New schema file `services/venice-controller/src/main/resources/avro/AdminOperation/v100/AdminOperation.avsc` — verbatim copy of v99 with one added field on `AddVersion`:
  ```
  degradedDatacenters : array<string>, default []
  ```
- `build.gradle` `versionOverrides` comment extended to note v100 is also staged. The actual pin stays at v98 — the generated Java `AdminOperation` class is unchanged, so no producers or consumers can see the new field yet.
- `AvroProtocolDefinition.ADMIN_OPERATION` stays at 98. `AdminOperationSerializer.initProtocolMap()` continues to load v1..v98 only; v99 and v100 remain inert until activated by a future PR.

This is a forward-compatible schema-only change with no behavioral impact.

### Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

Schema-only change; no behavior change to test. Verified the existing protocol tests pass:

- `AdminOperationProtocolCompatibilityTest.testAdminOperationProtocolCompatibility` — PASSED
- `AdminOperationSerializerTest` (testAdminOperationSerializer, testDownloadAndSchemaIfNecessary, testGetSchema, testSerializeDeserializeWithDocChange, testValidateAdminOperation) — all PASSED

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.