### PR TITLE
[controller] Fix NPE in /job when parent version is absent

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4516,28 +4516,32 @@ public class VeniceParentHelixAdmin implements Admin {
     Store parentStore = repository.getStore(storeName);
     Version version = parentStore.getVersion(versionNum);
 
-    // Version may be absent between two consecutive VPJ polls (retention eviction, supersession,
-    // controller leadership change, or manual cleanup). Return a terminal status with HTTP 200 so
-    // VPJ exits its poll loop, rather than letting an unguarded deref below escape as HTTP 500.
-    // Both branches must be terminal (NOT_CREATED is non-terminal, so VPJ would keep polling):
-    // - versionNum <= largestUsedVersionNumber: the version existed once and was retired -> ARCHIVED.
-    // - versionNum > largestUsedVersionNumber: a version that was never created is being polled,
-    // which is a genuine inconsistency rather than a transient absence -> ERROR.
+    // The version may be absent from parent store metadata. Short-circuit here so the unguarded
+    // deref below (the KILLED check) cannot escape as HTTP 500. The two cases need different
+    // statuses, distinguished by largestUsedVersionNumber:
+    // - versionNum <= largestUsedVersionNumber: the version existed once and was retired (retention
+    // eviction, supersession, manual cleanup) -> terminal ARCHIVED so VPJ stops polling and fails
+    // the push.
+    // - versionNum > largestUsedVersionNumber: the parent version has not been materialized yet.
+    // This is the legitimate pre-creation window at the start of a push (child regions report
+    // "version creation got delayed"), not an inconsistency -> non-terminal NOT_CREATED so VPJ keeps
+    // polling until the version is created. Returning a terminal status here would abort in-flight
+    // pushes.
     if (version == null) {
       boolean wasRetired = versionNum <= parentStore.getLargestUsedVersionNumber();
-      ExecutionStatus terminalStatus = wasRetired ? ExecutionStatus.ARCHIVED : ExecutionStatus.ERROR;
+      ExecutionStatus absentStatus = wasRetired ? ExecutionStatus.ARCHIVED : ExecutionStatus.NOT_CREATED;
       String statusDetails = wasRetired
           ? "Parent version " + versionNum + " was retired and is no longer present in store metadata"
-          : "Parent version " + versionNum + " was never created (largest used version number is "
+          : "Parent version " + versionNum + " has not been created yet (largest used version number is "
               + parentStore.getLargestUsedVersionNumber() + ")";
       LOGGER.info(
           "Version {} for store {} not present in parent store metadata; returning {}: {}",
           versionNum,
           storeName,
-          terminalStatus,
+          absentStatus,
           statusDetails);
       return new OfflinePushStatusInfo(
-          terminalStatus,
+          absentStatus,
           null,
           extraInfo,
           statusDetails,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4516,6 +4516,28 @@ public class VeniceParentHelixAdmin implements Admin {
     Store parentStore = repository.getStore(storeName);
     Version version = parentStore.getVersion(versionNum);
 
+    // Version may be absent between two consecutive VPJ polls (retention eviction, supersession,
+    // controller leadership change, or manual cleanup). The protocol already defines terminal
+    // values for this state — return one with HTTP 200 so VPJ exits its poll loop, rather than
+    // letting an unguarded deref below escape as HTTP 500.
+    if (version == null) {
+      ExecutionStatus terminalStatus = versionNum <= parentStore.getLargestUsedVersionNumber()
+          ? ExecutionStatus.ARCHIVED
+          : ExecutionStatus.NOT_CREATED;
+      LOGGER.info(
+          "Version {} for store {} no longer present in parent store metadata; returning {}",
+          versionNum,
+          storeName,
+          terminalStatus);
+      return new OfflinePushStatusInfo(
+          terminalStatus,
+          null,
+          extraInfo,
+          "Parent version " + versionNum + " no longer present in store metadata",
+          extraDetails,
+          extraInfoUpdateTimestamp);
+    }
+
     // Check if push is in a terminal status in target regions for pushes using deferred swap and try
     // updating the parent status. Parent status should only be updated if it is currently in a STARTED state to avoid
     // multiple duplicate updates as vpj will keep polling until all regions are complete

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4517,23 +4517,30 @@ public class VeniceParentHelixAdmin implements Admin {
     Version version = parentStore.getVersion(versionNum);
 
     // Version may be absent between two consecutive VPJ polls (retention eviction, supersession,
-    // controller leadership change, or manual cleanup). The protocol already defines terminal
-    // values for this state — return one with HTTP 200 so VPJ exits its poll loop, rather than
-    // letting an unguarded deref below escape as HTTP 500.
+    // controller leadership change, or manual cleanup). Return a terminal status with HTTP 200 so
+    // VPJ exits its poll loop, rather than letting an unguarded deref below escape as HTTP 500.
+    // Both branches must be terminal (NOT_CREATED is non-terminal, so VPJ would keep polling):
+    // - versionNum <= largestUsedVersionNumber: the version existed once and was retired -> ARCHIVED.
+    // - versionNum > largestUsedVersionNumber: a version that was never created is being polled,
+    // which is a genuine inconsistency rather than a transient absence -> ERROR.
     if (version == null) {
-      ExecutionStatus terminalStatus = versionNum <= parentStore.getLargestUsedVersionNumber()
-          ? ExecutionStatus.ARCHIVED
-          : ExecutionStatus.NOT_CREATED;
+      boolean wasRetired = versionNum <= parentStore.getLargestUsedVersionNumber();
+      ExecutionStatus terminalStatus = wasRetired ? ExecutionStatus.ARCHIVED : ExecutionStatus.ERROR;
+      String statusDetails = wasRetired
+          ? "Parent version " + versionNum + " was retired and is no longer present in store metadata"
+          : "Parent version " + versionNum + " was never created (largest used version number is "
+              + parentStore.getLargestUsedVersionNumber() + ")";
       LOGGER.info(
-          "Version {} for store {} no longer present in parent store metadata; returning {}",
+          "Version {} for store {} not present in parent store metadata; returning {}: {}",
           versionNum,
           storeName,
-          terminalStatus);
+          terminalStatus,
+          statusDetails);
       return new OfflinePushStatusInfo(
           terminalStatus,
           null,
           extraInfo,
-          "Parent version " + versionNum + " no longer present in store metadata",
+          statusDetails,
           extraDetails,
           extraInfoUpdateTimestamp);
     }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2236,6 +2236,58 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   @Test
+  public void testAbsentVersionReturnsArchived() {
+    // Version is null (e.g. pruned by retention/supersession) and versionNum <= largestUsedVersionNumber,
+    // meaning the version existed at some point. Expect ARCHIVED instead of NPE/500.
+    Map<ExecutionStatus, ControllerClient> clientMap = getMockJobStatusQueryClient();
+    Map<String, ControllerClient> controllerClients = new HashMap<>();
+    controllerClients.put("cluster", clientMap.get(ExecutionStatus.STARTED));
+
+    Store store = mock(Store.class);
+    doReturn(false).when(store).isIncrementalPushEnabled();
+    doReturn(store).when(internalAdmin).getStore(anyString(), anyString());
+    doReturn(null).when(store).getVersion(anyInt());
+    doReturn(5).when(store).getLargestUsedVersionNumber();
+
+    HelixVeniceClusterResources resources = mock(HelixVeniceClusterResources.class);
+    doReturn(mock(ClusterLockManager.class)).when(resources).getClusterLockManager();
+    doReturn(resources).when(internalAdmin).getHelixVeniceClusterResources(anyString());
+    ReadWriteStoreRepository repository = mock(ReadWriteStoreRepository.class);
+    doReturn(repository).when(resources).getStoreMetadataRepository();
+    doReturn(store).when(repository).getStore(anyString());
+
+    Admin.OfflinePushStatusInfo offlineJobStatus =
+        parentAdmin.getOffLineJobStatus("IGNORED", "topic1_v3", controllerClients);
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.ARCHIVED);
+  }
+
+  @Test
+  public void testAbsentVersionReturnsNotCreated() {
+    // Version is null and versionNum > largestUsedVersionNumber, meaning the requested version
+    // was never created. Expect NOT_CREATED instead of NPE/500.
+    Map<ExecutionStatus, ControllerClient> clientMap = getMockJobStatusQueryClient();
+    Map<String, ControllerClient> controllerClients = new HashMap<>();
+    controllerClients.put("cluster", clientMap.get(ExecutionStatus.STARTED));
+
+    Store store = mock(Store.class);
+    doReturn(false).when(store).isIncrementalPushEnabled();
+    doReturn(store).when(internalAdmin).getStore(anyString(), anyString());
+    doReturn(null).when(store).getVersion(anyInt());
+    doReturn(2).when(store).getLargestUsedVersionNumber();
+
+    HelixVeniceClusterResources resources = mock(HelixVeniceClusterResources.class);
+    doReturn(mock(ClusterLockManager.class)).when(resources).getClusterLockManager();
+    doReturn(resources).when(internalAdmin).getHelixVeniceClusterResources(anyString());
+    ReadWriteStoreRepository repository = mock(ReadWriteStoreRepository.class);
+    doReturn(repository).when(resources).getStoreMetadataRepository();
+    doReturn(store).when(repository).getStore(anyString());
+
+    Admin.OfflinePushStatusInfo offlineJobStatus =
+        parentAdmin.getOffLineJobStatus("IGNORED", "topic1_v9", controllerClients);
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.NOT_CREATED);
+  }
+
+  @Test
   public void testUpdateStore() {
     String storeName = Utils.getUniqueString("testUpdateStore");
     Store store = TestUtils.createTestStore(storeName, "test", System.currentTimeMillis());

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2262,9 +2262,10 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   @Test
-  public void testAbsentVersionReturnsNotCreated() {
+  public void testAbsentVersionReturnsError() {
     // Version is null and versionNum > largestUsedVersionNumber, meaning the requested version
-    // was never created. Expect NOT_CREATED instead of NPE/500.
+    // was never created. This is a genuine inconsistency, so expect the terminal ERROR status
+    // (not the non-terminal NOT_CREATED, which would leave VPJ polling) instead of NPE/500.
     Map<ExecutionStatus, ControllerClient> clientMap = getMockJobStatusQueryClient();
     Map<String, ControllerClient> controllerClients = new HashMap<>();
     controllerClients.put("cluster", clientMap.get(ExecutionStatus.STARTED));
@@ -2284,7 +2285,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
     Admin.OfflinePushStatusInfo offlineJobStatus =
         parentAdmin.getOffLineJobStatus("IGNORED", "topic1_v9", controllerClients);
-    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.NOT_CREATED);
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.ERROR);
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2262,10 +2262,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   @Test
-  public void testAbsentVersionReturnsError() {
-    // Version is null and versionNum > largestUsedVersionNumber, meaning the requested version
-    // was never created. This is a genuine inconsistency, so expect the terminal ERROR status
-    // (not the non-terminal NOT_CREATED, which would leave VPJ polling) instead of NPE/500.
+  public void testAbsentVersionReturnsNotCreated() {
+    // Version is null and versionNum > largestUsedVersionNumber, meaning the parent version has not
+    // been materialized yet (the legitimate pre-creation window at the start of a push). Expect the
+    // non-terminal NOT_CREATED so VPJ keeps polling, instead of NPE/500 or a terminal status that
+    // would abort an in-flight push.
     Map<ExecutionStatus, ControllerClient> clientMap = getMockJobStatusQueryClient();
     Map<String, ControllerClient> controllerClients = new HashMap<>();
     controllerClients.put("cluster", clientMap.get(ExecutionStatus.STARTED));
@@ -2285,7 +2286,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
     Admin.OfflinePushStatusInfo offlineJobStatus =
         parentAdmin.getOffLineJobStatus("IGNORED", "topic1_v9", controllerClients);
-    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.ERROR);
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.NOT_CREATED);
   }
 
   @Test


### PR DESCRIPTION

## Problem Statement
Fixes [VENG-12673](https://linkedin.atlassian.net/browse/VENG-12673) — `/job` venice-controller returns HTTP 500 from an unguarded NPE when the requested version is no longer present in parent store metadata.                                                                                                                                                                                                     
                                                                                                                                                                                                                
`VeniceParentHelixAdmin#getOffLineJobStatus` looks up `parentStore.getVersion(versionNum)` (annotated `@Nullable`) and then dereferences it in the non-terminal branch (`version.getStatus().equals(KILLED)`). The version can legitimately be absent between two consecutive VPJ polls for several operational reasons:                                                                                                                                                                                                                                                                                                     
  - Retention eviction (version exceeded retain-count).                                                                                                                                                         
  - Supersession (newer push completed, older retired).                                                                                                                                                         
  - Controller leadership change (new leader's metadata view briefly differs during refresh).                                                                                                                   
  - Manual cleanup or repush truncation.                                                                                                                                                                        
                                                                                                                                                                                                                
The unguarded deref escapes the framework's recognized-exception path as HTTP 500. VPJ retries on 5xx, error-rate alarms fire, oncall is paged — all for a state the protocol already has terminal values for. An adjacent branch in the same method already null-guards the same value, confirming the omission is an oversight.                                                                                           
                         


## Solution
Short-circuit at the point of lookup: if `version == null`, return a terminal status with HTTP 200 so VPJ exits its poll loop cleanly. Distinguish:                                                                                                                                                                                                                                                                     
  - `ARCHIVED` if `versionNum <= parentStore.getLargestUsedVersionNumber()` (version existed once and was retired).                                                                                             
  - `NOT_CREATED` if `versionNum > parentStore.getLargestUsedVersionNumber()` (version was never created).                                                                                                      
                                                                                                                                                                                                 
This also eliminates a second unguarded deref further down at `version.getStatus()` in the deferred-swap terminal branch, which would have been reachable when `isTargetRegionPushWithDeferredSwap=true` with `version==null`.  


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.