### PR TITLE
[fast-client] External-storage hooks: listeners + deserialization seam

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/AbstractStoreMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/AbstractStoreMetadata.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -36,6 +37,9 @@ public abstract class AbstractStoreMetadata implements StoreMetadata {
   private final InstanceHealthMonitor instanceHealthMonitor;
   protected volatile AbstractClientRoutingStrategy routingStrategy;
   protected final String storeName;
+  private final CopyOnWriteArrayList<StoreVersionSwitchListener> versionSwitchListeners = new CopyOnWriteArrayList<>();
+  private final CopyOnWriteArrayList<StoreConfigChangeListener> storeConfigChangeListeners =
+      new CopyOnWriteArrayList<>();
 
   public AbstractStoreMetadata(ClientConfig clientConfig) {
     this.clientConfig = clientConfig;
@@ -250,4 +254,92 @@ public abstract class AbstractStoreMetadata implements StoreMetadata {
     throw new VeniceClientException("Unknown request type: " + requestType);
   }
 
+  @Override
+  public void registerVersionSwitchListener(StoreVersionSwitchListener listener) {
+    if (listener == null) {
+      throw new IllegalArgumentException("StoreVersionSwitchListener must not be null");
+    }
+    versionSwitchListeners.addIfAbsent(listener);
+  }
+
+  @Override
+  public void unregisterVersionSwitchListener(StoreVersionSwitchListener listener) {
+    if (listener == null) {
+      return;
+    }
+    versionSwitchListeners.remove(listener);
+  }
+
+  /**
+   * Notify all registered listeners that the store's current serving version changed from {@code previousVersion}
+   * to {@code newVersion}. Each listener is invoked synchronously on the calling thread; listener exceptions are
+   * caught and logged so that one bad listener cannot break the metadata refresh or starve other listeners.
+   */
+  protected void fireVersionSwitch(int previousVersion, int newVersion) {
+    if (versionSwitchListeners.isEmpty()) {
+      return;
+    }
+    for (StoreVersionSwitchListener listener: versionSwitchListeners) {
+      try {
+        listener.onVersionSwitch(previousVersion, newVersion);
+      } catch (Throwable t) {
+        LOGGER.error(
+            "Store {} version-switch listener {} threw on transition {} -> {}",
+            storeName,
+            listener.getClass().getName(),
+            previousVersion,
+            newVersion,
+            t);
+      }
+    }
+  }
+
+  @Override
+  public void registerStoreConfigChangeListener(StoreConfigChangeListener listener) {
+    if (listener == null) {
+      throw new IllegalArgumentException("StoreConfigChangeListener must not be null");
+    }
+    storeConfigChangeListeners.addIfAbsent(listener);
+  }
+
+  @Override
+  public void unregisterStoreConfigChangeListener(StoreConfigChangeListener listener) {
+    if (listener == null) {
+      return;
+    }
+    storeConfigChangeListeners.remove(listener);
+  }
+
+  /**
+   * Notify all registered listeners that the store-level config snapshot has changed. Fires only when
+   * {@code previous} and {@code current} differ by value-equality, so callers may invoke this on every refresh
+   * without manual diffing. Listener exceptions are caught and logged.
+   *
+   * @param previous snapshot from the prior refresh, or {@code null} on the first refresh after client start
+   * @param current  snapshot just materialized; must not be {@code null}
+   */
+  protected void fireStoreConfigChange(StoreConfigSnapshot previous, StoreConfigSnapshot current) {
+    if (current == null) {
+      throw new IllegalArgumentException("current snapshot must not be null");
+    }
+    if (current.equals(previous)) {
+      return;
+    }
+    if (storeConfigChangeListeners.isEmpty()) {
+      return;
+    }
+    for (StoreConfigChangeListener listener: storeConfigChangeListeners) {
+      try {
+        listener.onStoreConfigChange(previous, current);
+      } catch (Throwable t) {
+        LOGGER.error(
+            "Store {} store-config-change listener {} threw on transition {} -> {}",
+            storeName,
+            listener.getClass().getName(),
+            previous,
+            current,
+            t);
+      }
+    }
+  }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
@@ -40,6 +40,7 @@ import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -116,6 +117,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
   private CountDownLatch isReadyLatch = new CountDownLatch(1);
   private AtomicReference<String> serverClusterName = new AtomicReference<>();
   private final AtomicInteger fetchedCurrentVersionPartitionResourceInCompletionRetries = new AtomicInteger();
+  private volatile StoreConfigSnapshot lastStoreConfigSnapshot = null;
 
   private Set<String> harClusters;
 
@@ -386,9 +388,22 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
    * @param onDemandRefresh
    * @return if the fetched metadata was an updated version
    */
-  synchronized void updateCache(boolean onDemandRefresh) throws InterruptedException {
+  /**
+   * Refresh the in-memory cache from a single METADATA fetch. Listener callbacks are NOT invoked inline; instead the
+   * method returns a list of {@link Runnable}s that the caller must run AFTER releasing the synchronized monitor and
+   * AFTER setting {@code isReady = true}. This protects listeners from two hazards:
+   * <ol>
+   *   <li>A slow listener stalling all callers that block on this monitor.</li>
+   *   <li>A listener calling {@link #getCurrentStoreVersion()} on the initial transition before {@code isReady} is
+   *       set, which would throw.</li>
+   * </ol>
+   * On the error-recovery path the recursive call's pending callbacks are merged so the eventually-successful update
+   * is the one whose listeners fire.
+   */
+  synchronized List<Runnable> updateCache(boolean onDemandRefresh) throws InterruptedException {
     LOGGER.debug("Metadata fetch operation for store: {} started", storeName);
     long currentTimeMs = System.currentTimeMillis();
+    List<Runnable> pendingCallbacks = new ArrayList<>(2);
     // call the METADATA endpoint
     try {
       TransportClientResponse transportClientResponse = fetchMetadata().get();
@@ -495,14 +510,18 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
           routingInfo)) {
         // If the fetched current version is different from the local current version, update it
         // and update the cluster stats.
+        int previousVersion = currentVersion.get();
         LOGGER.info(
             "Updating current version for store: {} from {} to {}",
             storeName,
-            currentVersion.get(),
+            previousVersion,
             fetchedCurrentVersion);
         currentVersion.set(fetchedCurrentVersion);
         clusterStats.updateCurrentVersion(fetchedCurrentVersion);
         fetchedCurrentVersionPartitionResourceInCompletionRetries.set(0);
+        final int capturedPreviousVersion = previousVersion;
+        final int capturedNewVersion = fetchedCurrentVersion;
+        pendingCallbacks.add(() -> fireVersionSwitch(capturedPreviousVersion, capturedNewVersion));
       } else {
         if (currentVersion.get() != fetchedCurrentVersion) {
           int retries = fetchedCurrentVersionPartitionResourceInCompletionRetries.incrementAndGet();
@@ -531,6 +550,13 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
           "Metadata fetch operation for store: {} finished successfully with current version {}.",
           storeName,
           fetchedCurrentVersion);
+
+      // Diff and queue the store-config-change callback. Done last so listeners see a fully committed cache.
+      // Actual notification is deferred until the caller has released the synchronized monitor and set isReady.
+      StoreConfigSnapshot newSnapshot = buildStoreConfigSnapshot();
+      final StoreConfigSnapshot previousSnapshot = lastStoreConfigSnapshot;
+      lastStoreConfigSnapshot = newSnapshot;
+      pendingCallbacks.add(() -> fireStoreConfigChange(previousSnapshot, newSnapshot));
     } catch (ExecutionException e) {
       // perform an on demand refresh if update fails in case of store migration
       // TODO: need a better way to handle store migration
@@ -538,7 +564,9 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
         LOGGER.warn("Metadata fetch operation for store: {} failed with exception {}", storeName, e.getMessage());
         isServiceDiscovered = false;
         discoverD2Service();
-        updateCache(true);
+        // The outer (failed) attempt produced no committed state, so discard its pending callbacks and adopt the
+        // recovery attempt's instead.
+        return updateCache(true);
       } else {
         // pass the error along if the on demand refresh also fails
         clusterStats.recordVersionUpdateFailure();
@@ -547,6 +575,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
             e.getCause());
       }
     }
+    return pendingCallbacks;
   }
 
   public static boolean whetherToSwitchToFetchedCurrentVersion(
@@ -628,11 +657,16 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
 
   private void refresh() {
     try {
-      updateCache(false);
+      List<Runnable> pendingCallbacks = updateCache(false);
       if (!isReady) {
         isReadyLatch.countDown();
         isReady = true;
         LOGGER.info("Metadata initial fetch completed successfully for store: {}", storeName);
+      }
+      // Fire deferred listener notifications outside the updateCache() monitor and only after isReady is set, so
+      // listeners can safely call StoreMetadata#getCurrentStoreVersion() from within the callback.
+      for (Runnable cb: pendingCallbacks) {
+        cb.run();
       }
     } catch (VeniceClientException clientException) {
       if (clientException.getCause() instanceof VeniceClientHttpException) {
@@ -780,6 +814,18 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
   @Override
   public int getBatchGetLimit() {
     return batchGetLimit.get();
+  }
+
+  /**
+   * Materialize the store-level config snapshot from the local cache. Called once at the end of every successful
+   * {@link #updateCache(boolean)}; the result is diffed against {@link #lastStoreConfigSnapshot} to decide whether
+   * to fire {@link StoreConfigChangeListener}s.
+   *
+   * <p>External-storage fields default to safe values until {@link MetadataResponseRecord} is extended to carry them
+   * over the wire. The TODO on {@link StoreConfigSnapshot} tracks the gap.
+   */
+  private StoreConfigSnapshot buildStoreConfigSnapshot() {
+    return new StoreConfigSnapshot(batchGetLimit.get(), com.linkedin.venice.meta.ExternalStorageReadMode.VENICE_ONLY);
   }
 
   /**

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreConfigChangeListener.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreConfigChangeListener.java
@@ -1,0 +1,24 @@
+package com.linkedin.venice.fastclient.meta;
+
+/**
+ * Callback notified whenever the Fast Client observes a change to the store-level configuration that it tracks.
+ * Fires from within the metadata refresh loop after the new snapshot has been committed to the local cache, so
+ * listeners may safely call {@link StoreMetadata} getters and observe the new state.
+ *
+ * <p>Implementations must be thread-safe and short-running; the metadata refresh thread is shared across all reads
+ * for the store. Any exception thrown by a listener is caught and logged, and does not affect other listeners or
+ * the metadata refresh itself.
+ *
+ * <p>Current-version flips are delivered by {@link StoreVersionSwitchListener} (and only that). Partition and
+ * replica-routing updates that happen on every metadata refresh, even when the current version does not change, are
+ * not delivered by either listener today.
+ */
+@FunctionalInterface
+public interface StoreConfigChangeListener {
+  /**
+   * @param previous the snapshot observed before this refresh, or {@code null} for the first refresh after client
+   *                 start (i.e. the listener was registered before any metadata had been materialized)
+   * @param current  the snapshot observed by the current refresh; never {@code null}
+   */
+  void onStoreConfigChange(StoreConfigSnapshot previous, StoreConfigSnapshot current);
+}

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreConfigSnapshot.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreConfigSnapshot.java
@@ -1,0 +1,64 @@
+package com.linkedin.venice.fastclient.meta;
+
+import com.linkedin.venice.meta.ExternalStorageReadMode;
+import java.util.Objects;
+
+
+/**
+ * Immutable view of the store-level configuration the Fast Client metadata refresh has materialized. Used as the
+ * payload of {@link StoreConfigChangeListener} so that consumers can react to runtime changes (e.g. operator flips
+ * to {@link ExternalStorageReadMode}) without having to poll {@link StoreMetadata} themselves.
+ *
+ * <p>Only fields that change at store-granularity (not per-version) belong here. Current-version transitions are
+ * delivered by {@link StoreVersionSwitchListener} instead; per-version per-refresh state — partition count, replicas,
+ * compression dictionary — is not delivered by either listener today (callers can still poll {@link StoreMetadata}
+ * for those).
+ *
+ * <p>Equality is value-based across all snapshot fields, which is what {@link AbstractStoreMetadata#fireStoreConfigChange}
+ * uses to suppress callbacks when the snapshot has not actually changed.
+ */
+public final class StoreConfigSnapshot {
+  private final int batchGetLimit;
+  // TODO(external-storage): populate from the metadata response once {@link
+  // AvroProtocolDefinition#METADATA_SYSTEM_SCHEMA_STORE}
+  // (currently v44) and {@link AvroProtocolDefinition#SERVER_METADATA_RESPONSE} (currently v2) advance to carry
+  // externalStorageReadMode on the wire. Until then this is sourced from a callable-provided default.
+  private final ExternalStorageReadMode externalStorageReadMode;
+
+  public StoreConfigSnapshot(int batchGetLimit, ExternalStorageReadMode externalStorageReadMode) {
+    this.batchGetLimit = batchGetLimit;
+    this.externalStorageReadMode =
+        externalStorageReadMode == null ? ExternalStorageReadMode.VENICE_ONLY : externalStorageReadMode;
+  }
+
+  public int getBatchGetLimit() {
+    return batchGetLimit;
+  }
+
+  public ExternalStorageReadMode getExternalStorageReadMode() {
+    return externalStorageReadMode;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof StoreConfigSnapshot)) {
+      return false;
+    }
+    StoreConfigSnapshot that = (StoreConfigSnapshot) other;
+    return batchGetLimit == that.batchGetLimit && externalStorageReadMode == that.externalStorageReadMode;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(batchGetLimit, externalStorageReadMode);
+  }
+
+  @Override
+  public String toString() {
+    return "StoreConfigSnapshot{batchGetLimit=" + batchGetLimit + ", externalStorageReadMode=" + externalStorageReadMode
+        + '}';
+  }
+}

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadata.java
@@ -56,4 +56,52 @@ public interface StoreMetadata extends SchemaReader {
 
   <K> void routeRequest(RequestContext requestContext, RecordSerializer<K> keySerializer);
 
+  /**
+   * Register a callback that fires when the metadata refresh loop observes a change to the store's current serving
+   * version. The callback is invoked after the new version has been committed to the local cache. See
+   * {@link StoreVersionSwitchListener} for threading and exception semantics.
+   *
+   * <p>{@code listener} must not be {@code null}. Default implementations of {@link StoreMetadata} (e.g. test fakes)
+   * treat the registration itself as a no-op but still enforce the non-null contract so behavior is consistent with
+   * the canonical {@link AbstractStoreMetadata} implementation.
+   *
+   * @throws IllegalArgumentException if {@code listener} is {@code null}
+   */
+  default void registerVersionSwitchListener(StoreVersionSwitchListener listener) {
+    if (listener == null) {
+      throw new IllegalArgumentException("StoreVersionSwitchListener must not be null");
+    }
+  }
+
+  /**
+   * Remove a previously registered version-switch listener. No-op if the listener was never registered or is
+   * {@code null}.
+   */
+  default void unregisterVersionSwitchListener(StoreVersionSwitchListener listener) {
+  }
+
+  /**
+   * Register a callback that fires when the metadata refresh loop observes a change to the store-level config
+   * snapshot (e.g. operator-driven {@link com.linkedin.venice.meta.ExternalStorageReadMode} flip). The callback is invoked
+   * after the new snapshot has been committed to the local cache. See {@link StoreConfigChangeListener} for
+   * threading and exception semantics.
+   *
+   * <p>{@code listener} must not be {@code null}. Default implementations of {@link StoreMetadata} (e.g. test fakes)
+   * treat the registration itself as a no-op but still enforce the non-null contract so behavior is consistent with
+   * the canonical {@link AbstractStoreMetadata} implementation.
+   *
+   * @throws IllegalArgumentException if {@code listener} is {@code null}
+   */
+  default void registerStoreConfigChangeListener(StoreConfigChangeListener listener) {
+    if (listener == null) {
+      throw new IllegalArgumentException("StoreConfigChangeListener must not be null");
+    }
+  }
+
+  /**
+   * Remove a previously registered store-config-change listener. No-op if the listener was never registered or is
+   * {@code null}.
+   */
+  default void unregisterStoreConfigChangeListener(StoreConfigChangeListener listener) {
+  }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreVersionSwitchListener.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreVersionSwitchListener.java
@@ -1,0 +1,23 @@
+package com.linkedin.venice.fastclient.meta;
+
+/**
+ * Callback notified whenever the Fast Client observes a change in a store's current serving version. Fires from
+ * within the metadata refresh loop after the new version has been committed to the local cache, so listeners may
+ * safely call {@link StoreMetadata#getCurrentStoreVersion()} and observe the new value.
+ *
+ * <p>Implementations must be thread-safe and short-running; the metadata refresh thread is shared across all reads
+ * for the store. Any exception thrown by a listener is caught and logged, and does not affect other listeners or
+ * the metadata refresh itself.
+ */
+@FunctionalInterface
+public interface StoreVersionSwitchListener {
+  /**
+   * @param previousVersion the version that was current before this refresh, or {@code -1} for the first refresh
+   *                        after client start
+   * @param newVersion      the new current version observed by the metadata refresh. May be
+   *                        {@link com.linkedin.venice.meta.Store#NON_EXISTING_VERSION} (i.e. {@code 0}) if the store
+   *                        currently has no serving version (e.g. brand-new store), so implementations must tolerate
+   *                        that value rather than assume {@code newVersion > 0}.
+   */
+  void onVersionSwitch(int previousVersion, int newVersion);
+}

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/AbstractStoreMetadataTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/AbstractStoreMetadataTest.java
@@ -1,0 +1,317 @@
+package com.linkedin.venice.fastclient.meta;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+import com.linkedin.venice.client.store.transport.TransportClientResponse;
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.compression.VeniceCompressor;
+import com.linkedin.venice.fastclient.ClientConfig;
+import com.linkedin.venice.fastclient.RequestContext;
+import com.linkedin.venice.meta.ExternalStorageReadMode;
+import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.utils.concurrent.ChainedCompletableFuture;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.avro.Schema;
+import org.testng.annotations.Test;
+
+
+public class AbstractStoreMetadataTest {
+  private static final String STORE_NAME = "testStore";
+
+  @Test
+  public void registerAndFireDeliversTransitionToListener() {
+    TestStoreMetadata metadata = newMetadata();
+    List<int[]> received = new ArrayList<>();
+    metadata.registerVersionSwitchListener((prev, next) -> received.add(new int[] { prev, next }));
+
+    metadata.fireVersionSwitch(-1, 3);
+
+    assertEquals(received.size(), 1);
+    assertEquals(received.get(0)[0], -1);
+    assertEquals(received.get(0)[1], 3);
+  }
+
+  @Test
+  public void firingWithNoListenersIsSafe() {
+    TestStoreMetadata metadata = newMetadata();
+    metadata.fireVersionSwitch(-1, 3);
+    metadata.fireVersionSwitch(3, 4);
+  }
+
+  @Test
+  public void multipleListenersAllFire() {
+    TestStoreMetadata metadata = newMetadata();
+    AtomicInteger a = new AtomicInteger();
+    AtomicInteger b = new AtomicInteger();
+    metadata.registerVersionSwitchListener((p, n) -> a.incrementAndGet());
+    metadata.registerVersionSwitchListener((p, n) -> b.incrementAndGet());
+
+    metadata.fireVersionSwitch(3, 4);
+
+    assertEquals(a.get(), 1);
+    assertEquals(b.get(), 1);
+  }
+
+  @Test
+  public void listenerExceptionDoesNotBlockOtherListeners() {
+    TestStoreMetadata metadata = newMetadata();
+    AtomicInteger reached = new AtomicInteger();
+    metadata.registerVersionSwitchListener((p, n) -> {
+      throw new RuntimeException("boom");
+    });
+    metadata.registerVersionSwitchListener((p, n) -> reached.incrementAndGet());
+
+    metadata.fireVersionSwitch(3, 4);
+
+    assertEquals(reached.get(), 1, "subsequent listener must still receive the transition");
+  }
+
+  @Test
+  public void unregisterStopsFurtherDeliveries() {
+    TestStoreMetadata metadata = newMetadata();
+    AtomicInteger received = new AtomicInteger();
+    StoreVersionSwitchListener listener = (p, n) -> received.incrementAndGet();
+    metadata.registerVersionSwitchListener(listener);
+    metadata.fireVersionSwitch(3, 4);
+
+    metadata.unregisterVersionSwitchListener(listener);
+    metadata.fireVersionSwitch(4, 5);
+
+    assertEquals(received.get(), 1);
+  }
+
+  @Test
+  public void registeringSameListenerTwiceFiresOnce() {
+    TestStoreMetadata metadata = newMetadata();
+    AtomicInteger received = new AtomicInteger();
+    StoreVersionSwitchListener listener = (p, n) -> received.incrementAndGet();
+    metadata.registerVersionSwitchListener(listener);
+    metadata.registerVersionSwitchListener(listener);
+
+    metadata.fireVersionSwitch(3, 4);
+
+    assertEquals(received.get(), 1);
+  }
+
+  @Test
+  public void registerRejectsNullListener() {
+    TestStoreMetadata metadata = newMetadata();
+    assertThrows(IllegalArgumentException.class, () -> metadata.registerVersionSwitchListener(null));
+  }
+
+  @Test
+  public void unregisterTolerantOfNullAndUnknownListeners() {
+    TestStoreMetadata metadata = newMetadata();
+    metadata.unregisterVersionSwitchListener(null);
+    metadata.unregisterVersionSwitchListener((p, n) -> {});
+  }
+
+  @Test
+  public void storeConfigChangeFiresOnInitialTransitionFromNull() {
+    TestStoreMetadata metadata = newMetadata();
+    List<StoreConfigSnapshot[]> received = new ArrayList<>();
+    metadata.registerStoreConfigChangeListener((prev, curr) -> received.add(new StoreConfigSnapshot[] { prev, curr }));
+
+    StoreConfigSnapshot first = new StoreConfigSnapshot(150, ExternalStorageReadMode.VENICE_ONLY);
+    metadata.fireStoreConfigChange(null, first);
+
+    assertEquals(received.size(), 1);
+    assertEquals(received.get(0)[0], null);
+    assertEquals(received.get(0)[1], first);
+  }
+
+  @Test
+  public void storeConfigChangeSuppressedWhenSnapshotEqual() {
+    TestStoreMetadata metadata = newMetadata();
+    AtomicInteger callCount = new AtomicInteger();
+    metadata.registerStoreConfigChangeListener((prev, curr) -> callCount.incrementAndGet());
+
+    StoreConfigSnapshot snapshot = new StoreConfigSnapshot(150, ExternalStorageReadMode.VENICE_ONLY);
+    metadata.fireStoreConfigChange(snapshot, snapshot);
+    metadata.fireStoreConfigChange(snapshot, new StoreConfigSnapshot(150, ExternalStorageReadMode.VENICE_ONLY));
+
+    assertEquals(callCount.get(), 0);
+  }
+
+  @Test
+  public void storeConfigChangeListenerExceptionDoesNotBlockOthers() {
+    TestStoreMetadata metadata = newMetadata();
+    AtomicInteger reached = new AtomicInteger();
+    metadata.registerStoreConfigChangeListener((p, c) -> {
+      throw new RuntimeException("boom");
+    });
+    metadata.registerStoreConfigChangeListener((p, c) -> reached.incrementAndGet());
+
+    metadata.fireStoreConfigChange(
+        new StoreConfigSnapshot(150, ExternalStorageReadMode.VENICE_ONLY),
+        new StoreConfigSnapshot(200, ExternalStorageReadMode.VENICE_ONLY));
+
+    assertEquals(reached.get(), 1);
+  }
+
+  @Test
+  public void unregisterStoreConfigChangeStopsFurtherDeliveries() {
+    TestStoreMetadata metadata = newMetadata();
+    AtomicInteger received = new AtomicInteger();
+    StoreConfigChangeListener listener = (p, c) -> received.incrementAndGet();
+    metadata.registerStoreConfigChangeListener(listener);
+    metadata.fireStoreConfigChange(
+        new StoreConfigSnapshot(150, ExternalStorageReadMode.VENICE_ONLY),
+        new StoreConfigSnapshot(200, ExternalStorageReadMode.VENICE_ONLY));
+
+    metadata.unregisterStoreConfigChangeListener(listener);
+    metadata.fireStoreConfigChange(
+        new StoreConfigSnapshot(200, ExternalStorageReadMode.VENICE_ONLY),
+        new StoreConfigSnapshot(300, ExternalStorageReadMode.VENICE_ONLY));
+
+    assertEquals(received.get(), 1);
+  }
+
+  @Test
+  public void registerStoreConfigChangeRejectsNullListener() {
+    TestStoreMetadata metadata = newMetadata();
+    assertThrows(IllegalArgumentException.class, () -> metadata.registerStoreConfigChangeListener(null));
+  }
+
+  @Test
+  public void fireStoreConfigChangeRejectsNullCurrentSnapshot() {
+    TestStoreMetadata metadata = newMetadata();
+    assertThrows(IllegalArgumentException.class, () -> metadata.fireStoreConfigChange(null, null));
+  }
+
+  private TestStoreMetadata newMetadata() {
+    return new TestStoreMetadata(STORE_NAME);
+  }
+
+  /**
+   * Concrete subclass of {@link AbstractStoreMetadata} used purely to drive the listener-plumbing tests. Methods
+   * required by the {@link StoreMetadata} contract that the listener tests never exercise are stubbed to throw, so
+   * accidental dependency on them in a listener test fails loudly. A small handful of plumbing methods
+   * ({@code getReplicas}, {@code getBatchGetLimit}, {@code start}, {@code close}) return benign defaults instead,
+   * because {@link AbstractStoreMetadata}'s lifecycle invokes some of these during construction / GC; throwing there
+   * would break the test fixture itself, not catch a missing listener path.
+   */
+  private static final class TestStoreMetadata extends AbstractStoreMetadata {
+    TestStoreMetadata(String storeName) {
+      super(buildClientConfig(storeName));
+    }
+
+    private static ClientConfig buildClientConfig(String storeName) {
+      ClientConfig clientConfig = org.mockito.Mockito.mock(ClientConfig.class);
+      org.mockito.Mockito.doReturn(storeName).when(clientConfig).getStoreName();
+      org.mockito.Mockito.doReturn(ClientRoutingStrategyType.LEAST_LOADED)
+          .when(clientConfig)
+          .getClientRoutingStrategyType();
+      return clientConfig;
+    }
+
+    @Override
+    public String getClusterName() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getCurrentStoreVersion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getPartitionId(int version, ByteBuffer key) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getPartitionId(int version, byte[] key) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> getReplicas(int version, int partitionId) {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public Schema getKeySchema() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Schema getValueSchema(int id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getValueSchemaId(Schema schema) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Schema getLatestValueSchema() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Integer getLatestValueSchemaId() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Schema getUpdateSchema(int valueSchemaId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public com.linkedin.venice.schema.writecompute.DerivedSchemaEntry getLatestUpdateSchema() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public VeniceCompressor getCompressor(CompressionStrategy compressionStrategy, int version) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getBatchGetLimit() {
+      return 0;
+    }
+
+    @Override
+    public void start() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public ChainedCompletableFuture<Integer, Integer> trackHealthBasedOnRequestToInstance(
+        String instance,
+        int version,
+        int partitionId,
+        CompletableFuture<TransportClientResponse> transportFuture) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <K> void routeRequest(RequestContext requestContext, RecordSerializer<K> keySerializer) {
+      throw new UnsupportedOperationException();
+    }
+
+    /** Expose the protected fire method so tests can drive transitions without a full refresh cycle. */
+    @Override
+    protected void fireVersionSwitch(int previousVersion, int newVersion) {
+      super.fireVersionSwitch(previousVersion, newVersion);
+    }
+
+    @Override
+    protected void fireStoreConfigChange(StoreConfigSnapshot previous, StoreConfigSnapshot current) {
+      super.fireStoreConfigChange(previous, current);
+    }
+  }
+}

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTest.java
@@ -423,6 +423,95 @@ public class RequestBasedMetadataTest {
     }
   }
 
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testVersionSwitchListenerFiresOnInitialStart() throws IOException, InterruptedException {
+    String storeName = "testStore";
+    ClientConfig clientConfig = RequestBasedMetadataTestUtils.getMockClientConfig(storeName, false, false);
+    RequestBasedMetadata requestBasedMetadata = null;
+    try {
+      requestBasedMetadata = getMockMetaData(clientConfig, storeName, false);
+      List<int[]> received = new java.util.concurrent.CopyOnWriteArrayList<>();
+      requestBasedMetadata.registerVersionSwitchListener((prev, next) -> received.add(new int[] { prev, next }));
+      requestBasedMetadata.start();
+
+      assertEquals(received.size(), 1);
+      assertEquals(received.get(0)[0], -1, "first transition's previousVersion must be the sentinel -1");
+      assertEquals(received.get(0)[1], CURRENT_VERSION);
+    } finally {
+      if (requestBasedMetadata != null) {
+        requestBasedMetadata.close();
+      }
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testVersionSwitchListenerNotFiredWhenVersionUnchanged() throws IOException, InterruptedException {
+    String storeName = "testStore";
+    ClientConfig clientConfig = RequestBasedMetadataTestUtils.getMockClientConfig(storeName, false, false);
+    RequestBasedMetadata requestBasedMetadata = null;
+    try {
+      requestBasedMetadata = getMockMetaData(clientConfig, storeName, false);
+      requestBasedMetadata.start();
+      AtomicInteger callCount = new AtomicInteger();
+      requestBasedMetadata.registerVersionSwitchListener((prev, next) -> callCount.incrementAndGet());
+
+      // Drive another updateCache; underlying mock returns the same CURRENT_VERSION → no transition.
+      // Run pending callbacks (refresh() does this normally) so we exercise the actual listener path.
+      requestBasedMetadata.updateCache(false).forEach(Runnable::run);
+
+      assertEquals(callCount.get(), 0);
+    } finally {
+      if (requestBasedMetadata != null) {
+        requestBasedMetadata.close();
+      }
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testStoreConfigChangeListenerFiresOnInitialStart() throws IOException, InterruptedException {
+    String storeName = "testStore";
+    ClientConfig clientConfig = RequestBasedMetadataTestUtils.getMockClientConfig(storeName, false, false);
+    RequestBasedMetadata requestBasedMetadata = null;
+    try {
+      requestBasedMetadata = getMockMetaData(clientConfig, storeName, false);
+      List<StoreConfigSnapshot[]> received = new java.util.concurrent.CopyOnWriteArrayList<>();
+      requestBasedMetadata
+          .registerStoreConfigChangeListener((prev, curr) -> received.add(new StoreConfigSnapshot[] { prev, curr }));
+      requestBasedMetadata.start();
+
+      assertEquals(received.size(), 1);
+      Assert.assertNull(received.get(0)[0], "first transition's previous snapshot must be null");
+      Assert.assertNotNull(received.get(0)[1]);
+      assertEquals(received.get(0)[1].getBatchGetLimit(), 150);
+    } finally {
+      if (requestBasedMetadata != null) {
+        requestBasedMetadata.close();
+      }
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testStoreConfigChangeListenerSuppressedWhenSnapshotUnchanged() throws IOException, InterruptedException {
+    String storeName = "testStore";
+    ClientConfig clientConfig = RequestBasedMetadataTestUtils.getMockClientConfig(storeName, false, false);
+    RequestBasedMetadata requestBasedMetadata = null;
+    try {
+      requestBasedMetadata = getMockMetaData(clientConfig, storeName, false);
+      requestBasedMetadata.start();
+      AtomicInteger callCount = new AtomicInteger();
+      requestBasedMetadata.registerStoreConfigChangeListener((prev, curr) -> callCount.incrementAndGet());
+
+      // Same mock metadata response → identical snapshot → listener must not fire when the deferred callback runs.
+      requestBasedMetadata.updateCache(false).forEach(Runnable::run);
+
+      assertEquals(callCount.get(), 0);
+    } finally {
+      if (requestBasedMetadata != null) {
+        requestBasedMetadata.close();
+      }
+    }
+  }
+
   @Test
   public void testIsPartitionResourceReady() {
     String storeName = "testStore";

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTestUtils.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTestUtils.java
@@ -302,12 +302,13 @@ public class RequestBasedMetadataTestUtils {
         }
 
         @Override
-        synchronized void updateCache(boolean onDemandRefresh) {
+        synchronized java.util.List<Runnable> updateCache(boolean onDemandRefresh) {
           if (firstUpdateFails && firstUpdate) {
             firstUpdate = false;
             throw new VeniceClientException("update cache exception");
           }
-          // otherwise no-op
+          // otherwise no-op; nothing to fire on the deferred-callback list
+          return java.util.Collections.emptyList();
         }
       };
 

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/StoreConfigSnapshotTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/StoreConfigSnapshotTest.java
@@ -1,0 +1,45 @@
+package com.linkedin.venice.fastclient.meta;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import com.linkedin.venice.meta.ExternalStorageReadMode;
+import org.testng.annotations.Test;
+
+
+public class StoreConfigSnapshotTest {
+  @Test
+  public void identicalSnapshotsCompareEqual() {
+    StoreConfigSnapshot a = new StoreConfigSnapshot(150, ExternalStorageReadMode.VENICE_ONLY);
+    StoreConfigSnapshot b = new StoreConfigSnapshot(150, ExternalStorageReadMode.VENICE_ONLY);
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  public void batchGetLimitDifferenceBreaksEquality() {
+    StoreConfigSnapshot a = new StoreConfigSnapshot(150, ExternalStorageReadMode.VENICE_ONLY);
+    StoreConfigSnapshot b = new StoreConfigSnapshot(200, ExternalStorageReadMode.VENICE_ONLY);
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void externalStorageReadModeDifferenceBreaksEquality() {
+    StoreConfigSnapshot a = new StoreConfigSnapshot(150, ExternalStorageReadMode.VENICE_ONLY);
+    StoreConfigSnapshot b = new StoreConfigSnapshot(150, ExternalStorageReadMode.DUAL_MODE_EARLY_RETURN);
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void nullExternalStorageReadModeCoercesToVeniceOnly() {
+    StoreConfigSnapshot snapshot = new StoreConfigSnapshot(150, null);
+    assertEquals(snapshot.getExternalStorageReadMode(), ExternalStorageReadMode.VENICE_ONLY);
+  }
+
+  @Test
+  public void accessorsReturnConstructorValues() {
+    StoreConfigSnapshot snapshot = new StoreConfigSnapshot(150, ExternalStorageReadMode.DUAL_MODE_CONSISTENCY_CHECK);
+    assertEquals(snapshot.getBatchGetLimit(), 150);
+    assertEquals(snapshot.getExternalStorageReadMode(), ExternalStorageReadMode.DUAL_MODE_CONSISTENCY_CHECK);
+  }
+}

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -384,6 +384,26 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
         LOGGER);
   }
 
+  /**
+   * Re-entry into the existing decompress + Avro-deserialize pipeline for callers that obtained raw Venice-format
+   * value bytes from a non-router transport (e.g. an external storage system holding the same wire bytes). Reuses
+   * {@link #decompressRecord} and {@link #tryToDeserialize} so any future change to the read path propagates here
+   * automatically.
+   */
+  @Override
+  public V decompressAndDeserialize(ByteBuffer rawValue, int schemaId, CompressionStrategy compressionStrategy, K key)
+      throws VeniceClientException {
+    if (rawValue == null) {
+      throw new IllegalArgumentException("rawValue must not be null");
+    }
+    if (compressionStrategy == null) {
+      throw new IllegalArgumentException("compressionStrategy must not be null");
+    }
+    ByteBuffer decompressed = decompressRecord(compressionStrategy, rawValue);
+    RecordDeserializer<V> deserializer = getDataRecordDeserializerFromCache(schemaId);
+    return tryToDeserialize(deserializer, decompressed, schemaId, key);
+  }
+
   public static <T, K> T tryToDeserializeWithVerboseLogging(
       RecordDeserializer<T> dataDeserializer,
       ByteBuffer data,

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericStoreClient.java
@@ -6,8 +6,10 @@ import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.client.store.streaming.VeniceResponseCompletableFuture;
 import com.linkedin.venice.client.store.streaming.VeniceResponseMap;
 import com.linkedin.venice.client.store.streaming.VeniceResponseMapImpl;
+import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.io.Closeable;
+import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
@@ -162,4 +164,30 @@ public interface AvroGenericStoreClient<K, V> extends Closeable {
    */
   @Deprecated
   Schema getLatestValueSchema();
+
+  /**
+   * Re-entry point for callers that obtained Venice-format raw value bytes from a path other than the standard
+   * Venice routing layer (e.g. an external storage system holding the same wire bytes) and want to run those bytes
+   * through this client's existing decompression + Avro deserialization pipeline without duplicating that logic.
+   *
+   * <p>The caller must supply both the {@code schemaId} and {@code compressionStrategy} that the bytes were written
+   * with; these are usually obtained out-of-band (for an external-storage integration they typically come from the
+   * per-version metadata that the Fast Client already tracks). The default implementation throws — only fast-client
+   * implementations override.
+   *
+   * @param rawValue            the value payload exactly as Venice would have written it on the wire (post-compression,
+   *                            post-Avro-serialization). Must not be {@code null}.
+   * @param schemaId            value schema id that the payload was serialized with
+   * @param compressionStrategy compression strategy that was applied before serialization
+   * @param key                 the key that produced this value (used only for error messages and tracing)
+   * @return the deserialized value
+   * @throws UnsupportedOperationException by default; fast-client implementations override
+   * @throws VeniceClientException if decompression or deserialization fails
+   */
+  default V decompressAndDeserialize(ByteBuffer rawValue, int schemaId, CompressionStrategy compressionStrategy, K key)
+      throws VeniceClientException {
+    throw new UnsupportedOperationException(
+        getClass().getSimpleName() + " does not support external-storage deserialization re-entry. "
+            + "This entry point is only implemented by the Venice Fast Client.");
+  }
 }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AbstractAvroStoreClientTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AbstractAvroStoreClientTest.java
@@ -833,4 +833,52 @@ public class AbstractAvroStoreClientTest {
     client.discoverD2Service(false);
     Assert.assertEquals(callCount.get(), 1, "second call is short-circuited by isServiceDiscovered");
   }
+
+  /**
+   * Verifies the external-storage deserialization re-entry: caller supplies the same Venice wire bytes that would
+   * have come back through the router (already produced by `valueSerializer`), plus (schemaId, compressionStrategy),
+   * and the client decodes the value exactly as the in-band path would. Uses NO_OP compression for a self-contained
+   * round-trip.
+   */
+  @Test
+  public void testDecompressAndDeserializeReEntersStandardPipeline() throws Exception {
+    TransportClient mockTransportClient = mock(TransportClient.class);
+    SimpleStoreClient<String, GenericRecord> client = new SimpleStoreClient<>(
+        mockTransportClient,
+        "test-store",
+        true,
+        AbstractAvroStoreClient.getDefaultDeserializationExecutor());
+
+    GenericRecord original = new GenericData.Record(VALUE_SCHEMA);
+    GenericRecord nested = new GenericData.Record(VALUE_SCHEMA.getField("record_field").schema());
+    nested.put("nested_field1", 3.14d);
+    original.put("int_field", 42);
+    original.put("float_field", 1.5f);
+    original.put("record_field", nested);
+    original.put("float_array_field1", Arrays.asList(0.1f, 0.2f));
+    original.put("float_array_field2", Arrays.asList(0.3f, 0.4f));
+    original.put("int_array_field2", Arrays.asList(7, 8));
+
+    byte[] rawBytes = valueSerializer.serialize(original);
+
+    GenericRecord roundTripped =
+        client.decompressAndDeserialize(ByteBuffer.wrap(rawBytes), 1, CompressionStrategy.NO_OP, "k1");
+
+    Assert.assertEquals(roundTripped.get("int_field"), 42);
+    Assert.assertEquals(roundTripped.get("float_field"), 1.5f);
+
+    // Null arg contracts.
+    try {
+      client.decompressAndDeserialize(null, 1, CompressionStrategy.NO_OP, "k1");
+      Assert.fail("expected IllegalArgumentException for null rawValue");
+    } catch (IllegalArgumentException expected) {
+      // expected
+    }
+    try {
+      client.decompressAndDeserialize(ByteBuffer.wrap(rawBytes), 1, null, "k1");
+      Assert.fail("expected IllegalArgumentException for null compressionStrategy");
+    } catch (IllegalArgumentException expected) {
+      // expected
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds three Fast Client extension points so an integration layer can react to store-level state changes and so an external storage system holding Venice-format wire bytes can route reads back through the existing decompress + Avro deserialization pipeline:

1. `StoreVersionSwitchListener` — fires when the current serving version changes.
2. `StoreConfigChangeListener` — fires when the store-level config snapshot (currently `batchGetLimit` and `externalStorageReadMode`) changes.
3. `AvroGenericStoreClient#decompressAndDeserialize(rawValue, schemaId, compressionStrategy, key)` — public re-entry point that takes raw value bytes plus the per-version `(schemaId, compressionStrategy)` and returns the typed value, reusing the in-band read path's existing helpers.

## Listeners

Both listeners are registered on `StoreMetadata` and implemented in `AbstractStoreMetadata` (the registries, fire-with-diff helper, and per-listener exception isolation live there; `RequestBasedMetadata` is just the call site).

`StoreVersionSwitchListener`:
- `onVersionSwitch(int previousVersion, int newVersion)`.
- Initial transition reports `previousVersion = -1`.
- `newVersion` may equal `Store.NON_EXISTING_VERSION (0)` for never-pushed stores. Implementations must tolerate that value rather than assume `> 0`.
- Listener exceptions are caught and logged so one bad listener cannot break the refresh loop or other listeners.

`StoreConfigChangeListener`:
- `onStoreConfigChange(StoreConfigSnapshot previous, StoreConfigSnapshot current)`.
- `previous` is `null` for the first refresh after registration, otherwise the prior snapshot.
- `StoreConfigSnapshot` is immutable and value-equal across fields. The fire helper short-circuits when `current.equals(previous)`, so callers don't have to diff.
- The snapshot intentionally only carries store-level state. Current-version flips go through `StoreVersionSwitchListener`. Partition / replica-routing updates that happen on every refresh, even when nothing else changed, are not delivered by either listener today — callers poll `StoreMetadata` for those.

Both `register*Listener` defaults on `StoreMetadata` and the `AbstractStoreMetadata` overrides reject `null` with `IllegalArgumentException` so behavior is consistent across implementations.

## Concurrency model

`RequestBasedMetadata.updateCache(boolean)` is `synchronized` and serves as the cache-mutation boundary. With listener hooks added, two new hazards have to be avoided:

1. A slow / blocking listener running inline would stall every other caller blocked on this monitor.
2. The intended listener contract is that `StoreMetadata#getCurrentStoreVersion()` is safe to call from within the callback. That getter throws when `!isReady()`, so firing the initial callback before `isReady` is set would break the contract.

The implementation:

- `updateCache(boolean)` returns `List<Runnable>` instead of `void`. Inside the synchronized block, the (previousVersion, newVersion) and (previousSnapshot, newSnapshot) transitions are captured into closure-captured locals and the corresponding `fireVersionSwitch` / `fireStoreConfigChange` calls are queued as deferred `Runnable`s.
- `refresh()` then: (a) releases the monitor by returning from the synchronized method, (b) sets `isReady = true` and counts down `isReadyLatch` if this was the first successful refresh, (c) runs the deferred callbacks.

By the time any listener executes, the monitor is no longer held and `isReady` is true. `getCurrentStoreVersion()` from within a callback works, and a slow listener can no longer block subsequent refresh attempts (the monitor is released; the next `refresh()` is gated only by the scheduler).

On the error-recovery path (`ExecutionException` during the outer fetch triggers `discoverD2Service()` + a recursive `updateCache(true)`), only the recovery attempt's pending callbacks are returned. The failed outer attempt produces no committed cache state, so it returns no callbacks; the recursive call's list is propagated up. This avoids firing transition callbacks that don't correspond to the cache's actual final state.

## External-storage deserialization re-entry seam

```java
// AvroGenericStoreClient
default V decompressAndDeserialize(
    ByteBuffer rawValue,
    int schemaId,
    CompressionStrategy compressionStrategy,
    K key) throws VeniceClientException {
  throw new UnsupportedOperationException(...);
}
```

`AbstractAvroStoreClient` overrides this and delegates to the existing private helpers `decompressRecord(...)` and `tryToDeserialize(...)`. There is no duplication of schema lookup, deserializer cache, or compression handling — any future change to the in-band read path propagates automatically.

Design constraints:

- The external read path's transport does not carry Venice routing headers, so the caller has to supply `(schemaId, compressionStrategy)` out-of-band. Both are available per-version: `schemaId` from the value-schema metadata `StoreMetadata` already tracks, `compressionStrategy` from the per-version info already surfaced via `getCompressor(...)`. The `StoreVersionSwitchListener` introduced above is the trigger for an integration layer to recompute these when the version changes.
- The default `throw UnsupportedOperationException` makes the new method opt-in on the `AvroGenericStoreClient` contract — existing non-fast-client implementations and callers are unaffected.
- Null arguments are rejected eagerly with `IllegalArgumentException`. A failing decompression / deserialization surfaces as `VeniceClientException`, the same as the in-band path.

## Tests

- `AbstractStoreMetadataTest`: registration, unregistration, null contract, exception isolation, suppress-when-unchanged for both listener types.
- `RequestBasedMetadataTest`: initial-fire and no-fire-when-unchanged paths drive the deferred-callback list via `.forEach(Runnable::run)` so the test exercises the same dispatch path the production `refresh()` does.
- `StoreConfigSnapshotTest`: value-equality semantics.
- `AbstractAvroStoreClientTest#testDecompressAndDeserializeReEntersStandardPipeline`: round-trips Venice wire bytes through the new seam with `NO_OP` compression; asserts both happy path and null-arg contracts.

## Backwards compatibility

- `decompressAndDeserialize` is a `default` method on `AvroGenericStoreClient` that throws by default; non-fast-client implementations and callers are unaffected.
- Listener registries are no-ops until a caller registers something.
- No on-disk or wire-format changes.