### PR TITLE
[vpj][common][test] Add VPJ dual-write external-storage path with batching and integration test

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.etl.ETLValueSchemaTransformation;
 import com.linkedin.venice.jobs.DataWriterComputeJob;
 import com.linkedin.venice.meta.BufferReplayPolicy;
 import com.linkedin.venice.meta.HybridStoreConfig;
+import com.linkedin.venice.meta.StorageMode;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.schema.vson.VsonSchema;
 import com.linkedin.venice.vpj.VenicePushJobConstants;
@@ -114,6 +115,15 @@ public class PushJobSetting implements Serializable {
   public boolean isChunkingEnabled;
   public boolean isRmdChunkingEnabled;
   public long storeStorageQuota;
+  /**
+   * Storage mode of the new version being pushed to, read from {@code Version.getStorageMode()} after the
+   * controller creates the new version. The version's storageMode is fixed at creation time (the controller
+   * copies the store-level value onto the version per linkedin/venice#2823), so reading the version's value
+   * rather than the store-level value avoids a race where a concurrent UpdateStore mutates the store-level
+   * value between job setup and version creation. Only populated when the VPJ-side dual-write writer-class
+   * is configured; otherwise stays {@link StorageMode#INTERNAL} (the default).
+   */
+  public StorageMode targetStorageMode = StorageMode.INTERNAL;
   public boolean isSchemaAutoRegisterFromPushJobEnabled;
   public CompressionStrategy storeCompressionStrategy;
   public boolean isStoreWriteComputeEnabled;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -61,6 +61,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.PERMISSION_700;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PERMISSION_777;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.POLL_JOB_STATUS_INTERVAL_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.POLL_STATUS_RETRY_ATTEMPTS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_TIMEOUT_OVERRIDE_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_TO_SEPARATE_REALTIME_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
@@ -2637,6 +2638,17 @@ public class VenicePushJob implements AutoCloseable {
     setting.chunkingEnabled = setting.isChunkingEnabled && !Version.isRealTimeTopic(setting.topic);
     setting.rmdChunkingEnabled = setting.chunkingEnabled && setting.isRmdChunkingEnabled;
     setting.kafkaSourceRegion = versionCreationResponse.getKafkaSourceRegion();
+
+    // Resolve the target storage mode from the *new version* (set by the controller at version-creation
+    // time per linkedin/venice#2823), not from the store-level value. The store-level value is mutable
+    // via the UpdateStore admin op and can drift between when VPJ first reads it and when the new
+    // version is created; the version's storageMode is fixed for the life of this push. Skip the extra
+    // round-trip when dual-write isn't even configured on the VPJ side — the gating predicate will
+    // already return false.
+    if (!props.getString(PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS, "").isEmpty()) {
+      Version newVersion = getStoreVersion(setting.storeName, setting.version);
+      setting.targetStorageMode = newVersion.getStorageMode();
+    }
 
     // Detect degraded-mode push from controller response
     Set<String> degradedDcs = versionCreationResponse.getDegradedDatacenters();

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
@@ -31,6 +31,8 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_SOURCE_KEY_SC
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.MAP_REDUCE_PARTITIONER_CLASS_CONFIG;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PARTITION_COUNT;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_PROP_PREFIX;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_TARGET_STORAGE_MODE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_TO_SEPARATE_REALTIME_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REDUCER_SPECULATIVE_EXECUTION_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
@@ -151,6 +153,17 @@ public class DataWriterMRJob extends DataWriterComputeJob {
         conf.set(key, props.getString(key));
       });
     }
+    // Forward every push.job.external.storage.* property to the MR job conf so the partition writer's
+    // gating predicate, buffering logic, and impl-specific configs reach executors — mirrors the Spark
+    // path in AbstractDataWriterSparkJob. Dual-write currently runs through the Spark path for fresh
+    // batch pushes; this keeps MR (the KIF-repush fallback) consistent so a future caller doesn't get
+    // silent dual-write skipping if the same store ever takes the MR code path.
+    for (String key: props.keySet()) {
+      if (key.startsWith(PUSH_JOB_EXTERNAL_STORAGE_PROP_PREFIX)) {
+        conf.set(key, props.getString(key));
+      }
+    }
+    conf.setInt(PUSH_JOB_TARGET_STORAGE_MODE, pushJobSetting.targetStorageMode.getValue());
     conf.setBoolean(ALLOW_DUPLICATE_KEY, pushJobSetting.isDuplicateKeyAllowed);
     conf.setBoolean(VeniceWriter.ENABLE_CHUNKING, pushJobSetting.chunkingEnabled);
     conf.setBoolean(VeniceWriter.ENABLE_RMD_CHUNKING, pushJobSetting.rmdChunkingEnabled);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -8,6 +8,9 @@ import static com.linkedin.venice.guid.GuidUtils.DEFAULT_GUID_GENERATOR_IMPLEMEN
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ALLOW_DUPLICATE_KEY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.COMPRESSION_STRATEGY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_IS_DUPLICATED_KEY_ALLOWED;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DERIVED_SCHEMA_ID_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ENABLE_WRITE_COMPUTE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
@@ -16,6 +19,11 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WR
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_TIME_WINDOW_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_COMPRESSION_STRATEGY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_TARGET_STORAGE_MODE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_TO_SEPARATE_REALTIME_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_DIR;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_ID_PROP;
@@ -45,6 +53,7 @@ import com.linkedin.venice.hadoop.engine.EngineTaskConfigProvider;
 import com.linkedin.venice.hadoop.input.kafka.KafkaInputUtils;
 import com.linkedin.venice.hadoop.schema.HDFSSchemaSource;
 import com.linkedin.venice.hadoop.task.TaskTracker;
+import com.linkedin.venice.meta.StorageMode;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
@@ -71,6 +80,7 @@ import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.views.MaterializedView;
 import com.linkedin.venice.views.VeniceView;
 import com.linkedin.venice.views.ViewUtils;
+import com.linkedin.venice.vpj.ExternalStorageWriteUtils;
 import com.linkedin.venice.writer.AbstractVeniceWriter;
 import com.linkedin.venice.writer.ComplexVeniceWriter;
 import com.linkedin.venice.writer.DeleteMetadata;
@@ -568,9 +578,10 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
             .setMaxRecordSizeBytes(Integer.parseInt(maxRecordSizeBytesStr))
             .build();
     String flatViewConfigMapString = props.getString(PUSH_JOB_VIEW_CONFIGS, "");
+    AbstractVeniceWriter<byte[], byte[], byte[]> baseWriter;
     if (!flatViewConfigMapString.isEmpty()) {
       mainWriter = veniceWriterFactoryFactory.createVeniceWriter(options);
-      return createCompositeVeniceWriter(
+      baseWriter = createCompositeVeniceWriter(
           veniceWriterFactoryFactory,
           mainWriter,
           flatViewConfigMapString,
@@ -578,7 +589,81 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
           chunkingEnabled,
           rmdChunkingEnabled);
     } else {
-      return veniceWriterFactoryFactory.createVeniceWriter(options);
+      baseWriter = veniceWriterFactoryFactory.createVeniceWriter(options);
+    }
+    return maybeDecorateForDualWriteToExternalStorage(baseWriter, topicName);
+  }
+
+  /**
+   * If the VPJ dual-write external-storage gate is on, reflectively load the configured
+   * {@link ExternalStorageWriter} impl, configure it for this task, and wrap {@code baseWriter} so each
+   * record lands in both Venice and the external sink. Otherwise return {@code baseWriter} unchanged.
+   */
+  private AbstractVeniceWriter<byte[], byte[], byte[]> maybeDecorateForDualWriteToExternalStorage(
+      AbstractVeniceWriter<byte[], byte[], byte[]> baseWriter,
+      String topicName) {
+    StorageMode targetStorageMode =
+        StorageMode.valueOf(props.getInt(PUSH_JOB_TARGET_STORAGE_MODE, StorageMode.INTERNAL.getValue()));
+    if (!ExternalStorageWriteUtils.isDualWriteToExternalStorageFromVpjEnabled(props, targetStorageMode)) {
+      return baseWriter;
+    }
+    // From here on, anything that throws must release the already-constructed Kafka-side writers
+    // ({@code baseWriter} for the no-views case; {@code mainWriter} + {@code childWriters} for the
+    // composite-view case). The reflective loader closes the external writer itself on configure failure,
+    // but the Kafka side isn't protected by it. Wrap the whole decoration so a retry-prone Spark task
+    // doesn't pile up Kafka producer leaks across attempts.
+    try {
+      // Validate the buffer threshold and retry policy before touching the impl so a bad config can't
+      // allocate (and then leak) external resources.
+      int batchSize = props.getInt(PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE, DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE);
+      if (batchSize < 1) {
+        throw new VeniceException(PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE + " must be >= 1, got " + batchSize);
+      }
+      int batchPutRetries =
+          props.getInt(PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES, DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES);
+      if (batchPutRetries < 0) {
+        throw new VeniceException(PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES + " must be >= 0, got " + batchPutRetries);
+      }
+      long batchPutRetryBackoffMs = props.getLong(
+          PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS,
+          DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS);
+      if (batchPutRetryBackoffMs < 0) {
+        throw new VeniceException(
+            PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS + " must be >= 0, got " + batchPutRetryBackoffMs);
+      }
+      String writerClassName = props.getString(PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS);
+      int partitionId = getEngineTaskConfigProvider().getTaskId();
+      // loadAndConfigure validates the class implements ExternalStorageWriter, instantiates it, and closes
+      // the impl on configure() failure so partially-initialized writers don't leak.
+      ExternalStorageWriter externalWriter =
+          ExternalStorageWriteUtils.loadAndConfigure(writerClassName, props, topicName, partitionId);
+      LOGGER.info(
+          "Dual-write to external storage enabled for topic {} partition {} via impl {} "
+              + "(batchSize={}, batchPutRetries={}, batchPutRetryBackoffMs={})",
+          topicName,
+          partitionId,
+          writerClassName,
+          batchSize,
+          batchPutRetries,
+          batchPutRetryBackoffMs);
+      return new DualWriteVeniceWriter(
+          topicName,
+          baseWriter,
+          externalWriter,
+          batchSize,
+          batchPutRetries,
+          batchPutRetryBackoffMs);
+    } catch (RuntimeException t) {
+      Utils.closeQuietlyWithErrorLogged(baseWriter);
+      if (mainWriter != null) {
+        Utils.closeQuietlyWithErrorLogged(mainWriter);
+      }
+      if (childWriters != null) {
+        for (AbstractVeniceWriter<byte[], byte[], byte[]> child: childWriters) {
+          Utils.closeQuietlyWithErrorLogged(child);
+        }
+      }
+      throw t;
     }
   }
 
@@ -710,23 +795,63 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
       logMessageProgress();
       if (veniceWriter != null) {
         boolean shouldEndAllSegments = false;
+        IOException closeError = null;
         try {
-          veniceWriter.flush();
-          shouldEndAllSegments = messageErrored.get() == 0 && messageSent == messageCompleted.get()
-              && (dataWriterTaskTracker == null || dataWriterTaskTracker.getProgress() == TaskTracker.PROGRESS_COMPLETED
-                  || dataWriterTaskTracker.getProgress() == TaskTracker.PROGRESS_NOT_SUPPORTED);
-        } finally {
-          veniceWriter.close(shouldEndAllSegments);
-        }
-        if (veniceWriter instanceof CompositeVeniceWriter) {
-          if (childWriters != null) {
-            for (AbstractVeniceWriter childWriter: childWriters) {
-              childWriter.close(shouldEndAllSegments);
+          try {
+            veniceWriter.flush();
+            shouldEndAllSegments = messageErrored.get() == 0 && messageSent == messageCompleted.get()
+                && (dataWriterTaskTracker == null
+                    || dataWriterTaskTracker.getProgress() == TaskTracker.PROGRESS_COMPLETED
+                    || dataWriterTaskTracker.getProgress() == TaskTracker.PROGRESS_NOT_SUPPORTED);
+          } finally {
+            try {
+              veniceWriter.close(shouldEndAllSegments);
+            } catch (IOException e) {
+              closeError = e;
             }
           }
+        } finally {
+          // When views are configured we also need to close the per-view child writers and the inner
+          // main version-topic writer. Check {@code mainWriter != null} rather than
+          // {@code veniceWriter instanceof CompositeVeniceWriter} so the cleanup still runs when the
+          // composite is wrapped by a {@link DualWriteVeniceWriter} (dual-write + views combination).
+          // {@code mainWriter} is non-null iff {@code createBasicVeniceWriter} took the composite
+          // branch. The cleanup runs in this {@code finally} so that an exception from
+          // {@code veniceWriter.close(...)} above (e.g. an {@link IOException} bubbling out of
+          // {@code ExternalStorageWriter.close()} via {@code DualWriteVeniceWriter}) does not orphan
+          // the underlying view writers. Cascading errors are attached to the first one via
+          // {@link Throwable#addSuppressed}.
           if (mainWriter != null) {
-            mainWriter.close(shouldEndAllSegments);
+            if (childWriters != null) {
+              for (AbstractVeniceWriter childWriter: childWriters) {
+                try {
+                  childWriter.close(shouldEndAllSegments);
+                } catch (IOException | RuntimeException e) {
+                  if (closeError == null) {
+                    closeError = e instanceof IOException ? (IOException) e : new IOException(e);
+                  } else {
+                    closeError.addSuppressed(e);
+                  }
+                }
+              }
+            }
+            try {
+              mainWriter.close(shouldEndAllSegments);
+            } catch (Exception e) {
+              // Static type {@code VeniceWriter.close(boolean)} doesn't declare {@link IOException},
+              // so this catch is currently {@link RuntimeException}-shaped, but use {@link Exception}
+              // so a future change that introduces a checked close exception (or a wrapped runtime
+              // surface from a Closeable resource) still ends up in the suppression chain.
+              if (closeError == null) {
+                closeError = e instanceof IOException ? (IOException) e : new IOException(e);
+              } else {
+                closeError.addSuppressed(e);
+              }
+            }
           }
+        }
+        if (closeError != null) {
+          throw closeError;
         }
       }
       maybePropagateCallbackException();

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriter.java
@@ -1,0 +1,387 @@
+package com.linkedin.venice.hadoop.task.datawriter;
+
+import com.linkedin.venice.pubsub.api.PubSubProduceResult;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
+import com.linkedin.venice.utils.ByteUtils;
+import com.linkedin.venice.writer.AbstractVeniceWriter;
+import com.linkedin.venice.writer.DeleteMetadata;
+import com.linkedin.venice.writer.PutMetadata;
+import com.linkedin.venice.writer.VeniceWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Wraps a Kafka-backed {@link AbstractVeniceWriter} and an {@link ExternalStorageWriter} so each batch-push
+ * record is written to the external sink first and then produced to Kafka. The Kafka future is what the
+ * caller waits on for at-least-once semantics; external-sink durability is synchronous from the caller's
+ * point of view, so a failed external write throws before the Kafka produce starts and the Spark task is
+ * retried.
+ *
+ * <p>The writer buffers up to {@code batchSize} consecutive put records and flushes them as a single
+ * {@link ExternalStorageWriter#batchPut(List)} before the corresponding Kafka produces fire. {@code
+ * batchSize = 1} (the default) disables buffering: every record is forwarded immediately as a one-element
+ * batch, matching pre-batching semantics. {@link #flush} and {@link #close} drain any pending buffer before
+ * doing their own work, so the producer's record ordering is preserved.
+ *
+ * <p>{@code update} and {@code delete} are not supported — batch pushes from clean input never call either.
+ * Both throw {@link UnsupportedOperationException} so a stray invocation fails the Spark task loudly rather
+ * than silently leaving the external sink and Venice in divergent states.
+ */
+public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], byte[]> {
+  private static final Logger LOGGER = LogManager.getLogger(DualWriteVeniceWriter.class);
+
+  private final AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter;
+  private final ExternalStorageWriter externalWriter;
+  private final int batchSize;
+  private final int batchPutRetries;
+  private final long batchPutRetryBackoffMs;
+  private final List<BufferedPut> putBuffer;
+
+  /**
+   * Convenience constructor for callers that don't need the buffered retry policy (e.g. unit tests that
+   * exercise the wrapper's other behaviors). {@code batchPutRetries = 0} means one attempt, original
+   * throw propagates immediately.
+   */
+  public DualWriteVeniceWriter(
+      String topicName,
+      AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter,
+      ExternalStorageWriter externalWriter,
+      int batchSize) {
+    this(topicName, kafkaWriter, externalWriter, batchSize, 0, 0L);
+  }
+
+  public DualWriteVeniceWriter(
+      String topicName,
+      AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter,
+      ExternalStorageWriter externalWriter,
+      int batchSize,
+      int batchPutRetries,
+      long batchPutRetryBackoffMs) {
+    super(topicName);
+    if (batchSize < 1) {
+      throw new IllegalArgumentException("batchSize must be >= 1, got " + batchSize);
+    }
+    if (batchPutRetries < 0) {
+      throw new IllegalArgumentException("batchPutRetries must be >= 0, got " + batchPutRetries);
+    }
+    if (batchPutRetryBackoffMs < 0) {
+      throw new IllegalArgumentException("batchPutRetryBackoffMs must be >= 0, got " + batchPutRetryBackoffMs);
+    }
+    this.kafkaWriter = kafkaWriter;
+    this.externalWriter = externalWriter;
+    this.batchSize = batchSize;
+    this.batchPutRetries = batchPutRetries;
+    this.batchPutRetryBackoffMs = batchPutRetryBackoffMs;
+    this.putBuffer = new ArrayList<>(batchSize);
+  }
+
+  @Override
+  public CompletableFuture<PubSubProduceResult> put(
+      byte[] key,
+      byte[] value,
+      int valueSchemaId,
+      PubSubProducerCallback callback) {
+    return bufferPut(new BufferedPut(key, value, valueSchemaId, VeniceWriter.APP_DEFAULT_LOGICAL_TS, callback, null));
+  }
+
+  @Override
+  public CompletableFuture<PubSubProduceResult> put(
+      byte[] key,
+      byte[] value,
+      int valueSchemaId,
+      long logicalTimestamp,
+      PubSubProducerCallback callback) {
+    return bufferPut(new BufferedPut(key, value, valueSchemaId, logicalTimestamp, callback, null));
+  }
+
+  @Override
+  public CompletableFuture<PubSubProduceResult> put(
+      byte[] key,
+      byte[] value,
+      int valueSchemaId,
+      PubSubProducerCallback callback,
+      PutMetadata putMetadata) {
+    return bufferPut(
+        new BufferedPut(key, value, valueSchemaId, VeniceWriter.APP_DEFAULT_LOGICAL_TS, callback, putMetadata));
+  }
+
+  @Override
+  public CompletableFuture<PubSubProduceResult> put(
+      byte[] key,
+      byte[] value,
+      int valueSchemaId,
+      long logicalTimestamp,
+      PubSubProducerCallback callback,
+      PutMetadata putMetadata) {
+    return bufferPut(new BufferedPut(key, value, valueSchemaId, logicalTimestamp, callback, putMetadata));
+  }
+
+  @Override
+  public CompletableFuture<PubSubProduceResult> delete(byte[] key, PubSubProducerCallback callback) {
+    throw new UnsupportedOperationException(
+        getClass().getSimpleName() + " does not support delete — dual-write to external storage targets "
+            + "batch-only stores from clean batch-push input, which never call delete()");
+  }
+
+  @Override
+  public CompletableFuture<PubSubProduceResult> delete(
+      byte[] key,
+      long logicalTimestamp,
+      PubSubProducerCallback callback) {
+    throw new UnsupportedOperationException(
+        getClass().getSimpleName() + " does not support delete — dual-write to external storage targets "
+            + "batch-only stores from clean batch-push input, which never call delete()");
+  }
+
+  @Override
+  public CompletableFuture<PubSubProduceResult> delete(
+      byte[] key,
+      PubSubProducerCallback callback,
+      DeleteMetadata deleteMetadata) {
+    throw new UnsupportedOperationException(
+        getClass().getSimpleName() + " does not support delete — dual-write to external storage targets "
+            + "batch-only stores from clean batch-push input, which never call delete()");
+  }
+
+  @Override
+  public Future<PubSubProduceResult> update(
+      byte[] key,
+      byte[] update,
+      int valueSchemaId,
+      int derivedSchemaId,
+      PubSubProducerCallback callback) {
+    throw new UnsupportedOperationException(getClass().getSimpleName() + " does not support update");
+  }
+
+  @Override
+  public CompletableFuture<PubSubProduceResult> update(
+      byte[] key,
+      byte[] update,
+      int valueSchemaId,
+      int derivedSchemaId,
+      long logicalTimestamp,
+      PubSubProducerCallback callback) {
+    throw new UnsupportedOperationException(getClass().getSimpleName() + " does not support update");
+  }
+
+  @Override
+  public void flush() {
+    drainBuffer();
+    externalWriter.flush();
+    kafkaWriter.flush();
+  }
+
+  @Override
+  public void close() throws IOException {
+    close(true);
+  }
+
+  @Override
+  public void close(boolean gracefulClose) throws IOException {
+    IOException firstError = null;
+    // Self-flush so close() alone is sufficient to meet the ExternalStorageWriter lifecycle contract:
+    // drains the wrapper's buffer and forces externalWriter.flush() + kafkaWriter.flush() before either
+    // is closed. AbstractPartitionWriter.close() also calls flush() explicitly before close(), but
+    // self-flushing here protects any caller that uses the wrapper in a different lifecycle.
+    try {
+      flush();
+    } catch (RuntimeException e) {
+      firstError = new IOException("Failed to flush before close", e);
+    }
+    try {
+      externalWriter.close();
+    } catch (IOException | RuntimeException e) {
+      // External impls are pluggable — an unchecked throw must not skip kafkaWriter.close() below,
+      // otherwise the Kafka producer leaks during task shutdown.
+      IOException wrapped = e instanceof IOException ? (IOException) e : new IOException(e);
+      if (firstError == null) {
+        firstError = wrapped;
+      } else {
+        firstError.addSuppressed(wrapped);
+      }
+    }
+    try {
+      kafkaWriter.close(gracefulClose);
+    } catch (IOException | RuntimeException e) {
+      IOException wrapped = e instanceof IOException ? (IOException) e : new IOException(e);
+      if (firstError == null) {
+        firstError = wrapped;
+      } else {
+        firstError.addSuppressed(wrapped);
+      }
+    }
+    if (firstError != null) {
+      throw firstError;
+    }
+  }
+
+  /** Visible for testing — current buffered-but-not-yet-flushed put count. */
+  int getBufferedPutCount() {
+    return putBuffer.size();
+  }
+
+  private CompletableFuture<PubSubProduceResult> bufferPut(BufferedPut record) {
+    putBuffer.add(record);
+    if (putBuffer.size() >= batchSize) {
+      return drainBuffer();
+    }
+    // Partial batch — return the placeholder; it will be completed when drainBuffer() runs.
+    return record.future;
+  }
+
+  /**
+   * Writes the buffered puts to the external sink as one {@code batchPut}, then forwards each record to
+   * the Kafka writer in order. Returns the future of the last buffered record so the on-threshold path of
+   * {@link #bufferPut} can return it to the caller. Returns {@code null} when the buffer is empty.
+   *
+   * <p>The body is wrapped in {@code try/catch/finally} so that on any throw — from
+   * {@code externalWriter.batchPut} OR from a synchronous failure inside {@code invokeKafkaPut} — every
+   * buffered record's placeholder future is completed exceptionally and the buffer is cleared. Without
+   * this, a failure would leave the buffer dirty; a subsequent {@code close()} (which self-flushes via
+   * {@code flush() → drainBuffer()}) would replay the same records, contradicting the at-least-once-then-
+   * retry contract.
+   */
+  private CompletableFuture<PubSubProduceResult> drainBuffer() {
+    if (putBuffer.isEmpty()) {
+      return null;
+    }
+    List<ExternalStorageRecord> externalRecords = new ArrayList<>(putBuffer.size());
+    for (BufferedPut buffered: putBuffer) {
+      externalRecords.add(new ExternalStorageRecord(buffered.key, toRocksDbFormattedValue(buffered)));
+    }
+    CompletableFuture<PubSubProduceResult> last = null;
+    try {
+      batchPutWithRetry(externalRecords);
+      for (BufferedPut buffered: putBuffer) {
+        CompletableFuture<PubSubProduceResult> kafkaFuture = invokeKafkaPut(buffered);
+        kafkaFuture.whenComplete((result, error) -> {
+          if (error != null) {
+            buffered.future.completeExceptionally(error);
+          } else {
+            buffered.future.complete(result);
+          }
+        });
+        last = buffered.future;
+      }
+      return last;
+    } catch (Throwable t) {
+      // Complete every pending future exceptionally so callers awaiting them see the failure. CompletableFuture
+      // is idempotent on complete/completeExceptionally — futures already linked to a Kafka future in the loop
+      // above will be unaffected by this call.
+      for (BufferedPut buffered: putBuffer) {
+        buffered.future.completeExceptionally(t);
+      }
+      throw t;
+    } finally {
+      // Always clear the buffer so the next drainBuffer() (e.g. close() self-flushing after this failure)
+      // does not replay the same records to the external sink.
+      putBuffer.clear();
+    }
+  }
+
+  /**
+   * Invoke {@code externalWriter.batchPut(records)} with bounded retry. Up to {@code batchPutRetries + 1}
+   * attempts total, with a {@code batchPutRetryBackoffMs} fixed sleep between attempts. The original
+   * (first) failure is preserved as the thrown exception; later failures are attached via
+   * {@code addSuppressed} so operators can see the full retry pattern in the executor log.
+   *
+   * <p>Interruption during the backoff sleep aborts the retry — the executor wants to shut down — and
+   * surfaces the original failure with the {@link InterruptedException} suppressed.
+   */
+  private void batchPutWithRetry(List<ExternalStorageRecord> records) {
+    int attempts = batchPutRetries + 1;
+    RuntimeException lastError = null;
+    for (int attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        externalWriter.batchPut(records);
+        if (attempt > 1) {
+          LOGGER.info("externalWriter.batchPut succeeded on attempt {}/{}", attempt, attempts);
+        }
+        return;
+      } catch (RuntimeException e) {
+        if (lastError == null) {
+          lastError = e;
+        } else {
+          lastError.addSuppressed(e);
+        }
+        if (attempt < attempts) {
+          LOGGER.warn(
+              "externalWriter.batchPut failed on attempt {}/{}; retrying after {}ms",
+              attempt,
+              attempts,
+              batchPutRetryBackoffMs,
+              e);
+          if (batchPutRetryBackoffMs > 0) {
+            try {
+              Thread.sleep(batchPutRetryBackoffMs);
+            } catch (InterruptedException ie) {
+              Thread.currentThread().interrupt();
+              lastError.addSuppressed(ie);
+              throw lastError;
+            }
+          }
+        }
+      }
+    }
+    throw lastError;
+  }
+
+  /**
+   * Build a value blob matching Venice's RocksDB on-disk format: 4-byte big-endian schema id followed by
+   * the compressed Avro payload. A reader pulling from the external sink reassembles the same logical bytes
+   * a Venice client sees, regardless of whether the value was chunked for Kafka transport.
+   */
+  private static byte[] toRocksDbFormattedValue(BufferedPut bp) {
+    byte[] formatted = new byte[ExternalStorageRecord.SCHEMA_ID_PREFIX_LENGTH + bp.value.length];
+    ByteUtils.writeInt(formatted, bp.valueSchemaId, 0);
+    System.arraycopy(bp.value, 0, formatted, ExternalStorageRecord.SCHEMA_ID_PREFIX_LENGTH, bp.value.length);
+    return formatted;
+  }
+
+  private CompletableFuture<PubSubProduceResult> invokeKafkaPut(BufferedPut bp) {
+    boolean hasMetadata = bp.putMetadata != null;
+    boolean hasTimestamp = bp.logicalTimestamp != VeniceWriter.APP_DEFAULT_LOGICAL_TS;
+    if (hasMetadata && hasTimestamp) {
+      return kafkaWriter.put(bp.key, bp.value, bp.valueSchemaId, bp.logicalTimestamp, bp.callback, bp.putMetadata);
+    }
+    if (hasMetadata) {
+      return kafkaWriter.put(bp.key, bp.value, bp.valueSchemaId, bp.callback, bp.putMetadata);
+    }
+    if (hasTimestamp) {
+      return kafkaWriter.put(bp.key, bp.value, bp.valueSchemaId, bp.logicalTimestamp, bp.callback);
+    }
+    return kafkaWriter.put(bp.key, bp.value, bp.valueSchemaId, bp.callback);
+  }
+
+  private static final class BufferedPut {
+    final byte[] key;
+    final byte[] value;
+    final int valueSchemaId;
+    final long logicalTimestamp;
+    final PubSubProducerCallback callback;
+    final PutMetadata putMetadata;
+    final CompletableFuture<PubSubProduceResult> future;
+
+    BufferedPut(
+        byte[] key,
+        byte[] value,
+        int valueSchemaId,
+        long logicalTimestamp,
+        PubSubProducerCallback callback,
+        PutMetadata putMetadata) {
+      this.key = key;
+      this.value = value;
+      this.valueSchemaId = valueSchemaId;
+      this.logicalTimestamp = logicalTimestamp;
+      this.callback = callback;
+      this.putMetadata = putMetadata;
+      this.future = new CompletableFuture<>();
+    }
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/ExternalStorageRecord.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/ExternalStorageRecord.java
@@ -1,0 +1,42 @@
+package com.linkedin.venice.hadoop.task.datawriter;
+
+/**
+ * Immutable carrier passed to {@link ExternalStorageWriter#batchPut(java.util.List)}. Holds one record's
+ * serialized key and a value blob whose layout matches Venice's on-disk format in RocksDB:
+ *
+ * <pre>
+ *   value = [4-byte big-endian value schema id] [compressed Avro value bytes]
+ * </pre>
+ *
+ * <p>Implementations can either store the value as-is (an external reader uses the same logical reassembly
+ * that Venice clients do — read first 4 bytes for the schema id, decompress the rest with the schema) or
+ * split out the schema id by parsing the prefix locally. Either way, a reader pulling from the external
+ * sink will see the same logical bytes a Venice client would observe after RocksDB's chunked-value
+ * reassembly: the chunking that Venice does for Kafka transport is invisible at this seam.
+ *
+ * <p>Byte arrays are passed through by reference for efficiency and must not be mutated by the implementation.
+ */
+public final class ExternalStorageRecord {
+  /** Length of the 4-byte big-endian schema id prefix on every value. */
+  public static final int SCHEMA_ID_PREFIX_LENGTH = Integer.BYTES;
+
+  private final byte[] key;
+  private final byte[] value;
+
+  public ExternalStorageRecord(byte[] key, byte[] value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  public byte[] getKey() {
+    return key;
+  }
+
+  /**
+   * Returns the value with the 4-byte big-endian schema id prefix in front of the Avro payload. The schema id
+   * can be parsed from the first {@link #SCHEMA_ID_PREFIX_LENGTH} bytes.
+   */
+  public byte[] getValue() {
+    return value;
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/ExternalStorageWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/ExternalStorageWriter.java
@@ -1,0 +1,54 @@
+package com.linkedin.venice.hadoop.task.datawriter;
+
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.Closeable;
+import java.util.List;
+
+
+/**
+ * VPJ-side dual-write sink. The Venice Push Job invokes implementations of this interface alongside Kafka
+ * produce so that each record lands both in Venice and in a configured external storage system.
+ *
+ * <p>Lifecycle (one instance per Spark/MR partition writer task):
+ * <ol>
+ *   <li>{@link #configure(VeniceProperties, String, int)} once, right after no-arg construction.</li>
+ *   <li>{@link #batchPut(List)} per buffered batch of records. The wrapper guarantees records inside a
+ *       single batch are in the same order as they were submitted; ordering across batches is preserved as
+ *       well.</li>
+ *   <li>{@link #flush()} once, before {@link #close()}, to force durability of any buffered records.</li>
+ *   <li>{@link #close()} once.</li>
+ * </ol>
+ *
+ * <p>Implementations are loaded reflectively by class name from the VPJ config key
+ * {@code push.job.external.storage.writer.class}. Must have a public no-arg constructor. Must be idempotent
+ * on key — Spark task retries can replay a partition.
+ *
+ * <p>{@code batchPut} is <em>synchronous from the caller's point of view</em>: it must throw on durable-write
+ * failure so the Spark task fails and is retried. Implementations may buffer internally as long as
+ * {@link #flush()} drains.
+ *
+ * <p><b>Deletes are not part of this SPI.</b> Dual-write to external storage targets batch-only stores from
+ * clean batch-push input, where every record carries a non-null value and no delete is ever produced
+ * (Venice's batch-push path only emits deletes for KIF repush with TTL tombstones, which is out of scope for
+ * dual-write). The {@link DualWriteVeniceWriter} that wraps this SPI throws
+ * {@link UnsupportedOperationException} from its {@code delete} overrides so a stray delete fails the Spark
+ * task loudly rather than silently leaving the external sink in a divergent state.
+ */
+public interface ExternalStorageWriter extends Closeable {
+  /**
+   * Called once on the executor after no-arg construction. Implementations should read whatever job-level
+   * configuration they need from {@code jobProps} and prepare any per-task resources (connection pools,
+   * output paths, etc.).
+   */
+  void configure(VeniceProperties jobProps, String topicName, int partitionId);
+
+  /**
+   * Durable bulk-write of {@code records}. The list may contain one or more records; an empty list is a
+   * no-op. Implementations should treat this as a synchronous write — return only after every record is
+   * durable, or throw.
+   */
+  void batchPut(List<ExternalStorageRecord> records);
+
+  /** Force durability of any buffered records. Called by the partition writer before {@link #close()}. */
+  void flush();
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -47,6 +47,8 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_TOPIC_CHUNKING_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PARTITION_COUNT;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_PROP_PREFIX;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_TARGET_STORAGE_MODE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_TO_SEPARATE_REALTIME_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_POLICY;
@@ -336,6 +338,22 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
       jobConf.set(VALUE_SCHEMA_DIR, pushJobSetting.valueSchemaDir);
       jobConf.set(RMD_SCHEMA_DIR, pushJobSetting.rmdSchemaDir);
     }
+
+    // Forward every push.job.external.storage.* property to the Spark RuntimeConfig so the partition
+    // writer's gating predicate and buffering logic — and impl-specific configs the configured
+    // ExternalStorageWriter reads in its configure() method (cluster endpoints, credentials, table
+    // mappings, etc.) — reach the executor task properties. OSS Venice does not interpret the
+    // impl-specific keys beyond the two gating ones; everything else is opaque pass-through.
+    for (String key: props.keySet()) {
+      if (key.startsWith(PUSH_JOB_EXTERNAL_STORAGE_PROP_PREFIX)) {
+        jobConf.set(key, props.getString(key));
+      }
+    }
+    // Target storage mode is always set: pushJobSetting.targetStorageMode is initialized to INTERNAL and
+    // populated from the controller at job setup, so the partition writer can rely on its presence. The
+    // key does not live under the push.job.external.storage.* prefix because it is OSS-owned, not
+    // impl-specific.
+    jobConf.set(PUSH_JOB_TARGET_STORAGE_MODE, pushJobSetting.targetStorageMode.getValue());
 
     // Incremental push throttling configs - pass through to partition writer
     jobConf.set(INCREMENTAL_PUSH, pushJobSetting.isIncrementalPush);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/ExternalStorageWriteUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/ExternalStorageWriteUtils.java
@@ -1,0 +1,96 @@
+package com.linkedin.venice.vpj;
+
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.hadoop.task.datawriter.ExternalStorageWriter;
+import com.linkedin.venice.meta.StorageMode;
+import com.linkedin.venice.utils.ReflectUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+
+
+/**
+ * Helpers for the VPJ external-storage dual-write path: the gating predicate, the typed reflective loader
+ * for {@link ExternalStorageWriter} impls, and the load+configure helper that ensures the impl is closed
+ * if configuration fails.
+ */
+public final class ExternalStorageWriteUtils {
+  private ExternalStorageWriteUtils() {
+  }
+
+  /**
+   * Returns true iff both halves of the dual-write gate are satisfied:
+   * <ul>
+   *   <li>The VPJ-side {@code push.job.external.storage.writer.class} config is set to a non-empty value
+   *       (i.e. an implementation is wired in for this push).</li>
+   *   <li>The store-version-side {@code targetStorageMode} is {@link StorageMode#DUAL_WRITE} (i.e. the
+   *       version being pushed to has opted into dual-write at the store level).</li>
+   * </ul>
+   * Either half missing means the path stays off and the partition writer falls back to today's Kafka-only
+   * produce.
+   */
+  public static boolean isDualWriteToExternalStorageFromVpjEnabled(
+      VeniceProperties jobProps,
+      StorageMode targetStorageMode) {
+    if (jobProps == null || targetStorageMode == null) {
+      return false;
+    }
+    if (jobProps.getString(PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS, "").isEmpty()) {
+      return false;
+    }
+    return targetStorageMode == StorageMode.DUAL_WRITE;
+  }
+
+  /**
+   * Reflectively load and instantiate an {@link ExternalStorageWriter} implementation, validating that the
+   * configured class actually implements the interface before invoking its no-arg constructor.
+   *
+   * @throws VeniceException with a precise message when the class cannot be loaded, does not implement the
+   *           SPI, or cannot be instantiated. Wrapping the underlying causes keeps stack traces useful while
+   *           surfacing the configured class name in the message for operators triaging mis-configured pushes.
+   */
+  public static ExternalStorageWriter loadExternalStorageWriter(String className) {
+    Class<?> loadedClass;
+    try {
+      loadedClass = ReflectUtils.loadClass(className);
+    } catch (Exception e) {
+      throw new VeniceException(
+          "Failed to load " + ExternalStorageWriter.class.getSimpleName() + " class '" + className + "'",
+          e);
+    }
+    if (!ExternalStorageWriter.class.isAssignableFrom(loadedClass)) {
+      throw new VeniceException(
+          "Configured class '" + className + "' does not implement " + ExternalStorageWriter.class.getName());
+    }
+    try {
+      @SuppressWarnings("unchecked")
+      Class<ExternalStorageWriter> typedClass = (Class<ExternalStorageWriter>) loadedClass;
+      return ReflectUtils.callConstructor(typedClass, new Class<?>[0], new Object[0]);
+    } catch (Exception e) {
+      throw new VeniceException(
+          "Failed to instantiate " + ExternalStorageWriter.class.getSimpleName() + " '" + className + "'",
+          e);
+    }
+  }
+
+  /**
+   * Load the configured {@link ExternalStorageWriter} and invoke {@link ExternalStorageWriter#configure}.
+   * If {@code configure} throws, the partially-constructed writer is closed (best-effort) before the
+   * exception is propagated, so executor tasks do not leak connection pools / file handles / etc.
+   */
+  public static ExternalStorageWriter loadAndConfigure(
+      String className,
+      VeniceProperties jobProps,
+      String topicName,
+      int partitionId) {
+    ExternalStorageWriter writer = loadExternalStorageWriter(className);
+    try {
+      writer.configure(jobProps, topicName, partitionId);
+      return writer;
+    } catch (RuntimeException e) {
+      Utils.closeQuietlyWithErrorLogged(writer);
+      throw e;
+    }
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -494,6 +494,67 @@ public final class VenicePushJobConstants {
    */
   public static final String DATA_WRITER_COMPUTE_JOB_CLASS = "data.writer.compute.job.class";
 
+  /**
+   * Namespace for the external-storage dual-write subsystem. Every property whose key starts with this
+   * prefix is forwarded verbatim from the VPJ driver into the Spark executor's {@code RuntimeConfig} so
+   * that impls of {@code ExternalStorageWriter} can read their own configuration (cluster endpoints,
+   * credentials, table mappings, timeouts, etc.) from {@code VeniceProperties} inside {@code configure()}.
+   * <p>OSS Venice interprets a small set of keys under this prefix directly:
+   * <ul>
+   *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS} — gating: impl class name</li>
+   *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE} — buffer threshold for the dual-write wrapper</li>
+   *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES} — bounded retry count for {@code batchPut}</li>
+   *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS} — sleep between retry attempts</li>
+   * </ul>
+   * Any other key under this prefix is opaque pass-through and is the responsibility of the impl to
+   * interpret. Operators should not assume new OSS-owned keys will appear here without a release note.
+   */
+  public static final String PUSH_JOB_EXTERNAL_STORAGE_PROP_PREFIX = "push.job.external.storage.";
+
+  /**
+   * Fully-qualified class name of the external storage writer used by the VPJ dual-write path. The class must
+   * implement {@code com.linkedin.venice.hadoop.task.datawriter.ExternalStorageWriter}. Presence of a non-empty
+   * value here is the VPJ-side half of the dual-write gating predicate; the store-version-side half is
+   * {@code Version.getStorageMode() == StorageMode.DUAL_WRITE}.
+   */
+  public static final String PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS = "push.job.external.storage.writer.class";
+
+  /**
+   * Maximum number of records the VPJ partition writer buffers before calling
+   * {@code ExternalStorageWriter.batchPut(...)}. {@code 1} (the default) disables buffering — every record is
+   * forwarded to the external sink immediately via a single-element {@code batchPut}, matching pre-batching
+   * semantics. Values greater than {@code 1} accumulate up to {@code N} records per task, then flush as one
+   * batchPut before the corresponding Kafka produces fire. Any partial batch is drained on {@code flush()}.
+   */
+  public static final String PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE = "push.job.external.storage.batch.size";
+  public static final int DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE = 1;
+
+  /**
+   * Number of retries the dual-write wrapper performs on a failing {@code ExternalStorageWriter.batchPut}
+   * call before letting the exception propagate (which fails the Spark task and triggers a whole-partition
+   * replay). {@code 3} retries (4 attempts total) is a conservative default that absorbs transient
+   * network blips on the external sink without burning Spark task attempts. Set to {@code 0} to opt out
+   * (single attempt, original throw propagates immediately).
+   */
+  public static final String PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES = "push.job.external.storage.batchput.retries";
+  public static final int DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES = 3;
+
+  /**
+   * Backoff between {@code batchPut} retry attempts in milliseconds. Fixed (not exponential) — operators
+   * can tune via this knob if exponential is later proven necessary.
+   */
+  public static final String PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS =
+      "push.job.external.storage.batchput.retry.backoff.ms";
+  public static final long DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS = 1000L;
+
+  /**
+   * Integer-encoded {@link com.linkedin.venice.meta.StorageMode} of the version being pushed to. Set by the
+   * VPJ driver from the store-level storage mode at job setup, propagated to each Spark executor's task
+   * properties, and consulted by the dual-write gating predicate so that the path only engages when the
+   * target version's storage mode is {@code DUAL_WRITE}. Defaults to {@code INTERNAL} (value {@code 0}).
+   */
+  public static final String PUSH_JOB_TARGET_STORAGE_MODE = "push.job.target.storage.mode";
+
   public static final String PUSH_TO_SEPARATE_REALTIME_TOPIC = "push.to.separate.realtime.topic";
   public static final String STORE_SEPARATE_REALTIME_TOPIC_ENABLED = "store.separate.realtime.topic.enabled";
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriterTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriterTest.java
@@ -1,0 +1,423 @@
+package com.linkedin.venice.hadoop.task.datawriter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+import static org.testng.Assert.fail;
+
+import com.linkedin.venice.pubsub.api.PubSubProduceResult;
+import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.writer.AbstractVeniceWriter;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.testng.annotations.Test;
+
+
+public class DualWriteVeniceWriterTest {
+  private static final String TOPIC = "test_store_v1";
+  private static final byte[] KEY_PREFIX = "key_".getBytes();
+  private static final byte[] VALUE_PREFIX = "value_".getBytes();
+  private static final int SCHEMA_ID = 7;
+
+  @Test
+  public void rejectsBatchSizeLessThanOne() {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mock(AbstractVeniceWriter.class);
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    assertThrows(IllegalArgumentException.class, () -> new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 0));
+  }
+
+  @Test
+  public void batchSizeOneFlushesEveryRecordImmediately() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 1)) {
+      writer.put(key(1), value(1), SCHEMA_ID, null);
+      assertEquals(external.batchPutInvocations.size(), 1, "Per-record flush expected at batchSize=1");
+      assertEquals(external.batchPutInvocations.get(0).size(), 1);
+
+      writer.put(key(2), value(2), SCHEMA_ID, null);
+      assertEquals(external.batchPutInvocations.size(), 2);
+      assertEquals(external.batchPutInvocations.get(1).size(), 1);
+      assertEquals(writer.getBufferedPutCount(), 0, "Buffer must be empty at batchSize=1");
+    }
+  }
+
+  @Test
+  public void batchSizeNAccumulatesUntilThreshold() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 5)) {
+      for (int i = 1; i <= 4; i++) {
+        writer.put(key(i), value(i), SCHEMA_ID, null);
+      }
+      assertEquals(external.batchPutInvocations.size(), 0, "No flush expected before threshold");
+      assertEquals(writer.getBufferedPutCount(), 4);
+
+      writer.put(key(5), value(5), SCHEMA_ID, null);
+      assertEquals(external.batchPutInvocations.size(), 1, "Threshold should trigger a flush");
+      assertEquals(external.batchPutInvocations.get(0).size(), 5);
+      assertEquals(writer.getBufferedPutCount(), 0);
+
+      // Second full batch
+      for (int i = 6; i <= 10; i++) {
+        writer.put(key(i), value(i), SCHEMA_ID, null);
+      }
+      assertEquals(external.batchPutInvocations.size(), 2);
+      assertEquals(external.batchPutInvocations.get(1).size(), 5);
+    }
+  }
+
+  @Test
+  public void partialBatchDrainedOnFlush() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 10)) {
+      for (int i = 1; i <= 3; i++) {
+        writer.put(key(i), value(i), SCHEMA_ID, null);
+      }
+      assertEquals(external.batchPutInvocations.size(), 0);
+      writer.flush();
+      assertEquals(external.batchPutInvocations.size(), 1);
+      assertEquals(external.batchPutInvocations.get(0).size(), 3, "Partial batch should drain on flush");
+      assertTrue(external.flushCount > 0, "flush() should also call externalWriter.flush()");
+    }
+  }
+
+  @Test
+  public void closeDrainsBufferAndClosesBothSides() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 100);
+    writer.put(key(1), value(1), SCHEMA_ID, null);
+    writer.put(key(2), value(2), SCHEMA_ID, null);
+    writer.close();
+
+    assertEquals(external.batchPutInvocations.size(), 1, "close() should drain via flush() before closing");
+    assertEquals(external.batchPutInvocations.get(0).size(), 2);
+    assertTrue(external.closed, "external.close() must be called");
+  }
+
+  @Test
+  public void putFutureCompletesAfterDrain() throws Exception {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 3)) {
+      CompletableFuture<PubSubProduceResult> first = writer.put(key(1), value(1), SCHEMA_ID, null);
+      CompletableFuture<PubSubProduceResult> second = writer.put(key(2), value(2), SCHEMA_ID, null);
+      assertFalse(first.isDone(), "Buffered put future should not complete until drain");
+      assertFalse(second.isDone());
+
+      writer.flush();
+      assertTrue(first.isDone(), "Drain via flush should complete the buffered put's future");
+      assertTrue(second.isDone());
+    }
+  }
+
+  @Test
+  public void updateIsNotSupported() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 1)) {
+      assertThrows(UnsupportedOperationException.class, () -> writer.update(key(1), value(1), SCHEMA_ID, -1, null));
+    }
+  }
+
+  @Test
+  public void deleteIsNotSupported() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 1)) {
+      assertThrows(UnsupportedOperationException.class, () -> writer.delete(key(1), null));
+    }
+  }
+
+  @Test
+  public void closeSelfFlushesDrainsBufferAndFlushesBothInnerWriters() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 100);
+    writer.put(key(1), value(1), SCHEMA_ID, null);
+    writer.put(key(2), value(2), SCHEMA_ID, null);
+    // Intentionally skip calling writer.flush(); the contract says close() alone is sufficient.
+    writer.close();
+
+    assertEquals(
+        external.batchPutInvocations.size(),
+        1,
+        "close() must drain pending puts via the buffer before closing");
+    assertEquals(external.batchPutInvocations.get(0).size(), 2);
+    assertTrue(
+        external.flushCount > 0,
+        "close() must call externalWriter.flush() so impls with internal buffers drain");
+    assertTrue(external.closed, "externalWriter.close() must still run after the self-flush");
+  }
+
+  @Test
+  public void valueIsRocksDbFormattedWithBigEndianSchemaIdPrefix() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    byte[] rawValue = value(42);
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 1)) {
+      writer.put(key(42), rawValue, SCHEMA_ID, null);
+    }
+
+    assertEquals(external.batchPutInvocations.size(), 1);
+    assertEquals(external.batchPutInvocations.get(0).size(), 1);
+    ExternalStorageRecord forwarded = external.batchPutInvocations.get(0).get(0);
+    byte[] formattedValue = forwarded.getValue();
+    assertEquals(
+        formattedValue.length,
+        ExternalStorageRecord.SCHEMA_ID_PREFIX_LENGTH + rawValue.length,
+        "Forwarded value should be schema-id prefix followed by the raw value bytes");
+    ByteBuffer view = ByteBuffer.wrap(formattedValue);
+    assertEquals(view.getInt(), SCHEMA_ID, "First 4 bytes must be the BE-encoded value schema id");
+    byte[] payload = new byte[view.remaining()];
+    view.get(payload);
+    assertEquals(payload, rawValue, "Bytes after the prefix must equal the original value payload");
+  }
+
+  // --- Retry tests ---------------------------------------------------------------------------------
+
+  @Test
+  public void rejectsNegativeBatchPutRetries() {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mock(AbstractVeniceWriter.class);
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 1, -1, 0));
+  }
+
+  @Test
+  public void rejectsNegativeBatchPutRetryBackoff() {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mock(AbstractVeniceWriter.class);
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 1, 3, -1));
+  }
+
+  /**
+   * Transient external failure: external throws on attempts 1 and 2, succeeds on attempt 3. With
+   * {@code batchPutRetries=3} (4 attempts total), the wrapper recovers without falling through to
+   * Spark's whole-partition retry, and the corresponding Kafka produce eventually fires.
+   */
+  @Test
+  public void recoversAfterTransientExternalFailureWithinRetryBudget() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    external.failBatchPutTimes = 2; // succeed on the 3rd attempt
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 1, 3, 0)) {
+      writer.put(key(1), value(1), SCHEMA_ID, null);
+      assertEquals(external.batchPutAttempts, 3, "Expected 3 attempts: 2 failures + 1 success");
+      assertEquals(
+          external.batchPutInvocations.size(),
+          1,
+          "Only the successful attempt should add to the recorded batchPut history");
+      verify(kafkaWriter).put(any(), any(), anyInt(), any());
+    }
+  }
+
+  /**
+   * External keeps failing past the retry budget. Total attempts = {@code batchPutRetries + 1}; the
+   * original failure propagates and the later failures are attached via {@code getSuppressed()}.
+   */
+  @Test
+  public void exhaustingRetriesPropagatesOriginalFailureWithSuppressedRetries() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    external.failBatchPutTimes = Integer.MAX_VALUE; // never succeed
+    DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 1, 3, 0);
+    try {
+      RuntimeException raised =
+          expectThrows(RuntimeException.class, () -> writer.put(key(1), value(1), SCHEMA_ID, null));
+      assertEquals(external.batchPutAttempts, 4, "Expected 1 initial + 3 retries = 4 total attempts");
+      assertTrue(
+          raised.getMessage().contains("simulated batchPut failure #1"),
+          "First failure should be the propagating exception; got: " + raised.getMessage());
+      Throwable[] suppressed = raised.getSuppressed();
+      assertEquals(suppressed.length, 3, "Subsequent 3 failures should be attached via addSuppressed");
+      assertTrue(suppressed[0].getMessage().contains("simulated batchPut failure #2"));
+      assertTrue(suppressed[1].getMessage().contains("simulated batchPut failure #3"));
+      assertTrue(suppressed[2].getMessage().contains("simulated batchPut failure #4"));
+      verify(kafkaWriter, never()).put(any(), any(), anyInt(), any());
+    } finally {
+      try {
+        writer.close();
+      } catch (Exception ignored) {
+      }
+    }
+  }
+
+  // --- Failure-mode tests --------------------------------------------------------------------------
+
+  /**
+   * I4 (1): external-throw at the {@code batchPut} boundary fails the put synchronously AND the wrapper
+   * never invokes any {@code kafkaWriter.put} for the failed batch. Protects the external-first ordering
+   * invariant: a regression that silently produced to Kafka on external failure would mean external sink
+   * and Venice diverge.
+   */
+  @Test
+  public void externalBatchPutFailureBlocksKafkaProduce() throws Exception {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    external.throwOnBatchPut = new RuntimeException("simulated external storage failure");
+    DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 1);
+    try {
+      RuntimeException raised =
+          expectThrows(RuntimeException.class, () -> writer.put(key(1), value(1), SCHEMA_ID, null));
+      assertTrue(
+          raised.getMessage().contains("simulated external storage failure"),
+          "Caller should see the original failure; got: " + raised.getMessage());
+      verify(kafkaWriter, never()).put(any(), any(), anyInt(), any());
+      verify(kafkaWriter, never()).put(any(), any(), anyInt(), any(), any());
+      assertEquals(writer.getBufferedPutCount(), 0, "Buffer must be cleared even on failure path");
+    } finally {
+      // Close path: flush() will try to drainBuffer again, but buffer is empty so it's a no-op. external
+      // throwOnBatchPut is still set but no batchPut happens since the buffer is empty.
+      try {
+        writer.close();
+      } catch (Exception ignored) {
+        // Close may surface lingering errors from earlier; tolerate here — the assertions above are what
+        // we care about.
+      }
+    }
+  }
+
+  /**
+   * I4 (2): a failing Kafka future surfaces as exceptional completion on the buffered put's future,
+   * which is how Spark detects task failure for buffered writes.
+   */
+  @Test
+  public void kafkaFutureFailurePropagatesToBufferedPutFuture() throws Exception {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mock(AbstractVeniceWriter.class);
+    RuntimeException kafkaError = new RuntimeException("simulated Kafka produce failure");
+    CompletableFuture<PubSubProduceResult> failed = new CompletableFuture<>();
+    failed.completeExceptionally(kafkaError);
+    doReturn(failed).when(kafkaWriter).put(any(), any(), anyInt(), any());
+    doReturn(CompletableFuture.completedFuture(null)).when(kafkaWriter).put(any(), any(), anyInt(), any(), any());
+
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 3)) {
+      CompletableFuture<PubSubProduceResult> first = writer.put(key(1), value(1), SCHEMA_ID, null);
+      writer.put(key(2), value(2), SCHEMA_ID, null);
+      writer.flush();
+
+      assertTrue(first.isDone());
+      ExecutionException ee = expectThrows(ExecutionException.class, first::get);
+      assertTrue(
+          ee.getCause().getMessage().contains("simulated Kafka produce failure"),
+          "Buffered put's future should carry the Kafka failure cause; got: " + ee.getCause().getMessage());
+    }
+  }
+
+  /**
+   * I4 (3): when both inner close calls throw, the first IOException propagates and the second is
+   * attached via {@code getSuppressed()}. Protects against silent loss of diagnostics during executor
+   * shutdown when both Kafka and the external sink can fail concurrently (e.g. network partition).
+   */
+  @Test
+  public void closeMultiFailureSuppression() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    IOException kafkaCloseError = new IOException("kafka close exploded");
+    doThrow(kafkaCloseError).when(kafkaWriter).close(true);
+
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    external.throwOnClose = new IOException("external close exploded");
+
+    DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 1);
+    try {
+      writer.close();
+      fail("Expected IOException from one of the two failing close calls");
+    } catch (IOException raised) {
+      assertEquals(
+          raised.getMessage(),
+          "external close exploded",
+          "First reported error should be the externalWriter close (called before kafkaWriter close)");
+      Throwable[] suppressed = raised.getSuppressed();
+      assertEquals(suppressed.length, 1, "Kafka close's IOException should be attached via addSuppressed");
+      assertEquals(suppressed[0].getMessage(), "kafka close exploded");
+    }
+  }
+
+  private static AbstractVeniceWriter<byte[], byte[], byte[]> mockKafkaWriter() {
+    @SuppressWarnings("unchecked")
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mock(AbstractVeniceWriter.class);
+    CompletableFuture<PubSubProduceResult> completed = CompletableFuture.completedFuture(null);
+    // any() (no class) matches null callbacks; any(Class) does not.
+    doReturn(completed).when(kafkaWriter).put(any(), any(), anyInt(), any());
+    doReturn(completed).when(kafkaWriter).put(any(), any(), anyInt(), any(), any());
+    return kafkaWriter;
+  }
+
+  private static byte[] key(int i) {
+    return concat(KEY_PREFIX, Integer.toString(i).getBytes());
+  }
+
+  private static byte[] value(int i) {
+    return concat(VALUE_PREFIX, Integer.toString(i).getBytes());
+  }
+
+  private static byte[] concat(byte[] a, byte[] b) {
+    byte[] out = new byte[a.length + b.length];
+    System.arraycopy(a, 0, out, 0, a.length);
+    System.arraycopy(b, 0, out, a.length, b.length);
+    return out;
+  }
+
+  /**
+   * Minimal recording impl of {@link ExternalStorageWriter} for unit-test assertions. Captures every
+   * {@code batchPut} invocation as a separate list snapshot. Flags allow per-test injection of failures.
+   */
+  private static final class RecordingExternalStorageWriter implements ExternalStorageWriter {
+    final List<List<ExternalStorageRecord>> batchPutInvocations = new ArrayList<>();
+    int flushCount = 0;
+    int batchPutAttempts = 0;
+    boolean closed = false;
+    RuntimeException throwOnBatchPut = null;
+    /** Number of leading {@code batchPut} attempts that should throw before the first success. */
+    int failBatchPutTimes = 0;
+    IOException throwOnClose = null;
+
+    @Override
+    public void configure(VeniceProperties jobProps, String topicName, int partitionId) {
+    }
+
+    @Override
+    public void batchPut(List<ExternalStorageRecord> records) {
+      batchPutAttempts++;
+      if (throwOnBatchPut != null) {
+        throw throwOnBatchPut;
+      }
+      if (batchPutAttempts <= failBatchPutTimes) {
+        throw new RuntimeException("simulated batchPut failure #" + batchPutAttempts);
+      }
+      batchPutInvocations.add(new ArrayList<>(records));
+    }
+
+    @Override
+    public void flush() {
+      flushCount++;
+    }
+
+    @Override
+    public void close() throws IOException {
+      closed = true;
+      if (throwOnClose != null) {
+        throw throwOnClose;
+      }
+    }
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/vpj/ExternalStorageWriteUtilsTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/vpj/ExternalStorageWriteUtilsTest.java
@@ -1,0 +1,194 @@
+package com.linkedin.venice.vpj;
+
+import static com.linkedin.venice.vpj.ExternalStorageWriteUtils.isDualWriteToExternalStorageFromVpjEnabled;
+import static com.linkedin.venice.vpj.ExternalStorageWriteUtils.loadAndConfigure;
+import static com.linkedin.venice.vpj.ExternalStorageWriteUtils.loadExternalStorageWriter;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.hadoop.task.datawriter.ExternalStorageRecord;
+import com.linkedin.venice.hadoop.task.datawriter.ExternalStorageWriter;
+import com.linkedin.venice.meta.StorageMode;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+
+public class ExternalStorageWriteUtilsTest {
+  private static final String IMPL_CLASS = "com.example.LiveExternalWriter";
+
+  private static VeniceProperties propsWithClass(String value) {
+    Properties props = new Properties();
+    if (value != null) {
+      props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS, value);
+    }
+    return new VeniceProperties(props);
+  }
+
+  @AfterMethod(alwaysRun = true)
+  public void resetTestWriterState() {
+    RecordingTestWriter.resetAll();
+  }
+
+  // --- isDualWriteToExternalStorageFromVpjEnabled -----------------------------------------------
+
+  @Test
+  public void bothHalvesSetReturnsTrue() {
+    assertTrue(isDualWriteToExternalStorageFromVpjEnabled(propsWithClass(IMPL_CLASS), StorageMode.DUAL_WRITE));
+  }
+
+  @Test
+  public void writerClassMissingReturnsFalse() {
+    assertFalse(isDualWriteToExternalStorageFromVpjEnabled(propsWithClass(null), StorageMode.DUAL_WRITE));
+  }
+
+  @Test
+  public void writerClassEmptyReturnsFalse() {
+    assertFalse(isDualWriteToExternalStorageFromVpjEnabled(propsWithClass(""), StorageMode.DUAL_WRITE));
+  }
+
+  @Test
+  public void storageModeInternalReturnsFalse() {
+    assertFalse(isDualWriteToExternalStorageFromVpjEnabled(propsWithClass(IMPL_CLASS), StorageMode.INTERNAL));
+  }
+
+  @Test
+  public void storageModeExternalReturnsFalse() {
+    assertFalse(isDualWriteToExternalStorageFromVpjEnabled(propsWithClass(IMPL_CLASS), StorageMode.EXTERNAL));
+  }
+
+  @Test
+  public void nullStorageModeReturnsFalse() {
+    assertFalse(isDualWriteToExternalStorageFromVpjEnabled(propsWithClass(IMPL_CLASS), null));
+  }
+
+  @Test
+  public void nullPropsReturnsFalse() {
+    assertFalse(isDualWriteToExternalStorageFromVpjEnabled(null, StorageMode.DUAL_WRITE));
+  }
+
+  // --- loadExternalStorageWriter ----------------------------------------------------------------
+
+  @Test
+  public void loadExternalStorageWriterReturnsInstanceOfConfiguredImpl() {
+    ExternalStorageWriter writer = loadExternalStorageWriter(RecordingTestWriter.class.getName());
+    assertNotNull(writer);
+    assertTrue(writer instanceof RecordingTestWriter);
+  }
+
+  @Test
+  public void loadExternalStorageWriterFailsClearlyWhenClassMissing() {
+    VeniceException e =
+        expectThrows(VeniceException.class, () -> loadExternalStorageWriter("com.example.does.not.Exist"));
+    assertTrue(
+        e.getMessage().contains("Failed to load") && e.getMessage().contains("com.example.does.not.Exist"),
+        "Expected message to identify the missing class; got: " + e.getMessage());
+  }
+
+  @Test
+  public void loadExternalStorageWriterFailsClearlyWhenClassDoesNotImplementSpi() {
+    // String.class is loadable but does not implement ExternalStorageWriter.
+    VeniceException e = expectThrows(VeniceException.class, () -> loadExternalStorageWriter(String.class.getName()));
+    assertTrue(
+        e.getMessage().contains("does not implement") && e.getMessage().contains("ExternalStorageWriter"),
+        "Expected message to call out the missing interface; got: " + e.getMessage());
+  }
+
+  // --- loadAndConfigure -------------------------------------------------------------------------
+
+  @Test
+  public void loadAndConfigureInvokesConfigureOnTheInstance() {
+    ExternalStorageWriter writer =
+        loadAndConfigure(RecordingTestWriter.class.getName(), propsWithClass(IMPL_CLASS), "store_v1", 7);
+    assertTrue(writer instanceof RecordingTestWriter);
+    RecordingTestWriter recorded = RecordingTestWriter.lastInstance();
+    assertNotNull(recorded, "constructor should have published the instance");
+    assertTrue(recorded.wasConfigured(), "configure() should have been invoked");
+    assertFalse(recorded.wasClosed(), "close() should NOT have been called on the happy path");
+  }
+
+  @Test
+  public void loadAndConfigureClosesWriterWhenConfigureThrows() {
+    RecordingTestWriter.setThrowOnConfigure(true);
+    RuntimeException raised = expectThrows(
+        RuntimeException.class,
+        () -> loadAndConfigure(RecordingTestWriter.class.getName(), propsWithClass(IMPL_CLASS), "store_v1", 7));
+    assertTrue(
+        raised.getMessage().contains("simulated configure failure"),
+        "Caller should see the original configure() exception; got: " + raised.getMessage());
+    RecordingTestWriter recorded = RecordingTestWriter.lastInstance();
+    assertNotNull(recorded, "constructor should have published the instance");
+    assertTrue(
+        recorded.wasClosed(),
+        "Writer must be closed when configure() throws, to release any resources allocated by the no-arg ctor "
+            + "or by partial configure() work");
+  }
+
+  /**
+   * Public no-arg test impl loaded reflectively by the tests above. Per-test state lives on the instance
+   * (not on statics) so SpotBugs' {@code ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD} stays quiet; the
+   * constructor publishes the freshly-built instance to a static {@link AtomicReference} so tests can
+   * reach it without needing the helper to return the writer.
+   */
+  public static class RecordingTestWriter implements ExternalStorageWriter {
+    private static final AtomicReference<RecordingTestWriter> LAST_INSTANCE = new AtomicReference<>();
+    private static final AtomicBoolean THROW_ON_CONFIGURE = new AtomicBoolean(false);
+
+    private boolean configured = false;
+    private boolean closed = false;
+
+    public RecordingTestWriter() {
+      LAST_INSTANCE.set(this);
+    }
+
+    static void setThrowOnConfigure(boolean value) {
+      THROW_ON_CONFIGURE.set(value);
+    }
+
+    static RecordingTestWriter lastInstance() {
+      return LAST_INSTANCE.get();
+    }
+
+    static void resetAll() {
+      THROW_ON_CONFIGURE.set(false);
+      LAST_INSTANCE.set(null);
+    }
+
+    boolean wasConfigured() {
+      return configured;
+    }
+
+    boolean wasClosed() {
+      return closed;
+    }
+
+    @Override
+    public void configure(VeniceProperties jobProps, String topicName, int partitionId) {
+      if (THROW_ON_CONFIGURE.get()) {
+        throw new RuntimeException("simulated configure failure for " + topicName + "/" + partitionId);
+      }
+      configured = true;
+    }
+
+    @Override
+    public void batchPut(List<ExternalStorageRecord> records) {
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/InMemoryExternalStorageWriter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/InMemoryExternalStorageWriter.java
@@ -1,0 +1,114 @@
+package com.linkedin.venice.endToEnd;
+
+import com.linkedin.venice.hadoop.task.datawriter.ExternalStorageRecord;
+import com.linkedin.venice.hadoop.task.datawriter.ExternalStorageWriter;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+/**
+ * Integration-test {@link ExternalStorageWriter} that captures every {@code batchPut} / {@code delete} into
+ * static per-topic state. Each entry stores the raw {@code [4-byte BE schemaId][payload]} blob that the
+ * wrapper passed in, so the verification side can prove the on-disk format matches Venice's RocksDB layout.
+ *
+ * <p>Spark runs in local mode in integration tests, so static state is shared between Spark task threads
+ * and the test's verification code. {@link #clearAll()} resets everything between tests.
+ */
+public class InMemoryExternalStorageWriter implements ExternalStorageWriter {
+  /** Per-topic, key → RocksDB-formatted value blob ({@code [schemaId][payload]}). */
+  private static final ConcurrentMap<String, ConcurrentMap<ByteBuffer, byte[]>> SINK = new ConcurrentHashMap<>();
+
+  /** Per-topic max observed batch size across all {@code batchPut} invocations on every task. */
+  private static final ConcurrentMap<String, AtomicInteger> MAX_BATCH_SIZE_OBSERVED = new ConcurrentHashMap<>();
+
+  /** Per-topic total number of {@code batchPut} invocations across all tasks. */
+  private static final ConcurrentMap<String, AtomicInteger> BATCH_PUT_INVOCATIONS = new ConcurrentHashMap<>();
+
+  /**
+   * Key that the integration test uses to verify the OSS prefix-forwarding rule end-to-end: any
+   * {@code push.job.external.storage.*} property set by the test on the driver must reach
+   * {@link #configure}'s {@code VeniceProperties} on the executor.
+   */
+  static final String FORWARDED_CONFIG_PROBE_KEY = "push.job.external.storage.test.forwarded.value";
+
+  /** Per-topic snapshot of {@link #FORWARDED_CONFIG_PROBE_KEY} captured at configure() time. */
+  private static final ConcurrentMap<String, String> FORWARDED_CONFIG_OBSERVED = new ConcurrentHashMap<>();
+
+  private String topicName;
+  private ConcurrentMap<ByteBuffer, byte[]> shard;
+
+  public InMemoryExternalStorageWriter() {
+  }
+
+  @Override
+  public void configure(VeniceProperties jobProps, String topicName, int partitionId) {
+    this.topicName = topicName;
+    this.shard = SINK.computeIfAbsent(topicName, k -> new ConcurrentHashMap<>());
+    // Capture the probe key so the integration test can verify that arbitrary keys under the
+    // push.job.external.storage.* prefix are propagated from VPJ driver props to the executor.
+    String observed = jobProps.getString(FORWARDED_CONFIG_PROBE_KEY, "");
+    if (!observed.isEmpty()) {
+      FORWARDED_CONFIG_OBSERVED.put(topicName, observed);
+    }
+  }
+
+  @Override
+  public void batchPut(List<ExternalStorageRecord> records) {
+    if (records.isEmpty()) {
+      return;
+    }
+    BATCH_PUT_INVOCATIONS.computeIfAbsent(topicName, k -> new AtomicInteger()).incrementAndGet();
+    MAX_BATCH_SIZE_OBSERVED.computeIfAbsent(topicName, k -> new AtomicInteger())
+        .accumulateAndGet(records.size(), Math::max);
+    for (ExternalStorageRecord record: records) {
+      shard.put(ByteBuffer.wrap(record.getKey()), record.getValue());
+    }
+  }
+
+  @Override
+  public void flush() {
+  }
+
+  @Override
+  public void close() {
+  }
+
+  /** Snapshot of everything written to the sink for the given topic. Empty if nothing has been written. */
+  public static Map<ByteBuffer, byte[]> snapshotForTopic(String topicName) {
+    return SINK.getOrDefault(topicName, new ConcurrentHashMap<>());
+  }
+
+  /** Largest single-call {@code batchPut} size seen for the given topic. {@code 0} if no batchPut yet. */
+  public static int maxBatchSizeFor(String topicName) {
+    AtomicInteger counter = MAX_BATCH_SIZE_OBSERVED.get(topicName);
+    return counter == null ? 0 : counter.get();
+  }
+
+  /** Total number of {@code batchPut} invocations seen for the given topic. {@code 0} if none. */
+  public static int batchPutInvocationsFor(String topicName) {
+    AtomicInteger counter = BATCH_PUT_INVOCATIONS.get(topicName);
+    return counter == null ? 0 : counter.get();
+  }
+
+  /**
+   * Value of {@link #FORWARDED_CONFIG_PROBE_KEY} seen by {@code configure()} for the given topic.
+   * {@code null} if no instance observed it (either because nothing was configured for that topic or
+   * because the prefix-forwarding rule failed to propagate the key to the executor).
+   */
+  public static String forwardedConfigObservedFor(String topicName) {
+    return FORWARDED_CONFIG_OBSERVED.get(topicName);
+  }
+
+  /** Reset all captured state. Call from test @AfterMethod / @AfterClass to avoid cross-test leakage. */
+  public static void clearAll() {
+    SINK.clear();
+    MAX_BATCH_SIZE_OBSERVED.clear();
+    BATCH_PUT_INVOCATIONS.clear();
+    FORWARDED_CONFIG_OBSERVED.clear();
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVPJDualWriteExternalStorage.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVPJDualWriteExternalStorage.java
@@ -1,0 +1,264 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
+import static com.linkedin.venice.utils.TestWriteUtils.DEFAULT_USER_DATA_RECORD_COUNT;
+import static com.linkedin.venice.utils.TestWriteUtils.DEFAULT_USER_DATA_VALUE_PREFIX;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DATA_WRITER_COMPUTE_JOB_CLASS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SPARK_NATIVE_INPUT_FORMAT_ENABLED;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.hadoop.task.datawriter.ExternalStorageRecord;
+import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.meta.StorageMode;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.serializer.AvroGenericDeserializer;
+import com.linkedin.venice.serializer.AvroSerializer;
+import com.linkedin.venice.spark.datawriter.jobs.DataWriterSparkJob;
+import com.linkedin.venice.utils.ByteUtils;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.avro.Schema;
+import org.apache.commons.io.IOUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+/**
+ * End-to-end integration test for the VPJ external-storage dual-write path. The gating predicate fires only
+ * when both halves are set: the VPJ-side writer-class config AND the store-version-side {@code storageMode
+ * == DUAL_WRITE}. This test runs three parameterizations to exercise the cross-product:
+ *
+ * <ul>
+ *   <li>{@code batchSize=1, storageMode=DUAL_WRITE} — dual-write fires; the impl observes one batchPut of
+ *       size {@code 1} per record.</li>
+ *   <li>{@code batchSize=25, storageMode=DUAL_WRITE} — dual-write fires; the impl observes at least one
+ *       batchPut of size {@code 25}.</li>
+ *   <li>{@code batchSize=1, storageMode=INTERNAL} — gate is closed even though the writer-class is set;
+ *       the impl is never loaded and the in-memory sink stays empty for the push topic. Venice still
+ *       receives every record.</li>
+ * </ul>
+ */
+public class TestVPJDualWriteExternalStorage {
+  private static final int TEST_TIMEOUT_MS = 120_000;
+  private static final int STORE_VERSION_AVAILABILITY_TIMEOUT_SEC = 60;
+  private static final int READ_VERIFICATION_TIMEOUT_SEC = 60;
+
+  private VeniceClusterWrapper veniceCluster;
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    Utils.thisIsLocalhost();
+    VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
+        .numberOfServers(1)
+        .numberOfRouters(1)
+        .replicationFactor(1)
+        .partitionSize(100)
+        .sslToStorageNodes(false)
+        .sslToKafka(false)
+        .build();
+    veniceCluster = ServiceFactory.getVeniceCluster(options);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    IOUtils.closeQuietly(veniceCluster);
+  }
+
+  @AfterMethod(alwaysRun = true)
+  public void resetSink() {
+    InMemoryExternalStorageWriter.clearAll();
+  }
+
+  @DataProvider(name = "gateAndBatchSize")
+  public Object[][] gateAndBatchSize() {
+    return new Object[][] {
+        // batchSize, storageMode, expectDualWrite
+        { 1, StorageMode.DUAL_WRITE, true }, { 25, StorageMode.DUAL_WRITE, true }, { 1, StorageMode.INTERNAL, false } };
+  }
+
+  @Test(timeOut = TEST_TIMEOUT_MS, dataProvider = "gateAndBatchSize")
+  public void dualWritePathHonorsBothHalvesOfTheGate(int batchSize, StorageMode storageMode, boolean expectDualWrite)
+      throws Exception {
+    File inputDir = Utils.getTempDataDirectory();
+    writeSimpleAvroFileWithStringToStringSchema(inputDir);
+    String storeName = Utils.getUniqueString("dual_write_store_" + storageMode.name().toLowerCase() + "_b" + batchSize);
+
+    Schema stringSchema = Schema.parse("\"string\"");
+    Properties props = defaultVPJProps(veniceCluster, "file://" + inputDir.getAbsolutePath(), storeName);
+    props.setProperty(DATA_WRITER_COMPUTE_JOB_CLASS, DataWriterSparkJob.class.getCanonicalName());
+    props.setProperty(SPARK_NATIVE_INPUT_FORMAT_ENABLED, "true");
+    props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS, InMemoryExternalStorageWriter.class.getName());
+    props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE, String.valueOf(batchSize));
+    // Probe value to verify that arbitrary keys under the push.job.external.storage.* prefix are
+    // forwarded from the VPJ driver to the executor's task properties (the OSS prefix-forwarding rule
+    // in AbstractDataWriterSparkJob). Read back by InMemoryExternalStorageWriter.configure().
+    String expectedProbeValue = "probe-value-for-b" + batchSize + "-" + storageMode.name();
+    props.setProperty(InMemoryExternalStorageWriter.FORWARDED_CONFIG_PROBE_KEY, expectedProbeValue);
+
+    // Set the store-level storageMode up-front; the controller copies it onto every new version (#2823) and
+    // VPJ reads it back during validateStoreSettingAndPopulate as the per-push targetStorageMode.
+    UpdateStoreQueryParams storeParams = new UpdateStoreQueryParams().setStorageMode(storageMode);
+    createStoreForJob(
+        veniceCluster.getClusterName(),
+        stringSchema.toString(),
+        stringSchema.toString(),
+        props,
+        storeParams).close();
+
+    IntegrationTestPushUtils.runVPJ(props);
+
+    int currentVersion = waitForStoreVersionToBeServing(storeName);
+    String currentTopic = Version.composeKafkaTopic(storeName, currentVersion);
+
+    AvroGenericDeserializer<Object> sinkValueDeserializer = new AvroGenericDeserializer<>(stringSchema, stringSchema);
+
+    try (AvroGenericStoreClient<String, Object> client = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceCluster.getRandomRouterURL()))) {
+      // Wait-for-non-deterministic absorbs router routing-data readiness and ZSTD-dictionary-download
+      // latency for both the Venice-only and dual-write paths.
+      TestUtils.waitForNonDeterministicAssertion(READ_VERIFICATION_TIMEOUT_SEC, TimeUnit.SECONDS, true, true, () -> {
+        // Venice side: every input key returns the expected value via the thin client. Holds regardless of
+        // whether dual-write is engaged.
+        for (int i = 1; i <= DEFAULT_USER_DATA_RECORD_COUNT; i++) {
+          Object veniceValue = client.get(Integer.toString(i)).get();
+          assertNotNull(veniceValue, "Thin client returned null for key " + i);
+          assertEquals(
+              veniceValue.toString(),
+              DEFAULT_USER_DATA_VALUE_PREFIX + i,
+              "Venice value mismatch for key " + i);
+        }
+
+        Map<ByteBuffer, byte[]> sink = InMemoryExternalStorageWriter.snapshotForTopic(currentTopic);
+        int batchPutInvocations = InMemoryExternalStorageWriter.batchPutInvocationsFor(currentTopic);
+
+        if (!expectDualWrite) {
+          // Gate is closed: the wrapper must not load or invoke the external impl for this topic.
+          assertEquals(
+              batchPutInvocations,
+              0,
+              "Gate is closed (storageMode=" + storageMode
+                  + "); InMemoryExternalStorageWriter must never receive a batchPut for " + currentTopic);
+          assertTrue(sink.isEmpty(), "Gate is closed; sink for " + currentTopic + " must be empty");
+          // The impl is never loaded when the gate is closed, so the forwarded-config probe never
+          // executed — observed value should be null. (No assertion on the prefix forwarding itself in
+          // this branch; the positive branches below cover it.)
+          return;
+        }
+
+        // Verify the OSS prefix-forwarding rule: the probe value set on the VPJ driver under the
+        // push.job.external.storage.* prefix should have reached configure() on the executor.
+        assertEquals(
+            InMemoryExternalStorageWriter.forwardedConfigObservedFor(currentTopic),
+            expectedProbeValue,
+            "Custom push.job.external.storage.* property did not propagate from driver to executor's configure()");
+
+        // Dual-write fires: external sink received every record. The on-disk format matches Venice's
+        // RocksDB layout — first 4 bytes are the BE-encoded value schema id, the rest is the Avro payload
+        // (uncompressed here since the store uses NO_OP compression by default). A reader of the external
+        // sink decodes without any chunk reassembly.
+        assertEquals(
+            sink.size(),
+            DEFAULT_USER_DATA_RECORD_COUNT,
+            "External sink for topic " + currentTopic + " did not receive every pushed record");
+
+        // Build the bit-for-bit expected blob set by reproducing the same encoding the partition writer
+        // emits: AvroSerializer over the value schema, then prepend the BE schema-id prefix. The set is
+        // unordered because Spark task scheduling does not preserve input order in the sink map.
+        AvroSerializer<CharSequence> valueSerializer = new AvroSerializer<>(stringSchema);
+        Set<ByteBuffer> expectedFormattedValues = new HashSet<>();
+        for (int i = 1; i <= DEFAULT_USER_DATA_RECORD_COUNT; i++) {
+          byte[] avroPayload = valueSerializer.serialize(DEFAULT_USER_DATA_VALUE_PREFIX + i);
+          byte[] formatted = new byte[ExternalStorageRecord.SCHEMA_ID_PREFIX_LENGTH + avroPayload.length];
+          ByteUtils.writeInt(formatted, HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID, 0);
+          System
+              .arraycopy(avroPayload, 0, formatted, ExternalStorageRecord.SCHEMA_ID_PREFIX_LENGTH, avroPayload.length);
+          expectedFormattedValues.add(ByteBuffer.wrap(formatted));
+        }
+        Set<ByteBuffer> actualFormattedValues = new HashSet<>();
+        for (byte[] formattedValue: sink.values()) {
+          actualFormattedValues.add(ByteBuffer.wrap(formattedValue));
+        }
+        assertEquals(
+            actualFormattedValues,
+            expectedFormattedValues,
+            "Sink blobs must be bit-for-bit [4-byte BE schemaId][Avro-encoded value] for every input record");
+
+        // Cross-check via the deserializer path that an external reader who knows the format can decode
+        // back to the original value strings. Belt-and-suspenders relative to the byte-level set assert.
+        Set<String> decodedSinkValues = new HashSet<>();
+        for (byte[] formattedValue: sink.values()) {
+          ByteBuffer view = ByteBuffer.wrap(formattedValue);
+          int schemaId = view.getInt();
+          assertEquals(
+              schemaId,
+              HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID,
+              "Schema-id prefix should match the only registered value schema for this store");
+          decodedSinkValues.add(sinkValueDeserializer.deserialize(view).toString());
+        }
+        for (int i = 1; i <= DEFAULT_USER_DATA_RECORD_COUNT; i++) {
+          String expected = DEFAULT_USER_DATA_VALUE_PREFIX + i;
+          assertTrue(decodedSinkValues.contains(expected), "External sink missing decoded value " + expected);
+        }
+
+        // Batching contract: when batchSize > 1 the wrapper must flush at least one full-size batch; when
+        // batchSize == 1 the wrapper must never batch.
+        int observedMaxBatch = InMemoryExternalStorageWriter.maxBatchSizeFor(currentTopic);
+        assertTrue(batchPutInvocations > 0, "Expected at least one batchPut invocation for " + currentTopic);
+        if (batchSize == 1) {
+          assertEquals(
+              observedMaxBatch,
+              1,
+              "With batchSize=1 the wrapper must never batch; expected per-record batchPut of size 1");
+        } else {
+          assertEquals(
+              observedMaxBatch,
+              batchSize,
+              "With batchSize=" + batchSize + " the wrapper should have flushed at least one full batch");
+        }
+      });
+    }
+  }
+
+  private int waitForStoreVersionToBeServing(String storeName) {
+    AtomicInteger currentVersionRef = new AtomicInteger(0);
+    veniceCluster.useControllerClient(controllerClient -> {
+      TestUtils.waitForNonDeterministicAssertion(
+          STORE_VERSION_AVAILABILITY_TIMEOUT_SEC,
+          TimeUnit.SECONDS,
+          true,
+          true,
+          () -> {
+            int currentVersion = controllerClient.getStore(storeName).getStore().getCurrentVersion();
+            assertTrue(currentVersion > 0, "Store " + storeName + " has no current version yet");
+            veniceCluster.refreshAllRouterMetaData();
+            currentVersionRef.set(currentVersion);
+          });
+    });
+    return currentVersionRef.get();
+  }
+}


### PR DESCRIPTION
## Problem Statement

This PR adds the Venice Push Job side of the batch-only-store dual-write pipeline: when a store has `storageMode == DUAL_WRITE` and a `push.job.external.storage.writer.class` impl is configured, every batch-push record is buffered (up to `push.job.external.storage.batch.size`) and fanned out to an external storage system via a pluggable `ExternalStorageWriter` SPI in parallel with the normal Kafka produce, with each value written in Venice's on-disk RocksDB byte format (`[4-byte BE schemaId][Avro-encoded payload]`) so a reader of the external sink can decode without any Venice-specific reassembly.

The predecessor PRs landed the prerequisites: #2817 activated `StoreMetaValue v44` / `AdminOperation v99`, added the Java `StorageMode { INTERNAL, DUAL_WRITE, EXTERNAL }` enum, and exposed `Version.getStorageMode()`. #2823 added the `UpdateStore` admin op and the controller propagation that copies the store-level storage mode onto every new version. This PR is the VPJ-side consumer that closes the loop.

## Solution

### `ExternalStorageWriter` SPI (OSS)

New interface at `clients/venice-push-job/.../hadoop/task/datawriter/ExternalStorageWriter.java`. Lifecycle is one instance per Spark partition writer task: `configure(props, topicName, partitionId)` once → `batchPut(List<ExternalStorageRecord>)` + `delete(byte[] key)` per record/batch → `flush()` → `close()`. Signatures use only `byte[]`, primitives, `String`, and `VeniceProperties` — no LinkedIn-internal types, so out-of-tree impls compile against the OSS interface and ship via classpath.

`ExternalStorageRecord` carries `(key, value)` where **`value` matches Venice's on-disk RocksDB layout**: `[4-byte big-endian schemaId][Avro-encoded payload]`. A reader pulling from the external sink can decode without any chunk reassembly — Venice's per-Kafka-message chunking is invisible at this seam since the wrapper sees the un-chunked logical value.

### `DualWriteVeniceWriter` wrapper

`AbstractVeniceWriter<byte[], byte[], byte[]>` subclass that decorates the Kafka writer. For each `put`, it constructs the prefixed RocksDB-format value, buffers up to `push.job.external.storage.batch.size` records, then calls `externalWriter.batchPut(records)` followed by per-record `kafkaWriter.put(...)` in order. External-first ordering means a failed external write fails the Spark task before any Kafka produce, so retries replay the partition. `flush()` / `close()` / `delete()` drain any pending buffer to preserve producer ordering. `update()` throws — batch pushes don't call it. Composes cleanly with `CompositeVeniceWriter` (materialized views): the dual-write wrapper sits outside the composite.

### Two-half gating predicate

`ExternalStorageWriteUtils.isDualWriteToExternalStorageFromVpjEnabled(VeniceProperties, StorageMode)` returns `true` iff both halves are set:
- VPJ-side: `push.job.external.storage.writer.class` is non-empty (an impl is wired in for this push).
- Store-version side: `targetStorageMode == StorageMode.DUAL_WRITE`.

Either half missing falls back to today's Kafka-only behavior.

### Forwarding impl-specific configs from the VPJ driver to executors

Every property whose key starts with the new `push.job.external.storage.` prefix (defined as `PUSH_JOB_EXTERNAL_STORAGE_PROP_PREFIX` in `VenicePushJobConstants`) is forwarded verbatim from the VPJ driver into the Spark executor's `RuntimeConfig`. OSS Venice interprets only the two gating keys (`push.job.external.storage.writer.class`, `push.job.external.storage.batch.size`); everything else under the prefix is opaque pass-through so that out-of-tree `ExternalStorageWriter` impls can read their own configuration (cluster endpoints, credentials, table mappings, timeouts, etc.) from `VeniceProperties` inside `configure()` without any per-key plumbing in OSS.

### Plumbing target storage mode through VPJ

- `PushJobSetting.targetStorageMode` is populated **from the newly-created version's `Version.getStorageMode()`**, not the store-level value. The controller copies the store-level `storageMode` onto the new version at version-creation time (via `AbstractStore.addVersion` from #2823), so the version's value is the immutable source of truth for the duration of this push. Reading from the version closes a race where a concurrent `UpdateStore` could mutate the store-level value between VPJ's first `getStoreInfo` call and the actual version creation.
- The lookup runs in the `addVersionAndStartPush` flow right after the `VersionCreationResponse` arrives, via the existing `getStoreVersion(storeName, version)` helper. The extra round-trip is only paid when `push.job.external.storage.writer.class` is non-empty — otherwise the gating predicate would return `false` regardless and the read is skipped.
- `AbstractDataWriterSparkJob` writes `pushJobSetting.targetStorageMode.getValue()` into the Spark `RuntimeConfig` under `push.job.target.storage.mode` so executor tasks see it.
- `AbstractPartitionWriter.maybeDecorateForDualWriteToExternalStorage` decodes via `StorageMode.valueOf(int)` and passes to the predicate; on positive, reflectively loads the impl (`ReflectUtils.loadClass` + `callConstructor`), configures it, and wraps the Kafka writer in a `DualWriteVeniceWriter`.

###  Code changes
- [x] Added new code behind **a config**.
  - `push.job.external.storage.writer.class` — fully-qualified impl class name. Default unset; presence is half of the gate.
  - `push.job.external.storage.batch.size` — buffer threshold before flushing to the external sink. Default `1` (no buffering — every record fans out to a one-element `batchPut` immediately).
  - `push.job.external.storage.*` — opaque pass-through namespace. Any additional property under this prefix is forwarded from the driver to the executor's task properties so impls can read their own configuration in `configure()`.
  - `push.job.target.storage.mode` — int-encoded `StorageMode` of the version being pushed to; set by the VPJ driver from the store-level value. Default `0` (`INTERNAL`).
- [x] Introduced new **log lines**. One `LOGGER.info` per partition writer task announcing "Dual-write to external storage enabled for topic {} partition {} via impl {} (batchSize={})". Fires at most once per task and only when dual-write engages; no rate limiting needed.

###  **Concurrency-Specific Checks**
- [x] **No race conditions:** `DualWriteVeniceWriter` is per-task (one instance per Spark partition writer) and accessed serially by the writer-consumer lambda; per-instance buffer and `ExternalStorageWriter` impl have no shared mutable state across tasks. `InMemoryExternalStorageWriter` (test-only) uses `ConcurrentHashMap` for its static topic-shard map.
- [x] **No new synchronization primitives** in the production path. Test impl uses `ConcurrentHashMap` and `AtomicInteger`.
- [x] **No blocking calls** inside critical sections.
- [x] **Thread-safe collections** used in the test impl.
- [x] **No new threading.**

## How was this PR tested?

- [x] **New unit tests added:**
  - `DualWriteVeniceWriterTest` (9 cases): `batchSize=1` immediate flush; `batchSize=N` buffering until threshold; partial batch drained on flush; `delete()` drains pending puts first; `close()` drains and closes both sides; put-future completion after drain; `update()` rejection; `batchSize < 1` constructor rejection; **value bytes are RocksDB-formatted with BE-encoded schema-id prefix**.
  - `ExternalStorageWriteUtilsTest` (7 cases): writer-class present / missing / empty × `StorageMode` `DUAL_WRITE` / `INTERNAL` / `EXTERNAL` / `null` + null props.
- [x] **New integration test added:** `TestVPJDualWriteExternalStorage` runs three end-to-end parameterizations via a `DataProvider`:
  - `(batchSize=1, storageMode=DUAL_WRITE)` — dual-write fires; impl observes per-record `batchPut` of size 1.
  - `(batchSize=25, storageMode=DUAL_WRITE)` — dual-write fires; impl observes at least one `batchPut` of size 25.
  - `(batchSize=1, storageMode=INTERNAL)` — gate is closed despite the writer-class being set; Venice still receives every record but the in-memory sink stays empty and `batchPut` is never invoked.

  The positive cases assert via `TestUtils.waitForNonDeterministicAssertion` that the thin client returns every expected value AND that the sink contains **bit-for-bit `[4-byte BE schemaId][Avro-encoded value]` blobs** matching what `AvroSerializer.serialize(...)` produces for the input — a hard regression guard on the on-disk format. The same positive cases also set a probe property under the `push.job.external.storage.*` prefix on the driver and assert that `InMemoryExternalStorageWriter` observed it on the executor inside `configure()`, validating the prefix-forwarding rule end-to-end.
- [x] **Verified backward compatibility:** writer-class config defaults to unset, `targetStorageMode` defaults to `INTERNAL`, so the predicate stays `false` and `maybeDecorateForDualWriteToExternalStorage` returns the base writer unchanged. No behavioral change for existing pushes.
- [x] `./gradlew :clients:venice-push-job:test :clients:venice-push-job:compileJava :clients:venice-push-job:compileTestJava` — clean.
- [x] `./gradlew :internal:venice-test-common:integrationTest --tests TestVPJDualWriteExternalStorage` — 3/3 parameterizations pass.
- [x] `./gradlew :clients:venice-push-job:spotbugsMain :clients:venice-push-job:spotbugsTest :internal:venice-test-common:spotbugsIntegrationTest` — clean.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. New configs default to unset / off; the predicate stays `false` unless both halves are explicitly enabled; existing writer construction paths are unchanged when the gate is closed. The new SPI is additive — no existing interface is modified.
