### PR TITLE
[fast-client] Version-switch listener on StoreMetadata

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/AbstractStoreMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/AbstractStoreMetadata.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -36,6 +37,7 @@ public abstract class AbstractStoreMetadata implements StoreMetadata {
   private final InstanceHealthMonitor instanceHealthMonitor;
   protected volatile AbstractClientRoutingStrategy routingStrategy;
   protected final String storeName;
+  private final CopyOnWriteArrayList<StoreVersionSwitchListener> versionSwitchListeners = new CopyOnWriteArrayList<>();
 
   public AbstractStoreMetadata(ClientConfig clientConfig) {
     this.clientConfig = clientConfig;
@@ -250,4 +252,43 @@ public abstract class AbstractStoreMetadata implements StoreMetadata {
     throw new VeniceClientException("Unknown request type: " + requestType);
   }
 
+  @Override
+  public void registerVersionSwitchListener(StoreVersionSwitchListener listener) {
+    if (listener == null) {
+      throw new IllegalArgumentException("StoreVersionSwitchListener must not be null");
+    }
+    versionSwitchListeners.addIfAbsent(listener);
+  }
+
+  @Override
+  public void unregisterVersionSwitchListener(StoreVersionSwitchListener listener) {
+    if (listener == null) {
+      return;
+    }
+    versionSwitchListeners.remove(listener);
+  }
+
+  /**
+   * Notify all registered listeners that the store's current serving version changed from {@code previousVersion}
+   * to {@code newVersion}. Each listener is invoked synchronously on the calling thread; listener exceptions are
+   * caught and logged so that one bad listener cannot break the metadata refresh or starve other listeners.
+   */
+  protected void fireVersionSwitch(int previousVersion, int newVersion) {
+    if (versionSwitchListeners.isEmpty()) {
+      return;
+    }
+    for (StoreVersionSwitchListener listener: versionSwitchListeners) {
+      try {
+        listener.onVersionSwitch(previousVersion, newVersion);
+      } catch (Throwable t) {
+        LOGGER.error(
+            "Store {} version-switch listener {} threw on transition {} -> {}",
+            storeName,
+            listener.getClass().getName(),
+            previousVersion,
+            newVersion,
+            t);
+      }
+    }
+  }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
@@ -495,14 +495,16 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
           routingInfo)) {
         // If the fetched current version is different from the local current version, update it
         // and update the cluster stats.
+        int previousVersion = currentVersion.get();
         LOGGER.info(
             "Updating current version for store: {} from {} to {}",
             storeName,
-            currentVersion.get(),
+            previousVersion,
             fetchedCurrentVersion);
         currentVersion.set(fetchedCurrentVersion);
         clusterStats.updateCurrentVersion(fetchedCurrentVersion);
         fetchedCurrentVersionPartitionResourceInCompletionRetries.set(0);
+        fireVersionSwitch(previousVersion, fetchedCurrentVersion);
       } else {
         if (currentVersion.get() != fetchedCurrentVersion) {
           int retries = fetchedCurrentVersionPartitionResourceInCompletionRetries.incrementAndGet();

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadata.java
@@ -56,4 +56,19 @@ public interface StoreMetadata extends SchemaReader {
 
   <K> void routeRequest(RequestContext requestContext, RecordSerializer<K> keySerializer);
 
+  /**
+   * Register a callback that fires when the metadata refresh loop observes a change to the store's current serving
+   * version. The callback is invoked after the new version has been committed to the local cache. See
+   * {@link StoreVersionSwitchListener} for threading and exception semantics.
+   *
+   * <p>Default implementations of {@link StoreMetadata} (e.g. test fakes) treat this as a no-op.
+   */
+  default void registerVersionSwitchListener(StoreVersionSwitchListener listener) {
+  }
+
+  /**
+   * Remove a previously registered version-switch listener. No-op if the listener was never registered.
+   */
+  default void unregisterVersionSwitchListener(StoreVersionSwitchListener listener) {
+  }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreVersionSwitchListener.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreVersionSwitchListener.java
@@ -1,0 +1,20 @@
+package com.linkedin.venice.fastclient.meta;
+
+/**
+ * Callback notified whenever the Fast Client observes a change in a store's current serving version. Fires from
+ * within the metadata refresh loop after the new version has been committed to the local cache, so listeners may
+ * safely call {@link StoreMetadata#getCurrentStoreVersion()} and observe the new value.
+ *
+ * <p>Implementations must be thread-safe and short-running; the metadata refresh thread is shared across all reads
+ * for the store. Any exception thrown by a listener is caught and logged, and does not affect other listeners or
+ * the metadata refresh itself.
+ */
+@FunctionalInterface
+public interface StoreVersionSwitchListener {
+  /**
+   * @param previousVersion the version that was current before this refresh, or {@code -1} for the first refresh
+   *                        after client start
+   * @param newVersion      the new current version observed by the metadata refresh; always {@code > 0}
+   */
+  void onVersionSwitch(int previousVersion, int newVersion);
+}

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/AbstractStoreMetadataTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/AbstractStoreMetadataTest.java
@@ -1,0 +1,243 @@
+package com.linkedin.venice.fastclient.meta;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+import com.linkedin.venice.client.store.transport.TransportClientResponse;
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.compression.VeniceCompressor;
+import com.linkedin.venice.fastclient.ClientConfig;
+import com.linkedin.venice.fastclient.RequestContext;
+import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.utils.concurrent.ChainedCompletableFuture;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.avro.Schema;
+import org.testng.annotations.Test;
+
+
+public class AbstractStoreMetadataTest {
+  private static final String STORE_NAME = "testStore";
+
+  @Test
+  public void registerAndFireDeliversTransitionToListener() {
+    TestStoreMetadata metadata = newMetadata();
+    List<int[]> received = new ArrayList<>();
+    metadata.registerVersionSwitchListener((prev, next) -> received.add(new int[] { prev, next }));
+
+    metadata.fireVersionSwitch(-1, 3);
+
+    assertEquals(received.size(), 1);
+    assertEquals(received.get(0)[0], -1);
+    assertEquals(received.get(0)[1], 3);
+  }
+
+  @Test
+  public void firingWithNoListenersIsSafe() {
+    TestStoreMetadata metadata = newMetadata();
+    metadata.fireVersionSwitch(-1, 3);
+    metadata.fireVersionSwitch(3, 4);
+  }
+
+  @Test
+  public void multipleListenersAllFire() {
+    TestStoreMetadata metadata = newMetadata();
+    AtomicInteger a = new AtomicInteger();
+    AtomicInteger b = new AtomicInteger();
+    metadata.registerVersionSwitchListener((p, n) -> a.incrementAndGet());
+    metadata.registerVersionSwitchListener((p, n) -> b.incrementAndGet());
+
+    metadata.fireVersionSwitch(3, 4);
+
+    assertEquals(a.get(), 1);
+    assertEquals(b.get(), 1);
+  }
+
+  @Test
+  public void listenerExceptionDoesNotBlockOtherListeners() {
+    TestStoreMetadata metadata = newMetadata();
+    AtomicInteger reached = new AtomicInteger();
+    metadata.registerVersionSwitchListener((p, n) -> {
+      throw new RuntimeException("boom");
+    });
+    metadata.registerVersionSwitchListener((p, n) -> reached.incrementAndGet());
+
+    metadata.fireVersionSwitch(3, 4);
+
+    assertEquals(reached.get(), 1, "subsequent listener must still receive the transition");
+  }
+
+  @Test
+  public void unregisterStopsFurtherDeliveries() {
+    TestStoreMetadata metadata = newMetadata();
+    AtomicInteger received = new AtomicInteger();
+    StoreVersionSwitchListener listener = (p, n) -> received.incrementAndGet();
+    metadata.registerVersionSwitchListener(listener);
+    metadata.fireVersionSwitch(3, 4);
+
+    metadata.unregisterVersionSwitchListener(listener);
+    metadata.fireVersionSwitch(4, 5);
+
+    assertEquals(received.get(), 1);
+  }
+
+  @Test
+  public void registeringSameListenerTwiceFiresOnce() {
+    TestStoreMetadata metadata = newMetadata();
+    AtomicInteger received = new AtomicInteger();
+    StoreVersionSwitchListener listener = (p, n) -> received.incrementAndGet();
+    metadata.registerVersionSwitchListener(listener);
+    metadata.registerVersionSwitchListener(listener);
+
+    metadata.fireVersionSwitch(3, 4);
+
+    assertEquals(received.get(), 1);
+  }
+
+  @Test
+  public void registerRejectsNullListener() {
+    TestStoreMetadata metadata = newMetadata();
+    assertThrows(IllegalArgumentException.class, () -> metadata.registerVersionSwitchListener(null));
+  }
+
+  @Test
+  public void unregisterTolerantOfNullAndUnknownListeners() {
+    TestStoreMetadata metadata = newMetadata();
+    metadata.unregisterVersionSwitchListener(null);
+    metadata.unregisterVersionSwitchListener((p, n) -> {});
+  }
+
+  private TestStoreMetadata newMetadata() {
+    return new TestStoreMetadata(STORE_NAME);
+  }
+
+  /**
+   * Concrete subclass of {@link AbstractStoreMetadata} used purely to drive the listener-plumbing tests. All
+   * methods unrelated to version-switch notification are stubbed to throw, which guarantees that any future
+   * accidental dependency on them in a listener test would fail loudly rather than silently.
+   */
+  private static final class TestStoreMetadata extends AbstractStoreMetadata {
+    private final String storeName;
+
+    TestStoreMetadata(String storeName) {
+      super(buildClientConfig(storeName));
+      this.storeName = storeName;
+    }
+
+    private static ClientConfig buildClientConfig(String storeName) {
+      ClientConfig clientConfig = org.mockito.Mockito.mock(ClientConfig.class);
+      org.mockito.Mockito.doReturn(storeName).when(clientConfig).getStoreName();
+      org.mockito.Mockito.doReturn(ClientRoutingStrategyType.LEAST_LOADED)
+          .when(clientConfig)
+          .getClientRoutingStrategyType();
+      return clientConfig;
+    }
+
+    @Override
+    public String getStoreName() {
+      return storeName;
+    }
+
+    @Override
+    public String getClusterName() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getCurrentStoreVersion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getPartitionId(int version, ByteBuffer key) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getPartitionId(int version, byte[] key) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> getReplicas(int version, int partitionId) {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public Schema getKeySchema() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Schema getValueSchema(int id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getValueSchemaId(Schema schema) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Schema getLatestValueSchema() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Integer getLatestValueSchemaId() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Schema getUpdateSchema(int valueSchemaId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public com.linkedin.venice.schema.writecompute.DerivedSchemaEntry getLatestUpdateSchema() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public VeniceCompressor getCompressor(CompressionStrategy compressionStrategy, int version) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getBatchGetLimit() {
+      return 0;
+    }
+
+    @Override
+    public void start() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public ChainedCompletableFuture<Integer, Integer> trackHealthBasedOnRequestToInstance(
+        String instance,
+        int version,
+        int partitionId,
+        CompletableFuture<TransportClientResponse> transportFuture) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <K> void routeRequest(RequestContext requestContext, RecordSerializer<K> keySerializer) {
+      throw new UnsupportedOperationException();
+    }
+
+    /** Expose the protected fire method so tests can drive transitions without a full refresh cycle. */
+    @Override
+    protected void fireVersionSwitch(int previousVersion, int newVersion) {
+      super.fireVersionSwitch(previousVersion, newVersion);
+    }
+  }
+}

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTest.java
@@ -423,6 +423,49 @@ public class RequestBasedMetadataTest {
     }
   }
 
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testVersionSwitchListenerFiresOnInitialStart() throws IOException, InterruptedException {
+    String storeName = "testStore";
+    ClientConfig clientConfig = RequestBasedMetadataTestUtils.getMockClientConfig(storeName, false, false);
+    RequestBasedMetadata requestBasedMetadata = null;
+    try {
+      requestBasedMetadata = getMockMetaData(clientConfig, storeName, false);
+      List<int[]> received = new java.util.concurrent.CopyOnWriteArrayList<>();
+      requestBasedMetadata.registerVersionSwitchListener((prev, next) -> received.add(new int[] { prev, next }));
+      requestBasedMetadata.start();
+
+      assertEquals(received.size(), 1);
+      assertEquals(received.get(0)[0], -1, "first transition's previousVersion must be the sentinel -1");
+      assertEquals(received.get(0)[1], CURRENT_VERSION);
+    } finally {
+      if (requestBasedMetadata != null) {
+        requestBasedMetadata.close();
+      }
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testVersionSwitchListenerNotFiredWhenVersionUnchanged() throws IOException, InterruptedException {
+    String storeName = "testStore";
+    ClientConfig clientConfig = RequestBasedMetadataTestUtils.getMockClientConfig(storeName, false, false);
+    RequestBasedMetadata requestBasedMetadata = null;
+    try {
+      requestBasedMetadata = getMockMetaData(clientConfig, storeName, false);
+      requestBasedMetadata.start();
+      AtomicInteger callCount = new AtomicInteger();
+      requestBasedMetadata.registerVersionSwitchListener((prev, next) -> callCount.incrementAndGet());
+
+      // Drive another updateCache; underlying mock returns the same CURRENT_VERSION → no transition.
+      requestBasedMetadata.updateCache(false);
+
+      assertEquals(callCount.get(), 0);
+    } finally {
+      if (requestBasedMetadata != null) {
+        requestBasedMetadata.close();
+      }
+    }
+  }
+
   @Test
   public void testIsPartitionResourceReady() {
     String storeName = "testStore";


### PR DESCRIPTION
## Problem Statement
Fast Client consumers that wrap the Venice client (e.g. shadow-clients maintaining a parallel cache, version-aware routing layers) currently have no way to be notified when the metadata refresh observes a new current serving version. They have to poll `getCurrentStoreVersion()` from outside the refresh loop, which is racy with respect to the rest of the cache (replicas, partition count, schemas) being updated atomically inside `RequestBasedMetadata.updateCache`.

## Solution
Add a registration-style callback that fires from inside the refresh loop **after** the new current version has been committed to the local cache, so listeners may safely read the rest of the cache and observe the new value.

- **New `StoreVersionSwitchListener`** functional interface: `onVersionSwitch(int previousVersion, int newVersion)`. First refresh after client start delivers `previousVersion = -1` as a sentinel.

- **`StoreMetadata`** gains `register/unregisterVersionSwitchListener` with `default {}` no-op bodies so existing test fakes / mocks aren't forced to implement them.

- **`AbstractStoreMetadata`** owns the listener list (`CopyOnWriteArrayList` for rare-writer / frequent-reader access) and exposes a protected `fireVersionSwitch(prev, next)` that catches per-listener `Throwable` and logs at ERROR, so one buggy listener cannot break the refresh thread or starve sibling listeners.

- **`RequestBasedMetadata.updateCache`** captures `currentVersion.get()` immediately before `.set(fetchedCurrentVersion)`, then calls `fireVersionSwitch(previousVersion, fetchedCurrentVersion)` after the stat update. The fire happens only on the branch that actually accepts a new current version (i.e. when `whetherToSwitchToFetchedCurrentVersion` is true), so transitions that get deferred for partition-resource readiness do not generate spurious callbacks.

### Code changes
- [ ] Added new code behind a config. (no)
- [x] Introduced new log lines. One ERROR-level log on listener exception in `AbstractStoreMetadata.fireVersionSwitch`. Bounded by listener count, fires only on bad listener — no rate limiting needed.

### Concurrency-Specific Checks
- [x] **No race conditions:** listeners are stored in a `CopyOnWriteArrayList`; the iterator in `fireVersionSwitch` is snapshot-stable across concurrent register/unregister calls.
- [x] **Synchronization:** registration is intrinsically thread-safe via `CopyOnWriteArrayList.addIfAbsent` / `remove`; fire walks the snapshot iterator without holding any lock.
- [x] **No blocking calls inside critical sections** — `fireVersionSwitch` is called from `RequestBasedMetadata.updateCache` which is `synchronized`, but the listener iteration itself acquires no further locks. Listener contracts (Javadoc) require short, non-blocking work; exceptions are isolated per listener.
- [x] **Thread-safe collection used** (`CopyOnWriteArrayList`).
- [x] **Validated proper exception handling** — per-listener `try/catch (Throwable)` ensures one bad listener cannot kill the refresh thread.

## How was this PR tested?
- [x] **New unit tests added:** `AbstractStoreMetadataTest` (8 cases: register+fire, no-listeners-safe, multi-listener fan-out, exception isolation, unregister, dedup on double-register, null-reject on register, null/unknown tolerance on unregister).
- [x] **Modified or extended existing tests:** yes — `RequestBasedMetadataTest` gains two wiring tests (listener fires on initial `start()` with sentinel `-1`; no fire when a subsequent `updateCache` returns the same version).
- [x] **Verified backward compatibility:** yes — the two new `StoreMetadata` methods are `default` no-ops, so existing implementations of `StoreMetadata` compile and run unchanged.

## Does this PR introduce any user-facing or breaking changes?
- [x] **No.**

---

Middle of a 3-PR stack:
1. *Previously: `[venice-common][protocol] Java accessors for storageMode + externalStorageReadMode + external-table identity` (#2817)* — independent of this PR
2. **This PR** — version-switch listener (independent; can land in parallel with #2817)
3. *Next: `[fast-client] Store-config-change listener on StoreMetadata`* — depends on #2817 for `ExternalStorageReadMode`