### PR TITLE
[da-vinci][changelog] Skip BOOTSTRAP_TO_ONLINE_TIMEOUT watchdog for Stateless DVRT CDC

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -679,11 +679,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
        * For current / backup version re-ingestion, it should report failure to the replica, but should keep other
        * online replica continue serving and do not close ingestion task.
        *
-       * Skip for stateless DVRT CDC consumers (see {@link #skipValidationsForDaVinciClientEnabled}):
-       * a consumer that seeks past EOP never re-observes the EOP control message, so isComplete()
-       * stays false and the watchdog would false-positive every restart cycle.
+       * Skip for DaVinci clients with a custom ingestion lifecycle (see
+       * {@link #daVinciClientCustomLifecycleEnabled}) — e.g. stateless DVRT CDC consumers that seek past
+       * EOP never re-observe the EOP control message, so isComplete() stays false and the watchdog would
+       * false-positive every restart cycle.
        */
-      if (!shouldSkipValidationsForDaVinciClientEnabled() && !partitionConsumptionState.isComplete()
+      if (!isDaVinciClientCustomLifecycleEnabled() && !partitionConsumptionState.isComplete()
           && !partitionConsumptionState.isErrorReported() && !partitionConsumptionState.isStoreLevelPaused()
           && LatencyUtils.getElapsedTimeFromMsToMs(
               partitionConsumptionState.getConsumptionStartTimeInMs()) > getBootstrapTimeoutInMs()) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -683,7 +683,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
        * the EOP control message, so isComplete() stays false and the watchdog would false-positive
        * every restart cycle.
        */
-      if (!skipValidationsForDaVinciClientEnabled && !partitionConsumptionState.isComplete()
+      if (!shouldSkipValidationsForDaVinciClientEnabled() && !partitionConsumptionState.isComplete()
           && !partitionConsumptionState.isErrorReported() && !partitionConsumptionState.isStoreLevelPaused()
           && LatencyUtils.getElapsedTimeFromMsToMs(
               partitionConsumptionState.getConsumptionStartTimeInMs()) > getBootstrapTimeoutInMs()) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -679,9 +679,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
        * For current / backup version re-ingestion, it should report failure to the replica, but should keep other
        * online replica continue serving and do not close ingestion task.
        *
-       * Skip for stateless DVRT CDC consumers: a consumer that seeks past EOP never re-observes
-       * the EOP control message, so isComplete() stays false and the watchdog would false-positive
-       * every restart cycle.
+       * Skip for stateless DVRT CDC consumers (see {@link #skipValidationsForDaVinciClientEnabled}):
+       * a consumer that seeks past EOP never re-observes the EOP control message, so isComplete()
+       * stays false and the watchdog would false-positive every restart cycle.
        */
       if (!shouldSkipValidationsForDaVinciClientEnabled() && !partitionConsumptionState.isComplete()
           && !partitionConsumptionState.isErrorReported() && !partitionConsumptionState.isStoreLevelPaused()

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -679,9 +679,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
        * For current / backup version re-ingestion, it should report failure to the replica, but should keep other
        * online replica continue serving and do not close ingestion task.
        *
-       * Skip when validations are bypassed (DVRT / view-topic DaVinci): a stateless DVRT
-       * consumer seeking past EOP never re-observes the EOP control message, so isComplete()
-       * stays false and the watchdog would false-positive every restart cycle.
+       * Skip for stateless DVRT CDC consumers: a consumer that seeks past EOP never re-observes
+       * the EOP control message, so isComplete() stays false and the watchdog would false-positive
+       * every restart cycle.
        */
       if (!skipValidationsForDaVinciClientEnabled && !partitionConsumptionState.isComplete()
           && !partitionConsumptionState.isErrorReported() && !partitionConsumptionState.isStoreLevelPaused()

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -678,9 +678,14 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
        * For future version, it should fail the push job.
        * For current / backup version re-ingestion, it should report failure to the replica, but should keep other
        * online replica continue serving and do not close ingestion task.
+       *
+       * Skip when validations are bypassed (DVRT / view-topic DaVinci): a stateless DVRT
+       * consumer seeking past EOP never re-observes the EOP control message, so isComplete()
+       * stays false and the watchdog would false-positive every restart cycle.
        */
-      if (!partitionConsumptionState.isComplete() && !partitionConsumptionState.isErrorReported()
-          && !partitionConsumptionState.isStoreLevelPaused() && LatencyUtils.getElapsedTimeFromMsToMs(
+      if (!skipValidationsForDaVinciClientEnabled && !partitionConsumptionState.isComplete()
+          && !partitionConsumptionState.isErrorReported() && !partitionConsumptionState.isStoreLevelPaused()
+          && LatencyUtils.getElapsedTimeFromMsToMs(
               partitionConsumptionState.getConsumptionStartTimeInMs()) > getBootstrapTimeoutInMs()) {
         if (!pushTimeout) {
           pushTimeout = true;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -490,7 +490,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private boolean skipAfterBatchPushUnsubEnabled = false;
   private final List<AutoCloseable> thingsToClose = new ArrayList<>();
   private final Version version;
-  private boolean skipValidationsForDaVinciClientEnabled = false;
+  protected boolean skipValidationsForDaVinciClientEnabled = false;
   private long lastResubscriptionCheckTimestamp = System.currentTimeMillis();
 
   // Helper encapsulating blob transfer utility methods. Null when blob transfer is not configured.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -491,25 +491,27 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private final List<AutoCloseable> thingsToClose = new ArrayList<>();
   private final Version version;
   /**
-   * When true, this SIT skips several validations and short-circuits that are inappropriate for stateless
-   * DVRT CDC consumers — these consumers own their own lifecycle via seek APIs ({@code seekToCheckpoint},
-   * {@code seekToTail}, etc.) and have already opted out of the standard server-style validation pipeline.
+   * When true, this SIT runs with a custom ingestion lifecycle for DaVinci clients — used by stateless
+   * DVRT CDC consumers (which seek to arbitrary positions via the seek APIs) and view-topic DaVinci
+   * consumers (which read a non-push lifecycle topic). Neither follows the canonical
+   * SOP &rarr; records &rarr; EOP push contract the SIT was designed around, so the standard push-derived
+   * checks must be relaxed.
    *
-   * Specifically skipped when this flag is true:
-   *   - {@link #isReadyToServe} immediately returns true. TODO: implement a proper ready-to-serve check for
-   *     seekable DaVinci clients instead of unconditionally short-circuiting.
+   * Specifically, when this flag is true:
+   *   - {@link #isReadyToServe} immediately returns true. TODO: implement a proper ready-to-serve check
+   *     instead of unconditionally short-circuiting.
    *   - DIV (data integrity validation): drainer-side validation is skipped, any
    *     {@code FatalDataValidationException} that surfaces is logged and ignored rather than failing the SIT,
    *     and the related auto-unsubscribe of stuck non-current backup partitions on DIV error is skipped.
-   *   - Missing {@code StoreVersionState} on EOP is synthesized rather than throwing (for past-SOP seeks).
+   *   - If EOP is processed without a prior {@code StoreVersionState} (e.g. the consumer seeked past SOP),
+   *     a fresh {@code StoreVersionState} is synthesized instead of throwing.
    *   - {@link LeaderFollowerStoreIngestionTask#checkLongRunningTaskState} bootstrap timeout — the
    *     {@code BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS} watchdog (default 24h) is skipped.
-   *
-   * Set in the SIT constructor for DaVinci clients consuming from a view topic, and in
-   * {@link #validateAndSubscribePartition}'s user-seek branch (the entry point for every stateless DVRT
-   * CDC subscribe / seek API).
+   *   - The flag is also passed as the {@code inclusive} argument to
+   *     {@link AggKafkaConsumerService#subscribeConsumerFor}, so the subscription is inclusive of
+   *     the user-given start position (consume that position rather than start after it).
    */
-  private boolean skipValidationsForDaVinciClientEnabled = false;
+  private boolean daVinciClientCustomLifecycleEnabled = false;
   private long lastResubscriptionCheckTimestamp = System.currentTimeMillis();
 
   // Helper encapsulating blob transfer utility methods. Null when blob transfer is not configured.
@@ -718,7 +720,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       // which causes data loss;
       // 2. DIV will fail with CORRUPT error due to checksum failure due to problematic segments with the same id.
       if (this.isDaVinciClient && VeniceView.isViewTopic(kafkaVersionTopic)) {
-        this.skipValidationsForDaVinciClientEnabled = true;
+        this.daVinciClientCustomLifecycleEnabled = true;
       }
     } else {
       this.schemaIdToSchemaMap = null;
@@ -1260,8 +1262,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   // TEST ONLY
-  void setSkipValidationsForDaVinciClientEnabled() {
-    this.skipValidationsForDaVinciClientEnabled = true;
+  void setDaVinciClientCustomLifecycleEnabled() {
+    this.daVinciClientCustomLifecycleEnabled = true;
   }
 
   protected abstract boolean isHybridFollower(PartitionConsumptionState partitionConsumptionState);
@@ -1284,7 +1286,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected boolean isReadyToServe(PartitionConsumptionState partitionConsumptionState) {
     // For da-vinci client with ignoreFatalDivError enabled, we don't need to check for lag.
     // TODO: Implement proper way to check ready to serve for seekable da-vinci client
-    if (skipValidationsForDaVinciClientEnabled) {
+    if (daVinciClientCustomLifecycleEnabled) {
       partitionConsumptionState.lagHasCaughtUp();
       return true;
     }
@@ -2941,7 +2943,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         throw new VeniceException(
             "seekToCheckpoint is not supported for clients without the recordTransformer enabled");
       }
-      skipValidationsForDaVinciClientEnabled = true;
+      daVinciClientCustomLifecycleEnabled = true;
       subscribePosition = consumerAction.getPubSubPosition();
       LOGGER.info("Subscribed to user given partition: {} position: {}", topicPartition, subscribePosition);
       // report completion immediately for user seek subscription
@@ -3391,13 +3393,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       // TODO need a way to safeguard DIV errors from backup version that have once been current (but not anymore)
       // during re-balancing
       boolean needToUnsub = !(isCurrentVersion.getAsBoolean() || partitionConsumptionState.isEndOfPushReceived());
-      if (needToUnsub && !skipValidationsForDaVinciClientEnabled) {
+      if (needToUnsub && !daVinciClientCustomLifecycleEnabled) {
         errorMessage += ". Consumption will be halted.";
         ingestionNotificationDispatcher
             .reportError(Collections.singletonList(partitionConsumptionState), errorMessage, e);
         unSubscribePartition(new PubSubTopicPartitionImpl(versionTopic, faultyPartition), false);
       } else {
-        String message = skipValidationsForDaVinciClientEnabled
+        String message = daVinciClientCustomLifecycleEnabled
             ? "{} Ignoring FATAL DIV first time for user provided position subscription. {}"
             : "{}. Consumption will continue because it is either a current version replica or EOP has already been received. {}";
         if (skipAfterBatchPushUnsubEnabled) {
@@ -3796,7 +3798,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         // Sync latest store version level metadata to disk
         return previousStoreVersionState;
       } else {
-        if (skipValidationsForDaVinciClientEnabled) {
+        if (daVinciClientCustomLifecycleEnabled) {
           StoreVersionState storeVersionState =
               getNewStoreVersionState(kafkaMessageEnvelope.producerMetadata.messageTimestamp, !isHybridMode(), null);
           return storeVersionState;
@@ -4330,7 +4332,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
       // Only the ConsumptionTask validates messages if Global RT DIV is enabled, so we don't need to validate here
       // Also skip validation for seekable clients (CDC clients) as they don't need DIV
-      if (!isGlobalRtDivEnabled() && !skipValidationsForDaVinciClientEnabled) {
+      if (!isGlobalRtDivEnabled() && !daVinciClientCustomLifecycleEnabled) {
         drainerValidateMessage(consumerRecord, partitionConsumptionState, leaderProducedRecordContext);
       }
 
@@ -4509,7 +4511,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         versionedDIVStats.recordSuccessMsg(storeName, versionNumber);
       }
     } catch (FatalDataValidationException fatalException) {
-      if (skipValidationsForDaVinciClientEnabled) {
+      if (daVinciClientCustomLifecycleEnabled) {
         String msg = "Ignoring FatalDataValidationException in seeking client for replica: "
             + consumerRecord.getTopicPartition();
         if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
@@ -4855,7 +4857,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         this,
         partitionReplicaIngestionContext,
         startPosition,
-        skipValidationsForDaVinciClientEnabled);
+        daVinciClientCustomLifecycleEnabled);
 
     // If the record transformer is enabled, consumption should be paused until RocksDB scan for all partitions
     // has completed. Otherwise, there will be resource contention.
@@ -6656,7 +6658,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return resubscribeRequestQueue;
   }
 
-  boolean shouldSkipValidationsForDaVinciClientEnabled() {
-    return skipValidationsForDaVinciClientEnabled;
+  boolean isDaVinciClientCustomLifecycleEnabled() {
+    return daVinciClientCustomLifecycleEnabled;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -491,22 +491,23 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private final List<AutoCloseable> thingsToClose = new ArrayList<>();
   private final Version version;
   /**
-   * When true, this SIT skips several validations and short-circuits that are inappropriate for user-driven
-   * consumers (DVRT-based change-log consumers and view-topic DaVinci consumers). Such consumers own their own
-   * lifecycle via seek APIs and have already opted out of the standard server-style validation pipeline.
+   * When true, this SIT skips several validations and short-circuits that are inappropriate for stateless
+   * DVRT CDC consumers — these consumers own their own lifecycle via seek APIs ({@code seekToCheckpoint},
+   * {@code seekToTail}, etc.) and have already opted out of the standard server-style validation pipeline.
    *
    * Specifically skipped when this flag is true:
-   *   - {@link #isReadyToServe} immediately returns true (no lag check; partition reports caught-up).
-   *   - Drainer-side DIV validation in record processing.
-   *   - {@code FatalDataValidationException} is logged and ignored rather than failing the SIT.
-   *   - Missing {@code StoreVersionState} on EOP is synthesized rather than throwing.
-   *   - Auto-unsubscribe of stuck partitions on DIV error.
+   *   - {@link #isReadyToServe} immediately returns true. TODO: implement a proper ready-to-serve check for
+   *     seekable DaVinci clients instead of unconditionally short-circuiting.
+   *   - DIV (data integrity validation): drainer-side validation is skipped, any
+   *     {@code FatalDataValidationException} that surfaces is logged and ignored rather than failing the SIT,
+   *     and the related auto-unsubscribe of stuck non-current backup partitions on DIV error is skipped.
+   *   - Missing {@code StoreVersionState} on EOP is synthesized rather than throwing (for past-SOP seeks).
    *   - {@link LeaderFollowerStoreIngestionTask#checkLongRunningTaskState} bootstrap timeout — the
    *     {@code BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS} watchdog (default 24h) is skipped.
    *
    * Set in the SIT constructor for DaVinci clients consuming from a view topic, and in
-   * {@link #validateAndSubscribePartition}'s user-seek branch (the entry point for DVRT change-log consumers'
-   * seek / subscribe APIs).
+   * {@link #validateAndSubscribePartition}'s user-seek branch (the entry point for every stateless DVRT
+   * CDC subscribe / seek API).
    */
   private boolean skipValidationsForDaVinciClientEnabled = false;
   private long lastResubscriptionCheckTimestamp = System.currentTimeMillis();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -490,6 +490,24 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private boolean skipAfterBatchPushUnsubEnabled = false;
   private final List<AutoCloseable> thingsToClose = new ArrayList<>();
   private final Version version;
+  /**
+   * When true, this SIT skips several validations and short-circuits that are inappropriate for user-driven
+   * consumers (DVRT-based change-log consumers and view-topic DaVinci consumers). Such consumers own their own
+   * lifecycle via seek APIs and have already opted out of the standard server-style validation pipeline.
+   *
+   * Specifically skipped when this flag is true:
+   *   - {@link #isReadyToServe} immediately returns true (no lag check; partition reports caught-up).
+   *   - Drainer-side DIV validation in record processing.
+   *   - {@code FatalDataValidationException} is logged and ignored rather than failing the SIT.
+   *   - Missing {@code StoreVersionState} on EOP is synthesized rather than throwing.
+   *   - Auto-unsubscribe of stuck partitions on DIV error.
+   *   - {@link LeaderFollowerStoreIngestionTask#checkLongRunningTaskState} bootstrap timeout — the
+   *     {@code BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS} watchdog (default 24h) is skipped.
+   *
+   * Set in the SIT constructor for DaVinci clients consuming from a view topic, and in
+   * {@link #validateAndSubscribePartition}'s user-seek branch (the entry point for DVRT change-log consumers'
+   * seek / subscribe APIs).
+   */
   private boolean skipValidationsForDaVinciClientEnabled = false;
   private long lastResubscriptionCheckTimestamp = System.currentTimeMillis();
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -490,7 +490,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private boolean skipAfterBatchPushUnsubEnabled = false;
   private final List<AutoCloseable> thingsToClose = new ArrayList<>();
   private final Version version;
-  protected boolean skipValidationsForDaVinciClientEnabled = false;
+  private boolean skipValidationsForDaVinciClientEnabled = false;
   private long lastResubscriptionCheckTimestamp = System.currentTimeMillis();
 
   // Helper encapsulating blob transfer utility methods. Null when blob transfer is not configured.

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -2013,6 +2013,72 @@ public class LeaderFollowerStoreIngestionTaskTest {
     verify(mockHostLevelStats, times(1)).recordIngestionFailure();
   }
 
+  /**
+   * The BOOTSTRAP_TO_ONLINE_TIMEOUT watchdog must be skipped when
+   * {@code skipValidationsForDaVinciClientEnabled=true} — i.e. for SITs serving DVRT-based change-log consumers
+   * or view-topic DaVinci consumers. These consumers are user-driven (lifecycle owned by the caller via seek APIs)
+   * and already opt out of the standard validation pipeline via the same flag, so the watchdog would false-positive
+   * every restart when the caller seeks past EOP (stateless consumers' in-memory {@code isEndOfPushReceived} starts
+   * false, and the EOP control message — being in the past relative to the seek position — is never re-observed).
+   */
+  @Test
+  public void testIngestionTimeoutSkippedForDvrtClient() throws Exception {
+    LeaderFollowerStoreIngestionTask storeIngestionTask = mock(LeaderFollowerStoreIngestionTask.class);
+
+    // Set up the fields checkLongRunningTaskState reads directly.
+    AggVersionedIngestionStats mockVersionedIngestionStats = mock(AggVersionedIngestionStats.class);
+    HostLevelIngestionStats mockHostLevelStats = mock(HostLevelIngestionStats.class);
+    setField(storeIngestionTask, "versionedIngestionStats", mockVersionedIngestionStats);
+    setField(storeIngestionTask, "hostLevelIngestionStats", mockHostLevelStats);
+    setField(storeIngestionTask, "emitTehutiMetrics", new AtomicBoolean(false));
+    setField(storeIngestionTask, "storeName", "foo");
+    setField(storeIngestionTask, "skipValidationsForDaVinciClientEnabled", true);
+
+    doReturn("foo").when(storeIngestionTask).getStoreName();
+    doReturn(Lazy.of(() -> mock(VeniceWriter.class))).when(storeIngestionTask).getVeniceWriter();
+    doReturn(Lazy.of(() -> mock(VeniceWriter.class))).when(storeIngestionTask).getVeniceWriterForRealTime();
+    doCallRealMethod().when(storeIngestionTask).isEmitTehutiMetricsEnabled();
+    ReadOnlyStoreRepository storeRepository = mock(ReadOnlyStoreRepository.class);
+    doReturn(storeRepository).when(storeIngestionTask).getStoreRepository();
+    Store store = mock(Store.class);
+    doReturn(5).when(store).getCurrentVersion();
+    doReturn(store).when(storeRepository).getStoreOrThrow(anyString());
+
+    doReturn(TimeUnit.DAYS.toMillis(1)).when(storeIngestionTask).getBootstrapTimeoutInMs();
+    doReturn(new PubSubTopicImpl("foo_v1")).when(storeIngestionTask).getVersionTopic();
+    doCallRealMethod().when(storeIngestionTask).checkLongRunningTaskState();
+
+    Map<Integer, PartitionConsumptionState> pcsMap = new HashMap<>();
+    doReturn(pcsMap).when(storeIngestionTask).getPartitionConsumptionStateMap();
+
+    // All three partitions have elapsed > timeout AND isComplete()=false — would normally trip the watchdog.
+    addStandbyPcs(pcsMap, 1, TimeUnit.DAYS.toMillis(2));
+    addStandbyPcs(pcsMap, 2, TimeUnit.DAYS.toMillis(2));
+    addStandbyPcs(pcsMap, 3, TimeUnit.DAYS.toMillis(2));
+
+    // Future version (would normally throw VeniceTimeoutException with the gate off).
+    setVersion(storeIngestionTask, 10);
+    storeIngestionTask.checkLongRunningTaskState();
+
+    // Current version (would normally invoke reportError for each timed-out partition with the gate off).
+    setVersion(storeIngestionTask, 5);
+    storeIngestionTask.checkLongRunningTaskState();
+
+    // Backup version (same — would normally invoke reportError per partition with the gate off).
+    setVersion(storeIngestionTask, 1);
+    storeIngestionTask.checkLongRunningTaskState();
+
+    // No partition should be reported as errored and no ingestion-failure metric should fire.
+    verify(storeIngestionTask, never()).reportError(anyString(), anyInt(), any());
+    verify(mockVersionedIngestionStats, never()).recordIngestionFailureCount(anyString(), anyInt(), any());
+    verify(mockHostLevelStats, never()).recordIngestionFailure();
+
+    // check-time is still recorded for each call (independent of the watchdog branch).
+    verify(mockVersionedIngestionStats, times(1)).recordLongRunningTaskCheckTime(eq("foo"), eq(10), anyDouble());
+    verify(mockVersionedIngestionStats, times(1)).recordLongRunningTaskCheckTime(eq("foo"), eq(5), anyDouble());
+    verify(mockVersionedIngestionStats, times(1)).recordLongRunningTaskCheckTime(eq("foo"), eq(1), anyDouble());
+  }
+
   @Test
   public void testStopTrackingCurrentVersionIngestionOnDemotion() throws Exception {
     LeaderFollowerStoreIngestionTask storeIngestionTask = mock(LeaderFollowerStoreIngestionTask.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -2014,12 +2014,11 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
-   * The BOOTSTRAP_TO_ONLINE_TIMEOUT watchdog must be skipped when
-   * {@code skipValidationsForDaVinciClientEnabled=true} — i.e. for SITs serving DVRT-based change-log consumers
-   * or view-topic DaVinci consumers. These consumers are user-driven (lifecycle owned by the caller via seek APIs)
-   * and already opt out of the standard validation pipeline via the same flag, so the watchdog would false-positive
-   * every restart when the caller seeks past EOP (stateless consumers' in-memory {@code isEndOfPushReceived} starts
-   * false, and the EOP control message — being in the past relative to the seek position — is never re-observed).
+   * The BOOTSTRAP_TO_ONLINE_TIMEOUT watchdog must be skipped for stateless DVRT CDC consumers (signalled by
+   * {@code skipValidationsForDaVinciClientEnabled=true}): the consumer's in-memory {@code isEndOfPushReceived}
+   * starts false on every restart, and when the caller seeks past EOP the EOP control message is in the past
+   * relative to the seek position and is never re-observed — so {@code isComplete()} stays false and the
+   * watchdog would false-positive every restart cycle.
    */
   @Test
   public void testIngestionTimeoutSkippedForDvrtClient() throws Exception {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -2011,68 +2011,25 @@ public class LeaderFollowerStoreIngestionTaskTest {
     // Tehuti: now fires because emitTehutiMetrics=true
     verify(mockHostLevelStats, times(1)).recordCheckLongRunningTasksLatency(anyDouble());
     verify(mockHostLevelStats, times(1)).recordIngestionFailure();
-  }
 
-  /**
-   * The BOOTSTRAP_TO_ONLINE_TIMEOUT watchdog must be skipped for stateless DVRT CDC consumers (signalled by
-   * {@code skipValidationsForDaVinciClientEnabled=true}): the consumer's in-memory {@code isEndOfPushReceived}
-   * starts false on every restart, and when the caller seeks past EOP the EOP control message is in the past
-   * relative to the seek position and is never re-observed — so {@code isComplete()} stays false and the
-   * watchdog would false-positive every restart cycle.
-   */
-  @Test
-  public void testIngestionTimeoutSkippedForDvrtClient() throws Exception {
-    LeaderFollowerStoreIngestionTask storeIngestionTask = mock(LeaderFollowerStoreIngestionTask.class);
-
-    // Set up the fields checkLongRunningTaskState reads directly.
-    AggVersionedIngestionStats mockVersionedIngestionStats = mock(AggVersionedIngestionStats.class);
-    HostLevelIngestionStats mockHostLevelStats = mock(HostLevelIngestionStats.class);
-    setField(storeIngestionTask, "versionedIngestionStats", mockVersionedIngestionStats);
-    setField(storeIngestionTask, "hostLevelIngestionStats", mockHostLevelStats);
-    setField(storeIngestionTask, "emitTehutiMetrics", new AtomicBoolean(false));
-    setField(storeIngestionTask, "storeName", "foo");
-
+    // Gate verification: with skipValidationsForDaVinciClientEnabled=true (stateless DVRT CDC consumers),
+    // the BOOTSTRAP_TO_ONLINE_TIMEOUT watchdog must skip the timeout branch for every PCS, even though all
+    // three partitions still satisfy elapsed > timeout AND isComplete()=false.
     doReturn(true).when(storeIngestionTask).shouldSkipValidationsForDaVinciClientEnabled();
-    doReturn("foo").when(storeIngestionTask).getStoreName();
-    doReturn(Lazy.of(() -> mock(VeniceWriter.class))).when(storeIngestionTask).getVeniceWriter();
-    doReturn(Lazy.of(() -> mock(VeniceWriter.class))).when(storeIngestionTask).getVeniceWriterForRealTime();
-    doCallRealMethod().when(storeIngestionTask).isEmitTehutiMetricsEnabled();
-    ReadOnlyStoreRepository storeRepository = mock(ReadOnlyStoreRepository.class);
-    doReturn(storeRepository).when(storeIngestionTask).getStoreRepository();
-    Store store = mock(Store.class);
-    doReturn(5).when(store).getCurrentVersion();
-    doReturn(store).when(storeRepository).getStoreOrThrow(anyString());
+    clearInvocations(storeIngestionTask, mockVersionedIngestionStats, mockHostLevelStats);
 
-    doReturn(TimeUnit.DAYS.toMillis(1)).when(storeIngestionTask).getBootstrapTimeoutInMs();
-    doReturn(new PubSubTopicImpl("foo_v1")).when(storeIngestionTask).getVersionTopic();
-    doCallRealMethod().when(storeIngestionTask).checkLongRunningTaskState();
-
-    Map<Integer, PartitionConsumptionState> pcsMap = new HashMap<>();
-    doReturn(pcsMap).when(storeIngestionTask).getPartitionConsumptionStateMap();
-
-    // All three partitions have elapsed > timeout AND isComplete()=false — would normally trip the watchdog.
-    addStandbyPcs(pcsMap, 1, TimeUnit.DAYS.toMillis(2));
-    addStandbyPcs(pcsMap, 2, TimeUnit.DAYS.toMillis(2));
-    addStandbyPcs(pcsMap, 3, TimeUnit.DAYS.toMillis(2));
-
-    // Future version (would normally throw VeniceTimeoutException with the gate off).
-    setVersion(storeIngestionTask, 10);
+    setVersion(storeIngestionTask, 10); // future
+    storeIngestionTask.checkLongRunningTaskState();
+    setVersion(storeIngestionTask, 5); // current
+    storeIngestionTask.checkLongRunningTaskState();
+    setVersion(storeIngestionTask, 1); // backup
     storeIngestionTask.checkLongRunningTaskState();
 
-    // Current version (would normally invoke reportError for each timed-out partition with the gate off).
-    setVersion(storeIngestionTask, 5);
-    storeIngestionTask.checkLongRunningTaskState();
-
-    // Backup version (same — would normally invoke reportError per partition with the gate off).
-    setVersion(storeIngestionTask, 1);
-    storeIngestionTask.checkLongRunningTaskState();
-
-    // No partition should be reported as errored and no ingestion-failure metric should fire.
+    // No partition reported errored and no ingestion-failure metric fired.
     verify(storeIngestionTask, never()).reportError(anyString(), anyInt(), any());
     verify(mockVersionedIngestionStats, never()).recordIngestionFailureCount(anyString(), anyInt(), any());
     verify(mockHostLevelStats, never()).recordIngestionFailure();
-
-    // check-time is still recorded for each call (independent of the watchdog branch).
+    // Check-time is still recorded for each call (independent of the watchdog branch).
     verify(mockVersionedIngestionStats, times(1)).recordLongRunningTaskCheckTime(eq("foo"), eq(10), anyDouble());
     verify(mockVersionedIngestionStats, times(1)).recordLongRunningTaskCheckTime(eq("foo"), eq(5), anyDouble());
     verify(mockVersionedIngestionStats, times(1)).recordLongRunningTaskCheckTime(eq("foo"), eq(1), anyDouble());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -2030,9 +2030,9 @@ public class LeaderFollowerStoreIngestionTaskTest {
     verify(mockVersionedIngestionStats, never()).recordIngestionFailureCount(anyString(), anyInt(), any());
     verify(mockHostLevelStats, never()).recordIngestionFailure();
     // Check-time is still recorded for each call (independent of the watchdog branch).
-    verify(mockVersionedIngestionStats, times(1)).recordLongRunningTaskCheckTime(eq("foo"), eq(10), anyDouble());
-    verify(mockVersionedIngestionStats, times(1)).recordLongRunningTaskCheckTime(eq("foo"), eq(5), anyDouble());
-    verify(mockVersionedIngestionStats, times(1)).recordLongRunningTaskCheckTime(eq("foo"), eq(1), anyDouble());
+    verify(mockVersionedIngestionStats).recordLongRunningTaskCheckTime(eq("foo"), eq(10), anyDouble());
+    verify(mockVersionedIngestionStats).recordLongRunningTaskCheckTime(eq("foo"), eq(5), anyDouble());
+    verify(mockVersionedIngestionStats).recordLongRunningTaskCheckTime(eq("foo"), eq(1), anyDouble());
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -2012,10 +2012,10 @@ public class LeaderFollowerStoreIngestionTaskTest {
     verify(mockHostLevelStats, times(1)).recordCheckLongRunningTasksLatency(anyDouble());
     verify(mockHostLevelStats, times(1)).recordIngestionFailure();
 
-    // Gate verification: with skipValidationsForDaVinciClientEnabled=true (stateless DVRT CDC consumers),
+    // Gate verification: with daVinciClientCustomLifecycleEnabled=true (e.g. stateless DVRT CDC consumers),
     // the BOOTSTRAP_TO_ONLINE_TIMEOUT watchdog must NOT report any partition as errored — including the
     // timed-out ones (partitions 1 and 3) that would otherwise be added to timeoutPartitions.
-    doReturn(true).when(storeIngestionTask).shouldSkipValidationsForDaVinciClientEnabled();
+    doReturn(true).when(storeIngestionTask).isDaVinciClientCustomLifecycleEnabled();
     clearInvocations(storeIngestionTask, mockVersionedIngestionStats, mockHostLevelStats);
 
     setVersion(storeIngestionTask, 10); // future

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -2031,8 +2031,8 @@ public class LeaderFollowerStoreIngestionTaskTest {
     setField(storeIngestionTask, "hostLevelIngestionStats", mockHostLevelStats);
     setField(storeIngestionTask, "emitTehutiMetrics", new AtomicBoolean(false));
     setField(storeIngestionTask, "storeName", "foo");
-    setField(storeIngestionTask, "skipValidationsForDaVinciClientEnabled", true);
 
+    doReturn(true).when(storeIngestionTask).shouldSkipValidationsForDaVinciClientEnabled();
     doReturn("foo").when(storeIngestionTask).getStoreName();
     doReturn(Lazy.of(() -> mock(VeniceWriter.class))).when(storeIngestionTask).getVeniceWriter();
     doReturn(Lazy.of(() -> mock(VeniceWriter.class))).when(storeIngestionTask).getVeniceWriterForRealTime();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -2013,8 +2013,8 @@ public class LeaderFollowerStoreIngestionTaskTest {
     verify(mockHostLevelStats, times(1)).recordIngestionFailure();
 
     // Gate verification: with skipValidationsForDaVinciClientEnabled=true (stateless DVRT CDC consumers),
-    // the BOOTSTRAP_TO_ONLINE_TIMEOUT watchdog must skip the timeout branch for every PCS, even though all
-    // three partitions still satisfy elapsed > timeout AND isComplete()=false.
+    // the BOOTSTRAP_TO_ONLINE_TIMEOUT watchdog must NOT report any partition as errored — including the
+    // timed-out ones (partitions 1 and 3) that would otherwise be added to timeoutPartitions.
     doReturn(true).when(storeIngestionTask).shouldSkipValidationsForDaVinciClientEnabled();
     clearInvocations(storeIngestionTask, mockVersionedIngestionStats, mockHostLevelStats);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -2322,7 +2322,7 @@ public abstract class StoreIngestionTaskTest {
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
 
     runTest(Utils.setOf(PARTITION_FOO, PARTITION_BAR), () -> {
-      storeIngestionTaskUnderTest.setSkipValidationsForDaVinciClientEnabled();
+      storeIngestionTaskUnderTest.setDaVinciClientCustomLifecycleEnabled();
       ArgumentCaptor<InMemoryPubSubPosition> positionCaptor = ArgumentCaptor.forClass(InMemoryPubSubPosition.class);
       verify(mockLogNotifier, timeout(TEST_TIMEOUT_MS))
           .completed(eq(topic), eq(PARTITION_FOO), positionCaptor.capture(), eq("STANDBY"));
@@ -7033,7 +7033,7 @@ public abstract class StoreIngestionTaskTest {
     // Test 1: Non-CDC client with non-view topic should NOT skip validation
     runTest(Collections.singleton(PARTITION_FOO), () -> {
       assertFalse(
-          storeIngestionTaskUnderTest.shouldSkipValidationsForDaVinciClientEnabled(),
+          storeIngestionTaskUnderTest.isDaVinciClientCustomLifecycleEnabled(),
           "Non-CDC client with regular topic should not skip validation");
     }, AA_OFF);
 
@@ -7041,7 +7041,7 @@ public abstract class StoreIngestionTaskTest {
     StoreIngestionTaskTestConfig cdcNonViewConfig =
         new StoreIngestionTaskTestConfig(Collections.singleton(PARTITION_FOO), () -> {
           assertFalse(
-              storeIngestionTaskUnderTest.shouldSkipValidationsForDaVinciClientEnabled(),
+              storeIngestionTaskUnderTest.isDaVinciClientCustomLifecycleEnabled(),
               "CDC client with non-view topic should not skip validation");
         }, AA_OFF);
 
@@ -7055,7 +7055,7 @@ public abstract class StoreIngestionTaskTest {
     StoreIngestionTaskTestConfig cdcMaterializedViewConfig =
         new StoreIngestionTaskTestConfig(Collections.singleton(PARTITION_FOO), () -> {
           assertTrue(
-              storeIngestionTaskUnderTest.shouldSkipValidationsForDaVinciClientEnabled(),
+              storeIngestionTaskUnderTest.isDaVinciClientCustomLifecycleEnabled(),
               "CDC client with materialized view topic should skip validation");
         }, AA_OFF);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
@@ -8,6 +8,7 @@ import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstant
 import static com.linkedin.venice.stats.ClientType.CHANGE_DATA_CAPTURE_CLIENT;
 import static com.linkedin.venice.stats.VeniceMetricsRepository.getVeniceMetricsRepository;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingRecord;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
 import static com.linkedin.venice.utils.Utils.getTempDataDirectory;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
@@ -41,6 +42,7 @@ import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.samza.VeniceSystemProducer;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
@@ -331,6 +333,111 @@ public class TestVersionSpecificChangelogConsumer {
                 + "ms");
       }
     });
+  }
+
+  /**
+   * Hybrid-store sibling of {@link #testBatchStoreVersionSpecificClientEmitsSyntheticHeartbeats}: verifies that a
+   * stateless version-specific {@link VeniceChangelogConsumer} can {@code seekToTail()} (LATEST = post-EOP) on a
+   * hybrid store, restart, and continue receiving newly produced records.
+   *
+   * <p>Why this case warrants its own test: on a stateless DVRT consumer the in-memory {@link
+   * com.linkedin.venice.offsets.OffsetRecord} is cleared on every startup (alwaysBootstrapFromVersionTopic=true), so
+   * {@code isEndOfPushReceived} starts {@code false}. When the user seeks past EOP, the EOP control message is in
+   * the past and never re-observed — so {@link
+   * com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask#checkLongRunningTaskState()} would otherwise
+   * false-positive every restart cycle (its {@code isComplete()} predicate gates on {@code isEndOfPushReceived}).
+   * The watchdog now skips DVRT-driven SITs via {@code skipValidationsForDaVinciClientEnabled}; this test pins that
+   * behavior by setting {@code bootstrapToOnlineTimeoutInHours=0} before the restart so a regression would surface
+   * immediately rather than 24 h later.
+   *
+   * <p>Synthetic heartbeats are NOT emitted client-side for hybrid stores (see
+   * {@code VeniceChangelogConsumerDaVinciRecordTransformerImpl.maybeEnableSyntheticHeartbeats}, which requires
+   * {@code !isHybrid()}), so the assertion observes the real SIT state through {@code poll()}.
+   */
+  @Test(timeOut = TEST_TIMEOUT, priority = 3)
+  public void testHybridStoreVersionSpecificClientSeekToTailPostEop()
+      throws IOException, ExecutionException, InterruptedException {
+    File inputDir = getTempDataDirectory();
+    int numKeys = 10;
+    Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithIntToStringSchema(inputDir, "1", numKeys);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("hybrid-seek-post-eop");
+    testStoresToDelete.add(storeName);
+    Properties props = TestWriteUtils.defaultVPJProps(
+        parentControllers.get(0).getControllerUrl(),
+        inputDirPath,
+        storeName,
+        clusterWrapper.getPubSubClientProperties());
+    String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
+    String valueSchemaStr = STRING_SCHEMA.toString();
+    UpdateStoreQueryParams storeParms = ChangelogConsumerTestUtils.buildDefaultStoreParams();
+    MetricsRepository metricsRepository =
+        getVeniceMetricsRepository(CHANGE_DATA_CAPTURE_CLIENT, CONSUMER_METRIC_ENTITIES, true);
+    createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, storeParms);
+    ChangelogConsumerTestUtils.waitForMetaSystemStoreToBeReady(storeName, childControllerClientRegion0, clusterWrapper);
+    IntegrationTestPushUtils.runVPJ(props, 1, childControllerClientRegion0);
+
+    Properties consumerProperties = ChangelogConsumerTestUtils
+        .buildConsumerProperties(multiRegionMultiClusterWrapper, localKafka, clusterName, localZkServer);
+    ChangelogClientConfig globalChangelogClientConfig =
+        ChangelogConsumerTestUtils.buildBaseChangelogClientConfig(consumerProperties, localZkServer.getAddress(), 1)
+            .setD2Client(d2Client)
+            .setBootstrapFileSystemPath(Utils.getUniqueString(inputDirPath));
+    VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
+        new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
+
+    // Initial bootstrap consumes SOP/batch/EOP through the natural processEndOfPush path.
+    try (VeniceChangelogConsumer<Integer, Utf8> initialConsumer =
+        veniceChangelogConsumerClientFactory.getVersionSpecificChangelogConsumer(storeName, 1)) {
+      initialConsumer.subscribeAll().get();
+      Set<Integer> seenKeys = new HashSet<>();
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        for (PubSubMessage<Integer, ChangeEvent<Utf8>, VeniceChangeCoordinate> message: initialConsumer.poll(1000)) {
+          if (message.getKey() != null) {
+            seenKeys.add(message.getKey());
+          }
+        }
+        assertEquals(seenKeys.size(), numKeys, "Initial bootstrap should observe all batch records");
+      });
+    }
+
+    // Produce a pre-restart hybrid record so the VT carries data past EOP.
+    try (VeniceSystemProducer veniceProducer =
+        IntegrationTestPushUtils.getSamzaProducerForStream(multiRegionMultiClusterWrapper, 0, storeName)) {
+      sendStreamingRecord(veniceProducer, storeName, 9999, "hybrid-record-pre-restart", null);
+    }
+
+    // Shrink bootstrap timeout to zero; the SIT constructed for the next subscribe will inherit it. Without the
+    // skipValidationsForDaVinciClientEnabled guard on the watchdog, this would fail the test within seconds.
+    parentControllerClient.updateStore(storeName, new UpdateStoreQueryParams().setBootstrapToOnlineTimeoutInHours(0));
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+      assertEquals(childControllerClientRegion0.getStore(storeName).getStore().getBootstrapToOnlineTimeoutInHours(), 0);
+    });
+    Thread.sleep(2000); // brief settle so the server's storeRepository refreshes before the new SIT is constructed
+
+    // Restart with seekToTail (LATEST = past EOP), produce one more nearline record, and verify it arrives.
+    try (VeniceChangelogConsumer<Integer, Utf8> restartedConsumer =
+        veniceChangelogConsumerClientFactory.getVersionSpecificChangelogConsumer(storeName, 1)) {
+      restartedConsumer.seekToTail().get();
+
+      try (VeniceSystemProducer veniceProducer =
+          IntegrationTestPushUtils.getSamzaProducerForStream(multiRegionMultiClusterWrapper, 0, storeName)) {
+        sendStreamingRecord(veniceProducer, storeName, 10000, "hybrid-record-post-restart", null);
+      }
+
+      Set<Integer> seenKeys = new HashSet<>();
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        for (PubSubMessage<Integer, ChangeEvent<Utf8>, VeniceChangeCoordinate> message: restartedConsumer.poll(1000)) {
+          if (message.getKey() != null) {
+            seenKeys.add(message.getKey());
+          }
+        }
+        assertTrue(
+            seenKeys.contains(10000),
+            "Post-restart nearline record (key=10000) should be visible to a stateless DVRT CDC consumer after "
+                + "seekToTail. seenKeys=" + seenKeys);
+      });
+    }
   }
 
   @Test(timeOut = TEST_TIMEOUT, priority = 3)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
@@ -346,7 +346,7 @@ public class TestVersionSpecificChangelogConsumer {
    * the past and never re-observed — so {@link
    * com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask#checkLongRunningTaskState()} would otherwise
    * false-positive every restart cycle (its {@code isComplete()} predicate gates on {@code isEndOfPushReceived}).
-   * The watchdog now skips stateless DVRT CDC consumers via {@code skipValidationsForDaVinciClientEnabled}; this test pins that
+   * The watchdog now skips stateless DVRT CDC consumers via {@code daVinciClientCustomLifecycleEnabled}; this test pins that
    * behavior by setting {@code bootstrapToOnlineTimeoutInHours=0} before the restart so a regression would surface
    * immediately rather than 24 h later.
    */
@@ -404,7 +404,7 @@ public class TestVersionSpecificChangelogConsumer {
     }
 
     // Shrink bootstrap timeout to zero; the SIT constructed for the next subscribe will inherit it. Without the
-    // skipValidationsForDaVinciClientEnabled guard on the watchdog, this would fail the test within seconds.
+    // daVinciClientCustomLifecycleEnabled guard on the watchdog, this would fail the test within seconds.
     parentControllerClient.updateStore(storeName, new UpdateStoreQueryParams().setBootstrapToOnlineTimeoutInHours(0));
     // Wait deterministically until the Venice server's metadata repo — the actual source the SIT consults when
     // constructed — observes the new timeout. The child-controller view propagates faster than the server's repo,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
@@ -340,7 +340,7 @@ public class TestVersionSpecificChangelogConsumer {
    * stateless version-specific {@link VeniceChangelogConsumer} can {@code seekToTail()} (LATEST = post-EOP) on a
    * hybrid store, restart, and continue receiving newly produced records.
    *
-   * <p>Why this case warrants its own test: on a stateless DVRT consumer the in-memory {@link
+   * Why this case warrants its own test: on a stateless DVRT consumer the in-memory {@link
    * com.linkedin.venice.offsets.OffsetRecord} is cleared on every startup (alwaysBootstrapFromVersionTopic=true), so
    * {@code isEndOfPushReceived} starts {@code false}. When the user seeks past EOP, the EOP control message is in
    * the past and never re-observed — so {@link
@@ -350,7 +350,7 @@ public class TestVersionSpecificChangelogConsumer {
    * behavior by setting {@code bootstrapToOnlineTimeoutInHours=0} before the restart so a regression would surface
    * immediately rather than 24 h later.
    *
-   * <p>Synthetic heartbeats are NOT emitted client-side for hybrid stores (see
+   * Synthetic heartbeats are NOT emitted client-side for hybrid stores (see
    * {@code VeniceChangelogConsumerDaVinciRecordTransformerImpl.maybeEnableSyntheticHeartbeats}, which requires
    * {@code !isHybrid()}), so the assertion observes the real SIT state through {@code poll()}.
    */

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
@@ -346,7 +346,7 @@ public class TestVersionSpecificChangelogConsumer {
    * the past and never re-observed — so {@link
    * com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask#checkLongRunningTaskState()} would otherwise
    * false-positive every restart cycle (its {@code isComplete()} predicate gates on {@code isEndOfPushReceived}).
-   * The watchdog now skips DVRT-driven SITs via {@code skipValidationsForDaVinciClientEnabled}; this test pins that
+   * The watchdog now skips stateless DVRT CDC consumers via {@code skipValidationsForDaVinciClientEnabled}; this test pins that
    * behavior by setting {@code bootstrapToOnlineTimeoutInHours=0} before the restart so a regression would surface
    * immediately rather than 24 h later.
    *

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
@@ -410,10 +410,20 @@ public class TestVersionSpecificChangelogConsumer {
     // Shrink bootstrap timeout to zero; the SIT constructed for the next subscribe will inherit it. Without the
     // skipValidationsForDaVinciClientEnabled guard on the watchdog, this would fail the test within seconds.
     parentControllerClient.updateStore(storeName, new UpdateStoreQueryParams().setBootstrapToOnlineTimeoutInHours(0));
+    // Wait deterministically until the Venice server's metadata repo — the actual source the SIT consults when
+    // constructed — observes the new timeout. The child-controller view propagates faster than the server's repo,
+    // so we wait on the latter directly to avoid a flaky arbitrary sleep.
     TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-      assertEquals(childControllerClientRegion0.getStore(storeName).getStore().getBootstrapToOnlineTimeoutInHours(), 0);
+      assertEquals(
+          clusterWrapper.getVeniceServers()
+              .get(0)
+              .getVeniceServer()
+              .getKafkaStoreIngestionService()
+              .getMetadataRepo()
+              .getStoreOrThrow(storeName)
+              .getBootstrapToOnlineTimeoutInHours(),
+          0);
     });
-    Thread.sleep(2000); // brief settle so the server's storeRepository refreshes before the new SIT is constructed
 
     // Restart with seekToTail (LATEST = past EOP), produce one more nearline record, and verify it arrives.
     try (VeniceChangelogConsumer<Integer, Utf8> restartedConsumer =

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
@@ -349,10 +349,6 @@ public class TestVersionSpecificChangelogConsumer {
    * The watchdog now skips stateless DVRT CDC consumers via {@code skipValidationsForDaVinciClientEnabled}; this test pins that
    * behavior by setting {@code bootstrapToOnlineTimeoutInHours=0} before the restart so a regression would surface
    * immediately rather than 24 h later.
-   *
-   * Synthetic heartbeats are NOT emitted client-side for hybrid stores (see
-   * {@code VeniceChangelogConsumerDaVinciRecordTransformerImpl.maybeEnableSyntheticHeartbeats}, which requires
-   * {@code !isHybrid()}), so the assertion observes the real SIT state through {@code poll()}.
    */
   @Test(timeOut = TEST_TIMEOUT, priority = 3)
   public void testHybridStoreVersionSpecificClientSeekToTailPostEop()


### PR DESCRIPTION
## Problem Statement

A stateless DVRT changelog consumer gets killed by the 24-hour bootstrap-timeout watchdog on every restart whenever the user seeks past end-of-push (the normal state after a checkpoint resume in steady-state hybrid consumption).

Stateless consumers don't persist their consumption state to disk, so on every startup the consumer's in-memory "I've observed end-of-push" flag starts false. The seek API immediately reports the partition as ready (so downstream pipelines flow records normally), but the EOP marker is in the past relative to the seek position, so the consumer never re-observes it and the flag never flips. The bootstrap-timeout watchdog gates on that flag, so 24 hours later it fires for every partition — even though the consumer was healthy the entire time.

Net effect: the pipeline appears caught up right up until a hard failure every 24 hours.

## Solution

Skip the bootstrap-timeout watchdog for SITs serving DVRT changelog or view-topic DaVinci consumers. The watchdog is designed to catch incomplete pushes; these consumers are user-driven (the caller owns the lifecycle via the seek APIs) and already opt out of the standard validation pipeline via an existing flag. This reuses that flag rather than introducing a new one.

Also renamed the flag from `skipValidationsForDaVinciClientEnabled` to `daVinciClientCustomLifecycleEnabled`. The original name only described a subset of the behaviors it governs; the new name captures the current state.

### Code changes

- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.

### Concurrency-Specific Checks

- [x] No race conditions / thread safety issues.
- [x] No new synchronization needed.
- [x] No blocking calls in critical sections.
- [x] No new collections.
- [x] Exception handling unchanged.

## How was this PR tested?

- [x] **New unit test.** Companion to the existing `testIngestionTimeoutHandling` — pins the new gate behavior using the same mocked-SIT scaffolding. Runs in ~1.5s.
- [x] **New integration test.** Hybrid-store sibling of the existing batch test for stateless DVRT seek-past-EOP. Shrinks the bootstrap timeout to zero before the restart so a regression surfaces immediately.
- [x] **Verified backward compatibility** — non-DVRT call sites keep the existing 24-hour watchdog.

Bidirectional regression check locally on both tests: **without** the fix they fail with the production failure signature; **with** the fix they pass with zero watchdog firings.

## Does this PR introduce any user-facing or breaking changes?

- [x] **No.**
- [ ] Yes.
