### PR TITLE
[controller] Wire StoreLifecycleHooks call sites for version creation and deletion

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/hooks/StoreLifecycleHooks.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/hooks/StoreLifecycleHooks.java
@@ -120,6 +120,29 @@ public abstract class StoreLifecycleHooks {
   }
 
   /**
+   * Invoked prior to creating a new store. The hook has the option of aborting the creation.<br>
+   * <br>
+   * Note: at the time this hook fires, the store object has been configured but not yet persisted. Any lifecycle hooks
+   * configured on the store (e.g. via an initial hooks config) are available via {@code storeHooksConfigs}.<br>
+   * <br>
+   * Cardinality: once per store creation attempt.
+   */
+  public StoreLifecycleEventOutcome preStoreCreation(
+      String clusterName,
+      String storeName,
+      VeniceProperties storeHooksConfigs) {
+    return StoreLifecycleEventOutcome.PROCEED;
+  }
+
+  /**
+   * Invoked after a new store has been successfully created and persisted.<br>
+   * <br>
+   * Cardinality: once per successful store creation.
+   */
+  public void postStoreCreation(String clusterName, String storeName, VeniceProperties storeHooksConfigs) {
+  }
+
+  /**
    * Invoked prior to starting a new job. The hook has the option of aborting the job.<br>
    * <br>
    * N.B.: this hook returns a {@link StoreLifecycleEventOutcome}, and not a {@link StoreVersionLifecycleEventOutcome},

--- a/internal/venice-common/src/main/java/com/linkedin/venice/hooks/StoreLifecycleHooks.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/hooks/StoreLifecycleHooks.java
@@ -120,6 +120,26 @@ public abstract class StoreLifecycleHooks {
   }
 
   /**
+   * Invoked prior to deleting a store. The hook has the option of aborting the deletion.<br>
+   * <br>
+   * Cardinality: once per store deletion attempt.
+   */
+  public StoreLifecycleEventOutcome preStoreDeletion(
+      String clusterName,
+      String storeName,
+      VeniceProperties storeHooksConfigs) {
+    return StoreLifecycleEventOutcome.PROCEED;
+  }
+
+  /**
+   * Invoked after a store has been successfully deleted.<br>
+   * <br>
+   * Cardinality: once per successful store deletion.
+   */
+  public void postStoreDeletion(String clusterName, String storeName, VeniceProperties storeHooksConfigs) {
+  }
+
+  /**
    * Invoked prior to creating a new store. The hook has the option of aborting the creation.<br>
    * <br>
    * Note: at the time this hook fires, the store object has been configured but not yet persisted. Any lifecycle hooks

--- a/internal/venice-common/src/main/java/com/linkedin/venice/hooks/StoreLifecycleHooks.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/hooks/StoreLifecycleHooks.java
@@ -205,6 +205,33 @@ public abstract class StoreLifecycleHooks {
   }
 
   /**
+   * Invoked prior to deleting a store-version in a given region. The hook has the option of aborting the deletion.<br>
+   * <br>
+   * Cardinality: once per store-version deletion attempt per region.
+   */
+  public StoreLifecycleEventOutcome preStoreVersionDeletion(
+      String clusterName,
+      String storeName,
+      int versionNumber,
+      String regionName,
+      VeniceProperties storeHooksConfigs) {
+    return StoreLifecycleEventOutcome.PROCEED;
+  }
+
+  /**
+   * Invoked after deleting a store-version in a given region.<br>
+   * <br>
+   * Cardinality: once per successful store-version deletion per region.
+   */
+  public void postStoreVersionDeletion(
+      String clusterName,
+      String storeName,
+      int versionNumber,
+      String regionName,
+      VeniceProperties storeHooksConfigs) {
+  }
+
+  /**
    * Invoked prior to informing Da Vinci Clients about starting to ingest a new store-version.<br>
    * <br>
    * Cardinality: once per store-version per region.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -1255,6 +1255,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
       configureNewStore(newStore, config, largestUsedStoreVersion, largestUsedRTStoreVersion);
 
+      invokePreStoreCreationHooks(clusterName, storeName, newStore.getStoreLifecycleHooks());
       storeRepo.addStore(newStore);
       // Create global config for that store.
       ZkStoreConfigAccessor storeConfigAccessor = getHelixVeniceClusterResources(clusterName).getStoreConfigAccessor();
@@ -1273,6 +1274,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           owner,
           newStore.getLargestUsedVersionNumber(),
           newStore.getPartitionCount());
+      invokePostStoreCreationHooks(clusterName, storeName, newStore.getStoreLifecycleHooks());
     }
   }
 
@@ -6663,6 +6665,53 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         return null;
       }
     });
+  }
+
+  void invokePreStoreCreationHooks(String clusterName, String storeName, List<LifecycleHooksRecord> lifecycleHooks) {
+    for (LifecycleHooksRecord record: lifecycleHooks) {
+      StoreLifecycleHooks hook = getOrCreateHookInstance(record);
+      if (hook == null) {
+        continue;
+      }
+      Properties properties = new Properties();
+      properties.putAll(record.getStoreLifecycleHooksParams());
+      StoreLifecycleEventOutcome outcome;
+      try {
+        outcome = hook.preStoreCreation(clusterName, storeName, new VeniceProperties(properties));
+      } catch (Exception e) {
+        LOGGER.error(
+            "Exception in preStoreCreation hook {} for store {}",
+            record.getStoreLifecycleHooksClassName(),
+            storeName,
+            e);
+        continue;
+      }
+      if (StoreLifecycleEventOutcome.ABORT.equals(outcome)) {
+        throw new VeniceException(
+            "preStoreCreation hook " + record.getStoreLifecycleHooksClassName() + " aborted creation of store "
+                + storeName);
+      }
+    }
+  }
+
+  void invokePostStoreCreationHooks(String clusterName, String storeName, List<LifecycleHooksRecord> lifecycleHooks) {
+    for (LifecycleHooksRecord record: lifecycleHooks) {
+      StoreLifecycleHooks hook = getOrCreateHookInstance(record);
+      if (hook == null) {
+        continue;
+      }
+      Properties properties = new Properties();
+      properties.putAll(record.getStoreLifecycleHooksParams());
+      try {
+        hook.postStoreCreation(clusterName, storeName, new VeniceProperties(properties));
+      } catch (Exception e) {
+        LOGGER.error(
+            "Exception in postStoreCreation hook {} for store {}",
+            record.getStoreLifecycleHooksClassName(),
+            storeName,
+            e);
+      }
+    }
   }
 
   void invokePreStoreVersionCreationHooks(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -496,6 +496,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   private final Map<String, DeadStoreStats> deadStoreStatsMap = new VeniceConcurrentHashMap<>();
   private final Map<String, LogCompactionStats> logCompactionStatsMap = new VeniceConcurrentHashMap<>();
   private final Map<String, StoreLifecycleHooks> storeLifecycleHooksInstanceCache = new VeniceConcurrentHashMap<>();
+  private final Set<String> failedHookClasses = ConcurrentHashMap.newKeySet();
   private final Optional<ExternalETLService> externalETLService;
 
   // Test only.
@@ -3481,12 +3482,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 replicationFactor);
             addVersionLatencyStats.recordHelixResourceCreationLatency(
                 LatencyUtils.getElapsedTimeFromMsToMs(helixResourceCreationStartTime));
+            invokePostStoreVersionCreationHooks(
+                clusterName,
+                storeName,
+                version.getNumber(),
+                store.getStoreLifecycleHooks());
           }
-          invokePostStoreVersionCreationHooks(
-              clusterName,
-              storeName,
-              version.getNumber(),
-              store.getStoreLifecycleHooks());
         }
 
         if (startIngestion) {
@@ -6646,14 +6647,19 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   StoreLifecycleHooks getOrCreateHookInstance(LifecycleHooksRecord record) {
-    return storeLifecycleHooksInstanceCache.computeIfAbsent(record.getStoreLifecycleHooksClassName(), className -> {
+    String className = record.getStoreLifecycleHooksClassName();
+    if (failedHookClasses.contains(className)) {
+      return null;
+    }
+    return storeLifecycleHooksInstanceCache.computeIfAbsent(className, cn -> {
       try {
         return ReflectUtils.callConstructor(
-            ReflectUtils.loadClass(className),
+            ReflectUtils.loadClass(cn),
             new Class<?>[] { VeniceProperties.class },
             new Object[] { multiClusterConfigs.getCommonConfig().getProps() });
       } catch (Exception e) {
-        LOGGER.error("Failed to instantiate lifecycle hook class: {}", className, e);
+        LOGGER.error("Failed to instantiate lifecycle hook class: {}", cn, e);
+        failedHookClasses.add(cn);
         return null;
       }
     });

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -294,6 +294,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -1393,6 +1395,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 e);
           }
         }
+        invokePreStoreDeletionHooks(clusterName, storeName, store.getStoreLifecycleHooks());
         // Delete All versions and push statues
         deleteAllVersionsInStore(clusterName, storeName);
         resources.getPushMonitor().cleanupStoreStatus(storeName);
@@ -1436,6 +1439,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         }
         // Helix will remove all data under this store's znode including key and value schemas.
         resources.getStoreMetadataRepository().deleteStore(storeName);
+        invokePostStoreDeletionHooks(clusterName, storeName, store.getStoreLifecycleHooks());
       }
       // Delete ACLs associated with this store if this is parent controller & ACL authorizer is enabled.
       if (isParent() && authorizerService.isPresent()) {
@@ -6639,8 +6643,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     // Validate new lifecycle hooks
     if (newLifecycleHooks.isPresent()) {
       for (LifecycleHooksRecord lifecycleHooksRecord: newLifecycleHooks.get()) {
-        if (lifecycleHooksRecord.getStoreLifecycleHooksClassName() == null) {
-          throw new VeniceException("Cannot add lifecycle hooks with null class name");
+        String hookClassName = lifecycleHooksRecord.getStoreLifecycleHooksClassName();
+        if (hookClassName == null || hookClassName.trim().isEmpty()) {
+          throw new VeniceException("Cannot add lifecycle hooks with null or blank class name");
         }
       }
     }
@@ -6650,7 +6655,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   StoreLifecycleHooks getOrCreateHookInstance(LifecycleHooksRecord record) {
     String className = record.getStoreLifecycleHooksClassName();
-    if (className == null || className.isEmpty()) {
+    if (className == null || className.trim().isEmpty()) {
       LOGGER.warn("Skipping lifecycle hook record with null or empty class name");
       return null;
     }
@@ -6671,51 +6676,40 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     });
   }
 
+  void invokePreStoreDeletionHooks(String clusterName, String storeName, List<LifecycleHooksRecord> lifecycleHooks) {
+    invokePreHooks(
+        lifecycleHooks,
+        "preStoreDeletion",
+        (hook, props) -> hook.preStoreDeletion(clusterName, storeName, props),
+        (outcome, className) -> {
+          if (StoreLifecycleEventOutcome.ABORT.equals(outcome))
+            throw new VeniceException("preStoreDeletion hook " + className + " aborted deletion of store " + storeName);
+        });
+  }
+
+  void invokePostStoreDeletionHooks(String clusterName, String storeName, List<LifecycleHooksRecord> lifecycleHooks) {
+    invokeVoidHooks(
+        lifecycleHooks,
+        "postStoreDeletion",
+        (hook, props) -> hook.postStoreDeletion(clusterName, storeName, props));
+  }
+
   void invokePreStoreCreationHooks(String clusterName, String storeName, List<LifecycleHooksRecord> lifecycleHooks) {
-    for (LifecycleHooksRecord record: lifecycleHooks) {
-      StoreLifecycleHooks hook = getOrCreateHookInstance(record);
-      if (hook == null) {
-        continue;
-      }
-      Properties properties = new Properties();
-      properties.putAll(record.getStoreLifecycleHooksParams());
-      StoreLifecycleEventOutcome outcome;
-      try {
-        outcome = hook.preStoreCreation(clusterName, storeName, new VeniceProperties(properties));
-      } catch (Exception e) {
-        LOGGER.error(
-            "Exception in preStoreCreation hook {} for store {}",
-            record.getStoreLifecycleHooksClassName(),
-            storeName,
-            e);
-        continue;
-      }
-      if (StoreLifecycleEventOutcome.ABORT.equals(outcome)) {
-        throw new VeniceException(
-            "preStoreCreation hook " + record.getStoreLifecycleHooksClassName() + " aborted creation of store "
-                + storeName);
-      }
-    }
+    invokePreHooks(
+        lifecycleHooks,
+        "preStoreCreation",
+        (hook, props) -> hook.preStoreCreation(clusterName, storeName, props),
+        (outcome, className) -> {
+          if (StoreLifecycleEventOutcome.ABORT.equals(outcome))
+            throw new VeniceException("preStoreCreation hook " + className + " aborted creation of store " + storeName);
+        });
   }
 
   void invokePostStoreCreationHooks(String clusterName, String storeName, List<LifecycleHooksRecord> lifecycleHooks) {
-    for (LifecycleHooksRecord record: lifecycleHooks) {
-      StoreLifecycleHooks hook = getOrCreateHookInstance(record);
-      if (hook == null) {
-        continue;
-      }
-      Properties properties = new Properties();
-      properties.putAll(record.getStoreLifecycleHooksParams());
-      try {
-        hook.postStoreCreation(clusterName, storeName, new VeniceProperties(properties));
-      } catch (Exception e) {
-        LOGGER.error(
-            "Exception in postStoreCreation hook {} for store {}",
-            record.getStoreLifecycleHooksClassName(),
-            storeName,
-            e);
-      }
-    }
+    invokeVoidHooks(
+        lifecycleHooks,
+        "postStoreCreation",
+        (hook, props) -> hook.postStoreCreation(clusterName, storeName, props));
   }
 
   void invokePreStoreVersionCreationHooks(
@@ -6723,37 +6717,29 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       int versionNumber,
       List<LifecycleHooksRecord> lifecycleHooks) {
-    for (LifecycleHooksRecord record: lifecycleHooks) {
-      StoreLifecycleHooks hook = getOrCreateHookInstance(record);
-      if (hook == null) {
-        continue;
-      }
-      Properties properties = new Properties();
-      properties.putAll(record.getStoreLifecycleHooksParams());
-      StoreVersionLifecycleEventOutcome outcome;
-      try {
-        outcome = hook.preStoreVersionCreation(
+    invokePreHooks(
+        lifecycleHooks,
+        "preStoreVersionCreation",
+        (hook, props) -> hook.preStoreVersionCreation(
             clusterName,
             storeName,
             versionNumber,
             getRegionName(),
             Lazy.of(() -> null),
-            new VeniceProperties(properties));
-      } catch (Exception e) {
-        LOGGER.error(
-            "Exception in preStoreVersionCreation hook {} for store {} version {}",
-            record.getStoreLifecycleHooksClassName(),
-            storeName,
-            versionNumber,
-            e);
-        continue;
-      }
-      if (!StoreVersionLifecycleEventOutcome.PROCEED.equals(outcome)) {
-        throw new VeniceException(
-            "preStoreVersionCreation hook " + record.getStoreLifecycleHooksClassName() + " returned " + outcome
-                + " for store " + storeName + " version " + versionNumber);
-      }
-    }
+            props),
+        (outcome, className) -> {
+          if (StoreVersionLifecycleEventOutcome.ABORT.equals(outcome)
+              || StoreVersionLifecycleEventOutcome.ROLLBACK.equals(outcome))
+            throw new VeniceException(
+                "preStoreVersionCreation hook " + className + " returned " + outcome + " for store " + storeName
+                    + " version " + versionNumber);
+          else if (StoreVersionLifecycleEventOutcome.WAIT.equals(outcome))
+            LOGGER.warn(
+                "preStoreVersionCreation hook {} returned WAIT for store {} version {} but version creation is synchronous; proceeding",
+                className,
+                storeName,
+                versionNumber);
+        });
   }
 
   void invokePostStoreVersionCreationHooks(
@@ -6761,29 +6747,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       int versionNumber,
       List<LifecycleHooksRecord> lifecycleHooks) {
-    for (LifecycleHooksRecord record: lifecycleHooks) {
-      StoreLifecycleHooks hook = getOrCreateHookInstance(record);
-      if (hook == null) {
-        continue;
-      }
-      Properties properties = new Properties();
-      properties.putAll(record.getStoreLifecycleHooksParams());
-      try {
-        hook.postStoreVersionCreation(
-            clusterName,
-            storeName,
-            versionNumber,
-            getRegionName(),
-            new VeniceProperties(properties));
-      } catch (Exception e) {
-        LOGGER.error(
-            "Exception in postStoreVersionCreation hook {} for store {} version {}",
-            record.getStoreLifecycleHooksClassName(),
-            storeName,
-            versionNumber,
-            e);
-      }
-    }
+    invokeVoidHooks(
+        lifecycleHooks,
+        "postStoreVersionCreation",
+        (hook, props) -> hook.postStoreVersionCreation(clusterName, storeName, versionNumber, getRegionName(), props));
   }
 
   void invokePreStoreVersionDeletionHooks(
@@ -6791,36 +6758,16 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       int versionNumber,
       List<LifecycleHooksRecord> lifecycleHooks) {
-    for (LifecycleHooksRecord record: lifecycleHooks) {
-      StoreLifecycleHooks hook = getOrCreateHookInstance(record);
-      if (hook == null) {
-        continue;
-      }
-      Properties properties = new Properties();
-      properties.putAll(record.getStoreLifecycleHooksParams());
-      StoreLifecycleEventOutcome outcome;
-      try {
-        outcome = hook.preStoreVersionDeletion(
-            clusterName,
-            storeName,
-            versionNumber,
-            getRegionName(),
-            new VeniceProperties(properties));
-      } catch (Exception e) {
-        LOGGER.error(
-            "Exception in preStoreVersionDeletion hook {} for store {} version {}",
-            record.getStoreLifecycleHooksClassName(),
-            storeName,
-            versionNumber,
-            e);
-        continue;
-      }
-      if (StoreLifecycleEventOutcome.ABORT.equals(outcome)) {
-        throw new VeniceException(
-            "preStoreVersionDeletion hook " + record.getStoreLifecycleHooksClassName() + " aborted deletion of store "
-                + storeName + " version " + versionNumber);
-      }
-    }
+    invokePreHooks(
+        lifecycleHooks,
+        "preStoreVersionDeletion",
+        (hook, props) -> hook.preStoreVersionDeletion(clusterName, storeName, versionNumber, getRegionName(), props),
+        (outcome, className) -> {
+          if (StoreLifecycleEventOutcome.ABORT.equals(outcome))
+            throw new VeniceException(
+                "preStoreVersionDeletion hook " + className + " aborted deletion of store " + storeName + " version "
+                    + versionNumber);
+        });
   }
 
   void invokePostStoreVersionDeletionHooks(
@@ -6828,28 +6775,53 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       int versionNumber,
       List<LifecycleHooksRecord> lifecycleHooks) {
+    invokeVoidHooks(
+        lifecycleHooks,
+        "postStoreVersionDeletion",
+        (hook, props) -> hook.postStoreVersionDeletion(clusterName, storeName, versionNumber, getRegionName(), props));
+  }
+
+  private VeniceProperties buildHookProps(LifecycleHooksRecord record) {
+    Properties properties = new Properties();
+    properties.putAll(record.getStoreLifecycleHooksParams());
+    return new VeniceProperties(properties);
+  }
+
+  private void invokeVoidHooks(
+      List<LifecycleHooksRecord> lifecycleHooks,
+      String hookName,
+      BiConsumer<StoreLifecycleHooks, VeniceProperties> action) {
     for (LifecycleHooksRecord record: lifecycleHooks) {
       StoreLifecycleHooks hook = getOrCreateHookInstance(record);
       if (hook == null) {
         continue;
       }
-      Properties properties = new Properties();
-      properties.putAll(record.getStoreLifecycleHooksParams());
       try {
-        hook.postStoreVersionDeletion(
-            clusterName,
-            storeName,
-            versionNumber,
-            getRegionName(),
-            new VeniceProperties(properties));
+        action.accept(hook, buildHookProps(record));
       } catch (Exception e) {
-        LOGGER.error(
-            "Exception in postStoreVersionDeletion hook {} for store {} version {}",
-            record.getStoreLifecycleHooksClassName(),
-            storeName,
-            versionNumber,
-            e);
+        LOGGER.error("Exception in {} hook {}", hookName, record.getStoreLifecycleHooksClassName(), e);
       }
+    }
+  }
+
+  private <T> void invokePreHooks(
+      List<LifecycleHooksRecord> lifecycleHooks,
+      String hookName,
+      BiFunction<StoreLifecycleHooks, VeniceProperties, T> action,
+      BiConsumer<T, String> outcomeHandler) {
+    for (LifecycleHooksRecord record: lifecycleHooks) {
+      StoreLifecycleHooks hook = getOrCreateHookInstance(record);
+      if (hook == null) {
+        continue;
+      }
+      T outcome;
+      try {
+        outcome = action.apply(hook, buildHookProps(record));
+      } catch (Exception e) {
+        LOGGER.error("Exception in {} hook {}", hookName, record.getStoreLifecycleHooksClassName(), e);
+        continue;
+      }
+      outcomeHandler.accept(outcome, record.getStoreLifecycleHooksClassName());
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -134,6 +134,9 @@ import com.linkedin.venice.helix.ZkAllowlistAccessor;
 import com.linkedin.venice.helix.ZkClientFactory;
 import com.linkedin.venice.helix.ZkRoutersClusterManager;
 import com.linkedin.venice.helix.ZkStoreConfigAccessor;
+import com.linkedin.venice.hooks.StoreLifecycleEventOutcome;
+import com.linkedin.venice.hooks.StoreLifecycleHooks;
+import com.linkedin.venice.hooks.StoreVersionLifecycleEventOutcome;
 import com.linkedin.venice.ingestion.control.MultiRegionRealTimeTopicSwitcher;
 import com.linkedin.venice.ingestion.control.RealTimeTopicSwitcher;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
@@ -492,6 +495,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   private final Map<String, DeadStoreStats> deadStoreStatsMap = new VeniceConcurrentHashMap<>();
   private final Map<String, LogCompactionStats> logCompactionStatsMap = new VeniceConcurrentHashMap<>();
+  private final Map<String, StoreLifecycleHooks> storeLifecycleHooksInstanceCache = new VeniceConcurrentHashMap<>();
   private final Optional<ExternalETLService> externalETLService;
 
   // Test only.
@@ -3261,6 +3265,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             if (store.containsVersion(version.getNumber())) {
               throwVersionAlreadyExists(storeName, version.getNumber());
             }
+            invokePreStoreVersionCreationHooks(
+                clusterName,
+                storeName,
+                version.getNumber(),
+                store.getStoreLifecycleHooks());
             // Update ZK with the new version
             store.addVersion(version, true, currentRTVersionNumber);
             repository.updateStore(store);
@@ -3278,6 +3287,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               }
               version = new VersionImpl(storeName, versionNumber, pushJobId, numberOfPartitions);
             }
+            invokePreStoreVersionCreationHooks(
+                clusterName,
+                storeName,
+                version.getNumber(),
+                store.getStoreLifecycleHooks());
             long createBatchTopicStartTime = System.currentTimeMillis();
             if (clusterConfig.getConcurrentPushDetectionStrategy().isTopicWriteNeeded() || !isParent()) {
               topicToCreationTime.computeIfAbsent(version.kafkaTopicName(), topic -> System.currentTimeMillis());
@@ -3468,6 +3482,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             addVersionLatencyStats.recordHelixResourceCreationLatency(
                 LatencyUtils.getElapsedTimeFromMsToMs(helixResourceCreationStartTime));
           }
+          invokePostStoreVersionCreationHooks(
+              clusterName,
+              storeName,
+              version.getNumber(),
+              store.getStoreLifecycleHooks());
         }
 
         if (startIngestion) {
@@ -4333,6 +4352,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             storeName);
         return;
       }
+      invokePreStoreVersionDeletionHooks(clusterName, storeName, versionNumber, store.getStoreLifecycleHooks());
       String resourceName = Version.composeKafkaTopic(storeName, versionNumber);
       LOGGER.info("Deleting helix resource: {} in cluster: {}", resourceName, clusterName);
       deleteHelixResource(clusterName, resourceName);
@@ -4404,6 +4424,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         }
         resources.getVeniceVersionLifecycleEventManager()
             .notifyVersionDeleted(store, deletedVersion.get(), isSourceCluster);
+        invokePostStoreVersionDeletionHooks(clusterName, storeName, versionNumber, store.getStoreLifecycleHooks());
       }
     }
   }
@@ -6622,6 +6643,155 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
 
     return newLifecycleHooks.get();
+  }
+
+  StoreLifecycleHooks getOrCreateHookInstance(LifecycleHooksRecord record) {
+    return storeLifecycleHooksInstanceCache.computeIfAbsent(record.getStoreLifecycleHooksClassName(), className -> {
+      try {
+        return ReflectUtils.callConstructor(
+            ReflectUtils.loadClass(className),
+            new Class<?>[] { VeniceProperties.class },
+            new Object[] { multiClusterConfigs.getCommonConfig().getProps() });
+      } catch (Exception e) {
+        LOGGER.error("Failed to instantiate lifecycle hook class: {}", className, e);
+        return null;
+      }
+    });
+  }
+
+  void invokePreStoreVersionCreationHooks(
+      String clusterName,
+      String storeName,
+      int versionNumber,
+      List<LifecycleHooksRecord> lifecycleHooks) {
+    for (LifecycleHooksRecord record: lifecycleHooks) {
+      StoreLifecycleHooks hook = getOrCreateHookInstance(record);
+      if (hook == null) {
+        continue;
+      }
+      Properties properties = new Properties();
+      properties.putAll(record.getStoreLifecycleHooksParams());
+      StoreVersionLifecycleEventOutcome outcome;
+      try {
+        outcome = hook.preStoreVersionCreation(
+            clusterName,
+            storeName,
+            versionNumber,
+            getRegionName(),
+            null,
+            new VeniceProperties(properties));
+      } catch (Exception e) {
+        LOGGER.error(
+            "Exception in preStoreVersionCreation hook {} for store {} version {}",
+            record.getStoreLifecycleHooksClassName(),
+            storeName,
+            versionNumber,
+            e);
+        continue;
+      }
+      if (StoreVersionLifecycleEventOutcome.ABORT.equals(outcome)) {
+        throw new VeniceException(
+            "preStoreVersionCreation hook " + record.getStoreLifecycleHooksClassName() + " aborted creation of store "
+                + storeName + " version " + versionNumber);
+      }
+    }
+  }
+
+  void invokePostStoreVersionCreationHooks(
+      String clusterName,
+      String storeName,
+      int versionNumber,
+      List<LifecycleHooksRecord> lifecycleHooks) {
+    for (LifecycleHooksRecord record: lifecycleHooks) {
+      StoreLifecycleHooks hook = getOrCreateHookInstance(record);
+      if (hook == null) {
+        continue;
+      }
+      Properties properties = new Properties();
+      properties.putAll(record.getStoreLifecycleHooksParams());
+      try {
+        hook.postStoreVersionCreation(
+            clusterName,
+            storeName,
+            versionNumber,
+            getRegionName(),
+            new VeniceProperties(properties));
+      } catch (Exception e) {
+        LOGGER.error(
+            "Exception in postStoreVersionCreation hook {} for store {} version {}",
+            record.getStoreLifecycleHooksClassName(),
+            storeName,
+            versionNumber,
+            e);
+      }
+    }
+  }
+
+  void invokePreStoreVersionDeletionHooks(
+      String clusterName,
+      String storeName,
+      int versionNumber,
+      List<LifecycleHooksRecord> lifecycleHooks) {
+    for (LifecycleHooksRecord record: lifecycleHooks) {
+      StoreLifecycleHooks hook = getOrCreateHookInstance(record);
+      if (hook == null) {
+        continue;
+      }
+      Properties properties = new Properties();
+      properties.putAll(record.getStoreLifecycleHooksParams());
+      StoreLifecycleEventOutcome outcome;
+      try {
+        outcome = hook.preStoreVersionDeletion(
+            clusterName,
+            storeName,
+            versionNumber,
+            getRegionName(),
+            new VeniceProperties(properties));
+      } catch (Exception e) {
+        LOGGER.error(
+            "Exception in preStoreVersionDeletion hook {} for store {} version {}",
+            record.getStoreLifecycleHooksClassName(),
+            storeName,
+            versionNumber,
+            e);
+        continue;
+      }
+      if (StoreLifecycleEventOutcome.ABORT.equals(outcome)) {
+        throw new VeniceException(
+            "preStoreVersionDeletion hook " + record.getStoreLifecycleHooksClassName() + " aborted deletion of store "
+                + storeName + " version " + versionNumber);
+      }
+    }
+  }
+
+  void invokePostStoreVersionDeletionHooks(
+      String clusterName,
+      String storeName,
+      int versionNumber,
+      List<LifecycleHooksRecord> lifecycleHooks) {
+    for (LifecycleHooksRecord record: lifecycleHooks) {
+      StoreLifecycleHooks hook = getOrCreateHookInstance(record);
+      if (hook == null) {
+        continue;
+      }
+      Properties properties = new Properties();
+      properties.putAll(record.getStoreLifecycleHooksParams());
+      try {
+        hook.postStoreVersionDeletion(
+            clusterName,
+            storeName,
+            versionNumber,
+            getRegionName(),
+            new VeniceProperties(properties));
+      } catch (Exception e) {
+        LOGGER.error(
+            "Exception in postStoreVersionDeletion hook {} for store {} version {}",
+            record.getStoreLifecycleHooksClassName(),
+            storeName,
+            versionNumber,
+            e);
+      }
+    }
   }
 
   static Map<String, StoreViewConfigRecord> mergeNewViewConfigsIntoOldConfigs(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -6650,6 +6650,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   StoreLifecycleHooks getOrCreateHookInstance(LifecycleHooksRecord record) {
     String className = record.getStoreLifecycleHooksClassName();
+    if (className == null || className.isEmpty()) {
+      LOGGER.warn("Skipping lifecycle hook record with null or empty class name");
+      return null;
+    }
     if (failedHookClasses.contains(className)) {
       return null;
     }
@@ -6733,7 +6737,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             storeName,
             versionNumber,
             getRegionName(),
-            null,
+            Lazy.of(() -> null),
             new VeniceProperties(properties));
       } catch (Exception e) {
         LOGGER.error(
@@ -6744,10 +6748,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             e);
         continue;
       }
-      if (StoreVersionLifecycleEventOutcome.ABORT.equals(outcome)) {
+      if (!StoreVersionLifecycleEventOutcome.PROCEED.equals(outcome)) {
         throw new VeniceException(
-            "preStoreVersionCreation hook " + record.getStoreLifecycleHooksClassName() + " aborted creation of store "
-                + storeName + " version " + versionNumber);
+            "preStoreVersionCreation hook " + record.getStoreLifecycleHooksClassName() + " returned " + outcome
+                + " for store " + storeName + " version " + versionNumber);
       }
     }
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminStoreLifecycleHooks.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminStoreLifecycleHooks.java
@@ -19,11 +19,15 @@ import com.linkedin.venice.meta.LifecycleHooksRecordImpl;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -74,9 +78,20 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
             ArgumentMatchers.any());
 
     hookCache = new VeniceConcurrentHashMap<>();
-    Field cacheField = VeniceHelixAdmin.class.getDeclaredField("storeLifecycleHooksInstanceCache");
-    cacheField.setAccessible(true);
-    cacheField.set(admin, hookCache);
+    Set<String> failedHookClasses = ConcurrentHashMap.newKeySet();
+    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+      try {
+        Field cacheField = VeniceHelixAdmin.class.getDeclaredField("storeLifecycleHooksInstanceCache");
+        cacheField.setAccessible(true);
+        cacheField.set(admin, hookCache);
+        Field failedField = VeniceHelixAdmin.class.getDeclaredField("failedHookClasses");
+        failedField.setAccessible(true);
+        failedField.set(admin, failedHookClasses);
+      } catch (NoSuchFieldException | IllegalAccessException e) {
+        throw new RuntimeException(e);
+      }
+      return null;
+    });
   }
 
   @DataProvider(name = "hookMethods")
@@ -222,13 +237,16 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
     VeniceControllerClusterConfig clusterConfig = mock(VeniceControllerClusterConfig.class);
     doReturn(clusterConfig).when(multiClusterConfigs).getCommonConfig();
     doReturn(new VeniceProperties(new Properties())).when(clusterConfig).getProps();
-    try {
-      Field field = VeniceHelixAdmin.class.getDeclaredField("multiClusterConfigs");
-      field.setAccessible(true);
-      field.set(admin, multiClusterConfigs);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+      try {
+        Field field = VeniceHelixAdmin.class.getDeclaredField("multiClusterConfigs");
+        field.setAccessible(true);
+        field.set(admin, multiClusterConfigs);
+      } catch (NoSuchFieldException | IllegalAccessException e) {
+        throw new RuntimeException(e);
+      }
+      return null;
+    });
   }
 
   @FunctionalInterface

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminStoreLifecycleHooks.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminStoreLifecycleHooks.java
@@ -76,6 +76,16 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
             ArgumentMatchers.anyString(),
             ArgumentMatchers.anyInt(),
             ArgumentMatchers.any());
+    doCallRealMethod().when(admin)
+        .invokePreStoreCreationHooks(
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.any());
+    doCallRealMethod().when(admin)
+        .invokePostStoreCreationHooks(
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.any());
 
     hookCache = new VeniceConcurrentHashMap<>();
     Set<String> failedHookClasses = ConcurrentHashMap.newKeySet();
@@ -96,56 +106,96 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
 
   @DataProvider(name = "hookMethods")
   public Object[][] hookMethods() {
+    Consumer<TrackingHooks> verifyVersionParams = h -> {
+      assertEquals(h.lastCluster, CLUSTER);
+      assertEquals(h.lastStore, STORE);
+      assertEquals(h.lastVersion, VERSION);
+      assertEquals(h.lastRegion, REGION);
+    };
+    Consumer<TrackingHooks> verifyStoreParams = h -> {
+      assertEquals(h.lastCluster, CLUSTER);
+      assertEquals(h.lastStore, STORE);
+    };
     return new Object[][] {
-        { "pre-creation", (HookInvoker) (a, r) -> a.invokePreStoreVersionCreationHooks(CLUSTER, STORE, VERSION, r),
-            (Predicate<TrackingHooks>) h -> h.preCreationCalled },
-        { "post-creation", (HookInvoker) (a, r) -> a.invokePostStoreVersionCreationHooks(CLUSTER, STORE, VERSION, r),
-            (Predicate<TrackingHooks>) h -> h.postCreationCalled },
-        { "pre-deletion", (HookInvoker) (a, r) -> a.invokePreStoreVersionDeletionHooks(CLUSTER, STORE, VERSION, r),
-            (Predicate<TrackingHooks>) h -> h.preDeletionCalled },
-        { "post-deletion", (HookInvoker) (a, r) -> a.invokePostStoreVersionDeletionHooks(CLUSTER, STORE, VERSION, r),
-            (Predicate<TrackingHooks>) h -> h.postDeletionCalled }, };
+        { "pre-store-creation", (HookInvoker) (a, r) -> a.invokePreStoreCreationHooks(CLUSTER, STORE, r),
+            (Predicate<TrackingHooks>) h -> h.preStoreCreationCalled, verifyStoreParams },
+        { "post-store-creation", (HookInvoker) (a, r) -> a.invokePostStoreCreationHooks(CLUSTER, STORE, r),
+            (Predicate<TrackingHooks>) h -> h.postStoreCreationCalled, verifyStoreParams },
+        { "pre-version-creation",
+            (HookInvoker) (a, r) -> a.invokePreStoreVersionCreationHooks(CLUSTER, STORE, VERSION, r),
+            (Predicate<TrackingHooks>) h -> h.preCreationCalled, verifyVersionParams },
+        { "post-version-creation",
+            (HookInvoker) (a, r) -> a.invokePostStoreVersionCreationHooks(CLUSTER, STORE, VERSION, r),
+            (Predicate<TrackingHooks>) h -> h.postCreationCalled, verifyVersionParams },
+        { "pre-version-deletion",
+            (HookInvoker) (a, r) -> a.invokePreStoreVersionDeletionHooks(CLUSTER, STORE, VERSION, r),
+            (Predicate<TrackingHooks>) h -> h.preDeletionCalled, verifyVersionParams },
+        { "post-version-deletion",
+            (HookInvoker) (a, r) -> a.invokePostStoreVersionDeletionHooks(CLUSTER, STORE, VERSION, r),
+            (Predicate<TrackingHooks>) h -> h.postDeletionCalled, verifyVersionParams }, };
   }
 
   @DataProvider(name = "preHookMethods")
   public Object[][] preHookMethods() {
     return new Object[][] {
-        { "pre-creation", (Consumer<TrackingHooks>) h -> h.preCreationOutcome = StoreVersionLifecycleEventOutcome.ABORT,
+        { "pre-store-creation",
+            (Consumer<TrackingHooks>) h -> h.preStoreCreationOutcome = StoreLifecycleEventOutcome.ABORT,
+            (HookInvoker) (a, r) -> a.invokePreStoreCreationHooks(CLUSTER, STORE, r) },
+        { "pre-version-creation",
+            (Consumer<TrackingHooks>) h -> h.preCreationOutcome = StoreVersionLifecycleEventOutcome.ABORT,
             (HookInvoker) (a, r) -> a.invokePreStoreVersionCreationHooks(CLUSTER, STORE, VERSION, r) },
-        { "pre-deletion", (Consumer<TrackingHooks>) h -> h.preDeletionOutcome = StoreLifecycleEventOutcome.ABORT,
+        { "pre-version-deletion",
+            (Consumer<TrackingHooks>) h -> h.preDeletionOutcome = StoreLifecycleEventOutcome.ABORT,
             (HookInvoker) (a, r) -> a.invokePreStoreVersionDeletionHooks(CLUSTER, STORE, VERSION, r) }, };
   }
 
   @Test(dataProvider = "hookMethods")
-  public void testHookIsCalled(String desc, HookInvoker invoke, Predicate<TrackingHooks> calledFlag) {
+  public void testHookIsCalled(
+      String desc,
+      HookInvoker invoke,
+      Predicate<TrackingHooks> calledFlag,
+      Consumer<TrackingHooks> ignored) {
     TrackingHooks hook = registerHook(new TrackingHooks());
     invoke.accept(admin, hookRecords(TrackingHooks.class));
     assertTrue(calledFlag.test(hook), desc + " hook should have been called");
   }
 
   @Test(dataProvider = "hookMethods")
-  public void testHookReceivesCorrectParams(String desc, HookInvoker invoke, Predicate<TrackingHooks> ignored) {
+  public void testHookReceivesCorrectParams(
+      String desc,
+      HookInvoker invoke,
+      Predicate<TrackingHooks> ignored,
+      Consumer<TrackingHooks> verifyParams) {
     TrackingHooks hook = registerHook(new TrackingHooks());
     invoke.accept(admin, hookRecords(TrackingHooks.class));
-    assertEquals(hook.lastCluster, CLUSTER, desc + ": cluster");
-    assertEquals(hook.lastStore, STORE, desc + ": store");
-    assertEquals(hook.lastVersion, VERSION, desc + ": version");
-    assertEquals(hook.lastRegion, REGION, desc + ": region");
+    verifyParams.accept(hook);
   }
 
   @Test(dataProvider = "hookMethods")
-  public void testExceptionInHookIsSwallowed(String desc, HookInvoker invoke, Predicate<TrackingHooks> ignored) {
+  public void testExceptionInHookIsSwallowed(
+      String desc,
+      HookInvoker invoke,
+      Predicate<TrackingHooks> ignored,
+      Consumer<TrackingHooks> ignored2) {
     registerHook(new ThrowingHooks());
     invoke.accept(admin, hookRecords(ThrowingHooks.class));
   }
 
   @Test(dataProvider = "hookMethods")
-  public void testEmptyHookListIsNoOp(String desc, HookInvoker invoke, Predicate<TrackingHooks> ignored) {
+  public void testEmptyHookListIsNoOp(
+      String desc,
+      HookInvoker invoke,
+      Predicate<TrackingHooks> ignored,
+      Consumer<TrackingHooks> ignored2) {
     invoke.accept(admin, Collections.emptyList());
   }
 
   @Test(dataProvider = "hookMethods")
-  public void testUnknownHookClassIsSkipped(String desc, HookInvoker invoke, Predicate<TrackingHooks> ignored) {
+  public void testUnknownHookClassIsSkipped(
+      String desc,
+      HookInvoker invoke,
+      Predicate<TrackingHooks> ignored,
+      Consumer<TrackingHooks> ignored2) {
     LifecycleHooksRecord badRecord = new LifecycleHooksRecordImpl("com.nonexistent.HookClass", Collections.emptyMap());
     invoke.accept(admin, Collections.singletonList(badRecord));
   }
@@ -254,6 +304,8 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
   }
 
   public static class TrackingHooks extends StoreLifecycleHooks {
+    boolean preStoreCreationCalled;
+    boolean postStoreCreationCalled;
     boolean preCreationCalled;
     boolean postCreationCalled;
     boolean preDeletionCalled;
@@ -264,6 +316,7 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
     int lastVersion;
     String lastRegion;
 
+    StoreLifecycleEventOutcome preStoreCreationOutcome = StoreLifecycleEventOutcome.PROCEED;
     StoreVersionLifecycleEventOutcome preCreationOutcome = StoreVersionLifecycleEventOutcome.PROCEED;
     StoreLifecycleEventOutcome preDeletionOutcome = StoreLifecycleEventOutcome.PROCEED;
 
@@ -273,6 +326,24 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
 
     public TrackingHooks(VeniceProperties defaultConfigs) {
       super(defaultConfigs);
+    }
+
+    @Override
+    public StoreLifecycleEventOutcome preStoreCreation(
+        String clusterName,
+        String storeName,
+        VeniceProperties storeHooksConfigs) {
+      preStoreCreationCalled = true;
+      lastCluster = clusterName;
+      lastStore = storeName;
+      return preStoreCreationOutcome;
+    }
+
+    @Override
+    public void postStoreCreation(String clusterName, String storeName, VeniceProperties storeHooksConfigs) {
+      postStoreCreationCalled = true;
+      lastCluster = clusterName;
+      lastStore = storeName;
     }
 
     @Override
@@ -342,6 +413,19 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
 
     public ThrowingHooks(VeniceProperties defaultConfigs) {
       super(defaultConfigs);
+    }
+
+    @Override
+    public StoreLifecycleEventOutcome preStoreCreation(
+        String clusterName,
+        String storeName,
+        VeniceProperties storeHooksConfigs) {
+      throw new RuntimeException("pre-store-creation hook failure");
+    }
+
+    @Override
+    public void postStoreCreation(String clusterName, String storeName, VeniceProperties storeHooksConfigs) {
+      throw new RuntimeException("post-store-creation hook failure");
     }
 
     @Override

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminStoreLifecycleHooks.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminStoreLifecycleHooks.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
@@ -77,6 +78,16 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
             ArgumentMatchers.anyInt(),
             ArgumentMatchers.any());
     doCallRealMethod().when(admin)
+        .invokePreStoreDeletionHooks(
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.any());
+    doCallRealMethod().when(admin)
+        .invokePostStoreDeletionHooks(
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.any());
+    doCallRealMethod().when(admin)
         .invokePreStoreCreationHooks(
             ArgumentMatchers.anyString(),
             ArgumentMatchers.anyString(),
@@ -117,6 +128,10 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
       assertEquals(h.lastStore, STORE);
     };
     return new Object[][] {
+        { "pre-store-deletion", (HookInvoker) (a, r) -> a.invokePreStoreDeletionHooks(CLUSTER, STORE, r),
+            (Predicate<TrackingHooks>) h -> h.preStoreDeletionCalled, verifyStoreParams },
+        { "post-store-deletion", (HookInvoker) (a, r) -> a.invokePostStoreDeletionHooks(CLUSTER, STORE, r),
+            (Predicate<TrackingHooks>) h -> h.postStoreDeletionCalled, verifyStoreParams },
         { "pre-store-creation", (HookInvoker) (a, r) -> a.invokePreStoreCreationHooks(CLUSTER, STORE, r),
             (Predicate<TrackingHooks>) h -> h.preStoreCreationCalled, verifyStoreParams },
         { "post-store-creation", (HookInvoker) (a, r) -> a.invokePostStoreCreationHooks(CLUSTER, STORE, r),
@@ -138,6 +153,9 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
   @DataProvider(name = "preHookMethods")
   public Object[][] preHookMethods() {
     return new Object[][] {
+        { "pre-store-deletion",
+            (Consumer<TrackingHooks>) h -> h.preStoreDeletionOutcome = StoreLifecycleEventOutcome.ABORT,
+            (HookInvoker) (a, r) -> a.invokePreStoreDeletionHooks(CLUSTER, STORE, r) },
         { "pre-store-creation",
             (Consumer<TrackingHooks>) h -> h.preStoreCreationOutcome = StoreLifecycleEventOutcome.ABORT,
             (HookInvoker) (a, r) -> a.invokePreStoreCreationHooks(CLUSTER, STORE, r) },
@@ -196,6 +214,7 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
       HookInvoker invoke,
       Predicate<TrackingHooks> ignored,
       Consumer<TrackingHooks> ignored2) {
+    injectMultiClusterConfigs(); // ensure the only reason for null is the missing class, not NPE on reflection
     LifecycleHooksRecord badRecord = new LifecycleHooksRecordImpl("com.nonexistent.HookClass", Collections.emptyMap());
     invoke.accept(admin, Collections.singletonList(badRecord));
   }
@@ -235,7 +254,7 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
     LifecycleHooksRecord record = new LifecycleHooksRecordImpl("com.nonexistent.HookClass", Collections.emptyMap());
     injectMultiClusterConfigs();
 
-    assertFalse(admin.getOrCreateHookInstance(record) != null, "should return null for unknown hook class");
+    assertNull(admin.getOrCreateHookInstance(record), "should return null for unknown hook class");
   }
 
   @Test
@@ -304,6 +323,8 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
   }
 
   public static class TrackingHooks extends StoreLifecycleHooks {
+    boolean preStoreDeletionCalled;
+    boolean postStoreDeletionCalled;
     boolean preStoreCreationCalled;
     boolean postStoreCreationCalled;
     boolean preCreationCalled;
@@ -316,6 +337,7 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
     int lastVersion;
     String lastRegion;
 
+    StoreLifecycleEventOutcome preStoreDeletionOutcome = StoreLifecycleEventOutcome.PROCEED;
     StoreLifecycleEventOutcome preStoreCreationOutcome = StoreLifecycleEventOutcome.PROCEED;
     StoreVersionLifecycleEventOutcome preCreationOutcome = StoreVersionLifecycleEventOutcome.PROCEED;
     StoreLifecycleEventOutcome preDeletionOutcome = StoreLifecycleEventOutcome.PROCEED;
@@ -326,6 +348,24 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
 
     public TrackingHooks(VeniceProperties defaultConfigs) {
       super(defaultConfigs);
+    }
+
+    @Override
+    public StoreLifecycleEventOutcome preStoreDeletion(
+        String clusterName,
+        String storeName,
+        VeniceProperties storeHooksConfigs) {
+      preStoreDeletionCalled = true;
+      lastCluster = clusterName;
+      lastStore = storeName;
+      return preStoreDeletionOutcome;
+    }
+
+    @Override
+    public void postStoreDeletion(String clusterName, String storeName, VeniceProperties storeHooksConfigs) {
+      postStoreDeletionCalled = true;
+      lastCluster = clusterName;
+      lastStore = storeName;
     }
 
     @Override
@@ -413,6 +453,19 @@ public class TestVeniceHelixAdminStoreLifecycleHooks {
 
     public ThrowingHooks(VeniceProperties defaultConfigs) {
       super(defaultConfigs);
+    }
+
+    @Override
+    public StoreLifecycleEventOutcome preStoreDeletion(
+        String clusterName,
+        String storeName,
+        VeniceProperties storeHooksConfigs) {
+      throw new RuntimeException("pre-store-deletion hook failure");
+    }
+
+    @Override
+    public void postStoreDeletion(String clusterName, String storeName, VeniceProperties storeHooksConfigs) {
+      throw new RuntimeException("post-store-deletion hook failure");
     }
 
     @Override

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminStoreLifecycleHooks.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminStoreLifecycleHooks.java
@@ -1,0 +1,370 @@
+package com.linkedin.venice.controller;
+
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.hooks.StoreLifecycleEventOutcome;
+import com.linkedin.venice.hooks.StoreLifecycleHooks;
+import com.linkedin.venice.hooks.StoreVersionLifecycleEventOutcome;
+import com.linkedin.venice.meta.LifecycleHooksRecord;
+import com.linkedin.venice.meta.LifecycleHooksRecordImpl;
+import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import org.mockito.ArgumentMatchers;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class TestVeniceHelixAdminStoreLifecycleHooks {
+  private static final String CLUSTER = "test-cluster";
+  private static final String STORE = "test-store";
+  private static final String REGION = "test-region";
+  private static final int VERSION = 1;
+
+  private VeniceHelixAdmin admin;
+  private Map<String, StoreLifecycleHooks> hookCache;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    admin = mock(VeniceHelixAdmin.class);
+    doReturn(REGION).when(admin).getRegionName();
+
+    doCallRealMethod().when(admin).getOrCreateHookInstance(ArgumentMatchers.any());
+    doCallRealMethod().when(admin)
+        .invokePreStoreVersionCreationHooks(
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyInt(),
+            ArgumentMatchers.any());
+    doCallRealMethod().when(admin)
+        .invokePostStoreVersionCreationHooks(
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyInt(),
+            ArgumentMatchers.any());
+    doCallRealMethod().when(admin)
+        .invokePreStoreVersionDeletionHooks(
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyInt(),
+            ArgumentMatchers.any());
+    doCallRealMethod().when(admin)
+        .invokePostStoreVersionDeletionHooks(
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyInt(),
+            ArgumentMatchers.any());
+
+    hookCache = new VeniceConcurrentHashMap<>();
+    Field cacheField = VeniceHelixAdmin.class.getDeclaredField("storeLifecycleHooksInstanceCache");
+    cacheField.setAccessible(true);
+    cacheField.set(admin, hookCache);
+  }
+
+  @DataProvider(name = "hookMethods")
+  public Object[][] hookMethods() {
+    return new Object[][] {
+        { "pre-creation", (HookInvoker) (a, r) -> a.invokePreStoreVersionCreationHooks(CLUSTER, STORE, VERSION, r),
+            (Predicate<TrackingHooks>) h -> h.preCreationCalled },
+        { "post-creation", (HookInvoker) (a, r) -> a.invokePostStoreVersionCreationHooks(CLUSTER, STORE, VERSION, r),
+            (Predicate<TrackingHooks>) h -> h.postCreationCalled },
+        { "pre-deletion", (HookInvoker) (a, r) -> a.invokePreStoreVersionDeletionHooks(CLUSTER, STORE, VERSION, r),
+            (Predicate<TrackingHooks>) h -> h.preDeletionCalled },
+        { "post-deletion", (HookInvoker) (a, r) -> a.invokePostStoreVersionDeletionHooks(CLUSTER, STORE, VERSION, r),
+            (Predicate<TrackingHooks>) h -> h.postDeletionCalled }, };
+  }
+
+  @DataProvider(name = "preHookMethods")
+  public Object[][] preHookMethods() {
+    return new Object[][] {
+        { "pre-creation", (Consumer<TrackingHooks>) h -> h.preCreationOutcome = StoreVersionLifecycleEventOutcome.ABORT,
+            (HookInvoker) (a, r) -> a.invokePreStoreVersionCreationHooks(CLUSTER, STORE, VERSION, r) },
+        { "pre-deletion", (Consumer<TrackingHooks>) h -> h.preDeletionOutcome = StoreLifecycleEventOutcome.ABORT,
+            (HookInvoker) (a, r) -> a.invokePreStoreVersionDeletionHooks(CLUSTER, STORE, VERSION, r) }, };
+  }
+
+  @Test(dataProvider = "hookMethods")
+  public void testHookIsCalled(String desc, HookInvoker invoke, Predicate<TrackingHooks> calledFlag) {
+    TrackingHooks hook = registerHook(new TrackingHooks());
+    invoke.accept(admin, hookRecords(TrackingHooks.class));
+    assertTrue(calledFlag.test(hook), desc + " hook should have been called");
+  }
+
+  @Test(dataProvider = "hookMethods")
+  public void testHookReceivesCorrectParams(String desc, HookInvoker invoke, Predicate<TrackingHooks> ignored) {
+    TrackingHooks hook = registerHook(new TrackingHooks());
+    invoke.accept(admin, hookRecords(TrackingHooks.class));
+    assertEquals(hook.lastCluster, CLUSTER, desc + ": cluster");
+    assertEquals(hook.lastStore, STORE, desc + ": store");
+    assertEquals(hook.lastVersion, VERSION, desc + ": version");
+    assertEquals(hook.lastRegion, REGION, desc + ": region");
+  }
+
+  @Test(dataProvider = "hookMethods")
+  public void testExceptionInHookIsSwallowed(String desc, HookInvoker invoke, Predicate<TrackingHooks> ignored) {
+    registerHook(new ThrowingHooks());
+    invoke.accept(admin, hookRecords(ThrowingHooks.class));
+  }
+
+  @Test(dataProvider = "hookMethods")
+  public void testEmptyHookListIsNoOp(String desc, HookInvoker invoke, Predicate<TrackingHooks> ignored) {
+    invoke.accept(admin, Collections.emptyList());
+  }
+
+  @Test(dataProvider = "hookMethods")
+  public void testUnknownHookClassIsSkipped(String desc, HookInvoker invoke, Predicate<TrackingHooks> ignored) {
+    LifecycleHooksRecord badRecord = new LifecycleHooksRecordImpl("com.nonexistent.HookClass", Collections.emptyMap());
+    invoke.accept(admin, Collections.singletonList(badRecord));
+  }
+
+  @Test(dataProvider = "preHookMethods")
+  public void testAbortOutcomeThrows(String desc, Consumer<TrackingHooks> configureAbort, HookInvoker invoke) {
+    TrackingHooks hook = registerHook(new TrackingHooks());
+    configureAbort.accept(hook);
+    expectThrows(VeniceException.class, () -> invoke.accept(admin, hookRecords(TrackingHooks.class)));
+  }
+
+  @Test
+  public void testHookInstanceIsCached() {
+    TrackingHooks hook = registerHook(new TrackingHooks());
+    LifecycleHooksRecord record = new LifecycleHooksRecordImpl(TrackingHooks.class.getName(), Collections.emptyMap());
+
+    StoreLifecycleHooks first = admin.getOrCreateHookInstance(record);
+    StoreLifecycleHooks second = admin.getOrCreateHookInstance(record);
+
+    assertNotNull(first);
+    assertSame(first, second, "same instance should be returned for the same class name");
+    assertSame(first, hook, "cached instance should be the one we registered");
+  }
+
+  @Test
+  public void testHookInstanceCreatedViaReflectionIfNotCached() {
+    LifecycleHooksRecord record = new LifecycleHooksRecordImpl(TrackingHooks.class.getName(), Collections.emptyMap());
+    injectMultiClusterConfigs();
+
+    StoreLifecycleHooks created = admin.getOrCreateHookInstance(record);
+    assertNotNull(created);
+    assertTrue(created instanceof TrackingHooks);
+  }
+
+  @Test
+  public void testHookInstanceReturnsNullForUnknownClass() {
+    LifecycleHooksRecord record = new LifecycleHooksRecordImpl("com.nonexistent.HookClass", Collections.emptyMap());
+    injectMultiClusterConfigs();
+
+    assertFalse(admin.getOrCreateHookInstance(record) != null, "should return null for unknown hook class");
+  }
+
+  @Test
+  public void testMultipleHooksAllInvoked() {
+    TrackingHooks hook1 = new TrackingHooks();
+    TrackingHooks hook2 = new TrackingHooks();
+    hookCache.put("hook1", hook1);
+    hookCache.put("hook2", hook2);
+
+    admin.invokePreStoreVersionCreationHooks(CLUSTER, STORE, VERSION, recordsForKeys("hook1", "hook2"));
+
+    assertTrue(hook1.preCreationCalled);
+    assertTrue(hook2.preCreationCalled);
+  }
+
+  @Test
+  public void testFirstHookAbortStopsRemainingHooks() {
+    TrackingHooks hook1 = new TrackingHooks();
+    hook1.preCreationOutcome = StoreVersionLifecycleEventOutcome.ABORT;
+    TrackingHooks hook2 = new TrackingHooks();
+    hookCache.put("hook1", hook1);
+    hookCache.put("hook2", hook2);
+
+    expectThrows(
+        VeniceException.class,
+        () -> admin.invokePreStoreVersionCreationHooks(CLUSTER, STORE, VERSION, recordsForKeys("hook1", "hook2")));
+    assertFalse(hook2.preCreationCalled, "second hook should not be called after first hook aborts");
+  }
+
+  private List<LifecycleHooksRecord> hookRecords(Class<? extends StoreLifecycleHooks> hookClass) {
+    return Collections.singletonList(new LifecycleHooksRecordImpl(hookClass.getName(), Collections.emptyMap()));
+  }
+
+  private List<LifecycleHooksRecord> recordsForKeys(String... keys) {
+    List<LifecycleHooksRecord> records = new ArrayList<>();
+    for (String key: keys) {
+      records.add(new LifecycleHooksRecordImpl(key, Collections.emptyMap()));
+    }
+    return records;
+  }
+
+  private <T extends StoreLifecycleHooks> T registerHook(T hook) {
+    hookCache.put(hook.getClass().getName(), hook);
+    return hook;
+  }
+
+  private void injectMultiClusterConfigs() {
+    VeniceControllerMultiClusterConfig multiClusterConfigs = mock(VeniceControllerMultiClusterConfig.class);
+    VeniceControllerClusterConfig clusterConfig = mock(VeniceControllerClusterConfig.class);
+    doReturn(clusterConfig).when(multiClusterConfigs).getCommonConfig();
+    doReturn(new VeniceProperties(new Properties())).when(clusterConfig).getProps();
+    try {
+      Field field = VeniceHelixAdmin.class.getDeclaredField("multiClusterConfigs");
+      field.setAccessible(true);
+      field.set(admin, multiClusterConfigs);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @FunctionalInterface
+  interface HookInvoker extends BiConsumer<VeniceHelixAdmin, List<LifecycleHooksRecord>> {
+  }
+
+  public static class TrackingHooks extends StoreLifecycleHooks {
+    boolean preCreationCalled;
+    boolean postCreationCalled;
+    boolean preDeletionCalled;
+    boolean postDeletionCalled;
+
+    String lastCluster;
+    String lastStore;
+    int lastVersion;
+    String lastRegion;
+
+    StoreVersionLifecycleEventOutcome preCreationOutcome = StoreVersionLifecycleEventOutcome.PROCEED;
+    StoreLifecycleEventOutcome preDeletionOutcome = StoreLifecycleEventOutcome.PROCEED;
+
+    public TrackingHooks() {
+      super(new VeniceProperties(new Properties()));
+    }
+
+    public TrackingHooks(VeniceProperties defaultConfigs) {
+      super(defaultConfigs);
+    }
+
+    @Override
+    public StoreVersionLifecycleEventOutcome preStoreVersionCreation(
+        String clusterName,
+        String storeName,
+        int versionNumber,
+        String regionName,
+        com.linkedin.venice.utils.lazy.Lazy<com.linkedin.venice.controllerapi.JobStatusQueryResponse> jobStatus,
+        VeniceProperties storeHooksConfigs) {
+      preCreationCalled = true;
+      lastCluster = clusterName;
+      lastStore = storeName;
+      lastVersion = versionNumber;
+      lastRegion = regionName;
+      return preCreationOutcome;
+    }
+
+    @Override
+    public void postStoreVersionCreation(
+        String clusterName,
+        String storeName,
+        int versionNumber,
+        String regionName,
+        VeniceProperties storeHooksConfigs) {
+      postCreationCalled = true;
+      lastCluster = clusterName;
+      lastStore = storeName;
+      lastVersion = versionNumber;
+      lastRegion = regionName;
+    }
+
+    @Override
+    public StoreLifecycleEventOutcome preStoreVersionDeletion(
+        String clusterName,
+        String storeName,
+        int versionNumber,
+        String regionName,
+        VeniceProperties storeHooksConfigs) {
+      preDeletionCalled = true;
+      lastCluster = clusterName;
+      lastStore = storeName;
+      lastVersion = versionNumber;
+      lastRegion = regionName;
+      return preDeletionOutcome;
+    }
+
+    @Override
+    public void postStoreVersionDeletion(
+        String clusterName,
+        String storeName,
+        int versionNumber,
+        String regionName,
+        VeniceProperties storeHooksConfigs) {
+      postDeletionCalled = true;
+      lastCluster = clusterName;
+      lastStore = storeName;
+      lastVersion = versionNumber;
+      lastRegion = regionName;
+    }
+  }
+
+  public static class ThrowingHooks extends StoreLifecycleHooks {
+    public ThrowingHooks() {
+      super(new VeniceProperties(new Properties()));
+    }
+
+    public ThrowingHooks(VeniceProperties defaultConfigs) {
+      super(defaultConfigs);
+    }
+
+    @Override
+    public StoreVersionLifecycleEventOutcome preStoreVersionCreation(
+        String clusterName,
+        String storeName,
+        int versionNumber,
+        String regionName,
+        com.linkedin.venice.utils.lazy.Lazy<com.linkedin.venice.controllerapi.JobStatusQueryResponse> jobStatus,
+        VeniceProperties storeHooksConfigs) {
+      throw new RuntimeException("pre-creation hook failure");
+    }
+
+    @Override
+    public void postStoreVersionCreation(
+        String clusterName,
+        String storeName,
+        int versionNumber,
+        String regionName,
+        VeniceProperties storeHooksConfigs) {
+      throw new RuntimeException("post-creation hook failure");
+    }
+
+    @Override
+    public StoreLifecycleEventOutcome preStoreVersionDeletion(
+        String clusterName,
+        String storeName,
+        int versionNumber,
+        String regionName,
+        VeniceProperties storeHooksConfigs) {
+      throw new RuntimeException("pre-deletion hook failure");
+    }
+
+    @Override
+    public void postStoreVersionDeletion(
+        String clusterName,
+        String storeName,
+        int versionNumber,
+        String regionName,
+        VeniceProperties storeHooksConfigs) {
+      throw new RuntimeException("post-deletion hook failure");
+    }
+  }
+}


### PR DESCRIPTION
## Problem Statement

`StoreLifecycleHooks` defined several hook methods (pre/post store-version creation, schema registration, push job, version swap) but none of them had call sites — they were never actually invoked. Store-level creation hooks and version deletion hooks didn't exist at all.

## Solution

**`StoreLifecycleHooks`** — adds four new methods:
- `preStoreCreation` / `postStoreCreation` — store lifecycle events
- `preStoreVersionDeletion` / `postStoreVersionDeletion` — version deletion lifecycle events

**`VeniceHelixAdmin`** — wires six call sites:

| Hook | When |
|------|------|
| `preStoreCreation` | after `configureNewStore`, before `storeRepo.addStore` |
| `postStoreCreation` | after store and schemas fully persisted |
| `preStoreVersionCreation` | before batch topic creation, for both new-version and store-migration clone paths |
| `postStoreVersionCreation` | inside `if (startIngestion)`, after Helix resource creation |
| `preStoreVersionDeletion` | after confirming the version exists, before any resources are torn down |
| `postStoreVersionDeletion` | after `notifyVersionDeleted` |

Hook instances are cached in `storeLifecycleHooksInstanceCache` (same pattern as `DeferredVersionSwapService`). A `failedHookClasses` set prevents repeated reflection attempts for bad class names. Exceptions from hooks are swallowed and logged; any non-PROCEED outcome from a pre-hook throws `VeniceException`.

### Code changes
- [ ] Added new code behind **a config**. No — hooks only fire when a store has lifecycle hooks configured.
- [ ] Introduced new **log lines**. Yes — error logs on hook instantiation failure and hook exception; warn log on null/empty class name.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging. These are error paths; no rate limiting needed.

### **Concurrency-Specific Checks**
- [x] No race conditions. Hook invocations happen inside the store write lock.
- [x] Thread-safe collections used: `storeLifecycleHooksInstanceCache` uses `VeniceConcurrentHashMap`, `failedHookClasses` uses `ConcurrentHashMap.newKeySet()`.
- [x] No blocking calls inside critical sections. Hook exceptions are caught.

## How was this PR tested?

- [x] New unit tests: `TestVeniceHelixAdminStoreLifecycleHooks` — 40 test executions via `@DataProvider` across all 6 hook methods, covering: hook called, correct params, exception swallowed, empty list no-op, unknown class skipped, ABORT/WAIT/ROLLBACK throws `VeniceException`, instance caching, multiple hooks, abort stops remaining hooks.

## Does this PR introduce any user-facing or breaking changes?
- [x] No.