### PR TITLE
[controller] Extract push-job-details, store-migration, and hybrid-policy helpers 

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HybridStoreConfigPolicy.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HybridStoreConfigPolicy.java
@@ -1,0 +1,351 @@
+package com.linkedin.venice.controller;
+
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.ACTIVE_ACTIVE_REPLICATION_ENABLED;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.BUFFER_REPLAY_POLICY;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.DATA_REPLICATION_POLICY;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.INCREMENTAL_PUSH_ENABLED;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.OFFSET_LAG_TO_GO_ONLINE;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.REAL_TIME_TOPIC_NAME;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.REWIND_TIME_IN_SECONDS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.SEPARATE_REAL_TIME_TOPIC_ENABLED;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.TIME_LAG_TO_GO_ONLINE;
+import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD;
+import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
+import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REAL_TIME_TOPIC_NAME;
+import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REWIND_TIME_IN_SECONDS;
+import static com.linkedin.venice.meta.Version.DEFAULT_RT_VERSION_NUMBER;
+
+import com.linkedin.venice.controller.kafka.protocol.admin.HybridStoreConfigRecord;
+import com.linkedin.venice.controller.kafka.protocol.admin.UpdateStore;
+import com.linkedin.venice.exceptions.ErrorType;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.exceptions.VeniceHttpException;
+import com.linkedin.venice.meta.BufferReplayPolicy;
+import com.linkedin.venice.meta.DataReplicationPolicy;
+import com.linkedin.venice.meta.HybridStoreConfig;
+import com.linkedin.venice.meta.HybridStoreConfigImpl;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.utils.Utils;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.http.HttpStatus;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Encodes Venice's policy for hybrid + replication configuration on a store: when a store
+ * counts as hybrid, how user-supplied update options merge onto the existing config, and the
+ * auto-enable / auto-disable rules at hybrid <-> batch transitions. Pure computation against
+ * in-memory state; no I/O.
+ */
+final class HybridStoreConfigPolicy {
+  private HybridStoreConfigPolicy() {
+  }
+
+  /**
+   * A store is hybrid iff its {@link HybridStoreConfig} is non-null and at least one of the
+   * rewind / offset-lag / time-lag thresholds is non-negative. A negative threshold sentinel is
+   * how a store is set back to batch-only.
+   */
+  static boolean isHybrid(HybridStoreConfig hybridStoreConfig) {
+    return hybridStoreConfig != null
+        && (hybridStoreConfig.getRewindTimeInSeconds() >= 0 || hybridStoreConfig.getOffsetLagThresholdToGoOnline() >= 0
+            || hybridStoreConfig.getProducerTimestampLagThresholdToGoOnlineInSeconds() >= 0);
+  }
+
+  /** @see #isHybrid(HybridStoreConfig) */
+  static boolean isHybrid(HybridStoreConfigRecord hybridStoreConfigRecord) {
+    HybridStoreConfig hybridStoreConfig = null;
+    if (hybridStoreConfigRecord != null) {
+      hybridStoreConfig = new HybridStoreConfigImpl(
+          hybridStoreConfigRecord.rewindTimeInSeconds,
+          hybridStoreConfigRecord.offsetLagThresholdToGoOnline,
+          hybridStoreConfigRecord.producerTimestampLagThresholdToGoOnlineInSeconds,
+          DataReplicationPolicy.valueOf(hybridStoreConfigRecord.dataReplicationPolicy),
+          BufferReplayPolicy.valueOf(hybridStoreConfigRecord.bufferReplayPolicy),
+          hybridStoreConfigRecord.realTimeTopicName.toString());
+    }
+    return isHybrid(hybridStoreConfig);
+  }
+
+  /**
+   * Merge user-supplied hybrid options on top of {@code oldStore}'s current hybrid config.
+   *
+   * <p>Returns null when {@code oldStore} is currently batch-only and no hybrid option has been
+   * specified (i.e. the caller is not converting the store to hybrid). When converting a
+   * batch-only store to hybrid, the rewind time plus at least one of the lag thresholds must be
+   * specified, otherwise {@link VeniceException} is thrown.
+   */
+  static HybridStoreConfig mergeNewSettingsIntoOldHybridStoreConfig(
+      Store oldStore,
+      Optional<Long> hybridRewindSeconds,
+      Optional<Long> hybridOffsetLagThreshold,
+      Optional<Long> hybridTimeLagThreshold,
+      Optional<DataReplicationPolicy> hybridDataReplicationPolicy,
+      Optional<BufferReplayPolicy> bufferReplayPolicy,
+      Optional<String> realTimeTopicName) {
+    if (!hybridRewindSeconds.isPresent() && !hybridOffsetLagThreshold.isPresent() && !oldStore.isHybrid()) {
+      return null; // For the nullable union in the avro record
+    }
+    HybridStoreConfig mergedHybridStoreConfig;
+    if (oldStore.isHybrid()) { // for an existing hybrid store, just replace any specified values
+      HybridStoreConfig oldHybridConfig = oldStore.getHybridStoreConfig().clone();
+      mergedHybridStoreConfig = new HybridStoreConfigImpl(
+          hybridRewindSeconds.isPresent() ? hybridRewindSeconds.get() : oldHybridConfig.getRewindTimeInSeconds(),
+          hybridOffsetLagThreshold.isPresent()
+              ? hybridOffsetLagThreshold.get()
+              : oldHybridConfig.getOffsetLagThresholdToGoOnline(),
+          hybridTimeLagThreshold.isPresent()
+              ? hybridTimeLagThreshold.get()
+              : oldHybridConfig.getProducerTimestampLagThresholdToGoOnlineInSeconds(),
+          hybridDataReplicationPolicy.isPresent()
+              ? hybridDataReplicationPolicy.get()
+              : oldHybridConfig.getDataReplicationPolicy(),
+          bufferReplayPolicy.isPresent() ? bufferReplayPolicy.get() : oldHybridConfig.getBufferReplayPolicy(),
+          realTimeTopicName.orElseGet(oldHybridConfig::getRealTimeTopicName));
+    } else {
+      // switching a non-hybrid store to hybrid; must specify:
+      // 1. rewind time
+      // 2. either offset lag threshold or time lag threshold, or both
+      if (!(hybridRewindSeconds.isPresent()
+          && (hybridOffsetLagThreshold.isPresent() || hybridTimeLagThreshold.isPresent()))) {
+        throw new VeniceException(
+            oldStore.getName() + " was not a hybrid store.  In order to make it a hybrid store both "
+                + " rewind time in seconds and offset or time lag threshold must be specified");
+      }
+
+      String newRealTimeTopicName = oldStore.getLargestUsedRTVersionNumber() > DEFAULT_RT_VERSION_NUMBER
+          && Utils.isRTVersioningApplicable(oldStore.getName())
+              ? Utils.composeRealTimeTopic(oldStore.getName(), oldStore.getLargestUsedRTVersionNumber())
+              : DEFAULT_REAL_TIME_TOPIC_NAME;
+
+      mergedHybridStoreConfig = new HybridStoreConfigImpl(
+          hybridRewindSeconds.get(),
+          // If not specified, offset/time lag threshold will be -1 and will not be used to determine whether
+          // a partition is ready to serve
+          hybridOffsetLagThreshold.orElse(DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD),
+          hybridTimeLagThreshold.orElse(DEFAULT_HYBRID_TIME_LAG_THRESHOLD),
+          hybridDataReplicationPolicy.orElse(DataReplicationPolicy.NON_AGGREGATE),
+          bufferReplayPolicy.orElse(BufferReplayPolicy.REWIND_FROM_EOP),
+          realTimeTopicName.orElse(newRealTimeTopicName));
+    }
+    if (mergedHybridStoreConfig.getRewindTimeInSeconds() > 0
+        && mergedHybridStoreConfig.getOffsetLagThresholdToGoOnline() < 0
+        && mergedHybridStoreConfig.getProducerTimestampLagThresholdToGoOnlineInSeconds() < 0) {
+      throw new VeniceException(
+          "Both offset lag threshold and time lag threshold are negative when setting hybrid" + " configs for store "
+              + oldStore.getName());
+    }
+    return mergedHybridStoreConfig;
+  }
+
+  /**
+   * Apply user-supplied hybrid + replication updates to {@code setStore}, return whether the
+   * store is being converted from batch to hybrid. Mutates {@code setStore} and
+   * {@code updatedConfigsList}; performs no I/O.
+   */
+  static boolean applyHybridAndReplicationConfigUpdates(
+      String storeName,
+      Store currStore,
+      UpdateStore setStore,
+      VeniceControllerClusterConfig controllerConfig,
+      Optional<Long> hybridRewindSeconds,
+      Optional<Long> hybridOffsetLagThreshold,
+      Optional<Long> hybridTimeLagThreshold,
+      Optional<DataReplicationPolicy> hybridDataReplicationPolicy,
+      Optional<BufferReplayPolicy> hybridBufferReplayPolicy,
+      Optional<String> realTimeTopicName,
+      Optional<Boolean> activeActiveReplicationEnabled,
+      Optional<Boolean> incrementalPushEnabled,
+      List<CharSequence> updatedConfigsList,
+      Logger logger) {
+    HybridStoreConfig updatedHybridStoreConfig = resolveUpdatedHybridConfig(
+        currStore,
+        hybridRewindSeconds,
+        hybridOffsetLagThreshold,
+        hybridTimeLagThreshold,
+        hybridDataReplicationPolicy,
+        hybridBufferReplayPolicy,
+        realTimeTopicName,
+        updatedConfigsList);
+
+    boolean storeBeingConvertedToHybrid = resolveReplicationPolicyToggles(
+        currStore,
+        setStore,
+        controllerConfig,
+        updatedHybridStoreConfig,
+        activeActiveReplicationEnabled,
+        incrementalPushEnabled,
+        updatedConfigsList);
+
+    if (updatedHybridStoreConfig == null) {
+      setStore.hybridStoreConfig = null;
+    } else {
+      setStore.hybridStoreConfig = toRecord(updatedHybridStoreConfig);
+    }
+
+    maybeConvertBatchStoreToActiveActiveHybridForIncrementalPush(
+        storeName,
+        currStore,
+        setStore,
+        controllerConfig,
+        updatedHybridStoreConfig,
+        incrementalPushEnabled,
+        updatedConfigsList,
+        logger);
+
+    return storeBeingConvertedToHybrid;
+  }
+
+  /**
+   * Merge user-supplied hybrid options on top of the current store's hybrid config, track which
+   * config keys were touched in {@code updatedConfigsList}.
+   */
+  private static HybridStoreConfig resolveUpdatedHybridConfig(
+      Store currStore,
+      Optional<Long> hybridRewindSeconds,
+      Optional<Long> hybridOffsetLagThreshold,
+      Optional<Long> hybridTimeLagThreshold,
+      Optional<DataReplicationPolicy> hybridDataReplicationPolicy,
+      Optional<BufferReplayPolicy> hybridBufferReplayPolicy,
+      Optional<String> realTimeTopicName,
+      List<CharSequence> updatedConfigsList) {
+    hybridRewindSeconds.map(addToUpdatedConfigList(updatedConfigsList, REWIND_TIME_IN_SECONDS));
+    hybridOffsetLagThreshold.map(addToUpdatedConfigList(updatedConfigsList, OFFSET_LAG_TO_GO_ONLINE));
+    hybridTimeLagThreshold.map(addToUpdatedConfigList(updatedConfigsList, TIME_LAG_TO_GO_ONLINE));
+    hybridDataReplicationPolicy.map(addToUpdatedConfigList(updatedConfigsList, DATA_REPLICATION_POLICY));
+    hybridBufferReplayPolicy.map(addToUpdatedConfigList(updatedConfigsList, BUFFER_REPLAY_POLICY));
+    realTimeTopicName.map(addToUpdatedConfigList(updatedConfigsList, REAL_TIME_TOPIC_NAME));
+
+    return mergeNewSettingsIntoOldHybridStoreConfig(
+        currStore,
+        hybridRewindSeconds,
+        hybridOffsetLagThreshold,
+        hybridTimeLagThreshold,
+        hybridDataReplicationPolicy,
+        hybridBufferReplayPolicy,
+        realTimeTopicName);
+  }
+
+  /**
+   * Resolve the A/A, incremental-push, and separate-RT toggles on {@code setStore} based on
+   * user input plus auto-enable/auto-disable rules at hybrid/batch transitions. Returns whether
+   * the store is being converted from batch to hybrid.
+   */
+  private static boolean resolveReplicationPolicyToggles(
+      Store currStore,
+      UpdateStore setStore,
+      VeniceControllerClusterConfig controllerConfig,
+      HybridStoreConfig updatedHybridStoreConfig,
+      Optional<Boolean> activeActiveReplicationEnabled,
+      Optional<Boolean> incrementalPushEnabled,
+      List<CharSequence> updatedConfigsList) {
+    boolean storeBeingConvertedToHybrid =
+        !currStore.isHybrid() && updatedHybridStoreConfig != null && isHybrid(updatedHybridStoreConfig);
+    boolean storeBeingConvertedToBatch = currStore.isHybrid() && !isHybrid(updatedHybridStoreConfig);
+    if (storeBeingConvertedToBatch && activeActiveReplicationEnabled.orElse(false)) {
+      throw new VeniceHttpException(
+          HttpStatus.SC_BAD_REQUEST,
+          "Cannot convert store to batch-only and enable Active/Active together.",
+          ErrorType.BAD_REQUEST);
+    }
+    if (storeBeingConvertedToBatch && incrementalPushEnabled.orElse(false)) {
+      throw new VeniceHttpException(
+          HttpStatus.SC_BAD_REQUEST,
+          "Cannot convert store to batch-only and enable incremental push together.",
+          ErrorType.BAD_REQUEST);
+    }
+
+    setStore.activeActiveReplicationEnabled = activeActiveReplicationEnabled
+        .map(addToUpdatedConfigList(updatedConfigsList, ACTIVE_ACTIVE_REPLICATION_ENABLED))
+        .orElseGet(currStore::isActiveActiveReplicationEnabled);
+    if (storeBeingConvertedToHybrid && !setStore.activeActiveReplicationEnabled && !currStore.isSystemStore()
+        && controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()) {
+      setStore.activeActiveReplicationEnabled = true;
+      updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
+    }
+    if (storeBeingConvertedToBatch && setStore.activeActiveReplicationEnabled) {
+      setStore.activeActiveReplicationEnabled = false;
+      updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
+    }
+
+    setStore.incrementalPushEnabled =
+        incrementalPushEnabled.map(addToUpdatedConfigList(updatedConfigsList, INCREMENTAL_PUSH_ENABLED))
+            .orElseGet(currStore::isIncrementalPushEnabled);
+    if (!setStore.incrementalPushEnabled && !currStore.isSystemStore() && storeBeingConvertedToHybrid
+        && setStore.activeActiveReplicationEnabled
+        && controllerConfig.enabledIncrementalPushForHybridActiveActiveUserStores()) {
+      setStore.incrementalPushEnabled = true;
+      updatedConfigsList.add(INCREMENTAL_PUSH_ENABLED);
+    }
+    if (setStore.incrementalPushEnabled && controllerConfig.enabledSeparateRealTimeTopicForStoreWithIncrementalPush()) {
+      setStore.separateRealTimeTopicEnabled = true;
+      updatedConfigsList.add(SEPARATE_REAL_TIME_TOPIC_ENABLED);
+    }
+    if (storeBeingConvertedToBatch && setStore.incrementalPushEnabled) {
+      setStore.incrementalPushEnabled = false;
+      updatedConfigsList.add(INCREMENTAL_PUSH_ENABLED);
+    }
+
+    return storeBeingConvertedToHybrid;
+  }
+
+  /**
+   * Enabling incremental push on a non-hybrid batch store implicitly converts it into an
+   * Active/Active hybrid store using default hybrid settings.
+   */
+  private static void maybeConvertBatchStoreToActiveActiveHybridForIncrementalPush(
+      String storeName,
+      Store currStore,
+      UpdateStore setStore,
+      VeniceControllerClusterConfig controllerConfig,
+      HybridStoreConfig updatedHybridStoreConfig,
+      Optional<Boolean> incrementalPushEnabled,
+      List<CharSequence> updatedConfigsList,
+      Logger logger) {
+    if (!incrementalPushEnabled.orElseGet(currStore::isIncrementalPushEnabled)
+        || isHybrid(currStore.getHybridStoreConfig()) || isHybrid(updatedHybridStoreConfig)) {
+      return;
+    }
+    logger.info(
+        "Enabling incremental push for a batch store:{}. Converting it to Active/Active hybrid store with default configs.",
+        storeName);
+    HybridStoreConfigRecord hybridStoreConfigRecord = new HybridStoreConfigRecord();
+    hybridStoreConfigRecord.rewindTimeInSeconds = DEFAULT_REWIND_TIME_IN_SECONDS;
+    updatedConfigsList.add(REWIND_TIME_IN_SECONDS);
+    hybridStoreConfigRecord.offsetLagThresholdToGoOnline = DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD;
+    updatedConfigsList.add(OFFSET_LAG_TO_GO_ONLINE);
+    hybridStoreConfigRecord.producerTimestampLagThresholdToGoOnlineInSeconds = DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
+    updatedConfigsList.add(TIME_LAG_TO_GO_ONLINE);
+    hybridStoreConfigRecord.dataReplicationPolicy = DataReplicationPolicy.NON_AGGREGATE.getValue();
+    updatedConfigsList.add(DATA_REPLICATION_POLICY);
+    hybridStoreConfigRecord.bufferReplayPolicy = BufferReplayPolicy.REWIND_FROM_EOP.getValue();
+    updatedConfigsList.add(BUFFER_REPLAY_POLICY);
+    hybridStoreConfigRecord.realTimeTopicName = DEFAULT_REAL_TIME_TOPIC_NAME;
+    setStore.hybridStoreConfig = hybridStoreConfigRecord;
+    if (!currStore.isSystemStore() && controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()) {
+      setStore.activeActiveReplicationEnabled = true;
+      updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
+    }
+  }
+
+  private static HybridStoreConfigRecord toRecord(HybridStoreConfig hybridStoreConfig) {
+    HybridStoreConfigRecord hybridStoreConfigRecord = new HybridStoreConfigRecord();
+    hybridStoreConfigRecord.offsetLagThresholdToGoOnline = hybridStoreConfig.getOffsetLagThresholdToGoOnline();
+    hybridStoreConfigRecord.rewindTimeInSeconds = hybridStoreConfig.getRewindTimeInSeconds();
+    hybridStoreConfigRecord.producerTimestampLagThresholdToGoOnlineInSeconds =
+        hybridStoreConfig.getProducerTimestampLagThresholdToGoOnlineInSeconds();
+    hybridStoreConfigRecord.dataReplicationPolicy = hybridStoreConfig.getDataReplicationPolicy().getValue();
+    hybridStoreConfigRecord.bufferReplayPolicy = hybridStoreConfig.getBufferReplayPolicy().getValue();
+    hybridStoreConfigRecord.realTimeTopicName = hybridStoreConfig.getRealTimeTopicName();
+    return hybridStoreConfigRecord;
+  }
+
+  private static <T> Function<T, T> addToUpdatedConfigList(List<CharSequence> updatedConfigList, String config) {
+    return configValue -> {
+      updatedConfigList.add(config);
+      return configValue;
+    };
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HybridStoreConfigPolicy.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HybridStoreConfigPolicy.java
@@ -170,7 +170,7 @@ final class HybridStoreConfigPolicy {
         realTimeTopicName,
         updatedConfigsList);
 
-    boolean storeBeingConvertedToHybrid = resolveReplicationPolicyToggles(
+    resolveReplicationPolicyToggles(
         currStore,
         setStore,
         controllerConfig,
@@ -195,7 +195,12 @@ final class HybridStoreConfigPolicy {
         updatedConfigsList,
         logger);
 
-    return storeBeingConvertedToHybrid;
+    // Derive from the final setStore so the implicit batch->hybrid conversion above is reflected.
+    // Computing this earlier (before maybeConvertBatchStoreToActiveActiveHybridForIncrementalPush) would
+    // return false when enabling incremental push on a batch store, even though setStore.hybridStoreConfig
+    // has been synthesized into a hybrid record - causing the downstream partial-update auto-enable gate in
+    // ParentControllerConfigUpdateUtils.checkAndMaybeApplyPartialUpdateConfig to be skipped incorrectly.
+    return !currStore.isHybrid() && isHybrid(setStore.hybridStoreConfig);
   }
 
   /**
@@ -230,10 +235,9 @@ final class HybridStoreConfigPolicy {
 
   /**
    * Resolve the A/A, incremental-push, and separate-RT toggles on {@code setStore} based on
-   * user input plus auto-enable/auto-disable rules at hybrid/batch transitions. Returns whether
-   * the store is being converted from batch to hybrid.
+   * user input plus auto-enable/auto-disable rules at hybrid/batch transitions.
    */
-  private static boolean resolveReplicationPolicyToggles(
+  private static void resolveReplicationPolicyToggles(
       Store currStore,
       UpdateStore setStore,
       VeniceControllerClusterConfig controllerConfig,
@@ -287,8 +291,6 @@ final class HybridStoreConfigPolicy {
       setStore.incrementalPushEnabled = false;
       updatedConfigsList.add(INCREMENTAL_PUSH_ENABLED);
     }
-
-    return storeBeingConvertedToHybrid;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HybridStoreConfigPolicy.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HybridStoreConfigPolicy.java
@@ -27,7 +27,6 @@ import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.utils.Utils;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -284,8 +283,7 @@ final class HybridStoreConfigPolicy {
       this.activeActiveReplicationEnabled = activeActiveReplicationEnabled;
       this.incrementalPushEnabled = incrementalPushEnabled;
       this.enableSeparateRealTimeTopic = enableSeparateRealTimeTopic;
-      // Defensive copy + unmodifiable so the returned decision can't be mutated by callers.
-      this.updatedConfigs = Collections.unmodifiableList(new ArrayList<>(updatedConfigs));
+      this.updatedConfigs = updatedConfigs;
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HybridStoreConfigPolicy.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HybridStoreConfigPolicy.java
@@ -26,6 +26,8 @@ import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.utils.Utils;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -249,6 +251,51 @@ final class HybridStoreConfigPolicy {
       Optional<Boolean> activeActiveReplicationEnabled,
       Optional<Boolean> incrementalPushEnabled,
       List<CharSequence> updatedConfigsList) {
+    ReplicationToggleDecision decision = computeReplicationToggleDecision(
+        currStore,
+        controllerConfig,
+        updatedHybridStoreConfig,
+        activeActiveReplicationEnabled,
+        incrementalPushEnabled);
+    setStore.activeActiveReplicationEnabled = decision.activeActiveReplicationEnabled;
+    setStore.incrementalPushEnabled = decision.incrementalPushEnabled;
+    if (decision.enableSeparateRealTimeTopic) {
+      setStore.separateRealTimeTopicEnabled = true;
+    }
+    updatedConfigsList.addAll(decision.updatedConfigs);
+  }
+
+  /**
+   * Resolved A/A and incremental-push toggles plus the should-enable signal for separate-RT, paired
+   * with the config keys that were touched while computing them. Returned by
+   * {@link #computeReplicationToggleDecision} so the impure apply step can stay trivial.
+   */
+  static final class ReplicationToggleDecision {
+    final boolean activeActiveReplicationEnabled;
+    final boolean incrementalPushEnabled;
+    final boolean enableSeparateRealTimeTopic;
+    final List<CharSequence> updatedConfigs;
+
+    ReplicationToggleDecision(
+        boolean activeActiveReplicationEnabled,
+        boolean incrementalPushEnabled,
+        boolean enableSeparateRealTimeTopic,
+        List<CharSequence> updatedConfigs) {
+      this.activeActiveReplicationEnabled = activeActiveReplicationEnabled;
+      this.incrementalPushEnabled = incrementalPushEnabled;
+      this.enableSeparateRealTimeTopic = enableSeparateRealTimeTopic;
+      // Defensive copy + unmodifiable so the returned decision can't be mutated by callers.
+      this.updatedConfigs = Collections.unmodifiableList(new ArrayList<>(updatedConfigs));
+    }
+  }
+
+  static ReplicationToggleDecision computeReplicationToggleDecision(
+      Store currStore,
+      VeniceControllerClusterConfig controllerConfig,
+      HybridStoreConfig updatedHybridStoreConfig,
+      Optional<Boolean> activeActiveReplicationEnabled,
+      Optional<Boolean> incrementalPushEnabled) {
+    List<CharSequence> updatedConfigs = new ArrayList<>();
     boolean storeBeingConvertedToHybrid =
         !currStore.isHybrid() && updatedHybridStoreConfig != null && isHybrid(updatedHybridStoreConfig);
     boolean storeBeingConvertedToBatch = currStore.isHybrid() && !isHybrid(updatedHybridStoreConfig);
@@ -265,36 +312,47 @@ final class HybridStoreConfigPolicy {
           ErrorType.BAD_REQUEST);
     }
 
-    setStore.activeActiveReplicationEnabled = activeActiveReplicationEnabled
-        .map(addToUpdatedConfigList(updatedConfigsList, ACTIVE_ACTIVE_REPLICATION_ENABLED))
-        .orElseGet(currStore::isActiveActiveReplicationEnabled);
-    if (storeBeingConvertedToHybrid && !setStore.activeActiveReplicationEnabled && !currStore.isSystemStore()
+    boolean resolvedActiveActiveReplicationEnabled =
+        activeActiveReplicationEnabled.map(addToUpdatedConfigList(updatedConfigs, ACTIVE_ACTIVE_REPLICATION_ENABLED))
+            .orElseGet(currStore::isActiveActiveReplicationEnabled);
+    if (storeBeingConvertedToHybrid && !resolvedActiveActiveReplicationEnabled && !currStore.isSystemStore()
         && controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()) {
-      setStore.activeActiveReplicationEnabled = true;
-      updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
+      resolvedActiveActiveReplicationEnabled = true;
+      updatedConfigs.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
     }
-    if (storeBeingConvertedToBatch && setStore.activeActiveReplicationEnabled) {
-      setStore.activeActiveReplicationEnabled = false;
-      updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
+    if (storeBeingConvertedToBatch && resolvedActiveActiveReplicationEnabled) {
+      resolvedActiveActiveReplicationEnabled = false;
+      updatedConfigs.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
     }
 
-    setStore.incrementalPushEnabled =
-        incrementalPushEnabled.map(addToUpdatedConfigList(updatedConfigsList, INCREMENTAL_PUSH_ENABLED))
+    boolean resolvedIncrementalPushEnabled =
+        incrementalPushEnabled.map(addToUpdatedConfigList(updatedConfigs, INCREMENTAL_PUSH_ENABLED))
             .orElseGet(currStore::isIncrementalPushEnabled);
-    if (!setStore.incrementalPushEnabled && !currStore.isSystemStore() && storeBeingConvertedToHybrid
-        && setStore.activeActiveReplicationEnabled
+    // Note: reads the resolved (post-auto-enable) A/A value, not the user input, so an
+    // auto-enabled A/A on batch->hybrid can also unlock the auto-enable of incremental push.
+    if (!resolvedIncrementalPushEnabled && !currStore.isSystemStore() && storeBeingConvertedToHybrid
+        && resolvedActiveActiveReplicationEnabled
         && controllerConfig.enabledIncrementalPushForHybridActiveActiveUserStores()) {
-      setStore.incrementalPushEnabled = true;
-      updatedConfigsList.add(INCREMENTAL_PUSH_ENABLED);
+      resolvedIncrementalPushEnabled = true;
+      updatedConfigs.add(INCREMENTAL_PUSH_ENABLED);
     }
-    if (setStore.incrementalPushEnabled && controllerConfig.enabledSeparateRealTimeTopicForStoreWithIncrementalPush()) {
-      setStore.separateRealTimeTopicEnabled = true;
-      updatedConfigsList.add(SEPARATE_REAL_TIME_TOPIC_ENABLED);
+
+    boolean enableSeparateRealTimeTopic = false;
+    if (resolvedIncrementalPushEnabled && controllerConfig.enabledSeparateRealTimeTopicForStoreWithIncrementalPush()) {
+      enableSeparateRealTimeTopic = true;
+      updatedConfigs.add(SEPARATE_REAL_TIME_TOPIC_ENABLED);
     }
-    if (storeBeingConvertedToBatch && setStore.incrementalPushEnabled) {
-      setStore.incrementalPushEnabled = false;
-      updatedConfigsList.add(INCREMENTAL_PUSH_ENABLED);
+
+    if (storeBeingConvertedToBatch && resolvedIncrementalPushEnabled) {
+      resolvedIncrementalPushEnabled = false;
+      updatedConfigs.add(INCREMENTAL_PUSH_ENABLED);
     }
+
+    return new ReplicationToggleDecision(
+        resolvedActiveActiveReplicationEnabled,
+        resolvedIncrementalPushEnabled,
+        enableSeparateRealTimeTopic,
+        updatedConfigs);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HybridStoreConfigPolicy.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HybridStoreConfigPolicy.java
@@ -58,13 +58,17 @@ final class HybridStoreConfigPolicy {
   static boolean isHybrid(HybridStoreConfigRecord hybridStoreConfigRecord) {
     HybridStoreConfig hybridStoreConfig = null;
     if (hybridStoreConfigRecord != null) {
+      // realTimeTopicName may be null on records produced before the field was added (PR #1345);
+      // HybridStoreConfigImpl normalizes a null name to its default, so just guard the .toString().
       hybridStoreConfig = new HybridStoreConfigImpl(
           hybridStoreConfigRecord.rewindTimeInSeconds,
           hybridStoreConfigRecord.offsetLagThresholdToGoOnline,
           hybridStoreConfigRecord.producerTimestampLagThresholdToGoOnlineInSeconds,
           DataReplicationPolicy.valueOf(hybridStoreConfigRecord.dataReplicationPolicy),
           BufferReplayPolicy.valueOf(hybridStoreConfigRecord.bufferReplayPolicy),
-          hybridStoreConfigRecord.realTimeTopicName.toString());
+          hybridStoreConfigRecord.realTimeTopicName == null
+              ? null
+              : hybridStoreConfigRecord.realTimeTopicName.toString());
     }
     return isHybrid(hybridStoreConfig);
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/PushJobDetailsManager.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/PushJobDetailsManager.java
@@ -1,0 +1,212 @@
+package com.linkedin.venice.controller;
+
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.annotation.VisibleForTesting;
+import com.linkedin.venice.client.store.AvroSpecificStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.common.VeniceSystemStoreType;
+import com.linkedin.venice.common.VeniceSystemStoreUtils;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.SchemaResponse;
+import com.linkedin.venice.exceptions.InvalidVeniceSchemaException;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.schema.SchemaData;
+import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
+import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
+import com.linkedin.venice.status.protocol.BatchJobHeartbeatKey;
+import com.linkedin.venice.status.protocol.BatchJobHeartbeatValue;
+import com.linkedin.venice.status.protocol.PushJobDetails;
+import com.linkedin.venice.status.protocol.PushJobStatusRecordKey;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.concurrent.ConcurrencyUtils;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import com.linkedin.venice.writer.VeniceWriter;
+import com.linkedin.venice.writer.VeniceWriterOptions;
+import java.io.Closeable;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Owns the state and Kafka/D2 plumbing used to read and write push job details and batch job
+ * heartbeat values: lazily-created Venice writers against the push-job-details RT topic, lazy
+ * router-backed Avro store clients for both system stores, and the schema-id resolution that
+ * accompanies the writes.
+ */
+class PushJobDetailsManager implements Closeable {
+  private static final Logger LOGGER = LogManager.getLogger(PushJobDetailsManager.class);
+  private static final String PUSH_JOB_DETAILS_WRITER = "PUSH_JOB_DETAILS_WRITER";
+
+  private final Admin admin;
+  private final D2Client d2Client;
+  private final boolean sslEnabled;
+  private final String pushJobStatusStoreClusterName;
+  private final boolean multiRegion;
+  private final Optional<SSLFactory> sslFactory;
+
+  private final InternalAvroSpecificSerializer<PushJobDetails> pushJobDetailsSerializer =
+      AvroProtocolDefinition.PUSH_JOB_DETAILS.getSerializer();
+
+  private final Map<String, VeniceWriter> jobTrackingVeniceWriterMap = new VeniceConcurrentHashMap<>();
+
+  private final Object pushJobDetailsClientLock = new Object();
+  private AvroSpecificStoreClient<PushJobStatusRecordKey, PushJobDetails> pushJobDetailsStoreClient = null;
+
+  private final Object livenessHeartbeatClientLock = new Object();
+  private AvroSpecificStoreClient<BatchJobHeartbeatKey, BatchJobHeartbeatValue> livenessHeartbeatStoreClient = null;
+
+  // Lazily initialized.
+  private PubSubTopic pushJobDetailsRTTopic;
+  private int pushJobDetailsSchemaId = -1;
+
+  PushJobDetailsManager(
+      Admin admin,
+      D2Client d2Client,
+      boolean sslEnabled,
+      String pushJobStatusStoreClusterName,
+      boolean multiRegion,
+      Optional<SSLFactory> sslFactory) {
+    this.admin = admin;
+    this.d2Client = d2Client;
+    this.sslEnabled = sslEnabled;
+    this.pushJobStatusStoreClusterName = pushJobStatusStoreClusterName;
+    this.multiRegion = multiRegion;
+    this.sslFactory = sslFactory;
+  }
+
+  InternalAvroSpecificSerializer<PushJobDetails> getPushJobDetailsSerializer() {
+    return pushJobDetailsSerializer;
+  }
+
+  /**
+   * Write the push job details record onto the child controller's local push-job-details real-time
+   * topic. Lazily resolves the topic and constructs the underlying Venice writer on first use.
+   */
+  void writeToLocalRTTopic(PushJobStatusRecordKey key, PushJobDetails value) {
+    if (StringUtils.isBlank(pushJobStatusStoreClusterName) && multiRegion) {
+      throw new VeniceException(
+          ("Unable to send the push job details because " + ConfigKeys.PUSH_JOB_STATUS_STORE_CLUSTER_NAME)
+              + " is not configured");
+    }
+    String pushJobDetailsStoreName = VeniceSystemStoreUtils.getPushJobDetailsStoreName();
+    if (pushJobDetailsRTTopic == null) {
+      // Verify the RT topic exists and give some time in case it's getting created.
+      PubSubTopic expectedRTTopic =
+          admin.getPubSubTopicRepository().getTopic(Utils.composeRealTimeTopic(pushJobDetailsStoreName));
+      for (int attempt = 0; attempt < VeniceHelixAdmin.INTERNAL_STORE_GET_RRT_TOPIC_ATTEMPTS; attempt++) {
+        if (attempt > 0) {
+          Utils.sleep(VeniceHelixAdmin.INTERNAL_STORE_RTT_RETRY_BACKOFF_MS);
+        }
+        if (admin.getTopicManager().containsTopicAndAllPartitionsAreOnline(expectedRTTopic)) {
+          pushJobDetailsRTTopic = expectedRTTopic;
+          LOGGER.info("Topic {} exists and is configured to receive push job details events", expectedRTTopic);
+          break;
+        }
+      }
+      if (pushJobDetailsRTTopic == null) {
+        throw new VeniceException(
+            "Expected RT topic " + expectedRTTopic + " to receive push job details events"
+                + " not found. The topic either hasn't been created yet or it's mis-configured");
+      }
+    }
+
+    VeniceWriter pushJobDetailsWriter = jobTrackingVeniceWriterMap.computeIfAbsent(PUSH_JOB_DETAILS_WRITER, k -> {
+      pushJobDetailsSchemaId = fetchSystemStoreSchemaId(
+          pushJobStatusStoreClusterName,
+          pushJobDetailsStoreName,
+          value.getSchema().toString());
+      return admin.getVeniceWriterFactory()
+          .createVeniceWriter(
+              new VeniceWriterOptions.Builder(pushJobDetailsRTTopic.getName())
+                  .setKeyPayloadSerializer(new VeniceAvroKafkaSerializer(key.getSchema().toString()))
+                  .setValuePayloadSerializer(new VeniceAvroKafkaSerializer(value.getSchema().toString()))
+                  .build());
+    });
+
+    pushJobDetailsWriter.put(key, value, pushJobDetailsSchemaId, null);
+  }
+
+  PushJobDetails getPushJobDetails(@Nonnull PushJobStatusRecordKey key) {
+    Validate.notNull(key);
+    ConcurrencyUtils.executeUnderConditionalLock(() -> {
+      String storeName = VeniceSystemStoreUtils.getPushJobDetailsStoreName();
+      String d2Service = admin.getRouterD2Service(admin.discoverCluster(storeName));
+      pushJobDetailsStoreClient = ClientFactory.getAndStartSpecificAvroClient(
+          ClientConfig.defaultSpecificClientConfig(storeName, PushJobDetails.class)
+              .setD2ServiceName(d2Service)
+              .setD2Client(d2Client));
+    }, () -> pushJobDetailsStoreClient == null, pushJobDetailsClientLock);
+    try {
+      return pushJobDetailsStoreClient.get(key).get();
+    } catch (Exception e) {
+      throw new VeniceException(e);
+    }
+  }
+
+  BatchJobHeartbeatValue getBatchJobHeartbeatValue(@Nonnull BatchJobHeartbeatKey batchJobHeartbeatKey) {
+    Validate.notNull(batchJobHeartbeatKey);
+    ConcurrencyUtils.executeUnderConditionalLock(() -> {
+      String storeName = VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE.getPrefix();
+      String d2Service = admin.getRouterD2Service(admin.discoverCluster(storeName));
+      livenessHeartbeatStoreClient = ClientFactory.getAndStartSpecificAvroClient(
+          ClientConfig.defaultSpecificClientConfig(storeName, BatchJobHeartbeatValue.class)
+              .setD2ServiceName(d2Service)
+              .setD2Client(d2Client));
+    }, () -> livenessHeartbeatStoreClient == null, livenessHeartbeatClientLock);
+    try {
+      return livenessHeartbeatStoreClient.get(batchJobHeartbeatKey).get();
+    } catch (Exception e) {
+      throw new VeniceException(e);
+    }
+  }
+
+  @VisibleForTesting
+  void setPushJobDetailsStoreClient(AvroSpecificStoreClient<PushJobStatusRecordKey, PushJobDetails> client) {
+    pushJobDetailsStoreClient = client;
+  }
+
+  /**
+   * Resolve a value schema id for an internal system store. When this controller is the leader for the
+   * hosting cluster the lookup is local; otherwise it falls back to a remote controller call.
+   */
+  private Integer fetchSystemStoreSchemaId(String clusterName, String storeName, String valueSchemaStr) {
+    if (admin.isLeaderControllerFor(clusterName)) {
+      int valueSchemaId = admin.getValueSchemaId(clusterName, storeName, valueSchemaStr);
+      if (SchemaData.INVALID_VALUE_SCHEMA_ID == valueSchemaId) {
+        throw new InvalidVeniceSchemaException(
+            "Can not find any registered value schema for the store " + storeName + " that matches the requested schema"
+                + valueSchemaStr);
+      }
+      return valueSchemaId;
+    }
+
+    ControllerClient controllerClient = ControllerClient.constructClusterControllerClient(
+        clusterName,
+        admin.getLeaderController(clusterName).getUrl(sslEnabled),
+        sslFactory);
+    SchemaResponse response = controllerClient.getValueSchemaID(storeName, valueSchemaStr);
+    if (response.isError()) {
+      throw new VeniceException(
+          "Failed to fetch schema id for store: " + storeName + ", error: " + response.getError());
+    }
+    return response.getId();
+  }
+
+  @Override
+  public void close() {
+    jobTrackingVeniceWriterMap.values().forEach(Utils::closeQuietlyWithErrorLogged);
+    jobTrackingVeniceWriterMap.clear();
+    Utils.closeQuietlyWithErrorLogged(pushJobDetailsStoreClient);
+    Utils.closeQuietlyWithErrorLogged(livenessHeartbeatStoreClient);
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/PushJobDetailsManager.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/PushJobDetailsManager.java
@@ -30,7 +30,6 @@ import com.linkedin.venice.writer.VeniceWriterOptions;
 import java.io.Closeable;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 import org.apache.logging.log4j.LogManager;
@@ -136,7 +135,7 @@ class PushJobDetailsManager implements Closeable {
     pushJobDetailsWriter.put(key, value, pushJobDetailsSchemaId, null);
   }
 
-  PushJobDetails getPushJobDetails(@Nonnull PushJobStatusRecordKey key) {
+  PushJobDetails getPushJobDetails(PushJobStatusRecordKey key) {
     Validate.notNull(key);
     ConcurrencyUtils.executeUnderConditionalLock(() -> {
       String storeName = VeniceSystemStoreUtils.getPushJobDetailsStoreName();
@@ -153,7 +152,7 @@ class PushJobDetailsManager implements Closeable {
     }
   }
 
-  BatchJobHeartbeatValue getBatchJobHeartbeatValue(@Nonnull BatchJobHeartbeatKey batchJobHeartbeatKey) {
+  BatchJobHeartbeatValue getBatchJobHeartbeatValue(BatchJobHeartbeatKey batchJobHeartbeatKey) {
     Validate.notNull(batchJobHeartbeatKey);
     ConcurrencyUtils.executeUnderConditionalLock(() -> {
       String storeName = VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE.getPrefix();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/PushJobDetailsManager.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/PushJobDetailsManager.java
@@ -189,16 +189,17 @@ class PushJobDetailsManager implements Closeable {
       return valueSchemaId;
     }
 
-    ControllerClient controllerClient = ControllerClient.constructClusterControllerClient(
+    try (ControllerClient controllerClient = ControllerClient.constructClusterControllerClient(
         clusterName,
         admin.getLeaderController(clusterName).getUrl(sslEnabled),
-        sslFactory);
-    SchemaResponse response = controllerClient.getValueSchemaID(storeName, valueSchemaStr);
-    if (response.isError()) {
-      throw new VeniceException(
-          "Failed to fetch schema id for store: " + storeName + ", error: " + response.getError());
+        sslFactory)) {
+      SchemaResponse response = controllerClient.getValueSchemaID(storeName, valueSchemaStr);
+      if (response.isError()) {
+        throw new VeniceException(
+            "Failed to fetch schema id for store: " + storeName + ", error: " + response.getError());
+      }
+      return response.getId();
     }
-    return response.getId();
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreMigrationHelper.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreMigrationHelper.java
@@ -1,0 +1,82 @@
+package com.linkedin.venice.controller;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.NewStoreResponse;
+import com.linkedin.venice.controllerapi.SchemaResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.schema.SchemaEntry;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Cross-cluster store-migration plumbing: RPCs against the destination controller to create
+ * the cloned store, register its value schemas, and replicate per-region store-config overrides.
+ */
+final class StoreMigrationHelper {
+  private StoreMigrationHelper() {
+  }
+
+  static void cloneDestinationStoreAndSyncConfigs(
+      ControllerClient destControllerClient,
+      StoreInfo srcStore,
+      String keySchema,
+      List<SchemaEntry> valueSchemaEntries,
+      Map<String, Map<String, StoreInfo>> srcStoresInChildColos,
+      String destClusterName,
+      String storeName,
+      String localRegion,
+      Logger logger) {
+    NewStoreResponse newStoreResponse = destControllerClient
+        .createNewStore(storeName, srcStore.getOwner(), keySchema, valueSchemaEntries.get(0).getSchema().toString());
+    if (newStoreResponse.isError()) {
+      throw new VeniceException(
+          "Failed to create store " + storeName + " in dest cluster " + destClusterName + ". Error "
+              + newStoreResponse.getError());
+    }
+
+    for (SchemaEntry schemaEntry: valueSchemaEntries) {
+      SchemaResponse schemaResponse =
+          destControllerClient.addValueSchema(storeName, schemaEntry.getSchema().toString());
+      if (schemaResponse.isError()) {
+        throw new VeniceException(
+            "Failed to add value schema " + schemaEntry.getId() + " into store " + storeName + " in dest cluster "
+                + destClusterName + ". Error " + schemaResponse.getError());
+      }
+    }
+
+    UpdateStoreQueryParams params = new UpdateStoreQueryParams(srcStore, true);
+    Set<String> remainingRegions = new HashSet<>();
+    remainingRegions.add(localRegion);
+    for (Map.Entry<String, StoreInfo> entry: srcStoresInChildColos.get(storeName).entrySet()) {
+      UpdateStoreQueryParams paramsInChildColo = new UpdateStoreQueryParams(entry.getValue(), true);
+      if (params.isDifferent(paramsInChildColo)) {
+        paramsInChildColo.setRegionsFilter(entry.getKey());
+        logger.info("Sending update-store request {} to store {} in {}", paramsInChildColo, storeName, entry.getKey());
+        ControllerResponse updateStoreResponse = destControllerClient.updateStore(storeName, paramsInChildColo);
+        if (updateStoreResponse.isError()) {
+          throw new VeniceException(
+              "Failed to update store " + storeName + " in dest cluster " + destClusterName + " in region "
+                  + paramsInChildColo + ". Error " + updateStoreResponse.getError());
+        }
+      } else {
+        remainingRegions.add(entry.getKey());
+      }
+    }
+
+    params.setRegionsFilter(String.join(",", remainingRegions));
+    logger.info("Sending update-store request {} to store {} in {}", params, storeName, remainingRegions);
+    ControllerResponse updateStoreResponse = destControllerClient.updateStore(storeName, params);
+    if (updateStoreResponse.isError()) {
+      throw new VeniceException(
+          "Failed to update store " + storeName + " in dest cluster " + destClusterName + " in regions "
+              + remainingRegions + ". Error " + updateStoreResponse.getError());
+    }
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -227,7 +227,6 @@ import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
-import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
@@ -265,7 +264,6 @@ import com.linkedin.venice.utils.StoreUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
-import com.linkedin.venice.utils.concurrent.ConcurrencyUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.utils.locks.AutoCloseableLock;
@@ -397,8 +395,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   protected static final long INTERNAL_STORE_RTT_RETRY_BACKOFF_MS = TimeUnit.SECONDS.toMillis(5);
   private static final int PARTICIPANT_MESSAGE_STORE_SCHEMA_ID = 1;
   private static final long PUSH_STATUS_STORE_WRITER_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
-  private final InternalAvroSpecificSerializer<PushJobDetails> pushJobDetailsSerializer =
-      AvroProtocolDefinition.PUSH_JOB_DETAILS.getSerializer();
   private volatile static String SELF_URL;
 
   static final int VERSION_ID_UNSET = -1;
@@ -453,17 +449,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   private PropertyKey.Builder controllerClusterKeyBuilder;
 
-  private PubSubTopic pushJobDetailsRTTopic;
-
-  // Those variables will be initialized lazily.
-  private int pushJobDetailsSchemaId = -1;
-
   private final Map<String, DisabledPartitionStats> disabledPartitionStatMap = new HashMap<>();
   private final Map<String, PushJobStatusStats> pushJobStatusStatsMap = new HashMap<>();
   private final Map<String, AddVersionLatencyStats> addVersionLatencyStatsMap = new HashMap<>();
-
-  private static final String PUSH_JOB_DETAILS_WRITER = "PUSH_JOB_DETAILS_WRITER";
-  private final Map<String, VeniceWriter> jobTrackingVeniceWriterMap = new VeniceConcurrentHashMap<>();
 
   // This map stores the time when topics were created. It only contains topics whose information has not yet been
   // persisted to Zk.
@@ -486,11 +474,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   private final ParticipantStoreClientsManager participantStoreClientsManager;
   protected final PubSubTopicRepository pubSubTopicRepository;
 
-  private final Object PUSH_JOB_DETAILS_CLIENT_LOCK = new Object();
-  private AvroSpecificStoreClient<PushJobStatusRecordKey, PushJobDetails> pushJobDetailsStoreClient = null;
-
-  private final Object LIVENESS_HEARTBEAT_CLIENT_LOCK = new Object();
-  private AvroSpecificStoreClient<BatchJobHeartbeatKey, BatchJobHeartbeatValue> livenessHeartbeatStoreClient = null;
+  private final PushJobDetailsManager pushJobDetailsManager;
 
   private final Lazy<ByteBuffer> emptyPushZSTDDictionary;
 
@@ -904,6 +888,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
     pushJobUserErrorCheckpoints = commonConfig.getPushJobUserErrorCheckpoints();
     this.externalETLService = externalETLService;
+    this.pushJobDetailsManager = new PushJobDetailsManager(
+        this,
+        d2Client,
+        sslEnabled,
+        pushJobStatusStoreClusterName,
+        multiClusterConfigs.isMultiRegion(),
+        sslFactory);
   }
 
   private Set<RepushCandidateFilter> getRepushCandidateFiltersFromControllerConfig(
@@ -1545,28 +1536,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
   }
 
-  private Integer fetchSystemStoreSchemaId(String clusterName, String storeName, String valueSchemaStr) {
-    if (isLeaderControllerFor(clusterName)) {
-      // Can be fetched from local repository
-      int valueSchemaId = getValueSchemaId(clusterName, storeName, valueSchemaStr);
-      if (SchemaData.INVALID_VALUE_SCHEMA_ID == valueSchemaId) {
-        throw new InvalidVeniceSchemaException(
-            "Can not find any registered value schema for the store " + storeName + " that matches the requested schema"
-                + valueSchemaStr);
-      }
-      return valueSchemaId;
-    }
-
-    ControllerClient controllerClient = ControllerClient
-        .constructClusterControllerClient(clusterName, getLeaderController(clusterName).getUrl(sslEnabled), sslFactory);
-    SchemaResponse response = controllerClient.getValueSchemaID(storeName, valueSchemaStr);
-    if (response.isError()) {
-      throw new VeniceException(
-          "Failed to fetch schema id for store: " + storeName + ", error: " + response.getError());
-    }
-    return response.getId();
-  }
-
   static boolean isPushJobFailedDueToUserError(
       PushJobDetailsStatus status,
       PushJobDetails pushJobDetails,
@@ -1709,47 +1678,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   void sendPushJobDetailsToLocalRT(PushJobStatusRecordKey key, PushJobDetails value) {
-    // Emit push job status metrics
     emitPushJobStatusMetrics(pushJobStatusStatsMap, logCompactionStatsMap, key, value, pushJobUserErrorCheckpoints);
-    // Send push job details to the push job status system store
-    if (StringUtils.isBlank(getPushJobStatusStoreClusterName()) && multiClusterConfigs.isMultiRegion()) {
-      throw new VeniceException(
-          ("Unable to send the push job details because " + ConfigKeys.PUSH_JOB_STATUS_STORE_CLUSTER_NAME)
-              + " is not configured");
-    }
-    String pushJobDetailsStoreName = VeniceSystemStoreUtils.getPushJobDetailsStoreName();
-    if (pushJobDetailsRTTopic == null) {
-      // Verify the RT topic exists and give some time in case it's getting created.
-      PubSubTopic expectedRTTopic = pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(pushJobDetailsStoreName));
-      for (int attempt = 0; attempt < INTERNAL_STORE_GET_RRT_TOPIC_ATTEMPTS; attempt++) {
-        if (attempt > 0)
-          Utils.sleep(INTERNAL_STORE_RTT_RETRY_BACKOFF_MS);
-        if (getTopicManager().containsTopicAndAllPartitionsAreOnline(expectedRTTopic)) {
-          pushJobDetailsRTTopic = expectedRTTopic;
-          LOGGER.info("Topic {} exists and is configured to receive push job details events", expectedRTTopic);
-          break;
-        }
-      }
-      if (pushJobDetailsRTTopic == null) {
-        throw new VeniceException(
-            "Expected RT topic " + expectedRTTopic + " to receive push job details events"
-                + " not found. The topic either hasn't been created yet or it's mis-configured");
-      }
-    }
-
-    VeniceWriter pushJobDetailsWriter = jobTrackingVeniceWriterMap.computeIfAbsent(PUSH_JOB_DETAILS_WRITER, k -> {
-      pushJobDetailsSchemaId = fetchSystemStoreSchemaId(
-          pushJobStatusStoreClusterName,
-          VeniceSystemStoreUtils.getPushJobDetailsStoreName(),
-          value.getSchema().toString());
-      return getVeniceWriterFactory().createVeniceWriter(
-          new VeniceWriterOptions.Builder(pushJobDetailsRTTopic.getName())
-              .setKeyPayloadSerializer(new VeniceAvroKafkaSerializer(key.getSchema().toString()))
-              .setValuePayloadSerializer(new VeniceAvroKafkaSerializer(value.getSchema().toString()))
-              .build());
-    });
-
-    pushJobDetailsWriter.put(key, value, pushJobDetailsSchemaId, null);
+    pushJobDetailsManager.writeToLocalRTTopic(key, value);
   }
 
   /**
@@ -1757,20 +1687,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public PushJobDetails getPushJobDetails(@Nonnull PushJobStatusRecordKey key) {
-    Validate.notNull(key);
-    ConcurrencyUtils.executeUnderConditionalLock(() -> {
-      String storeName = VeniceSystemStoreUtils.getPushJobDetailsStoreName();
-      String d2Service = getRouterD2Service(discoverCluster(storeName));
-      pushJobDetailsStoreClient = ClientFactory.getAndStartSpecificAvroClient(
-          ClientConfig.defaultSpecificClientConfig(storeName, PushJobDetails.class)
-              .setD2ServiceName(d2Service)
-              .setD2Client(this.d2Client));
-    }, () -> pushJobDetailsStoreClient == null, PUSH_JOB_DETAILS_CLIENT_LOCK);
-    try {
-      return pushJobDetailsStoreClient.get(key).get();
-    } catch (Exception e) {
-      throw new VeniceException(e);
-    }
+    return pushJobDetailsManager.getPushJobDetails(key);
   }
 
   /**
@@ -1778,20 +1695,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public BatchJobHeartbeatValue getBatchJobHeartbeatValue(@Nonnull BatchJobHeartbeatKey batchJobHeartbeatKey) {
-    Validate.notNull(batchJobHeartbeatKey);
-    ConcurrencyUtils.executeUnderConditionalLock(() -> {
-      String storeName = VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE.getPrefix();
-      String d2Service = getRouterD2Service(discoverCluster(storeName));
-      livenessHeartbeatStoreClient = ClientFactory.getAndStartSpecificAvroClient(
-          ClientConfig.defaultSpecificClientConfig(storeName, BatchJobHeartbeatValue.class)
-              .setD2ServiceName(d2Service)
-              .setD2Client(this.d2Client));
-    }, () -> livenessHeartbeatStoreClient == null, LIVENESS_HEARTBEAT_CLIENT_LOCK);
-    try {
-      return livenessHeartbeatStoreClient.get(batchJobHeartbeatKey).get();
-    } catch (Exception e) {
-      throw new VeniceException(e);
-    }
+    return pushJobDetailsManager.getBatchJobHeartbeatValue(batchJobHeartbeatKey);
   }
 
   /**
@@ -9232,13 +9136,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       } catch (Exception e) {
         LOGGER.error("Failed to close zkClient. Swallowing and moving on.", e);
       }
-      this.jobTrackingVeniceWriterMap.values().forEach(Utils::closeQuietlyWithErrorLogged);
-      this.jobTrackingVeniceWriterMap.clear();
+      Utils.closeQuietlyWithErrorLogged(this.pushJobDetailsManager);
       Utils.closeQuietlyWithErrorLogged(this.dataRecoveryManager);
       Utils.closeQuietlyWithErrorLogged(this.participantStoreClientsManager);
       Utils.closeQuietlyWithErrorLogged(this.topicManagerRepository);
-      Utils.closeQuietlyWithErrorLogged(this.pushJobDetailsStoreClient);
-      Utils.closeQuietlyWithErrorLogged(this.livenessHeartbeatStoreClient);
       this.clusterControllerClientPerColoMap.values()
           .forEach(ccMap -> ccMap.values().forEach(Utils::closeQuietlyWithErrorLogged));
       // Clean up ZK subscriptions from lazily-created degraded DC state repositories
@@ -10461,7 +10362,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   // Only for testing
   public void setPushJobDetailsStoreClient(AvroSpecificStoreClient<PushJobStatusRecordKey, PushJobDetails> client) {
-    pushJobDetailsStoreClient = client;
+    pushJobDetailsManager.setPushJobDetailsStoreClient(client);
   }
 
   @Override
@@ -10482,7 +10383,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   InternalAvroSpecificSerializer<PushJobDetails> getPushJobDetailsSerializer() {
-    return pushJobDetailsSerializer;
+    return pushJobDetailsManager.getPushJobDetailsSerializer();
   }
 
   public LogContext getLogContext() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -68,7 +68,6 @@ import com.linkedin.venice.controller.init.SystemSchemaInitializationRoutine;
 import com.linkedin.venice.controller.kafka.StoreStatusDecider;
 import com.linkedin.venice.controller.kafka.consumer.AdminConsumerService;
 import com.linkedin.venice.controller.kafka.consumer.AdminMetadata;
-import com.linkedin.venice.controller.kafka.protocol.admin.HybridStoreConfigRecord;
 import com.linkedin.venice.controller.kafka.protocol.admin.StoreViewConfigRecord;
 import com.linkedin.venice.controller.kafka.protocol.serializer.AdminOperationSerializer;
 import com.linkedin.venice.controller.logcompaction.CompactionManager;
@@ -92,11 +91,9 @@ import com.linkedin.venice.controllerapi.ControllerClientFactory;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.ControllerRoute;
 import com.linkedin.venice.controllerapi.D2ControllerClient;
-import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.NodeReplicasReadinessState;
 import com.linkedin.venice.controllerapi.RepushInfo;
 import com.linkedin.venice.controllerapi.RepushJobResponse;
-import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.controllerapi.StoreComparisonInfo;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateClusterConfigQueryParams;
@@ -1881,53 +1878,16 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           .accept(VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(storeName));
     }
 
-    // Create a new store in destination cluster
-    NewStoreResponse newStoreResponse = destControllerClient
-        .createNewStore(storeName, srcStore.getOwner(), keySchema, valueSchemaEntries.get(0).getSchema().toString());
-    if (newStoreResponse.isError()) {
-      throw new VeniceException(
-          "Failed to create store " + storeName + " in dest cluster " + destClusterName + ". Error "
-              + newStoreResponse.getError());
-    }
-    // Add other value schemas
-    for (SchemaEntry schemaEntry: valueSchemaEntries) {
-      SchemaResponse schemaResponse =
-          destControllerClient.addValueSchema(storeName, schemaEntry.getSchema().toString());
-      if (schemaResponse.isError()) {
-        throw new VeniceException(
-            "Failed to add value schema " + schemaEntry.getId() + " into store " + storeName + " in dest cluster "
-                + destClusterName + ". Error " + schemaResponse.getError());
-      }
-    }
-
-    // Copy remaining properties that will make the cloned store almost identical to the original
-    UpdateStoreQueryParams params = new UpdateStoreQueryParams(srcStore, true);
-    Set<String> remainingRegions = new HashSet<>();
-    remainingRegions.add(multiClusterConfigs.getRegionName());
-    for (Map.Entry<String, StoreInfo> entry: srcStoresInChildColos.get(storeName).entrySet()) {
-      UpdateStoreQueryParams paramsInChildColo = new UpdateStoreQueryParams(entry.getValue(), true);
-      if (params.isDifferent(paramsInChildColo)) {
-        // Src parent controller calls dest parent controller to update store with store configs in child colo.
-        paramsInChildColo.setRegionsFilter(entry.getKey());
-        LOGGER.info("Sending update-store request {} to store {} in {}", paramsInChildColo, storeName, entry.getKey());
-        ControllerResponse updateStoreResponse = destControllerClient.updateStore(storeName, paramsInChildColo);
-        if (updateStoreResponse.isError()) {
-          throw new VeniceException(
-              "Failed to update store " + storeName + " in dest cluster " + destClusterName + " in region "
-                  + paramsInChildColo + ". Error " + updateStoreResponse.getError());
-        }
-      } else {
-        remainingRegions.add(entry.getKey());
-      }
-    }
-    params.setRegionsFilter(String.join(",", remainingRegions));
-    LOGGER.info("Sending update-store request {} to store {} in {}", params, storeName, remainingRegions);
-    ControllerResponse updateStoreResponse = destControllerClient.updateStore(storeName, params);
-    if (updateStoreResponse.isError()) {
-      throw new VeniceException(
-          "Failed to update store " + storeName + " in dest cluster " + destClusterName + " in regions "
-              + remainingRegions + ". Error " + updateStoreResponse.getError());
-    }
+    StoreMigrationHelper.cloneDestinationStoreAndSyncConfigs(
+        destControllerClient,
+        srcStore,
+        keySchema,
+        valueSchemaEntries,
+        srcStoresInChildColos,
+        destClusterName,
+        storeName,
+        multiClusterConfigs.getRegionName(),
+        LOGGER);
 
     Consumer<String> versionMigrationConsumer = migratingStoreName -> {
       Store migratingStore = this.getStore(srcClusterName, migratingStoreName);
@@ -4400,7 +4360,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
   }
 
-  private boolean hasFatalDataValidationError(PushMonitor pushMonitor, String topicName) {
+  private static boolean hasFatalDataValidationError(PushMonitor pushMonitor, String topicName) {
     try {
       OfflinePushStatus offlinePushStatus = pushMonitor.getOfflinePushOrThrow(topicName);
       return offlinePushStatus.hasFatalDataValidationError();
@@ -6147,7 +6107,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     final Optional<HybridStoreConfig> newHybridStoreConfig;
     if (hybridRewindSeconds.isPresent() || hybridOffsetLagThreshold.isPresent() || hybridTimeLagThreshold.isPresent()
         || hybridDataReplicationPolicy.isPresent() || hybridBufferReplayPolicy.isPresent()) {
-      HybridStoreConfig hybridConfig = mergeNewSettingsIntoOldHybridStoreConfig(
+      HybridStoreConfig hybridConfig = HybridStoreConfigPolicy.mergeNewSettingsIntoOldHybridStoreConfig(
           originalStore,
           hybridRewindSeconds,
           hybridOffsetLagThreshold,
@@ -6230,7 +6190,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         // To fix the final variable problem in the lambda expression
         final HybridStoreConfig finalHybridConfig = newHybridStoreConfig.get();
         storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
-          if (!isHybrid(finalHybridConfig)) {
+          if (!HybridStoreConfigPolicy.isHybrid(finalHybridConfig)) {
             /**
              * If all the hybrid config values are negative, it indicates that the store is being set back to batch-only store.
              * We cannot remove the RT topic immediately because with NR and AA, existing current version is
@@ -6793,78 +6753,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       LOGGER
           .warn("Exception thrown when replicating new update for store: {} as part of store migration", storeName, e);
     }
-  }
-
-  /**
-   * Used by both the {@link VeniceHelixAdmin} and the {@link VeniceParentHelixAdmin}
-   *
-   * @param oldStore Existing Store that is the source for updates. This object will not be modified by this method.
-   * @param hybridRewindSeconds Optional is present if the returned object should include a new rewind time
-   * @param hybridOffsetLagThreshold Optional is present if the returned object should include a new offset lag threshold
-   * @return null if oldStore has no hybrid configs and optionals are not present,
-   *   otherwise a fully specified {@link HybridStoreConfig}
-   */
-  protected static HybridStoreConfig mergeNewSettingsIntoOldHybridStoreConfig(
-      Store oldStore,
-      Optional<Long> hybridRewindSeconds,
-      Optional<Long> hybridOffsetLagThreshold,
-      Optional<Long> hybridTimeLagThreshold,
-      Optional<DataReplicationPolicy> hybridDataReplicationPolicy,
-      Optional<BufferReplayPolicy> bufferReplayPolicy,
-      Optional<String> realTimeTopicName) {
-    if (!hybridRewindSeconds.isPresent() && !hybridOffsetLagThreshold.isPresent() && !oldStore.isHybrid()) {
-      return null; // For the nullable union in the avro record
-    }
-    HybridStoreConfig mergedHybridStoreConfig;
-    if (oldStore.isHybrid()) { // for an existing hybrid store, just replace any specified values
-      HybridStoreConfig oldHybridConfig = oldStore.getHybridStoreConfig().clone();
-      mergedHybridStoreConfig = new HybridStoreConfigImpl(
-          hybridRewindSeconds.isPresent() ? hybridRewindSeconds.get() : oldHybridConfig.getRewindTimeInSeconds(),
-          hybridOffsetLagThreshold.isPresent()
-              ? hybridOffsetLagThreshold.get()
-              : oldHybridConfig.getOffsetLagThresholdToGoOnline(),
-          hybridTimeLagThreshold.isPresent()
-              ? hybridTimeLagThreshold.get()
-              : oldHybridConfig.getProducerTimestampLagThresholdToGoOnlineInSeconds(),
-          hybridDataReplicationPolicy.isPresent()
-              ? hybridDataReplicationPolicy.get()
-              : oldHybridConfig.getDataReplicationPolicy(),
-          bufferReplayPolicy.isPresent() ? bufferReplayPolicy.get() : oldHybridConfig.getBufferReplayPolicy(),
-          realTimeTopicName.orElseGet(oldHybridConfig::getRealTimeTopicName));
-    } else {
-      // switching a non-hybrid store to hybrid; must specify:
-      // 1. rewind time
-      // 2. either offset lag threshold or time lag threshold, or both
-      if (!(hybridRewindSeconds.isPresent()
-          && (hybridOffsetLagThreshold.isPresent() || hybridTimeLagThreshold.isPresent()))) {
-        throw new VeniceException(
-            oldStore.getName() + " was not a hybrid store.  In order to make it a hybrid store both "
-                + " rewind time in seconds and offset or time lag threshold must be specified");
-      }
-
-      String newRealTimeTopicName = oldStore.getLargestUsedRTVersionNumber() > DEFAULT_RT_VERSION_NUMBER
-          && Utils.isRTVersioningApplicable(oldStore.getName())
-              ? Utils.composeRealTimeTopic(oldStore.getName(), oldStore.getLargestUsedRTVersionNumber())
-              : DEFAULT_REAL_TIME_TOPIC_NAME;
-
-      mergedHybridStoreConfig = new HybridStoreConfigImpl(
-          hybridRewindSeconds.get(),
-          // If not specified, offset/time lag threshold will be -1 and will not be used to determine whether
-          // a partition is ready to serve
-          hybridOffsetLagThreshold.orElse(DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD),
-          hybridTimeLagThreshold.orElse(DEFAULT_HYBRID_TIME_LAG_THRESHOLD),
-          hybridDataReplicationPolicy.orElse(DataReplicationPolicy.NON_AGGREGATE),
-          bufferReplayPolicy.orElse(BufferReplayPolicy.REWIND_FROM_EOP),
-          realTimeTopicName.orElse(newRealTimeTopicName));
-    }
-    if (mergedHybridStoreConfig.getRewindTimeInSeconds() > 0
-        && mergedHybridStoreConfig.getOffsetLagThresholdToGoOnline() < 0
-        && mergedHybridStoreConfig.getProducerTimestampLagThresholdToGoOnlineInSeconds() < 0) {
-      throw new VeniceException(
-          "Both offset lag threshold and time lag threshold are negative when setting hybrid" + " configs for store "
-              + oldStore.getName());
-    }
-    return mergedHybridStoreConfig;
   }
 
   static PartitionerConfig mergeNewSettingsIntoOldPartitionerConfig(
@@ -9654,34 +9542,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       throwStoreDoesNotExist(clusterName, storeName);
     }
     return store;
-  }
-
-  /**
-   * A store is not hybrid in the following two scenarios:
-   * If hybridStoreConfig is null, it means store is not hybrid.
-   * If all the hybrid config values are negative, it indicates that the store is being set back to batch-only store.
-   */
-  boolean isHybrid(HybridStoreConfig hybridStoreConfig) {
-    return hybridStoreConfig != null
-        && (hybridStoreConfig.getRewindTimeInSeconds() >= 0 || hybridStoreConfig.getOffsetLagThresholdToGoOnline() >= 0
-            || hybridStoreConfig.getProducerTimestampLagThresholdToGoOnlineInSeconds() >= 0);
-  }
-
-  /**
-   * @see VeniceHelixAdmin#isHybrid(HybridStoreConfig)
-   */
-  boolean isHybrid(HybridStoreConfigRecord hybridStoreConfigRecord) {
-    HybridStoreConfig hybridStoreConfig = null;
-    if (hybridStoreConfigRecord != null) {
-      hybridStoreConfig = new HybridStoreConfigImpl(
-          hybridStoreConfigRecord.rewindTimeInSeconds,
-          hybridStoreConfigRecord.offsetLagThresholdToGoOnline,
-          hybridStoreConfigRecord.producerTimestampLagThresholdToGoOnlineInSeconds,
-          DataReplicationPolicy.valueOf(hybridStoreConfigRecord.dataReplicationPolicy),
-          BufferReplayPolicy.valueOf(hybridStoreConfigRecord.bufferReplayPolicy),
-          hybridStoreConfigRecord.realTimeTopicName.toString());
-    }
-    return isHybrid(hybridStoreConfig);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4,7 +4,6 @@ import static com.linkedin.venice.controller.VeniceHelixAdmin.VERSION_ID_UNSET;
 import static com.linkedin.venice.controller.kafka.consumer.AdminConsumptionTask.IGNORED_CURRENT_VERSION;
 import static com.linkedin.venice.controller.util.ParentControllerConfigUpdateUtils.addUpdateSchemaForStore;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ACCESS_CONTROLLED;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.ACTIVE_ACTIVE_REPLICATION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.AMPLIFICATION_FACTOR;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.AUTO_SCHEMA_REGISTER_FOR_PUSHJOB_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.BACKUP_STRATEGY;
@@ -14,13 +13,11 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.BLOB_DB_E
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.BLOB_TRANSFER_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.BLOB_TRANSFER_IN_SERVER_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.BUFFER_REPLAY_POLICY;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.CHUNKING_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLIENT_DECOMPRESSION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.COMPACTION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.COMPACTION_THRESHOLD_MILLISECONDS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.COMPRESSION_STRATEGY;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.DATA_REPLICATION_POLICY;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DISABLE_DAVINCI_PUSH_STATUS_STORE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DISABLE_META_STORE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_READS;
@@ -35,7 +32,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.FLINK_VEN
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.FUTURE_VERSION_ETL_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.GLOBAL_RT_DIV_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.HYBRID_STORE_DISK_QUOTA_ENABLED;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.INCREMENTAL_PUSH_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.INGESTION_PAUSED_REGIONS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.INGESTION_PAUSE_MODE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.IS_DAVINCI_HEARTBEAT_REPORTED;
@@ -52,7 +48,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.NATIVE_RE
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NEARLINE_PRODUCER_COMPRESSION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NEARLINE_PRODUCER_COUNT_PER_WRITER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NUM_VERSIONS_TO_PRESERVE;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.OFFSET_LAG_TO_GO_ONLINE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.OWNER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITIONER_CLASS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITIONER_PARAMS;
@@ -62,11 +57,9 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.PREVIOUS_
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PUSH_STREAM_SOURCE_ADDRESS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.READ_COMPUTATION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.READ_QUOTA_IN_CU;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.REAL_TIME_TOPIC_NAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REGULAR_VERSION_ETL_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REPLICATION_FACTOR;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REPLICATION_METADATA_PROTOCOL_VERSION_ID;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.REWIND_TIME_IN_SECONDS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.RMD_CHUNKING_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SEPARATE_REAL_TIME_TOPIC_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_MODE;
@@ -77,14 +70,9 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_MIG
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_VIEW;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TARGET_SWAP_REGION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TARGET_SWAP_REGION_WAIT_TIME;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.TIME_LAG_TO_GO_ONLINE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.UNUSED_SCHEMA_DELETION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.WRITE_COMPUTATION_ENABLED;
-import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD;
-import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
-import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REAL_TIME_TOPIC_NAME;
-import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REWIND_TIME_IN_SECONDS;
 import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 import static com.linkedin.venice.meta.Version.VERSION_SEPARATOR;
 import static com.linkedin.venice.meta.VersionStatus.CREATED;
@@ -145,7 +133,6 @@ import com.linkedin.venice.controller.kafka.protocol.admin.DerivedSchemaCreation
 import com.linkedin.venice.controller.kafka.protocol.admin.DisableStoreRead;
 import com.linkedin.venice.controller.kafka.protocol.admin.ETLStoreConfigRecord;
 import com.linkedin.venice.controller.kafka.protocol.admin.EnableStoreRead;
-import com.linkedin.venice.controller.kafka.protocol.admin.HybridStoreConfigRecord;
 import com.linkedin.venice.controller.kafka.protocol.admin.KillOfflinePushJob;
 import com.linkedin.venice.controller.kafka.protocol.admin.MetaSystemStoreAutoCreationValidation;
 import com.linkedin.venice.controller.kafka.protocol.admin.MetadataSchemaCreation;
@@ -226,7 +213,6 @@ import com.linkedin.venice.meta.DataReplicationPolicy;
 import com.linkedin.venice.meta.DegradedDcStates;
 import com.linkedin.venice.meta.ETLStoreConfig;
 import com.linkedin.venice.meta.ExternalStorageReadMode;
-import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.IngestionPauseMode;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.LifecycleHooksRecord;
@@ -3252,122 +3238,23 @@ public class VeniceParentHelixAdmin implements Admin {
       setStore.currentVersion =
           currentVersion.map(addToUpdatedConfigList(updatedConfigsList, VERSION)).orElse(IGNORED_CURRENT_VERSION);
 
-      hybridRewindSeconds.map(addToUpdatedConfigList(updatedConfigsList, REWIND_TIME_IN_SECONDS));
-      hybridOffsetLagThreshold.map(addToUpdatedConfigList(updatedConfigsList, OFFSET_LAG_TO_GO_ONLINE));
-      hybridTimeLagThreshold.map(addToUpdatedConfigList(updatedConfigsList, TIME_LAG_TO_GO_ONLINE));
-      hybridDataReplicationPolicy.map(addToUpdatedConfigList(updatedConfigsList, DATA_REPLICATION_POLICY));
-      hybridBufferReplayPolicy.map(addToUpdatedConfigList(updatedConfigsList, BUFFER_REPLAY_POLICY));
-      realTimeTopicName.map(addToUpdatedConfigList(updatedConfigsList, REAL_TIME_TOPIC_NAME));
-      HybridStoreConfig updatedHybridStoreConfig = VeniceHelixAdmin.mergeNewSettingsIntoOldHybridStoreConfig(
+      VeniceControllerClusterConfig controllerConfig =
+          veniceHelixAdmin.getHelixVeniceClusterResources(clusterName).getConfig();
+      boolean storeBeingConvertedToHybrid = HybridStoreConfigPolicy.applyHybridAndReplicationConfigUpdates(
+          storeName,
           currStore,
+          setStore,
+          controllerConfig,
           hybridRewindSeconds,
           hybridOffsetLagThreshold,
           hybridTimeLagThreshold,
           hybridDataReplicationPolicy,
           hybridBufferReplayPolicy,
-          realTimeTopicName);
-
-      // Get VeniceControllerClusterConfig for the cluster
-      VeniceControllerClusterConfig controllerConfig =
-          veniceHelixAdmin.getHelixVeniceClusterResources(clusterName).getConfig();
-      // Check if the store is being converted to a hybrid store
-      boolean storeBeingConvertedToHybrid = !currStore.isHybrid() && updatedHybridStoreConfig != null
-          && veniceHelixAdmin.isHybrid(updatedHybridStoreConfig);
-      // Check if the store is being converted to a batch store
-      boolean storeBeingConvertedToBatch = currStore.isHybrid() && !veniceHelixAdmin.isHybrid(updatedHybridStoreConfig);
-      if (storeBeingConvertedToBatch && activeActiveReplicationEnabled.orElse(false)) {
-        throw new VeniceHttpException(
-            HttpStatus.SC_BAD_REQUEST,
-            "Cannot convert store to batch-only and enable Active/Active together.",
-            ErrorType.BAD_REQUEST);
-      }
-      if (storeBeingConvertedToBatch && incrementalPushEnabled.orElse(false)) {
-        throw new VeniceHttpException(
-            HttpStatus.SC_BAD_REQUEST,
-            "Cannot convert store to batch-only and enable incremental push together.",
-            ErrorType.BAD_REQUEST);
-      }
-      // Update active-active replication config.
-      setStore.activeActiveReplicationEnabled = activeActiveReplicationEnabled
-          .map(addToUpdatedConfigList(updatedConfigsList, ACTIVE_ACTIVE_REPLICATION_ENABLED))
-          .orElseGet(currStore::isActiveActiveReplicationEnabled);
-      // Enable active-active replication automatically when batch user store being converted to hybrid store and
-      // active-active replication is enabled for all hybrid store via the cluster config
-      if (storeBeingConvertedToHybrid && !setStore.activeActiveReplicationEnabled && !currStore.isSystemStore()
-          && controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()) {
-        setStore.activeActiveReplicationEnabled = true;
-        updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
-      }
-      // When turning off hybrid store, we will also turn off A/A store config.
-      if (storeBeingConvertedToBatch && setStore.activeActiveReplicationEnabled) {
-        setStore.activeActiveReplicationEnabled = false;
-        updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
-      }
-
-      // Update incremental push config.
-      setStore.incrementalPushEnabled =
-          incrementalPushEnabled.map(addToUpdatedConfigList(updatedConfigsList, INCREMENTAL_PUSH_ENABLED))
-              .orElseGet(currStore::isIncrementalPushEnabled);
-      // Enable incremental push automatically when batch user store being converted to hybrid store and active-active
-      // replication is enabled or being and the cluster config allows it.
-      if (!setStore.incrementalPushEnabled && !currStore.isSystemStore() && storeBeingConvertedToHybrid
-          && setStore.activeActiveReplicationEnabled
-          && controllerConfig.enabledIncrementalPushForHybridActiveActiveUserStores()) {
-        setStore.incrementalPushEnabled = true;
-        updatedConfigsList.add(INCREMENTAL_PUSH_ENABLED);
-      }
-      // Enable separate real-time topic automatically when incremental push is enabled and cluster config allows it.
-      if (setStore.incrementalPushEnabled
-          && controllerConfig.enabledSeparateRealTimeTopicForStoreWithIncrementalPush()) {
-        setStore.separateRealTimeTopicEnabled = true;
-        updatedConfigsList.add(SEPARATE_REAL_TIME_TOPIC_ENABLED);
-      }
-
-      // When turning off hybrid store, we will also turn off incremental store config.
-      if (storeBeingConvertedToBatch && setStore.incrementalPushEnabled) {
-        setStore.incrementalPushEnabled = false;
-        updatedConfigsList.add(INCREMENTAL_PUSH_ENABLED);
-      }
-
-      if (updatedHybridStoreConfig == null) {
-        setStore.hybridStoreConfig = null;
-      } else {
-        HybridStoreConfigRecord hybridStoreConfigRecord = new HybridStoreConfigRecord();
-        hybridStoreConfigRecord.offsetLagThresholdToGoOnline =
-            updatedHybridStoreConfig.getOffsetLagThresholdToGoOnline();
-        hybridStoreConfigRecord.rewindTimeInSeconds = updatedHybridStoreConfig.getRewindTimeInSeconds();
-        hybridStoreConfigRecord.producerTimestampLagThresholdToGoOnlineInSeconds =
-            updatedHybridStoreConfig.getProducerTimestampLagThresholdToGoOnlineInSeconds();
-        hybridStoreConfigRecord.dataReplicationPolicy = updatedHybridStoreConfig.getDataReplicationPolicy().getValue();
-        hybridStoreConfigRecord.bufferReplayPolicy = updatedHybridStoreConfig.getBufferReplayPolicy().getValue();
-        hybridStoreConfigRecord.realTimeTopicName = updatedHybridStoreConfig.getRealTimeTopicName();
-        setStore.hybridStoreConfig = hybridStoreConfigRecord;
-      }
-
-      if (incrementalPushEnabled.orElseGet(currStore::isIncrementalPushEnabled)
-          && !veniceHelixAdmin.isHybrid(currStore.getHybridStoreConfig())
-          && !veniceHelixAdmin.isHybrid(updatedHybridStoreConfig)) {
-        LOGGER.info(
-            "Enabling incremental push for a batch store:{}. Converting it to Active/Active hybrid store with default configs.",
-            storeName);
-        HybridStoreConfigRecord hybridStoreConfigRecord = new HybridStoreConfigRecord();
-        hybridStoreConfigRecord.rewindTimeInSeconds = DEFAULT_REWIND_TIME_IN_SECONDS;
-        updatedConfigsList.add(REWIND_TIME_IN_SECONDS);
-        hybridStoreConfigRecord.offsetLagThresholdToGoOnline = DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD;
-        updatedConfigsList.add(OFFSET_LAG_TO_GO_ONLINE);
-        hybridStoreConfigRecord.producerTimestampLagThresholdToGoOnlineInSeconds = DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
-        updatedConfigsList.add(TIME_LAG_TO_GO_ONLINE);
-        hybridStoreConfigRecord.dataReplicationPolicy = DataReplicationPolicy.NON_AGGREGATE.getValue();
-        updatedConfigsList.add(DATA_REPLICATION_POLICY);
-        hybridStoreConfigRecord.bufferReplayPolicy = BufferReplayPolicy.REWIND_FROM_EOP.getValue();
-        updatedConfigsList.add(BUFFER_REPLAY_POLICY);
-        hybridStoreConfigRecord.realTimeTopicName = DEFAULT_REAL_TIME_TOPIC_NAME;
-        setStore.hybridStoreConfig = hybridStoreConfigRecord;
-        if (!currStore.isSystemStore() && controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()) {
-          setStore.activeActiveReplicationEnabled = true;
-          updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
-        }
-      }
+          realTimeTopicName,
+          activeActiveReplicationEnabled,
+          incrementalPushEnabled,
+          updatedConfigsList,
+          LOGGER);
 
       /**
        * Set storage quota according to store properties. For hybrid stores, rocksDB has the overhead ratio as we
@@ -3639,8 +3526,8 @@ public class VeniceParentHelixAdmin implements Admin {
             ErrorType.BAD_REQUEST);
       }
 
-      if (!getVeniceHelixAdmin().isHybrid(currStore.getHybridStoreConfig())
-          && getVeniceHelixAdmin().isHybrid(setStore.getHybridStoreConfig()) && setStore.getPartitionNum() == 0) {
+      if (!HybridStoreConfigPolicy.isHybrid(currStore.getHybridStoreConfig())
+          && HybridStoreConfigPolicy.isHybrid(setStore.getHybridStoreConfig()) && setStore.getPartitionNum() == 0) {
         // This is a new hybrid store and partition count is not specified.
         VeniceControllerClusterConfig config =
             getVeniceHelixAdmin().getHelixVeniceClusterResources(clusterName).getConfig();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/versionlifecycle/package-info.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/versionlifecycle/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Store-version lifecycle: add, increment, retire, delete, roll-forward, roll-back, and the
+ * topic / Helix resource plumbing that hangs off those transitions. Code is currently spread
+ * across {@code VeniceHelixAdmin} and {@code VeniceParentHelixAdmin}; this package is the
+ * landing zone for the upcoming extraction.
+ */
+package com.linkedin.venice.controller.versionlifecycle;

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
@@ -231,6 +231,7 @@ public class AbstractTestVeniceParentHelixAdmin {
     childClusterMap.put(regionName, "localhost");
     doReturn(childClusterMap).when(config).getChildDataCenterControllerUrlMap();
     doReturn(MAX_PARTITION_NUM).when(config).getMaxNumberOfPartitions();
+    doReturn(1L << 30).when(config).getPartitionSize();
     doReturn(DefaultIdentityParser.class.getName()).when(config).getIdentityParserClassName();
     return config;
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
@@ -27,7 +27,6 @@ import com.linkedin.venice.helix.StoragePersonaRepository;
 import com.linkedin.venice.helix.ZkRoutersClusterManager;
 import com.linkedin.venice.helix.ZkStoreConfigAccessor;
 import com.linkedin.venice.meta.ConcurrentPushDetectionStrategy;
-import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.IngestionPauseMode;
 import com.linkedin.venice.meta.OfflinePushStrategy;
 import com.linkedin.venice.meta.Store;
@@ -96,7 +95,6 @@ public class AbstractTestVeniceParentHelixAdmin {
     doReturn(true).when(topicManager).containsTopicAndAllPartitionsAreOnline(pubSubTopicRepository.getTopic(topicName));
 
     internalAdmin = mock(VeniceHelixAdmin.class);
-    when(internalAdmin.isHybrid((HybridStoreConfig) any())).thenCallRealMethod();
     doReturn(topicManager).when(internalAdmin).getTopicManager();
     SchemaEntry mockEntry = new SchemaEntry(0, TEST_SCHEMA);
     doReturn(mockEntry).when(internalAdmin).getKeySchema(anyString(), anyString());

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/HybridStoreConfigPolicyTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/HybridStoreConfigPolicyTest.java
@@ -1,0 +1,610 @@
+package com.linkedin.venice.controller;
+
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.ACTIVE_ACTIVE_REPLICATION_ENABLED;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.BUFFER_REPLAY_POLICY;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.DATA_REPLICATION_POLICY;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.INCREMENTAL_PUSH_ENABLED;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.OFFSET_LAG_TO_GO_ONLINE;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.REAL_TIME_TOPIC_NAME;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.REWIND_TIME_IN_SECONDS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.SEPARATE_REAL_TIME_TOPIC_ENABLED;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.TIME_LAG_TO_GO_ONLINE;
+import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD;
+import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
+import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REAL_TIME_TOPIC_NAME;
+import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REWIND_TIME_IN_SECONDS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.venice.controller.kafka.protocol.admin.HybridStoreConfigRecord;
+import com.linkedin.venice.controller.kafka.protocol.admin.UpdateStore;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.exceptions.VeniceHttpException;
+import com.linkedin.venice.meta.BufferReplayPolicy;
+import com.linkedin.venice.meta.DataReplicationPolicy;
+import com.linkedin.venice.meta.HybridStoreConfig;
+import com.linkedin.venice.meta.HybridStoreConfigImpl;
+import com.linkedin.venice.meta.Store;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.apache.http.HttpStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.testng.annotations.Test;
+
+
+public class HybridStoreConfigPolicyTest {
+  private static final Logger LOGGER = LogManager.getLogger(HybridStoreConfigPolicyTest.class);
+  private static final String STORE_NAME = "test_store";
+
+  // ---------- isHybrid ----------
+
+  @Test
+  public void isHybridReturnsFalseForNullConfig() {
+    assertFalse(HybridStoreConfigPolicy.isHybrid((HybridStoreConfig) null));
+  }
+
+  @Test
+  public void isHybridReturnsFalseWhenAllThresholdsNegative() {
+    HybridStoreConfig batchSentinel = new HybridStoreConfigImpl(
+        -1L,
+        -1L,
+        -1L,
+        DataReplicationPolicy.NON_AGGREGATE,
+        BufferReplayPolicy.REWIND_FROM_EOP,
+        DEFAULT_REAL_TIME_TOPIC_NAME);
+    assertFalse(HybridStoreConfigPolicy.isHybrid(batchSentinel));
+  }
+
+  @Test
+  public void isHybridReturnsTrueWhenRewindNonNegative() {
+    HybridStoreConfig hybrid = new HybridStoreConfigImpl(
+        0L,
+        -1L,
+        -1L,
+        DataReplicationPolicy.NON_AGGREGATE,
+        BufferReplayPolicy.REWIND_FROM_EOP,
+        DEFAULT_REAL_TIME_TOPIC_NAME);
+    assertTrue(HybridStoreConfigPolicy.isHybrid(hybrid));
+  }
+
+  @Test
+  public void isHybridReturnsFalseForNullRecord() {
+    assertFalse(HybridStoreConfigPolicy.isHybrid((HybridStoreConfigRecord) null));
+  }
+
+  @Test
+  public void isHybridReturnsTrueForHybridRecord() {
+    HybridStoreConfigRecord record = new HybridStoreConfigRecord();
+    record.rewindTimeInSeconds = 100L;
+    record.offsetLagThresholdToGoOnline = 1000L;
+    record.producerTimestampLagThresholdToGoOnlineInSeconds = -1L;
+    record.dataReplicationPolicy = DataReplicationPolicy.NON_AGGREGATE.getValue();
+    record.bufferReplayPolicy = BufferReplayPolicy.REWIND_FROM_EOP.getValue();
+    record.realTimeTopicName = DEFAULT_REAL_TIME_TOPIC_NAME;
+    assertTrue(HybridStoreConfigPolicy.isHybrid(record));
+  }
+
+  // ---------- mergeNewSettingsIntoOldHybridStoreConfig: edge cases ----------
+
+  @Test
+  public void mergeThrowsWhenConvertingBatchToHybridWithoutLagThreshold() {
+    Store batchStore = newBatchStore();
+    // Only rewind specified; need at least one lag threshold.
+    VeniceException ex = expectThrows(
+        VeniceException.class,
+        () -> HybridStoreConfigPolicy.mergeNewSettingsIntoOldHybridStoreConfig(
+            batchStore,
+            Optional.of(100L),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()));
+    assertTrue(ex.getMessage().contains("was not a hybrid store"), "Unexpected message: " + ex.getMessage());
+  }
+
+  @Test
+  public void mergePreservesExistingHybridValuesWhenNothingSpecified() {
+    HybridStoreConfig existing = new HybridStoreConfigImpl(
+        500L,
+        2000L,
+        300L,
+        DataReplicationPolicy.AGGREGATE,
+        BufferReplayPolicy.REWIND_FROM_SOP,
+        "custom_rt");
+    Store hybridStore = newHybridStore(existing);
+
+    HybridStoreConfig merged = HybridStoreConfigPolicy.mergeNewSettingsIntoOldHybridStoreConfig(
+        hybridStore,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+
+    assertNotNull(merged);
+    assertEquals(merged.getRewindTimeInSeconds(), 500L);
+    assertEquals(merged.getOffsetLagThresholdToGoOnline(), 2000L);
+    assertEquals(merged.getProducerTimestampLagThresholdToGoOnlineInSeconds(), 300L);
+    assertEquals(merged.getDataReplicationPolicy(), DataReplicationPolicy.AGGREGATE);
+    assertEquals(merged.getBufferReplayPolicy(), BufferReplayPolicy.REWIND_FROM_SOP);
+    assertEquals(merged.getRealTimeTopicName(), "custom_rt");
+  }
+
+  @Test
+  public void mergeThrowsWhenRewindPositiveButBothLagsNegative() {
+    HybridStoreConfig existing = new HybridStoreConfigImpl(
+        100L,
+        1000L,
+        -1L,
+        DataReplicationPolicy.NON_AGGREGATE,
+        BufferReplayPolicy.REWIND_FROM_EOP,
+        DEFAULT_REAL_TIME_TOPIC_NAME);
+    Store hybridStore = newHybridStore(existing);
+
+    // Drive offsetLag to -1 while keeping rewind > 0 and timeLag -1 — should trip the safety check.
+    VeniceException ex = expectThrows(
+        VeniceException.class,
+        () -> HybridStoreConfigPolicy.mergeNewSettingsIntoOldHybridStoreConfig(
+            hybridStore,
+            Optional.empty(),
+            Optional.of(-1L),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()));
+    assertTrue(
+        ex.getMessage().contains("Both offset lag threshold and time lag threshold are negative"),
+        "Unexpected message: " + ex.getMessage());
+  }
+
+  // ---------- applyHybridAndReplicationConfigUpdates: batch -> hybrid ----------
+
+  @Test
+  public void applyAutoEnablesActiveActiveOnBatchToHybridConversion() {
+    Store currStore = newBatchStore();
+    UpdateStore setStore = new UpdateStore();
+    List<CharSequence> updatedConfigs = new ArrayList<>();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+    when(controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()).thenReturn(true);
+    // Keep other auto-enables off so this test pins only the A/A flip.
+    when(controllerConfig.enabledIncrementalPushForHybridActiveActiveUserStores()).thenReturn(false);
+    when(controllerConfig.enabledSeparateRealTimeTopicForStoreWithIncrementalPush()).thenReturn(false);
+
+    boolean converted = HybridStoreConfigPolicy.applyHybridAndReplicationConfigUpdates(
+        STORE_NAME,
+        currStore,
+        setStore,
+        controllerConfig,
+        Optional.of(100L),
+        Optional.of(1000L),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        updatedConfigs,
+        LOGGER);
+
+    assertTrue(converted, "store should be flagged as batch -> hybrid conversion");
+    assertTrue(setStore.activeActiveReplicationEnabled, "A/A should be auto-enabled on conversion");
+    assertFalse(setStore.incrementalPushEnabled, "incremental push must remain off without explicit/auto trigger");
+    assertNotNull(setStore.hybridStoreConfig);
+    assertEquals(setStore.hybridStoreConfig.rewindTimeInSeconds, 100L);
+    assertEquals(setStore.hybridStoreConfig.offsetLagThresholdToGoOnline, 1000L);
+    assertTrue(updatedConfigs.contains(REWIND_TIME_IN_SECONDS));
+    assertTrue(updatedConfigs.contains(OFFSET_LAG_TO_GO_ONLINE));
+    assertTrue(updatedConfigs.contains(ACTIVE_ACTIVE_REPLICATION_ENABLED));
+    assertFalse(updatedConfigs.contains(INCREMENTAL_PUSH_ENABLED));
+  }
+
+  @Test
+  public void applyDoesNotAutoEnableActiveActiveForSystemStore() {
+    Store currStore = newBatchStore();
+    when(currStore.isSystemStore()).thenReturn(true);
+    UpdateStore setStore = new UpdateStore();
+    List<CharSequence> updatedConfigs = new ArrayList<>();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+    when(controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()).thenReturn(true);
+
+    boolean converted = HybridStoreConfigPolicy.applyHybridAndReplicationConfigUpdates(
+        STORE_NAME,
+        currStore,
+        setStore,
+        controllerConfig,
+        Optional.of(100L),
+        Optional.of(1000L),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        updatedConfigs,
+        LOGGER);
+
+    assertTrue(converted);
+    assertFalse(setStore.activeActiveReplicationEnabled, "system store must not get auto-A/A");
+    assertFalse(updatedConfigs.contains(ACTIVE_ACTIVE_REPLICATION_ENABLED));
+  }
+
+  @Test
+  public void applyAutoEnablesIncrementalPushOnBatchToHybridActiveActiveWhenClusterConfigAllows() {
+    Store currStore = newBatchStore();
+    UpdateStore setStore = new UpdateStore();
+    List<CharSequence> updatedConfigs = new ArrayList<>();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+    when(controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()).thenReturn(true);
+    when(controllerConfig.enabledIncrementalPushForHybridActiveActiveUserStores()).thenReturn(true);
+    when(controllerConfig.enabledSeparateRealTimeTopicForStoreWithIncrementalPush()).thenReturn(false);
+
+    HybridStoreConfigPolicy.applyHybridAndReplicationConfigUpdates(
+        STORE_NAME,
+        currStore,
+        setStore,
+        controllerConfig,
+        Optional.of(100L),
+        Optional.of(1000L),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        updatedConfigs,
+        LOGGER);
+
+    assertTrue(setStore.activeActiveReplicationEnabled);
+    assertTrue(setStore.incrementalPushEnabled, "incremental push should be auto-enabled on hybrid+A/A user store");
+    assertFalse(setStore.separateRealTimeTopicEnabled);
+    assertTrue(updatedConfigs.contains(INCREMENTAL_PUSH_ENABLED));
+    assertFalse(updatedConfigs.contains(SEPARATE_REAL_TIME_TOPIC_ENABLED));
+  }
+
+  @Test
+  public void applyAutoEnablesSeparateRealTimeTopicWhenIncrementalPushAndClusterConfigAllow() {
+    Store currStore = newBatchStore();
+    UpdateStore setStore = new UpdateStore();
+    List<CharSequence> updatedConfigs = new ArrayList<>();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+    when(controllerConfig.enabledSeparateRealTimeTopicForStoreWithIncrementalPush()).thenReturn(true);
+
+    HybridStoreConfigPolicy.applyHybridAndReplicationConfigUpdates(
+        STORE_NAME,
+        currStore,
+        setStore,
+        controllerConfig,
+        Optional.of(100L),
+        Optional.of(1000L),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(true),
+        updatedConfigs,
+        LOGGER);
+
+    assertTrue(setStore.incrementalPushEnabled);
+    assertTrue(setStore.separateRealTimeTopicEnabled);
+    assertTrue(updatedConfigs.contains(INCREMENTAL_PUSH_ENABLED));
+    assertTrue(updatedConfigs.contains(SEPARATE_REAL_TIME_TOPIC_ENABLED));
+  }
+
+  // ---------- applyHybridAndReplicationConfigUpdates: hybrid -> batch ----------
+
+  @Test
+  public void applyRejectsHybridToBatchConversionCombinedWithActiveActive() {
+    Store currStore = newHybridStore(newDefaultHybridConfig());
+    UpdateStore setStore = new UpdateStore();
+    List<CharSequence> updatedConfigs = new ArrayList<>();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+
+    VeniceHttpException ex = expectThrows(
+        VeniceHttpException.class,
+        () -> HybridStoreConfigPolicy.applyHybridAndReplicationConfigUpdates(
+            STORE_NAME,
+            currStore,
+            setStore,
+            controllerConfig,
+            Optional.of(-1L),
+            Optional.of(-1L),
+            Optional.of(-1L),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(true), // explicit A/A=true alongside hybrid->batch
+            Optional.empty(),
+            updatedConfigs,
+            LOGGER));
+    assertEquals(ex.getHttpStatusCode(), HttpStatus.SC_BAD_REQUEST);
+    assertTrue(ex.getMessage().contains("Active/Active"), "Unexpected message: " + ex.getMessage());
+  }
+
+  @Test
+  public void applyRejectsHybridToBatchConversionCombinedWithIncrementalPush() {
+    Store currStore = newHybridStore(newDefaultHybridConfig());
+    UpdateStore setStore = new UpdateStore();
+    List<CharSequence> updatedConfigs = new ArrayList<>();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+
+    VeniceHttpException ex = expectThrows(
+        VeniceHttpException.class,
+        () -> HybridStoreConfigPolicy.applyHybridAndReplicationConfigUpdates(
+            STORE_NAME,
+            currStore,
+            setStore,
+            controllerConfig,
+            Optional.of(-1L),
+            Optional.of(-1L),
+            Optional.of(-1L),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(true), // explicit incremental push=true alongside hybrid->batch
+            updatedConfigs,
+            LOGGER));
+    assertEquals(ex.getHttpStatusCode(), HttpStatus.SC_BAD_REQUEST);
+    assertTrue(ex.getMessage().contains("incremental push"), "Unexpected message: " + ex.getMessage());
+  }
+
+  @Test
+  public void applyAutoDisablesActiveActiveAndIncrementalPushOnHybridToBatchConversion() {
+    Store currStore = newHybridStore(newDefaultHybridConfig());
+    when(currStore.isActiveActiveReplicationEnabled()).thenReturn(true);
+    when(currStore.isIncrementalPushEnabled()).thenReturn(true);
+    UpdateStore setStore = new UpdateStore();
+    List<CharSequence> updatedConfigs = new ArrayList<>();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+
+    boolean converted = HybridStoreConfigPolicy.applyHybridAndReplicationConfigUpdates(
+        STORE_NAME,
+        currStore,
+        setStore,
+        controllerConfig,
+        Optional.of(-1L),
+        Optional.of(-1L),
+        Optional.of(-1L),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        updatedConfigs,
+        LOGGER);
+
+    assertFalse(converted, "store is being converted to batch, not to hybrid");
+    assertFalse(setStore.activeActiveReplicationEnabled, "A/A must be auto-disabled on hybrid->batch");
+    assertFalse(setStore.incrementalPushEnabled, "incremental push must be auto-disabled on hybrid->batch");
+    assertTrue(updatedConfigs.contains(ACTIVE_ACTIVE_REPLICATION_ENABLED));
+    assertTrue(updatedConfigs.contains(INCREMENTAL_PUSH_ENABLED));
+  }
+
+  // ---------- applyHybridAndReplicationConfigUpdates: implicit batch -> A/A hybrid via incremental push ----------
+
+  @Test
+  public void applyConvertsBatchStoreToActiveActiveHybridWhenEnablingIncrementalPush() {
+    Store currStore = newBatchStore();
+    UpdateStore setStore = new UpdateStore();
+    List<CharSequence> updatedConfigs = new ArrayList<>();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+    when(controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()).thenReturn(true);
+
+    boolean converted = HybridStoreConfigPolicy.applyHybridAndReplicationConfigUpdates(
+        STORE_NAME,
+        currStore,
+        setStore,
+        controllerConfig,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(true),
+        updatedConfigs,
+        LOGGER);
+
+    assertTrue(
+        converted,
+        "implicit batch->hybrid via incremental push must surface as storeBeingConvertedToHybrid=true so partial-update auto-enable runs");
+    assertTrue(setStore.incrementalPushEnabled);
+    assertNotNull(setStore.hybridStoreConfig, "implicit hybrid record should be synthesized");
+    assertEquals(setStore.hybridStoreConfig.rewindTimeInSeconds, DEFAULT_REWIND_TIME_IN_SECONDS);
+    assertEquals(setStore.hybridStoreConfig.offsetLagThresholdToGoOnline, DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD);
+    assertEquals(
+        setStore.hybridStoreConfig.producerTimestampLagThresholdToGoOnlineInSeconds,
+        DEFAULT_HYBRID_TIME_LAG_THRESHOLD);
+    assertEquals(setStore.hybridStoreConfig.dataReplicationPolicy, DataReplicationPolicy.NON_AGGREGATE.getValue());
+    assertEquals(setStore.hybridStoreConfig.bufferReplayPolicy, BufferReplayPolicy.REWIND_FROM_EOP.getValue());
+    assertEquals(setStore.hybridStoreConfig.realTimeTopicName, DEFAULT_REAL_TIME_TOPIC_NAME);
+    assertTrue(setStore.activeActiveReplicationEnabled, "A/A is auto-enabled alongside the implicit hybrid conversion");
+
+    assertTrue(updatedConfigs.contains(INCREMENTAL_PUSH_ENABLED));
+    assertTrue(updatedConfigs.contains(REWIND_TIME_IN_SECONDS));
+    assertTrue(updatedConfigs.contains(OFFSET_LAG_TO_GO_ONLINE));
+    assertTrue(updatedConfigs.contains(TIME_LAG_TO_GO_ONLINE));
+    assertTrue(updatedConfigs.contains(DATA_REPLICATION_POLICY));
+    assertTrue(updatedConfigs.contains(BUFFER_REPLAY_POLICY));
+    assertTrue(updatedConfigs.contains(ACTIVE_ACTIVE_REPLICATION_ENABLED));
+  }
+
+  @Test
+  public void applyDoesNotImplicitlyConvertSystemStoreToActiveActiveHybrid() {
+    Store currStore = newBatchStore();
+    when(currStore.isSystemStore()).thenReturn(true);
+    UpdateStore setStore = new UpdateStore();
+    List<CharSequence> updatedConfigs = new ArrayList<>();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+    when(controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()).thenReturn(true);
+
+    HybridStoreConfigPolicy.applyHybridAndReplicationConfigUpdates(
+        STORE_NAME,
+        currStore,
+        setStore,
+        controllerConfig,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(true),
+        updatedConfigs,
+        LOGGER);
+
+    // The implicit hybrid record is still synthesized, but A/A is NOT auto-enabled for system stores.
+    assertNotNull(setStore.hybridStoreConfig);
+    assertFalse(setStore.activeActiveReplicationEnabled);
+    assertFalse(updatedConfigs.contains(ACTIVE_ACTIVE_REPLICATION_ENABLED));
+  }
+
+  // ---------- applyHybridAndReplicationConfigUpdates: mid-life no-op ----------
+
+  @Test
+  public void applyOnHybridStoreWithoutChangesIsANoOp() {
+    HybridStoreConfig existing = newDefaultHybridConfig();
+    Store currStore = newHybridStore(existing);
+    when(currStore.isActiveActiveReplicationEnabled()).thenReturn(true);
+    UpdateStore setStore = new UpdateStore();
+    List<CharSequence> updatedConfigs = new ArrayList<>();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+    // Even if cluster-level toggles are on, they only fire on transitions.
+    when(controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()).thenReturn(true);
+    when(controllerConfig.enabledIncrementalPushForHybridActiveActiveUserStores()).thenReturn(true);
+    when(controllerConfig.enabledSeparateRealTimeTopicForStoreWithIncrementalPush()).thenReturn(true);
+
+    boolean converted = HybridStoreConfigPolicy.applyHybridAndReplicationConfigUpdates(
+        STORE_NAME,
+        currStore,
+        setStore,
+        controllerConfig,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        updatedConfigs,
+        LOGGER);
+
+    assertFalse(converted);
+    assertTrue(setStore.activeActiveReplicationEnabled, "A/A flag tracks currStore when not explicitly overridden");
+    assertFalse(setStore.incrementalPushEnabled, "incremental push tracks currStore when not explicitly overridden");
+    assertNotNull(setStore.hybridStoreConfig, "existing hybrid record is preserved");
+    assertEquals(setStore.hybridStoreConfig.rewindTimeInSeconds, existing.getRewindTimeInSeconds());
+    assertTrue(
+        updatedConfigs.isEmpty(),
+        "no config keys should be recorded for a no-op update, got: " + updatedConfigs);
+  }
+
+  @Test
+  public void applyOnBatchStoreWithoutChangesIsANoOp() {
+    Store currStore = newBatchStore();
+    UpdateStore setStore = new UpdateStore();
+    List<CharSequence> updatedConfigs = new ArrayList<>();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+
+    boolean converted = HybridStoreConfigPolicy.applyHybridAndReplicationConfigUpdates(
+        STORE_NAME,
+        currStore,
+        setStore,
+        controllerConfig,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        updatedConfigs,
+        LOGGER);
+
+    assertFalse(converted);
+    assertNull(setStore.hybridStoreConfig);
+    assertFalse(setStore.activeActiveReplicationEnabled);
+    assertFalse(setStore.incrementalPushEnabled);
+    assertTrue(updatedConfigs.isEmpty(), "no config keys should be recorded, got: " + updatedConfigs);
+  }
+
+  @Test
+  public void applyPassesRealTimeTopicNameThroughToHybridRecord() {
+    Store currStore = newBatchStore();
+    UpdateStore setStore = new UpdateStore();
+    List<CharSequence> updatedConfigs = new ArrayList<>();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+
+    HybridStoreConfigPolicy.applyHybridAndReplicationConfigUpdates(
+        STORE_NAME,
+        currStore,
+        setStore,
+        controllerConfig,
+        Optional.of(100L),
+        Optional.of(1000L),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of("custom_rt_v2"),
+        Optional.empty(),
+        Optional.empty(),
+        updatedConfigs,
+        LOGGER);
+
+    assertNotNull(setStore.hybridStoreConfig);
+    assertEquals(setStore.hybridStoreConfig.realTimeTopicName, "custom_rt_v2");
+    assertTrue(updatedConfigs.contains(REAL_TIME_TOPIC_NAME));
+  }
+
+  // ---------- helpers ----------
+
+  private static Store newBatchStore() {
+    Store store = mock(Store.class);
+    when(store.getName()).thenReturn(STORE_NAME);
+    when(store.isHybrid()).thenReturn(false);
+    when(store.getHybridStoreConfig()).thenReturn(null);
+    when(store.isActiveActiveReplicationEnabled()).thenReturn(false);
+    when(store.isIncrementalPushEnabled()).thenReturn(false);
+    when(store.isSystemStore()).thenReturn(false);
+    when(store.getLargestUsedRTVersionNumber()).thenReturn(0);
+    return store;
+  }
+
+  private static Store newHybridStore(HybridStoreConfig hybridConfig) {
+    Store store = mock(Store.class);
+    when(store.getName()).thenReturn(STORE_NAME);
+    when(store.isHybrid()).thenReturn(true);
+    when(store.getHybridStoreConfig()).thenReturn(hybridConfig);
+    when(store.isActiveActiveReplicationEnabled()).thenReturn(false);
+    when(store.isIncrementalPushEnabled()).thenReturn(false);
+    when(store.isSystemStore()).thenReturn(false);
+    when(store.getLargestUsedRTVersionNumber()).thenReturn(0);
+    return store;
+  }
+
+  private static HybridStoreConfig newDefaultHybridConfig() {
+    return new HybridStoreConfigImpl(
+        100L,
+        1000L,
+        -1L,
+        DataReplicationPolicy.NON_AGGREGATE,
+        BufferReplayPolicy.REWIND_FROM_EOP,
+        DEFAULT_REAL_TIME_TOPIC_NAME);
+  }
+
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/HybridStoreConfigPolicyTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/HybridStoreConfigPolicyTest.java
@@ -92,6 +92,19 @@ public class HybridStoreConfigPolicyTest {
     assertTrue(HybridStoreConfigPolicy.isHybrid(record));
   }
 
+  @Test
+  public void isHybridRecordWithNullRealTimeTopicNameUsesThresholdsWithoutThrowing() {
+    HybridStoreConfigRecord record = new HybridStoreConfigRecord();
+    record.rewindTimeInSeconds = 100L;
+    record.offsetLagThresholdToGoOnline = -1L;
+    record.producerTimestampLagThresholdToGoOnlineInSeconds = -1L;
+    record.dataReplicationPolicy = DataReplicationPolicy.NON_AGGREGATE.getValue();
+    record.bufferReplayPolicy = BufferReplayPolicy.REWIND_FROM_EOP.getValue();
+    record.realTimeTopicName = null;
+
+    assertTrue(HybridStoreConfigPolicy.isHybrid(record), "Hybrid classification ");
+  }
+
   // ---------- mergeNewSettingsIntoOldHybridStoreConfig: edge cases ----------
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/HybridStoreConfigPolicyTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/HybridStoreConfigPolicyTest.java
@@ -317,6 +317,179 @@ public class HybridStoreConfigPolicyTest {
   // ---------- applyHybridAndReplicationConfigUpdates: hybrid -> batch ----------
 
   @Test
+  public void computeReplicationToggleDecisionRejectsHybridToBatchConversionCombinedWithActiveActive() {
+    Store currStore = newHybridStore(newDefaultHybridConfig());
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+
+    HybridStoreConfig batchSentinel = new HybridStoreConfigImpl(
+        -1L,
+        -1L,
+        -1L,
+        DataReplicationPolicy.NON_AGGREGATE,
+        BufferReplayPolicy.REWIND_FROM_EOP,
+        DEFAULT_REAL_TIME_TOPIC_NAME);
+
+    VeniceHttpException ex = expectThrows(
+        VeniceHttpException.class,
+        () -> HybridStoreConfigPolicy.computeReplicationToggleDecision(
+            currStore,
+            controllerConfig,
+            batchSentinel,
+            Optional.of(true),
+            Optional.empty()));
+    assertEquals(ex.getHttpStatusCode(), HttpStatus.SC_BAD_REQUEST);
+    assertTrue(ex.getMessage().contains("Active/Active"), "Unexpected message: " + ex.getMessage());
+  }
+
+  @Test
+  public void computeReplicationToggleDecisionAutoEnablesActiveActiveOnBatchToHybridConversion() {
+    Store currStore = newBatchStore();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+    when(controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()).thenReturn(true);
+    when(controllerConfig.enabledIncrementalPushForHybridActiveActiveUserStores()).thenReturn(false);
+    when(controllerConfig.enabledSeparateRealTimeTopicForStoreWithIncrementalPush()).thenReturn(false);
+
+    HybridStoreConfigPolicy.ReplicationToggleDecision decision =
+        HybridStoreConfigPolicy.computeReplicationToggleDecision(
+            currStore,
+            controllerConfig,
+            newDefaultHybridConfig(),
+            Optional.empty(),
+            Optional.empty());
+
+    assertTrue(decision.activeActiveReplicationEnabled);
+    assertFalse(decision.incrementalPushEnabled);
+    assertFalse(decision.enableSeparateRealTimeTopic);
+    assertTrue(decision.updatedConfigs.contains(ACTIVE_ACTIVE_REPLICATION_ENABLED));
+  }
+
+  @Test
+  public void computeReplicationToggleDecisionEnablesSeparateRealTimeTopicWhenIncrementalPushIsEnabled() {
+    Store currStore = newBatchStore();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+    when(controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()).thenReturn(false);
+    when(controllerConfig.enabledIncrementalPushForHybridActiveActiveUserStores()).thenReturn(false);
+    when(controllerConfig.enabledSeparateRealTimeTopicForStoreWithIncrementalPush()).thenReturn(true);
+
+    HybridStoreConfigPolicy.ReplicationToggleDecision decision =
+        HybridStoreConfigPolicy.computeReplicationToggleDecision(
+            currStore,
+            controllerConfig,
+            newDefaultHybridConfig(),
+            Optional.empty(),
+            Optional.of(true));
+
+    assertFalse(decision.activeActiveReplicationEnabled);
+    assertTrue(decision.incrementalPushEnabled);
+    assertTrue(decision.enableSeparateRealTimeTopic);
+    assertTrue(decision.updatedConfigs.contains(INCREMENTAL_PUSH_ENABLED));
+    assertTrue(decision.updatedConfigs.contains(SEPARATE_REAL_TIME_TOPIC_ENABLED));
+  }
+
+  @Test
+  public void computeReplicationToggleDecisionRejectsHybridToBatchConversionCombinedWithIncrementalPush() {
+    Store currStore = newHybridStore(newDefaultHybridConfig());
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+
+    HybridStoreConfig batchSentinel = new HybridStoreConfigImpl(
+        -1L,
+        -1L,
+        -1L,
+        DataReplicationPolicy.NON_AGGREGATE,
+        BufferReplayPolicy.REWIND_FROM_EOP,
+        DEFAULT_REAL_TIME_TOPIC_NAME);
+
+    VeniceHttpException ex = expectThrows(
+        VeniceHttpException.class,
+        () -> HybridStoreConfigPolicy.computeReplicationToggleDecision(
+            currStore,
+            controllerConfig,
+            batchSentinel,
+            Optional.empty(),
+            Optional.of(true)));
+    assertEquals(ex.getHttpStatusCode(), HttpStatus.SC_BAD_REQUEST);
+    assertTrue(ex.getMessage().contains("incremental push"), "Unexpected message: " + ex.getMessage());
+  }
+
+  @Test
+  public void computeReplicationToggleDecisionAutoDisablesActiveActiveOnHybridToBatchConversion() {
+    Store currStore = newHybridStore(newDefaultHybridConfig());
+    when(currStore.isActiveActiveReplicationEnabled()).thenReturn(true);
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+
+    HybridStoreConfig batchSentinel = new HybridStoreConfigImpl(
+        -1L,
+        -1L,
+        -1L,
+        DataReplicationPolicy.NON_AGGREGATE,
+        BufferReplayPolicy.REWIND_FROM_EOP,
+        DEFAULT_REAL_TIME_TOPIC_NAME);
+
+    HybridStoreConfigPolicy.ReplicationToggleDecision decision =
+        HybridStoreConfigPolicy.computeReplicationToggleDecision(
+            currStore,
+            controllerConfig,
+            batchSentinel,
+            Optional.empty(),
+            Optional.empty());
+
+    assertFalse(decision.activeActiveReplicationEnabled, "A/A must be auto-disabled on hybrid->batch");
+    assertTrue(decision.updatedConfigs.contains(ACTIVE_ACTIVE_REPLICATION_ENABLED));
+  }
+
+  @Test
+  public void computeReplicationToggleDecisionAutoDisablesIncrementalPushOnHybridToBatchConversion() {
+    Store currStore = newHybridStore(newDefaultHybridConfig());
+    when(currStore.isIncrementalPushEnabled()).thenReturn(true);
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+
+    HybridStoreConfig batchSentinel = new HybridStoreConfigImpl(
+        -1L,
+        -1L,
+        -1L,
+        DataReplicationPolicy.NON_AGGREGATE,
+        BufferReplayPolicy.REWIND_FROM_EOP,
+        DEFAULT_REAL_TIME_TOPIC_NAME);
+
+    HybridStoreConfigPolicy.ReplicationToggleDecision decision =
+        HybridStoreConfigPolicy.computeReplicationToggleDecision(
+            currStore,
+            controllerConfig,
+            batchSentinel,
+            Optional.empty(),
+            Optional.empty());
+
+    assertFalse(decision.incrementalPushEnabled, "incremental push must be auto-disabled on hybrid->batch");
+    assertTrue(decision.updatedConfigs.contains(INCREMENTAL_PUSH_ENABLED));
+  }
+
+  @Test
+  public void computeReplicationToggleDecisionAutoEnablesIncrementalPushOnBatchToHybridWithAutoEnabledActiveActive() {
+    // Exercises the dependency on the RESOLVED (post-auto-enable) A/A value: A/A is auto-enabled
+    // by isActiveActiveReplicationEnabledAsDefaultForHybrid, which in turn unlocks the inc-push
+    // auto-enable gated by enabledIncrementalPushForHybridActiveActiveUserStores.
+    Store currStore = newBatchStore();
+    VeniceControllerClusterConfig controllerConfig = mock(VeniceControllerClusterConfig.class);
+    when(controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()).thenReturn(true);
+    when(controllerConfig.enabledIncrementalPushForHybridActiveActiveUserStores()).thenReturn(true);
+    when(controllerConfig.enabledSeparateRealTimeTopicForStoreWithIncrementalPush()).thenReturn(false);
+
+    HybridStoreConfigPolicy.ReplicationToggleDecision decision =
+        HybridStoreConfigPolicy.computeReplicationToggleDecision(
+            currStore,
+            controllerConfig,
+            newDefaultHybridConfig(),
+            Optional.empty(),
+            Optional.empty());
+
+    assertTrue(decision.activeActiveReplicationEnabled);
+    assertTrue(decision.incrementalPushEnabled);
+    assertFalse(decision.enableSeparateRealTimeTopic);
+    assertTrue(decision.updatedConfigs.contains(ACTIVE_ACTIVE_REPLICATION_ENABLED));
+    assertTrue(decision.updatedConfigs.contains(INCREMENTAL_PUSH_ENABLED));
+  }
+
+  @Test
   public void applyRejectsHybridToBatchConversionCombinedWithActiveActive() {
     Store currStore = newHybridStore(newDefaultHybridConfig());
     UpdateStore setStore = new UpdateStore();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/PushJobDetailsManagerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/PushJobDetailsManagerTest.java
@@ -1,0 +1,343 @@
+package com.linkedin.venice.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.venice.client.store.AvroSpecificStoreClient;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.common.VeniceSystemStoreUtils;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.SchemaResponse;
+import com.linkedin.venice.exceptions.InvalidVeniceSchemaException;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.Instance;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.manager.TopicManager;
+import com.linkedin.venice.schema.SchemaData;
+import com.linkedin.venice.status.protocol.BatchJobHeartbeatKey;
+import com.linkedin.venice.status.protocol.BatchJobHeartbeatValue;
+import com.linkedin.venice.status.protocol.PushJobDetails;
+import com.linkedin.venice.status.protocol.PushJobStatusRecordKey;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.writer.VeniceWriter;
+import com.linkedin.venice.writer.VeniceWriterFactory;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.mockito.MockedStatic;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class PushJobDetailsManagerTest {
+  private static final String CLUSTER_NAME = "test-cluster";
+  private static final int VALID_SCHEMA_ID = 7;
+
+  private Admin admin;
+  private D2Client d2Client;
+  private PubSubTopicRepository pubSubTopicRepository;
+  private TopicManager topicManager;
+  private VeniceWriterFactory veniceWriterFactory;
+  private PushJobDetailsManager manager;
+
+  @BeforeMethod
+  public void setUp() {
+    admin = mock(Admin.class);
+    d2Client = mock(D2Client.class);
+    pubSubTopicRepository = new PubSubTopicRepository();
+    topicManager = mock(TopicManager.class);
+    veniceWriterFactory = mock(VeniceWriterFactory.class);
+
+    when(admin.getPubSubTopicRepository()).thenReturn(pubSubTopicRepository);
+    when(admin.getTopicManager()).thenReturn(topicManager);
+    when(admin.getVeniceWriterFactory()).thenReturn(veniceWriterFactory);
+
+    manager = new PushJobDetailsManager(admin, d2Client, false, CLUSTER_NAME, true, Optional.empty());
+  }
+
+  @Test
+  public void testGetPushJobDetailsSerializerReturnsNonNull() {
+    assertNotNull(manager.getPushJobDetailsSerializer());
+  }
+
+  @Test
+  public void testWriteToLocalRTTopicThrowsWhenStoreClusterBlankAndMultiRegion() {
+    PushJobDetailsManager m =
+        new PushJobDetailsManager(admin, d2Client, false, "", /*multiRegion*/ true, Optional.empty());
+    VeniceException ex = expectThrows(
+        VeniceException.class,
+        () -> m.writeToLocalRTTopic(new PushJobStatusRecordKey(), new PushJobDetails()));
+    assertTrue(
+        ex.getMessage().contains("Unable to send the push job details"),
+        "Unexpected exception message: " + ex.getMessage());
+  }
+
+  @Test
+  public void testWriteToLocalRTTopicHappyPathReusesWriterAndCachesTopic() {
+    PubSubTopic rtTopic = expectedRTTopic();
+    when(topicManager.containsTopicAndAllPartitionsAreOnline(rtTopic)).thenReturn(true);
+    when(admin.isLeaderControllerFor(CLUSTER_NAME)).thenReturn(true);
+    when(admin.getValueSchemaId(eq(CLUSTER_NAME), eq(rtTopic.getStoreName()), any())).thenReturn(VALID_SCHEMA_ID);
+
+    VeniceWriter writer = mock(VeniceWriter.class);
+    when(veniceWriterFactory.createVeniceWriter(any())).thenReturn(writer);
+
+    PushJobStatusRecordKey key = new PushJobStatusRecordKey();
+    PushJobDetails value = new PushJobDetails();
+
+    manager.writeToLocalRTTopic(key, value);
+    manager.writeToLocalRTTopic(key, value);
+
+    // Writer + schema-id resolution + topic lookup all happen once and are cached for the second call.
+    verify(veniceWriterFactory, times(1)).createVeniceWriter(any());
+    verify(admin, times(1)).getValueSchemaId(eq(CLUSTER_NAME), eq(rtTopic.getStoreName()), any());
+    verify(topicManager, times(1)).containsTopicAndAllPartitionsAreOnline(rtTopic);
+    verify(writer, times(2)).put(eq(key), eq(value), eq(VALID_SCHEMA_ID), isNull());
+  }
+
+  @Test
+  public void testWriteToLocalRTTopicThrowsWhenTopicNeverAppears() {
+    PubSubTopic rtTopic = expectedRTTopic();
+    when(topicManager.containsTopicAndAllPartitionsAreOnline(rtTopic)).thenReturn(false);
+
+    try (MockedStatic<Utils> utilsMock = mockStatic(Utils.class, CALLS_REAL_METHODS)) {
+      // Skip the retry backoff so the test stays fast.
+      utilsMock.when(() -> Utils.sleep(anyLong())).thenReturn(true);
+
+      VeniceException ex = expectThrows(
+          VeniceException.class,
+          () -> manager.writeToLocalRTTopic(new PushJobStatusRecordKey(), new PushJobDetails()));
+      assertTrue(ex.getMessage().contains("not found"), "Unexpected exception message: " + ex.getMessage());
+    }
+
+    // Loop should have made every allowed attempt.
+    verify(topicManager, times(VeniceHelixAdmin.INTERNAL_STORE_GET_RRT_TOPIC_ATTEMPTS))
+        .containsTopicAndAllPartitionsAreOnline(rtTopic);
+    verify(veniceWriterFactory, never()).createVeniceWriter(any());
+  }
+
+  @Test
+  public void testWriteToLocalRTTopicThrowsInvalidSchemaWhenLeaderHasNoMatch() {
+    PubSubTopic rtTopic = expectedRTTopic();
+    when(topicManager.containsTopicAndAllPartitionsAreOnline(rtTopic)).thenReturn(true);
+    when(admin.isLeaderControllerFor(CLUSTER_NAME)).thenReturn(true);
+    when(admin.getValueSchemaId(eq(CLUSTER_NAME), eq(rtTopic.getStoreName()), any()))
+        .thenReturn(SchemaData.INVALID_VALUE_SCHEMA_ID);
+
+    assertThrows(
+        InvalidVeniceSchemaException.class,
+        () -> manager.writeToLocalRTTopic(new PushJobStatusRecordKey(), new PushJobDetails()));
+    verify(veniceWriterFactory, never()).createVeniceWriter(any());
+  }
+
+  @Test
+  public void testWriteToLocalRTTopicUsesRemoteControllerWhenNotLeader() {
+    PubSubTopic rtTopic = expectedRTTopic();
+    when(topicManager.containsTopicAndAllPartitionsAreOnline(rtTopic)).thenReturn(true);
+    when(admin.isLeaderControllerFor(CLUSTER_NAME)).thenReturn(false);
+    Instance leader = mock(Instance.class);
+    when(leader.getUrl(false)).thenReturn("http://leader");
+    when(admin.getLeaderController(CLUSTER_NAME)).thenReturn(leader);
+
+    VeniceWriter writer = mock(VeniceWriter.class);
+    when(veniceWriterFactory.createVeniceWriter(any())).thenReturn(writer);
+
+    ControllerClient controllerClient = mock(ControllerClient.class);
+    SchemaResponse okResponse = new SchemaResponse();
+    okResponse.setId(VALID_SCHEMA_ID);
+    when(controllerClient.getValueSchemaID(eq(rtTopic.getStoreName()), any())).thenReturn(okResponse);
+
+    PushJobStatusRecordKey key = new PushJobStatusRecordKey();
+    PushJobDetails value = new PushJobDetails();
+    try (MockedStatic<ControllerClient> controllerClientMock = mockStatic(ControllerClient.class)) {
+      controllerClientMock
+          .when(() -> ControllerClient.constructClusterControllerClient(eq(CLUSTER_NAME), eq("http://leader"), any()))
+          .thenReturn(controllerClient);
+
+      manager.writeToLocalRTTopic(key, value);
+    }
+
+    verify(writer).put(eq(key), eq(value), eq(VALID_SCHEMA_ID), isNull());
+    verify(admin, never()).getValueSchemaId(any(), any(), any());
+  }
+
+  @Test
+  public void testWriteToLocalRTTopicThrowsWhenRemoteControllerErrors() {
+    PubSubTopic rtTopic = expectedRTTopic();
+    when(topicManager.containsTopicAndAllPartitionsAreOnline(rtTopic)).thenReturn(true);
+    when(admin.isLeaderControllerFor(CLUSTER_NAME)).thenReturn(false);
+    Instance leader = mock(Instance.class);
+    when(leader.getUrl(false)).thenReturn("http://leader");
+    when(admin.getLeaderController(CLUSTER_NAME)).thenReturn(leader);
+
+    ControllerClient controllerClient = mock(ControllerClient.class);
+    SchemaResponse errorResponse = new SchemaResponse();
+    errorResponse.setError("boom");
+    when(controllerClient.getValueSchemaID(eq(rtTopic.getStoreName()), any())).thenReturn(errorResponse);
+
+    try (MockedStatic<ControllerClient> controllerClientMock = mockStatic(ControllerClient.class)) {
+      controllerClientMock
+          .when(() -> ControllerClient.constructClusterControllerClient(eq(CLUSTER_NAME), eq("http://leader"), any()))
+          .thenReturn(controllerClient);
+
+      VeniceException ex = expectThrows(
+          VeniceException.class,
+          () -> manager.writeToLocalRTTopic(new PushJobStatusRecordKey(), new PushJobDetails()));
+      assertTrue(ex.getMessage().contains("boom"), "Unexpected exception message: " + ex.getMessage());
+    }
+
+    verify(veniceWriterFactory, never()).createVeniceWriter(any());
+  }
+
+  @Test
+  public void testGetPushJobDetailsThrowsOnNullKey() {
+    assertThrows(IllegalArgumentException.class, () -> manager.getPushJobDetails(null));
+  }
+
+  @Test
+  public void testGetPushJobDetailsReturnsValueFromStoreClient() throws Exception {
+    AvroSpecificStoreClient<PushJobStatusRecordKey, PushJobDetails> client = mock(AvroSpecificStoreClient.class);
+    PushJobStatusRecordKey key = new PushJobStatusRecordKey();
+    PushJobDetails expected = new PushJobDetails();
+    when(client.get(key)).thenReturn(CompletableFuture.completedFuture(expected));
+    manager.setPushJobDetailsStoreClient(client);
+
+    assertSame(manager.getPushJobDetails(key), expected);
+  }
+
+  @Test
+  public void testGetPushJobDetailsLazilyInitializesClient() {
+    AvroSpecificStoreClient<PushJobStatusRecordKey, PushJobDetails> client = mock(AvroSpecificStoreClient.class);
+    PushJobStatusRecordKey key = new PushJobStatusRecordKey();
+    PushJobDetails expected = new PushJobDetails();
+    when(client.get(key)).thenReturn(CompletableFuture.completedFuture(expected));
+
+    when(admin.discoverCluster(any())).thenReturn(CLUSTER_NAME);
+    when(admin.getRouterD2Service(CLUSTER_NAME)).thenReturn("d2://router");
+
+    try (MockedStatic<ClientFactory> clientFactoryMock = mockStatic(ClientFactory.class)) {
+      clientFactoryMock.when(() -> ClientFactory.getAndStartSpecificAvroClient(any())).thenReturn(client);
+
+      assertSame(manager.getPushJobDetails(key), expected);
+      // Second invocation should reuse the cached client and not invoke the factory again.
+      assertSame(manager.getPushJobDetails(key), expected);
+      clientFactoryMock.verify(() -> ClientFactory.getAndStartSpecificAvroClient(any()), times(1));
+    }
+  }
+
+  @Test
+  public void testGetPushJobDetailsWrapsClientFailureAsVeniceException() {
+    AvroSpecificStoreClient<PushJobStatusRecordKey, PushJobDetails> client = mock(AvroSpecificStoreClient.class);
+    PushJobStatusRecordKey key = new PushJobStatusRecordKey();
+    CompletableFuture<PushJobDetails> failed = new CompletableFuture<>();
+    failed.completeExceptionally(new RuntimeException("downstream failure"));
+    when(client.get(key)).thenReturn(failed);
+    manager.setPushJobDetailsStoreClient(client);
+
+    VeniceException ex = expectThrows(VeniceException.class, () -> manager.getPushJobDetails(key));
+    assertTrue(ex.getCause() instanceof ExecutionException, "Expected ExecutionException cause");
+  }
+
+  @Test
+  public void testGetBatchJobHeartbeatValueThrowsOnNullKey() {
+    assertThrows(IllegalArgumentException.class, () -> manager.getBatchJobHeartbeatValue(null));
+  }
+
+  @Test
+  public void testGetBatchJobHeartbeatValueLazilyInitializesClient() throws Exception {
+    AvroSpecificStoreClient<BatchJobHeartbeatKey, BatchJobHeartbeatValue> client = mock(AvroSpecificStoreClient.class);
+    BatchJobHeartbeatKey key = new BatchJobHeartbeatKey();
+    BatchJobHeartbeatValue expected = new BatchJobHeartbeatValue();
+    when(client.get(key)).thenReturn(CompletableFuture.completedFuture(expected));
+
+    when(admin.discoverCluster(any())).thenReturn(CLUSTER_NAME);
+    when(admin.getRouterD2Service(CLUSTER_NAME)).thenReturn("d2://router");
+
+    try (MockedStatic<ClientFactory> clientFactoryMock = mockStatic(ClientFactory.class)) {
+      clientFactoryMock.when(() -> ClientFactory.getAndStartSpecificAvroClient(any())).thenReturn(client);
+
+      assertSame(manager.getBatchJobHeartbeatValue(key), expected);
+
+      // Second invocation should reuse the cached client and not invoke the factory again.
+      assertSame(manager.getBatchJobHeartbeatValue(key), expected);
+      clientFactoryMock.verify(() -> ClientFactory.getAndStartSpecificAvroClient(any()), times(1));
+    }
+  }
+
+  @Test
+  public void testGetBatchJobHeartbeatValueWrapsClientFailureAsVeniceException() {
+    AvroSpecificStoreClient<BatchJobHeartbeatKey, BatchJobHeartbeatValue> client = mock(AvroSpecificStoreClient.class);
+    BatchJobHeartbeatKey key = new BatchJobHeartbeatKey();
+    CompletableFuture<BatchJobHeartbeatValue> failed = new CompletableFuture<>();
+    failed.completeExceptionally(new RuntimeException("downstream failure"));
+    when(client.get(key)).thenReturn(failed);
+
+    when(admin.discoverCluster(any())).thenReturn(CLUSTER_NAME);
+    when(admin.getRouterD2Service(CLUSTER_NAME)).thenReturn("d2://router");
+
+    try (MockedStatic<ClientFactory> clientFactoryMock = mockStatic(ClientFactory.class)) {
+      clientFactoryMock.when(() -> ClientFactory.getAndStartSpecificAvroClient(any())).thenReturn(client);
+
+      VeniceException ex = expectThrows(VeniceException.class, () -> manager.getBatchJobHeartbeatValue(key));
+      assertTrue(ex.getCause() instanceof ExecutionException, "Expected ExecutionException cause");
+    }
+  }
+
+  @Test
+  public void testCloseClosesWritersAndStoreClients() {
+    // Populate the writer map by running one successful write.
+    PubSubTopic rtTopic = expectedRTTopic();
+    when(topicManager.containsTopicAndAllPartitionsAreOnline(rtTopic)).thenReturn(true);
+    when(admin.isLeaderControllerFor(CLUSTER_NAME)).thenReturn(true);
+    when(admin.getValueSchemaId(eq(CLUSTER_NAME), eq(rtTopic.getStoreName()), any())).thenReturn(VALID_SCHEMA_ID);
+    VeniceWriter writer = mock(VeniceWriter.class);
+    when(veniceWriterFactory.createVeniceWriter(any())).thenReturn(writer);
+    manager.writeToLocalRTTopic(new PushJobStatusRecordKey(), new PushJobDetails());
+
+    AvroSpecificStoreClient<PushJobStatusRecordKey, PushJobDetails> pushJobDetailsClient =
+        mock(AvroSpecificStoreClient.class);
+    manager.setPushJobDetailsStoreClient(pushJobDetailsClient);
+
+    AvroSpecificStoreClient<BatchJobHeartbeatKey, BatchJobHeartbeatValue> heartbeatClient =
+        mock(AvroSpecificStoreClient.class);
+    BatchJobHeartbeatKey heartbeatKey = new BatchJobHeartbeatKey();
+    when(heartbeatClient.get(heartbeatKey)).thenReturn(CompletableFuture.completedFuture(new BatchJobHeartbeatValue()));
+    when(admin.discoverCluster(any())).thenReturn(CLUSTER_NAME);
+    when(admin.getRouterD2Service(CLUSTER_NAME)).thenReturn("d2://router");
+    try (MockedStatic<ClientFactory> clientFactoryMock = mockStatic(ClientFactory.class)) {
+      clientFactoryMock.when(() -> ClientFactory.getAndStartSpecificAvroClient(any())).thenReturn(heartbeatClient);
+      manager.getBatchJobHeartbeatValue(heartbeatKey);
+    }
+
+    manager.close();
+
+    verify(writer).close();
+    verify(pushJobDetailsClient).close();
+    verify(heartbeatClient).close();
+  }
+
+  /**
+   * Mirrors how {@link PushJobDetailsManager#writeToLocalRTTopic} composes the expected
+   * push-job-details RT topic, so tests can stub the topic-manager check against the exact instance.
+   */
+  private PubSubTopic expectedRTTopic() {
+    String storeName = VeniceSystemStoreUtils.getPushJobDetailsStoreName();
+    return pubSubTopicRepository.getTopic(Utils.composeRealTimeTopic(storeName));
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/PushJobDetailsManagerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/PushJobDetailsManagerTest.java
@@ -175,6 +175,7 @@ public class PushJobDetailsManagerTest {
 
     verify(writer).put(eq(key), eq(value), eq(VALID_SCHEMA_ID), isNull());
     verify(admin, never()).getValueSchemaId(any(), any(), any());
+    verify(controllerClient).close();
   }
 
   @Test
@@ -203,6 +204,7 @@ public class PushJobDetailsManagerTest {
     }
 
     verify(veniceWriterFactory, never()).createVeniceWriter(any());
+    verify(controllerClient).close();
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
@@ -62,7 +62,7 @@ public class TestVeniceHelixAdminWithoutCluster {
     Optional<DataReplicationPolicy> dataReplicationPolicy = Optional.of(DataReplicationPolicy.NON_AGGREGATE);
     Optional<BufferReplayPolicy> bufferReplayPolicy = Optional.of(BufferReplayPolicy.REWIND_FROM_EOP);
     Optional<String> realTimeTopicName = Optional.of("storeName_rt");
-    HybridStoreConfig hybridStoreConfig = VeniceHelixAdmin.mergeNewSettingsIntoOldHybridStoreConfig(
+    HybridStoreConfig hybridStoreConfig = HybridStoreConfigPolicy.mergeNewSettingsIntoOldHybridStoreConfig(
         store,
         Optional.empty(),
         Optional.empty(),
@@ -74,7 +74,7 @@ public class TestVeniceHelixAdminWithoutCluster {
         hybridStoreConfig,
         "passing empty optionals and a non-hybrid store should generate a null hybrid config");
 
-    hybridStoreConfig = VeniceHelixAdmin.mergeNewSettingsIntoOldHybridStoreConfig(
+    hybridStoreConfig = HybridStoreConfigPolicy.mergeNewSettingsIntoOldHybridStoreConfig(
         store,
         rewind,
         lagOffset,
@@ -89,7 +89,7 @@ public class TestVeniceHelixAdminWithoutCluster {
     Assert.assertEquals(hybridStoreConfig.getDataReplicationPolicy(), DataReplicationPolicy.NON_AGGREGATE);
 
     // It's okay that time lag threshold or data replication policy is not specified
-    hybridStoreConfig = VeniceHelixAdmin.mergeNewSettingsIntoOldHybridStoreConfig(
+    hybridStoreConfig = HybridStoreConfigPolicy.mergeNewSettingsIntoOldHybridStoreConfig(
         store,
         rewind,
         lagOffset,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2521,7 +2521,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
     AdminOperation adminMessage = verifyAndGetSingleAdminOperation();
     UpdateStore updateStore = (UpdateStore) adminMessage.payloadUnion;
-    Assert.assertFalse(internalAdmin.isHybrid(updateStore.getHybridStoreConfig()));
+    Assert.assertFalse(HybridStoreConfigPolicy.isHybrid(updateStore.getHybridStoreConfig()));
     Assert.assertFalse(updateStore.incrementalPushEnabled);
     Assert.assertFalse(updateStore.activeActiveReplicationEnabled);
   }


### PR DESCRIPTION
## Problem Statement

`VeniceHelixAdmin` is approaching 10k LOC and `VeniceParentHelixAdmin` carries a ~120-line inlined block of hybrid + replication policy inside `updateStore`. Between them the two classes carry 20 distinct themes — the style guide (`docs/contributing/development/style-guide.md` §Encapsulation) calls out this exact shape: once a class's responsibility list grows long, split it.

This PR is the first wave: three well-bounded responsibilities lifted out, three pre-existing bugs found while extracting them, and a stub package planted to mark the next wave (version lifecycle).

Theomachy stage I

## What's in this PR

### 1. Three extractions

| New class | Suffix style | Responsibility |
|---|---|---|
| `PushJobDetailsManager` | `Manager` — stateful, implements `Closeable` | Owns the push-job-details RT writer, lazy router-backed Avro store clients for push-job-details and batch-job-heartbeat, schema-id resolution (leader vs. remote-controller fallback), and close lifecycle |
| `StoreMigrationHelper` | `Helper` — static-only utility | Cross-cluster store-migration RPC plumbing: `cloneDestinationStoreAndSyncConfigs` (`createNewStore` + value-schema sync + per-region `updateStore` overrides against a destination controller) |
| `HybridStoreConfigPolicy` | `Policy` — static-only, encodes business rules | `isHybrid`, `mergeNewSettingsIntoOldHybridStoreConfig`, and `applyHybridAndReplicationConfigUpdates`. Internally split into a pure `computeReplicationToggleDecision` (returns a `ReplicationToggleDecision` carrier) + an apply step, so toggle policy is testable without `UpdateStore` mocking |

`hasFatalDataValidationError` on `VeniceHelixAdmin` is now `static` since it never used `this`. Public APIs of both admin classes are unchanged.

### 2. Three pre-existing bug fixes uncovered during extraction

Each shipped as its own commit so they're easy to bisect / cherry-pick if needed:

- **`faa98907` — Stale `storeBeingConvertedToHybrid` flag.** The original inline block captured the flag *before* `maybeConvertBatchStoreToActiveActiveHybridForIncrementalPush` ran, so requests that only set `incrementalPushEnabled=true` on a batch store returned `false` even though the conversion had happened. Downstream, `ParentControllerConfigUpdateUtils.checkAndMaybeApplyPartialUpdateConfig` was skipping partial-update auto-enable for these stores. Fixed by deriving the return value from the final `setStore.hybridStoreConfig` after the implicit conversion runs.
- **`ca28fc6` — NPE in `isHybrid(HybridStoreConfigRecord)`.** The overload was calling `.toString()` on a possibly-null `realTimeTopicName`, NPE'ing on records produced before that field was added to the schema. `HybridStoreConfigImpl` already normalizes null, so just guard the `.toString()` call. Audited all 169 `isHybrid()` callsites — none assume `isHybrid==true` implies a non-null RT topic name; RT topic accesses route through `Utils.getRealTimeTopicName`, which has its own fallback.
- **`b5ba16d` — Leaked `ControllerClient`.** `fetchSystemStoreSchemaId` acquired a refcounted `ControllerClient` for the remote-controller fallback but never released it. Wrapped in try-with-resources so close fires on both success and error paths.

All three are pre-existing on `main`; the extraction commits (`1a52669`, `bbf4e45`) faithfully preserved them, and they are fixed in clearly-labelled follow-up commits. Each fix is pinned by tests.

### 3. Stub for the next stage

Added `services/venice-controller/.../controller/versionlifecycle/package-info.java` as a marker for the next extraction wave. Version lifecycle (add / increment / retire / delete / roll-forward / roll-back, plus the topic + Helix resource plumbing that hangs off those transitions) is the single largest remaining theme in both admin classes — ~3.6k lines across 71 methods. No code moves in this PR; the stub just declares where it will land so the next PR is a pure `git mv` + import update.

### Other behaviour notes (low-impact, call-outs for review)

- Log lines emitted by the extracted push-job-details methods now report under logger `PushJobDetailsManager` instead of `VeniceHelixAdmin`. Content unchanged.
- `close()` ordering shift in `VeniceHelixAdmin`: `pushJobDetailsStoreClient` and `livenessHeartbeatStoreClient` are now closed via `PushJobDetailsManager.close()` early in the sequence (alongside the writer map), rather than late. Reviewed the intervening close paths (`dataRecoveryManager`, `participantStoreClientsManager`, `topicManagerRepository`) — none touch those store clients during their own shutdown.

No protocol / schema / wire-format changes — no `[compat]` tag needed.

###  Code changes
- [ ] Added new code behind **a config**. (n/a — no new configs.)
- [ ] Introduced new **log lines**. (n/a — all logging moved verbatim; logger source changed for moved methods, see above.)
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

`PushJobDetailsManager` preserves the exact synchronization the source code used: `pushJobDetailsClientLock` and `livenessHeartbeatClientLock` guard lazy-init of each store client via `ConcurrencyUtils.executeUnderConditionalLock` (double-checked pattern), and `jobTrackingVeniceWriterMap` remains a `VeniceConcurrentHashMap` with `computeIfAbsent`. The two static helpers (`StoreMigrationHelper`, `HybridStoreConfigPolicy`) are stateless — no shared mutable state.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

`PushJobDetailsManagerTest` (15 cases): serializer non-null, blank-cluster guard, happy-path with writer + schema-id + topic caching, RT-topic retry-loop exhaustion, invalid-schema (leader path), remote-controller fallback (non-leader), remote-controller error, `ControllerClient.close()` verified on both branches, null-key guards for both getters, lazy-init + caching for both store clients, exception wrapping, `close()` releases writers + both clients. Diff coverage on the new class: **23/24 branches = 95.8%**.

`HybridStoreConfigPolicyTest` (796 lines): both `isHybrid` overloads (including the null-RT-name guard), `mergeNewSettingsIntoOldHybridStoreConfig`, `applyHybridAndReplicationConfigUpdates` covering batch→hybrid / hybrid→batch / implicit-IP conversion, and the four pure `computeReplicationToggleDecision` cases (hybrid→batch + IP rejection, A/A auto-disable, IP auto-disable, IP auto-enable via resolved A/A).

`TestVeniceHelixAdminWithoutCluster`, `TestVeniceParentHelixAdmin`, and `AbstractTestVeniceParentHelixAdmin` updated only to point at the new static helper locations + stub `partitionSize` (needed because the previously-mocked `isHybrid` is now static and runs for real, exposing an unstubbed `partitionSize=0`). No test logic changed.

Verified locally on `:services:venice-controller`:
- `test` — passes
- `jacocoTestCoverageVerification diffCoverage --continue` — passes
- `spotbugsMain` + `spotbugsTest` under `-Pspotallbugs` — clean
- `spotlessCheck`, `compileJava`, `compileTestJava` — clean

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

The three bug fixes correct latent defects (NPE crash, leaked client, missed partial-update auto-enable). No user-facing API changes; no downgrade required to revert.
