### PR TITLE
[protocol][build] Stage MetadataResponseRecord v3 (externalStorageReadMode)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -331,7 +331,11 @@ subprojects {
       def versionOverrides = [
           // AdminOperation v100 stages degradedDatacenters on AddVersion.
           // Pinned to the current active version until the Java wiring lands in a follow-up PR.
-          project(':services:venice-controller').file('src/main/resources/avro/AdminOperation/v99', PathValidation.DIRECTORY)
+          project(':services:venice-controller').file('src/main/resources/avro/AdminOperation/v99', PathValidation.DIRECTORY),
+          // MetadataResponseRecord v3 stages externalStorageReadMode (mirrors StoreProperties.externalStorageReadMode
+          // from StoreMetaValue v44). Pinned to the current active version until SERVER_METADATA_RESPONSE is bumped
+          // and server populate + Fast Client read land in follow-up PRs.
+          project(':internal:venice-common').file('src/main/resources/avro/MetadataResponseRecord/v2', PathValidation.DIRECTORY)
       ]
 
       def schemaDirs = [sourceDir]

--- a/internal/venice-common/src/main/resources/avro/MetadataResponseRecord/v3/MetadataResponseRecord.avsc
+++ b/internal/venice-common/src/main/resources/avro/MetadataResponseRecord/v3/MetadataResponseRecord.avsc
@@ -1,0 +1,138 @@
+{
+  "type": "record",
+  "name": "MetadataResponseRecord",
+  "namespace": "com.linkedin.venice.metadata.response",
+  "doc": "This record will store version properties, key & value schemas, and routing information",
+  "fields": [
+    {
+      "name": "versionMetadata",
+      "doc": "The current version number and other version properties such as the compression strategy",
+      "type": [
+        "null",
+        {
+          "name": "VersionProperties",
+          "type": "record",
+          "fields": [
+            {
+              "name": "currentVersion",
+              "doc": "Current version number",
+              "type": "int"
+            },
+            {
+              "name": "compressionStrategy",
+              "doc": "The current version's compression strategy. 0 -> NO_OP, 1 -> GZIP, 2 -> ZSTD, 3 -> ZSTD_WITH_DICT",
+              "type": {
+                "name": "CompressionStrategy",
+                "type": "int"
+              }
+            },
+            {
+              "name": "partitionCount",
+              "doc": "Partition count of the current version",
+              "type": "int"
+            },
+            {
+              "name": "partitionerClass",
+              "doc": "Partitioner class name",
+              "type": "string"
+            },
+            {
+              "name": "partitionerParams",
+              "doc": "Partitioner parameters",
+              "type": {
+                "type": "map",
+                "values": "string"
+              }
+            },
+            {
+              "name": "amplificationFactor",
+              "doc": "Partitioner amplification factor",
+              "type": "int"
+            }
+          ]
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "versions",
+      "doc": "List of all version numbers",
+      "type": {
+        "type": "array",
+        "items": "int"
+      }
+    },
+    {
+      "name": "keySchema",
+      "doc": "Key schema",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "string"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "valueSchemas",
+      "doc": "Value schemas",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "string"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "latestSuperSetValueSchemaId",
+      "doc": "Latest super set value schema ID",
+      "type": [
+        "null",
+        "int"
+      ],
+      "default": null
+    },
+    {
+      "name": "routingInfo",
+      "doc": "Routing table information, maps resource to partition ID to a list of replicas",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "array",
+            "items": "string"
+          }
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "helixGroupInfo",
+      "doc": "Helix group information, maps replicas to their respective groups",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "int"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "batchGetLimit",
+      "doc": "The max key number allowed in a batch get request",
+      "type": "int",
+      "default": 150
+    },
+    {
+      "name": "externalStorageReadMode",
+      "doc": "Store-level read routing for clients backed by both Venice local storage and a configured external storage system. 0 => VENICE_ONLY (default, reads served from Venice local storage only -- current behavior); 1 => DUAL_MODE_CONSISTENCY_CHECK; 2 => DUAL_MODE_EARLY_RETURN; 3 => EXTERNAL_ONLY. Mirrors StoreProperties.externalStorageReadMode (StoreMetaValue v44).",
+      "type": "int",
+      "default": 0
+    }
+  ]
+}

--- a/internal/venice-common/src/main/resources/avro/MetadataResponseRecord/v3/MetadataResponseRecord.avsc
+++ b/internal/venice-common/src/main/resources/avro/MetadataResponseRecord/v3/MetadataResponseRecord.avsc
@@ -130,7 +130,7 @@
     },
     {
       "name": "externalStorageReadMode",
-      "doc": "Store-level read routing for clients backed by both Venice local storage and a configured external storage system. 0 => VENICE_ONLY (default, reads served from Venice local storage only -- current behavior); 1 => DUAL_MODE_CONSISTENCY_CHECK; 2 => DUAL_MODE_EARLY_RETURN; 3 => EXTERNAL_ONLY. Mirrors StoreProperties.externalStorageReadMode (StoreMetaValue v44).",
+      "doc": "Store-level read routing for clients backed by both Venice local storage and a configured external storage system. 0 => VENICE_ONLY (default, reads served from Venice local storage only -- current behavior); 1 => DUAL_MODE_CONSISTENCY_CHECK; 2 => DUAL_MODE_EARLY_RETURN; 3 => EXTERNAL_ONLY.",
       "type": "int",
       "default": 0
     }


### PR DESCRIPTION
## Problem Statement
Today the metadata fetch response (`MetadataResponseRecord`, served by `ServerReadMetadataRepository` and consumed by Fast Clients via `RequestBasedMetadata`) does not carry the store-level `externalStorageReadMode`. That field landed on `StoreProperties` as part of `StoreMetaValue` v44 (#2817), but Fast Clients today cannot observe it without separately reading the meta system store.

A follow-up PR will populate the field server-side and consume it client-side; that PR needs a v3 wire format to land on top of. Staging the schema in its own PR keeps the protocol upgrade isolated from any code change that consumes it.

## Solution
- Adds `internal/venice-common/src/main/resources/avro/MetadataResponseRecord/v3/MetadataResponseRecord.avsc` — a copy of v2 with `externalStorageReadMode` (int, default 0 = `VENICE_ONLY`) appended.
- Pins MetadataResponseRecord codegen to v2 via the existing `versionOverrides` block in root `build.gradle`, matching the pattern used by AdminOperation v100 (#2816). This means **no Java change** in this PR — no `AvroProtocolDefinition` bump, no generated-class diff, no on-wire change.
- A follow-up PR will (a) remove the `MetadataResponseRecord/v2` pin, (b) bump `AvroProtocolDefinition.SERVER_METADATA_RESPONSE` 2 → 3, (c) populate the field in `ServerReadMetadataRepository.getMetadata`, and (d) read it in `RequestBasedMetadata.updateCache`.

The new field defaults to `0` (`VENICE_ONLY` = current behavior), so once the activation PR lands: v3 readers decode v2 payloads via the schema default, and v2 readers decode v3 payloads transparently by dropping the trailing field.

###  Code changes
- [ ] Added new code behind **a config**. (N/A — no Java change.)
- [ ] Introduced new **log lines**. (N/A.)

###  **Concurrency-Specific Checks**
N/A — schema-staging PR with no Java change.

## How was this PR tested?
- `./gradlew :services:venice-controller:test --tests "*MetadataResponseRecordCompatibilityTest*"` — PASS (walks `v1 ↔ v2 ↔ v3` pairwise compat).
- `./gradlew :internal:venice-common:clean :internal:venice-common:compileJava` — PASS; codegen log shows `Copying avro schema src/main/resources/avro/MetadataResponseRecord/v2/MetadataResponseRecord.avsc (OVERRIDE)`, and generated `MetadataResponseRecord.java` has **0** references to `externalStorageReadMode`.
- `./gradlew :clients:da-vinci-client:compileJava` — PASS.
- `./gradlew spotlessApply` — clean.

- [ ] New unit tests added. (Existing `MetadataResponseRecordCompatibilityTest` covers v3 automatically since it iterates from v1 to `getCurrentProtocolVersion()`.)
- [ ] New integration tests added. (N/A — no behavior change.)
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. Schema is staged but inactive; codegen, wire format, and runtime behavior are unchanged.
- [ ] Yes.