### PR TITLE
[venice-common][controller][compact] Activate StoreMetaValue v44 / AdminOperation v99 + Java accessors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -328,12 +328,7 @@ subprojects {
       // Protocol changes should pin the current version via this override and remove the override in a follow-up PR
       // when actually using the new protocol. Example to pin KME to v12 when introducing v13:
       // project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
-      def versionOverrides = [
-          // StoreMetaValue v44 and AdminOperation v99 stage targetRegionPromoted, storageMode, and externalStorageReadMode.
-          // Pinned to the current active versions until the corresponding Java wiring lands in follow-up PRs.
-          project(':internal:venice-common').file('src/main/resources/avro/StoreMetaValue/v43', PathValidation.DIRECTORY),
-          project(':services:venice-controller').file('src/main/resources/avro/AdminOperation/v98', PathValidation.DIRECTORY)
-      ]
+      def versionOverrides = []
 
       def schemaDirs = [sourceDir]
       sourceDir.eachDir { typeDir ->

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ExternalStorageReadMode.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ExternalStorageReadMode.java
@@ -1,0 +1,51 @@
+package com.linkedin.venice.meta;
+
+import com.linkedin.venice.utils.EnumUtils;
+import com.linkedin.venice.utils.VeniceEnumValue;
+import java.util.List;
+
+
+/**
+ * Store-level read routing for clients backed by both Venice local storage and a configured external storage system.
+ * Applies to the store as a whole, not per-version. Mirrors the {@code externalStorageReadMode} field staged on
+ * {@code StoreProperties} (StoreMetaValue v44) by PR #2814.
+ *
+ * <p>Field plumbing only at the OSS Venice layer; the actual routing decisions live in proprietary client code.
+ */
+public enum ExternalStorageReadMode implements VeniceEnumValue {
+  /** Default. All reads served from Venice local storage. No external-storage involvement. */
+  VENICE_ONLY(0),
+  /**
+   * Client reads from both Venice and the external storage in parallel; the external-storage result is compared
+   * against the Venice result for correctness metrics but never reaches the user. Used to validate dual-write
+   * correctness before cutover.
+   */
+  DUAL_MODE_CONSISTENCY_CHECK(1),
+  /**
+   * Client issues reads against both Venice and the external storage in parallel and returns the first response.
+   * On miss from the early responder, the slower one is awaited as a fallback. Enabled only after consistency
+   * checking has validated zero divergence over a sustained window.
+   */
+  DUAL_MODE_EARLY_RETURN(2),
+  /**
+   * All user-data reads served from the external storage. Venice continues to serve metadata (catalog, schemas,
+   * compression dictionary) and acts as the metadata/CDC path.
+   */
+  EXTERNAL_ONLY(3);
+
+  private final int value;
+  private static final List<ExternalStorageReadMode> TYPES = EnumUtils.getEnumValuesList(ExternalStorageReadMode.class);
+
+  ExternalStorageReadMode(int value) {
+    this.value = value;
+  }
+
+  public static ExternalStorageReadMode valueOf(int value) {
+    return EnumUtils.valueOf(TYPES, value, ExternalStorageReadMode.class);
+  }
+
+  @Override
+  public int getValue() {
+    return value;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -740,6 +740,16 @@ public class ReadOnlyStore implements Store {
     }
 
     @Override
+    public StorageMode getStorageMode() {
+      return this.delegate.getStorageMode();
+    }
+
+    @Override
+    public void setStorageMode(StorageMode storageMode) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Version cloneVersion() {
       return this.delegate.cloneVersion();
     }
@@ -1347,6 +1357,16 @@ public class ReadOnlyStore implements Store {
 
   @Override
   public void setIngestionPausedRegions(List<String> regions) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ExternalStorageReadMode getExternalStorageReadMode() {
+    return this.delegate.getExternalStorageReadMode();
+  }
+
+  @Override
+  public void setExternalStorageReadMode(ExternalStorageReadMode externalStorageReadMode) {
     throw new UnsupportedOperationException();
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -1371,6 +1371,16 @@ public class ReadOnlyStore implements Store {
   }
 
   @Override
+  public StorageMode getStorageMode() {
+    return this.delegate.getStorageMode();
+  }
+
+  @Override
+  public void setStorageMode(StorageMode storageMode) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public boolean isSchemaAutoRegisterFromPushJobEnabled() {
     return this.delegate.isSchemaAutoRegisterFromPushJobEnabled();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StorageMode.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StorageMode.java
@@ -1,0 +1,45 @@
+package com.linkedin.venice.meta;
+
+import com.linkedin.venice.utils.EnumUtils;
+import com.linkedin.venice.utils.VeniceEnumValue;
+import java.util.List;
+
+
+/**
+ * Per-version storage mode controlling where data for a Venice store version is persisted relative to the optional
+ * external storage system. Mirrors the {@code storageMode} field staged on {@code StoreVersion} (StoreMetaValue v44)
+ * by PR #2814.
+ *
+ * <p>Read-side routing is selected separately by {@link ExternalStorageReadMode} at the store level.
+ */
+public enum StorageMode implements VeniceEnumValue {
+  /** Default. Data persisted in Venice local storage only. Current behavior. */
+  INTERNAL(0),
+  /**
+   * Data is written to both Venice local storage and the configured external storage. The specific dual-write
+   * implementation — leader-consumer-pipeline vs Venice Push Job — is selected by separate server/VPJ configuration,
+   * not by this enum.
+   */
+  DUAL_WRITE(1),
+  /**
+   * External-storage-only. Venice's data partition becomes NoOp while metadata partitions are still persisted
+   * locally for checkpointing.
+   */
+  EXTERNAL(2);
+
+  private final int value;
+  private static final List<StorageMode> TYPES = EnumUtils.getEnumValuesList(StorageMode.class);
+
+  StorageMode(int value) {
+    this.value = value;
+  }
+
+  public static StorageMode valueOf(int value) {
+    return EnumUtils.valueOf(TYPES, value, StorageMode.class);
+  }
+
+  @Override
+  public int getValue() {
+    return value;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
@@ -198,6 +198,16 @@ public interface Store {
 
   void setIngestionPausedRegions(List<String> regions);
 
+  /**
+   * Store-level read routing for clients backed by both Venice local storage and a configured external storage
+   * system. Defaults to {@link ExternalStorageReadMode#VENICE_ONLY} (no external-storage involvement). Mirrors the
+   * {@code externalStorageReadMode} field staged on {@code StoreProperties} (StoreMetaValue v44) by PR #2814.
+   *
+   */
+  ExternalStorageReadMode getExternalStorageReadMode();
+
+  void setExternalStorageReadMode(ExternalStorageReadMode externalStorageReadMode);
+
   boolean isSchemaAutoRegisterFromPushJobEnabled();
 
   void setSchemaAutoRegisterFromPushJobEnabled(boolean value);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
@@ -208,6 +208,16 @@ public interface Store {
 
   void setExternalStorageReadMode(ExternalStorageReadMode externalStorageReadMode);
 
+  /**
+   * Store-level default storage mode. The controller copies this value into {@code StoreVersion.storageMode} when a
+   * new store version is created; existing versions are unaffected. Defaults to {@link StorageMode#INTERNAL}.
+   * Mirrors the {@code storageMode} field staged on {@code StoreProperties} (StoreMetaValue v44).
+   *
+   */
+  StorageMode getStorageMode();
+
+  void setStorageMode(StorageMode storageMode);
+
   boolean isSchemaAutoRegisterFromPushJobEnabled();
 
   void setSchemaAutoRegisterFromPushJobEnabled(boolean value);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
@@ -43,6 +43,7 @@ public class StoreInfo {
     storeInfo.setEnableStoreReads(store.isEnableReads());
     storeInfo.setEnableStoreWrites(store.isEnableWrites());
     storeInfo.setEtlStoreConfig(store.getEtlStoreConfig());
+    storeInfo.setExternalStorageReadMode(store.getExternalStorageReadMode());
     if (store.isHybrid()) {
       storeInfo.setHybridStoreConfig(store.getHybridStoreConfig());
     }
@@ -396,6 +397,7 @@ public class StoreInfo {
   private boolean flinkVeniceViewsEnabled = false;
   private int previousCurrentVersion = -1;
   private boolean separateRealTimeTopicEnabled = false;
+  private ExternalStorageReadMode externalStorageReadMode = ExternalStorageReadMode.VENICE_ONLY;
 
   public StoreInfo() {
   }
@@ -724,6 +726,15 @@ public class StoreInfo {
 
   public List<String> getIngestionPausedRegions() {
     return ingestionPausedRegions;
+  }
+
+  public ExternalStorageReadMode getExternalStorageReadMode() {
+    return externalStorageReadMode == null ? ExternalStorageReadMode.VENICE_ONLY : externalStorageReadMode;
+  }
+
+  public void setExternalStorageReadMode(ExternalStorageReadMode externalStorageReadMode) {
+    this.externalStorageReadMode =
+        externalStorageReadMode == null ? ExternalStorageReadMode.VENICE_ONLY : externalStorageReadMode;
   }
 
   public boolean isSchemaAutoRegisterFromPushJobEnabled() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
@@ -44,6 +44,7 @@ public class StoreInfo {
     storeInfo.setEnableStoreWrites(store.isEnableWrites());
     storeInfo.setEtlStoreConfig(store.getEtlStoreConfig());
     storeInfo.setExternalStorageReadMode(store.getExternalStorageReadMode());
+    storeInfo.setStorageMode(store.getStorageMode());
     if (store.isHybrid()) {
       storeInfo.setHybridStoreConfig(store.getHybridStoreConfig());
     }
@@ -398,6 +399,7 @@ public class StoreInfo {
   private int previousCurrentVersion = -1;
   private boolean separateRealTimeTopicEnabled = false;
   private ExternalStorageReadMode externalStorageReadMode = ExternalStorageReadMode.VENICE_ONLY;
+  private StorageMode storageMode = StorageMode.INTERNAL;
 
   public StoreInfo() {
   }
@@ -735,6 +737,14 @@ public class StoreInfo {
   public void setExternalStorageReadMode(ExternalStorageReadMode externalStorageReadMode) {
     this.externalStorageReadMode =
         externalStorageReadMode == null ? ExternalStorageReadMode.VENICE_ONLY : externalStorageReadMode;
+  }
+
+  public StorageMode getStorageMode() {
+    return storageMode == null ? StorageMode.INTERNAL : storageMode;
+  }
+
+  public void setStorageMode(StorageMode storageMode) {
+    this.storageMode = storageMode == null ? StorageMode.INTERNAL : storageMode;
   }
 
   public boolean isSchemaAutoRegisterFromPushJobEnabled() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStore.java
@@ -497,6 +497,16 @@ public class SystemStore extends AbstractStore {
   }
 
   @Override
+  public ExternalStorageReadMode getExternalStorageReadMode() {
+    return zkSharedStore.getExternalStorageReadMode();
+  }
+
+  @Override
+  public void setExternalStorageReadMode(ExternalStorageReadMode externalStorageReadMode) {
+    throwUnsupportedOperationException("setExternalStorageReadMode");
+  }
+
+  @Override
   public boolean isSchemaAutoRegisterFromPushJobEnabled() {
     return zkSharedStore.isSchemaAutoRegisterFromPushJobEnabled();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStore.java
@@ -507,6 +507,16 @@ public class SystemStore extends AbstractStore {
   }
 
   @Override
+  public StorageMode getStorageMode() {
+    return zkSharedStore.getStorageMode();
+  }
+
+  @Override
+  public void setStorageMode(StorageMode storageMode) {
+    throwUnsupportedOperationException("setStorageMode");
+  }
+
+  @Override
   public boolean isSchemaAutoRegisterFromPushJobEnabled() {
     return zkSharedStore.isSchemaAutoRegisterFromPushJobEnabled();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
@@ -330,6 +330,17 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
   void setPreviousCurrentVersion(int previousCurrentVersion);
 
   /**
+   * Per-version storage mode controlling where data is persisted relative to the configured external storage system.
+   * Defaults to {@link StorageMode#INTERNAL}. Mirrors the {@code storageMode} field staged on {@code StoreVersion}
+   * (StoreMetaValue v44) by PR #2814.
+   *
+   * <p>Field plumbing only at the OSS Venice layer; the actual write semantics live in proprietary code paths.
+   */
+  StorageMode getStorageMode();
+
+  void setStorageMode(StorageMode storageMode);
+
+  /**
    * Kafka topic name is composed by store name and version.
    * <p>
    * The Json deserializer will think it should be a field called kafkaTopicName if we use "getKafkaTopicName" here. So

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
@@ -501,6 +501,16 @@ public class VersionImpl implements Version {
   }
 
   @Override
+  public StorageMode getStorageMode() {
+    return StorageMode.valueOf(this.storeVersion.storageMode);
+  }
+
+  @Override
+  public void setStorageMode(StorageMode storageMode) {
+    this.storeVersion.storageMode = storageMode == null ? StorageMode.INTERNAL.getValue() : storageMode.getValue();
+  }
+
+  @Override
   public StoreVersion dataModel() {
     return this.storeVersion;
   }
@@ -590,6 +600,7 @@ public class VersionImpl implements Version {
     clonedVersion.setKeyUrnFields(getKeyUrnFields());
     clonedVersion.setRepushTtlSeconds(getRepushTtlSeconds());
     clonedVersion.setPreviousCurrentVersion(getPreviousCurrentVersion());
+    clonedVersion.setStorageMode(getStorageMode());
     return clonedVersion;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
@@ -216,6 +216,7 @@ public class ZKStore extends AbstractStore implements DataModelBackedStructure<S
     setBackupStrategy(store.getBackupStrategy());
     setIngestionPauseMode(store.getIngestionPauseMode());
     setIngestionPausedRegions(store.getIngestionPausedRegions());
+    setExternalStorageReadMode(store.getExternalStorageReadMode());
     setSchemaAutoRegisterFromPushJobEnabled(store.isSchemaAutoRegisterFromPushJobEnabled());
     setLatestSuperSetValueSchemaId(store.getLatestSuperSetValueSchemaId());
     setHybridStoreDiskQuotaEnabled(store.isHybridStoreDiskQuotaEnabled());
@@ -752,6 +753,18 @@ public class ZKStore extends AbstractStore implements DataModelBackedStructure<S
   @Override
   public void setIngestionPausedRegions(List<String> regions) {
     this.storeProperties.ingestionPausedRegions = regions.stream().map(Objects::toString).collect(Collectors.toList());
+  }
+
+  @Override
+  public ExternalStorageReadMode getExternalStorageReadMode() {
+    return ExternalStorageReadMode.valueOf(this.storeProperties.externalStorageReadMode);
+  }
+
+  @Override
+  public void setExternalStorageReadMode(ExternalStorageReadMode externalStorageReadMode) {
+    this.storeProperties.externalStorageReadMode = externalStorageReadMode == null
+        ? ExternalStorageReadMode.VENICE_ONLY.getValue()
+        : externalStorageReadMode.getValue();
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
@@ -217,6 +217,7 @@ public class ZKStore extends AbstractStore implements DataModelBackedStructure<S
     setIngestionPauseMode(store.getIngestionPauseMode());
     setIngestionPausedRegions(store.getIngestionPausedRegions());
     setExternalStorageReadMode(store.getExternalStorageReadMode());
+    setStorageMode(store.getStorageMode());
     setSchemaAutoRegisterFromPushJobEnabled(store.isSchemaAutoRegisterFromPushJobEnabled());
     setLatestSuperSetValueSchemaId(store.getLatestSuperSetValueSchemaId());
     setHybridStoreDiskQuotaEnabled(store.isHybridStoreDiskQuotaEnabled());
@@ -765,6 +766,16 @@ public class ZKStore extends AbstractStore implements DataModelBackedStructure<S
     this.storeProperties.externalStorageReadMode = externalStorageReadMode == null
         ? ExternalStorageReadMode.VENICE_ONLY.getValue()
         : externalStorageReadMode.getValue();
+  }
+
+  @Override
+  public StorageMode getStorageMode() {
+    return StorageMode.valueOf(this.storeProperties.storageMode);
+  }
+
+  @Override
+  public void setStorageMode(StorageMode storageMode) {
+    this.storeProperties.storageMode = storageMode == null ? StorageMode.INTERNAL.getValue() : storageMode.getValue();
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -71,7 +71,7 @@ public enum AvroProtocolDefinition {
    *
    * TODO: Move AdminOperation to venice-common module so that we can properly reference it here.
    */
-  ADMIN_OPERATION(98, SpecificData.get().getSchema(ByteBuffer.class), "AdminOperation"),
+  ADMIN_OPERATION(99, SpecificData.get().getSchema(ByteBuffer.class), "AdminOperation"),
 
   /**
    * Single chunk of a large multi-chunk value. Just a bunch of bytes.
@@ -111,7 +111,7 @@ public enum AvroProtocolDefinition {
   /**
    * Value schema for metadata system store.
    */
-  METADATA_SYSTEM_SCHEMA_STORE(43, StoreMetaValue.class),
+  METADATA_SYSTEM_SCHEMA_STORE(44, StoreMetaValue.class),
 
   /*
     Value Schema for Parent Controller Metadata system store

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/ExternalStorageReadModeTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/ExternalStorageReadModeTest.java
@@ -1,0 +1,22 @@
+package com.linkedin.venice.meta;
+
+import com.linkedin.venice.utils.CollectionUtils;
+import com.linkedin.venice.utils.VeniceEnumValueTest;
+import java.util.Map;
+
+
+public class ExternalStorageReadModeTest extends VeniceEnumValueTest<ExternalStorageReadMode> {
+  public ExternalStorageReadModeTest() {
+    super(ExternalStorageReadMode.class);
+  }
+
+  @Override
+  protected Map<Integer, ExternalStorageReadMode> expectedMapping() {
+    return CollectionUtils.<Integer, ExternalStorageReadMode>mapBuilder()
+        .put(0, ExternalStorageReadMode.VENICE_ONLY)
+        .put(1, ExternalStorageReadMode.DUAL_MODE_CONSISTENCY_CHECK)
+        .put(2, ExternalStorageReadMode.DUAL_MODE_EARLY_RETURN)
+        .put(3, ExternalStorageReadMode.EXTERNAL_ONLY)
+        .build();
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/StorageModeTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/StorageModeTest.java
@@ -1,0 +1,21 @@
+package com.linkedin.venice.meta;
+
+import com.linkedin.venice.utils.CollectionUtils;
+import com.linkedin.venice.utils.VeniceEnumValueTest;
+import java.util.Map;
+
+
+public class StorageModeTest extends VeniceEnumValueTest<StorageMode> {
+  public StorageModeTest() {
+    super(StorageMode.class);
+  }
+
+  @Override
+  protected Map<Integer, StorageMode> expectedMapping() {
+    return CollectionUtils.<Integer, StorageMode>mapBuilder()
+        .put(0, StorageMode.INTERNAL)
+        .put(1, StorageMode.DUAL_WRITE)
+        .put(2, StorageMode.EXTERNAL)
+        .build();
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestStoreInfo.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestStoreInfo.java
@@ -131,4 +131,27 @@ public class TestStoreInfo {
     // check updated value
     assertTrue(storeInfo.isFlinkVeniceViewsEnabled());
   }
+
+  @Test
+  public void testExternalStorageReadModeDefaultsToVeniceOnly() {
+    StoreInfo storeInfo = new StoreInfo();
+    assertEquals(storeInfo.getExternalStorageReadMode(), ExternalStorageReadMode.VENICE_ONLY);
+  }
+
+  @Test
+  public void testExternalStorageReadModeRoundTripsAllValues() {
+    StoreInfo storeInfo = new StoreInfo();
+    for (ExternalStorageReadMode mode: ExternalStorageReadMode.values()) {
+      storeInfo.setExternalStorageReadMode(mode);
+      assertEquals(storeInfo.getExternalStorageReadMode(), mode);
+    }
+  }
+
+  @Test
+  public void testExternalStorageReadModeNullCoercesToVeniceOnly() {
+    StoreInfo storeInfo = new StoreInfo();
+    storeInfo.setExternalStorageReadMode(ExternalStorageReadMode.DUAL_MODE_EARLY_RETURN);
+    storeInfo.setExternalStorageReadMode(null);
+    assertEquals(storeInfo.getExternalStorageReadMode(), ExternalStorageReadMode.VENICE_ONLY);
+  }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestStoreInfo.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestStoreInfo.java
@@ -154,4 +154,27 @@ public class TestStoreInfo {
     storeInfo.setExternalStorageReadMode(null);
     assertEquals(storeInfo.getExternalStorageReadMode(), ExternalStorageReadMode.VENICE_ONLY);
   }
+
+  @Test
+  public void testStorageModeDefaultsToInternal() {
+    StoreInfo storeInfo = new StoreInfo();
+    assertEquals(storeInfo.getStorageMode(), StorageMode.INTERNAL);
+  }
+
+  @Test
+  public void testStorageModeRoundTripsAllValues() {
+    StoreInfo storeInfo = new StoreInfo();
+    for (StorageMode mode: StorageMode.values()) {
+      storeInfo.setStorageMode(mode);
+      assertEquals(storeInfo.getStorageMode(), mode);
+    }
+  }
+
+  @Test
+  public void testStorageModeNullCoercesToInternal() {
+    StoreInfo storeInfo = new StoreInfo();
+    storeInfo.setStorageMode(StorageMode.EXTERNAL);
+    storeInfo.setStorageMode(null);
+    assertEquals(storeInfo.getStorageMode(), StorageMode.INTERNAL);
+  }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestVersion.java
@@ -379,4 +379,33 @@ public class TestVersion {
     // Case 5: Edge case - Valid maximum value
     assertEquals(PushType.valueOf(3), PushType.INCREMENTAL);
   }
+
+  @Test
+  public void testStorageModeFieldDefault() {
+    Version version = new VersionImpl("store", 1, "pushId");
+    assertEquals(version.getStorageMode(), StorageMode.INTERNAL);
+  }
+
+  @Test
+  public void testStorageModeRoundTrip() {
+    Version version = new VersionImpl("store", 1, "pushId");
+    version.setStorageMode(StorageMode.DUAL_WRITE);
+    assertEquals(version.getStorageMode(), StorageMode.DUAL_WRITE);
+  }
+
+  @Test
+  public void testCloneVersionPreservesStorageMode() {
+    Version version = new VersionImpl("store", 1, "pushId");
+    version.setStorageMode(StorageMode.EXTERNAL);
+    Version cloned = version.cloneVersion();
+    assertEquals(cloned.getStorageMode(), StorageMode.EXTERNAL);
+  }
+
+  @Test
+  public void testStorageModePersistsThroughAvroDataModel() {
+    VersionImpl version = new VersionImpl("store", 1, "pushId");
+    version.setStorageMode(StorageMode.DUAL_WRITE);
+    assertEquals(version.dataModel().storageMode, StorageMode.DUAL_WRITE.getValue());
+  }
+
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestZKStore.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestZKStore.java
@@ -513,4 +513,32 @@ public class TestZKStore {
         ExternalStorageReadMode.DUAL_MODE_CONSISTENCY_CHECK.getValue());
   }
 
+  @Test
+  public void testStoreLevelStorageModeDefault() {
+    Store store = TestUtils.createTestStore("testStore", "owner", System.currentTimeMillis());
+    Assert.assertEquals(store.getStorageMode(), StorageMode.INTERNAL);
+  }
+
+  @Test
+  public void testStoreLevelStorageModeRoundTrip() {
+    Store store = TestUtils.createTestStore("testStore", "owner", System.currentTimeMillis());
+    store.setStorageMode(StorageMode.DUAL_WRITE);
+    Assert.assertEquals(store.getStorageMode(), StorageMode.DUAL_WRITE);
+  }
+
+  @Test
+  public void testCloneStorePreservesStoreLevelStorageMode() {
+    Store store = TestUtils.createTestStore("testStore", "owner", System.currentTimeMillis());
+    store.setStorageMode(StorageMode.EXTERNAL);
+    Store clonedStore = store.cloneStore();
+    Assert.assertEquals(clonedStore.getStorageMode(), StorageMode.EXTERNAL);
+  }
+
+  @Test
+  public void testStoreLevelStorageModePersistsThroughAvroDataModel() {
+    ZKStore store = (ZKStore) TestUtils.createTestStore("testStore", "owner", System.currentTimeMillis());
+    store.setStorageMode(StorageMode.DUAL_WRITE);
+    Assert.assertEquals(store.dataModel().storageMode, StorageMode.DUAL_WRITE.getValue());
+  }
+
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestZKStore.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestZKStore.java
@@ -482,4 +482,35 @@ public class TestZKStore {
     Assert.assertEquals(clonedStore.getIngestionPauseMode(), IngestionPauseMode.ALL_VERSIONS);
     Assert.assertEquals(clonedStore.getIngestionPausedRegions(), Arrays.asList("prod-lor1"));
   }
+
+  @Test
+  public void testExternalStorageReadModeDefault() {
+    Store store = TestUtils.createTestStore("testStore", "owner", System.currentTimeMillis());
+    Assert.assertEquals(store.getExternalStorageReadMode(), ExternalStorageReadMode.VENICE_ONLY);
+  }
+
+  @Test
+  public void testExternalStorageReadModeRoundTrip() {
+    Store store = TestUtils.createTestStore("testStore", "owner", System.currentTimeMillis());
+    store.setExternalStorageReadMode(ExternalStorageReadMode.DUAL_MODE_CONSISTENCY_CHECK);
+    Assert.assertEquals(store.getExternalStorageReadMode(), ExternalStorageReadMode.DUAL_MODE_CONSISTENCY_CHECK);
+  }
+
+  @Test
+  public void testCloneStorePreservesExternalStorageReadMode() {
+    Store store = TestUtils.createTestStore("testStore", "owner", System.currentTimeMillis());
+    store.setExternalStorageReadMode(ExternalStorageReadMode.DUAL_MODE_EARLY_RETURN);
+    Store clonedStore = store.cloneStore();
+    Assert.assertEquals(clonedStore.getExternalStorageReadMode(), ExternalStorageReadMode.DUAL_MODE_EARLY_RETURN);
+  }
+
+  @Test
+  public void testExternalStorageReadModePersistsThroughAvroDataModel() {
+    ZKStore store = (ZKStore) TestUtils.createTestStore("testStore", "owner", System.currentTimeMillis());
+    store.setExternalStorageReadMode(ExternalStorageReadMode.DUAL_MODE_CONSISTENCY_CHECK);
+    Assert.assertEquals(
+        store.dataModel().externalStorageReadMode,
+        ExternalStorageReadMode.DUAL_MODE_CONSISTENCY_CHECK.getValue());
+  }
+
 }


### PR DESCRIPTION
## Problem Statement
Predecessor PR in this stack stages `StoreMetaValue` v44 and `AdminOperation` v99 with the following external-storage-related fields:

- **`StoreVersion`** (per-version): `storageMode`, `externalDbName`, `externalTableName` (all newly-added in v44).
- **`StoreProperties`** (per-store): `externalStorageReadMode`.
- **`UpdateStore`** (admin op): `storageMode`, `externalStorageReadMode`, `externalDbName`, `externalTableName` (operator-override surface).

`build.gradle`'s `versionOverrides` list still forces the Avro compiler to use v43 / v98 instead of letting it pick the highest-numeric directory, so v44 / v99 are not yet wire-real. Downstream consumers (Fast Client metadata refresh, controller, server, VPJ producers) need typed Java accessors to start integrating against.

## Solution
Drop the `versionOverrides` entries so the Avro compiler picks the latest schema directories (v44 / v99) naturally — that's exactly the remove-the-override step the comment above `versionOverrides` describes (*"remove the override in a follow-up PR when actually using the new protocol"*). Bump `AvroProtocolDefinition` constants in lockstep so the in-process protocol version matches the compiled schema. Add Java accessors that read/write directly from the now-Avro-backed `StoreProperties` / `StoreVersion` records (no transient POJO mirroring), so updates round-trip through ZK / metadata-system-store serialization.

- `build.gradle`: remove the `versionOverrides` entries for `StoreMetaValue` and `AdminOperation`. The Avro generator now selects v44 / v99 by the default max-numeric rule.
- `AvroProtocolDefinition`: bump constants so the in-process protocol version matches the compiled schema:
  - `METADATA_SYSTEM_SCHEMA_STORE`: 43 → 44
  - `ADMIN_OPERATION`: 98 → 99

- New enums (`VeniceEnumValue`, `EnumUtils`-backed `valueOf`):
  - `StorageMode { INTERNAL, DUAL_WRITE, EXTERNAL }` — mirrors `StoreVersion.storageMode`.
  - `ExternalStorageReadMode { VENICE_ONLY, DUAL_MODE_CONSISTENCY_CHECK, DUAL_MODE_EARLY_RETURN, EXTERNAL_ONLY }` — mirrors `StoreProperties.externalStorageReadMode`.

- **Store-level Java accessor** backed by `StoreProperties` Avro record:
  - `Store.get/setExternalStorageReadMode` → `storeProperties.externalStorageReadMode` (int ↔ enum).


### Code changes
- [ ] Added new code behind a config. (no.)
- [ ] Introduced new log lines. (no.)

### Concurrency-Specific Checks
- [x] **No race conditions:** new fields are plain Avro-record fields on the existing `storeProperties` / `storeVersion` containers, accessed under the same synchronization invariants as the fields they sit alongside.
- [x] **No new synchronization primitives required.**
- [x] **No blocking calls introduced.**
- [x] **No new collections;** only enum singletons and a primitive-or-enum-or-`String` field per type.
- [x] **No new threading.**

## How was this PR tested?
- [x] **New unit tests added:** `ExternalStorageReadModeTest`, `StorageModeTest` (`VeniceEnumValueTest`-based int-mapping coverage); new test methods in `TestStoreInfo`, `TestZKStore`, `TestVersion` for defaults / round-trip / clone preservation / null coercion for `storageMode`, `externalStorageReadMode`, `externalDbName`, `externalTableName`; plus "persists through Avro data model" tests on `TestZKStore` and `TestVersion` that read the value back through `dataModel()` to guard against a regression to transient POJO mirroring.
- [x] **Modified or extended existing tests:** yes (`TestStoreInfo` / `TestZKStore` / `TestVersion`).
- [x] **Verified the controller-side createStore admin-op flow** no longer NPEs on the new `UpdateStore` fields (`TestVeniceParentHelixAdmin` passes locally; previously failed with NPE on `externalDbName.toString()` during `AdminOperationSerializer.write`).
- [x] **Verified backward compatibility:** the v44 schema is forward-compatible with v43 because the new fields have defaults; downgrading a process that writes v44 records to one that reads v43 records works as long as both sides treat unknown fields as ignorable, which Avro does for record fields with defaults.

## Rollout note
Activating the v44 / v99 schemas changes what the controller writes to ZK and what controllers exchange via the admin topic. **All Venice services must be redeployed at this version** before any caller starts setting `storageMode` / `externalStorageReadMode` / `externalDbName` / `externalTableName` to non-default values, otherwise a v43-only service performing a read-modify-write could silently drop the new fields.

## Does this PR introduce any user-facing or breaking changes?
- [x] **No** (defaults preserve existing behavior; new fields are inert until callers opt in).