### PR TITLE
[controller] Use CrushEdRebalanceStrategy as default for storage cluster resources

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -281,7 +281,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.cloud.constants.CloudProvider;
-import org.apache.helix.controller.rebalancer.strategy.CrushRebalanceStrategy;
+import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.model.CloudConfig;
 import org.apache.helix.model.ClusterConfig;
 import org.apache.logging.log4j.LogManager;
@@ -840,7 +840,7 @@ public class VeniceControllerClusterConfig {
         ENABLE_HYBRID_PUSH_SSL_WHITELIST,
         true);
     this.pushSSLAllowlist = props.getListWithAlternative(PUSH_SSL_ALLOWLIST, PUSH_SSL_WHITELIST, new ArrayList<>());
-    this.helixRebalanceAlg = props.getString(HELIX_REBALANCE_ALG, CrushRebalanceStrategy.class.getName());
+    this.helixRebalanceAlg = props.getString(HELIX_REBALANCE_ALG, CrushEdRebalanceStrategy.class.getName());
     this.adminTopicReplicationFactor = props.getInt(ADMIN_TOPIC_REPLICATION_FACTOR, 3);
     if (adminTopicReplicationFactor < 1) {
       throw new ConfigurationException(ADMIN_TOPIC_REPLICATION_FACTOR + " cannot be less than 1.");


### PR DESCRIPTION
## Problem Statement

The default value of `helix.rebalance.alg` (`HELIX_REBALANCE_ALG`) for Venice storage cluster resources is currently `CrushRebalanceStrategy`. On smaller clusters and skewed topologies this can place multiple replicas of the same store on the same server — e.g., on a 10-server cluster with replication factor 3, all 3 replicas of a partition can end up on a single node, concentrating ~33% of that partition's read traffic on one server.

This was raised on the OSS venicedb community Slack (`#community-syncup`, https://venicedb.slack.com/archives/C0567KESECQ/p1779901221187329): a Whatnot operator observed exactly this skew on a 10-server load-test cluster with RF=3.

Apache Helix already ships `CrushEdRebalanceStrategy` ("Crush Even Distribution") to address this. It adjusts CRUSH placement to spread replicas more uniformly across nodes — a strict improvement for the small-cluster and skewed-cluster case, while still behaving well on larger clusters.

## Solution

Change the default of `HELIX_REBALANCE_ALG` in `VeniceControllerClusterConfig` from `CrushRebalanceStrategy` to `CrushEdRebalanceStrategy`.

This affects only storage cluster **store resources** (those created in `ZkHelixAdminClient#createVeniceStorageClusterResources`, which reads the default via `config.getHelixRebalanceAlg()`). The controller cluster resource set up in `VeniceHelixAdmin#createClusterIfRequired` is unchanged — it explicitly hard-codes `CrushRebalanceStrategy` for the meta-resource and the placement constraints there are different.

###  Code changes
- [ ] Added new code behind **a config**. _(No — modifies the default of an existing config key, `helix.rebalance.alg`.)_
- [ ] Introduced new **log lines**.

###  **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. _(Single-literal default change; no new control flow.)_
- [x] Proper **synchronization mechanisms** are used where needed. _(N/A.)_
- [x] No **blocking calls** inside critical sections. _(N/A.)_
- [x] Verified **thread-safe collections** are used. _(N/A.)_
- [x] Validated proper exception handling in multi-threaded code. _(N/A.)_

## How was this PR tested?

- [x] **Verified backward compatibility.** The existing `helix.rebalance.alg` config key continues to honor explicit overrides; deployments that pin `CrushRebalanceStrategy` are unaffected.
- [x] **Compiled clean** with `./gradlew :services:venice-controller:compileJava`.
- [x] **Controller unit tests pass** with `./gradlew :services:venice-controller:test`.

## Does this PR introduce any user-facing or breaking changes?

- [ ] No.
- [x] Yes. New deployments of Venice will use `CrushEdRebalanceStrategy` as the default placement algorithm for storage cluster store resources. Existing deployments with an explicit `helix.rebalance.alg` config are unaffected. Existing deployments relying on the default will see newly created resources placed via CrushEd (more even partition distribution); existing resources continue to use whatever strategy was active when they were created until a Helix rebalance is triggered.
