### PR TITLE
[da-vinci] Flush Global RT DIV State on Graceful Shutdown

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractStoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractStoreBufferService.java
@@ -42,6 +42,10 @@ public abstract class AbstractStoreBufferService extends AbstractVeniceService {
       PubSubTopicPartition topicPartition,
       StoreIngestionTask ingestionTask) throws InterruptedException;
 
+  public abstract CompletableFuture<Void> execSyncGlobalRtDivCommandAsync(
+      PubSubTopicPartition topicPartition,
+      StoreIngestionTask ingestionTask) throws InterruptedException;
+
   public abstract void execSyncOffsetFromSnapshotAsync(
       PubSubTopicPartition topicPartition,
       PartitionTracker vtDivSnapshot,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractStoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractStoreBufferService.java
@@ -42,7 +42,7 @@ public abstract class AbstractStoreBufferService extends AbstractVeniceService {
       PubSubTopicPartition topicPartition,
       StoreIngestionTask ingestionTask) throws InterruptedException;
 
-  public abstract CompletableFuture<Void> execSyncGlobalRtDivCommandAsync(
+  public abstract CompletableFuture<Void> execSyncGlobalRtDivAsync(
       PubSubTopicPartition topicPartition,
       StoreIngestionTask ingestionTask) throws InterruptedException;
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractStoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractStoreBufferService.java
@@ -46,7 +46,7 @@ public abstract class AbstractStoreBufferService extends AbstractVeniceService {
       PubSubTopicPartition topicPartition,
       StoreIngestionTask ingestionTask) throws InterruptedException;
 
-  public abstract void execSyncOffsetFromSnapshotAsync(
+  public abstract CompletableFuture<Void> execSyncOffsetFromSnapshotAsync(
       PubSubTopicPartition topicPartition,
       PartitionTracker vtDivSnapshot,
       CompletableFuture<Void> lastRecordPersistedFuture,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1512,6 +1512,18 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
   }
 
   /**
+   * A/A keys the DIV RT checkpoint by broker URL, matching its per-broker leader-start read in
+   * {@link #preparePositionCheckpointAndStartConsumptionAsLeader}.
+   */
+  @Override
+  protected void updateDivRtCheckpointPosition(
+      PartitionConsumptionState pcs,
+      String pubSubBrokerAddress,
+      PubSubPosition divRtCheckpointPosition) {
+    pcs.setDivRtCheckpointPosition(pubSubBrokerAddress, divRtCheckpointPosition);
+  }
+
+  /**
    * N.B. package-private for testing purposes.
    */
   static String getUpstreamKafkaUrlFromKafkaValue(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2261,7 +2261,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     try {
       if (shouldSendGlobalRtDiv(consumerRecord, pcs, kafkaUrl)) {
         sendGlobalRtDivMessage(
-            consumerRecord,
+            consumerRecord.getPosition(),
+            consumerRecord.getTopicPartition(),
             pcs,
             partition,
             kafkaUrl,
@@ -2425,6 +2426,88 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         Thread.currentThread().interrupt();
       }
     });
+  }
+
+  /**
+   * On-demand flush of both the RT and VT DIV state, invoked at graceful shutdown (see
+   * {@link StoreIngestionTask#executeShutdownRunnable}). Decoupled from the byte-threshold triggers.
+   *
+   * <ul>
+   *   <li><b>Leader:</b> for each RT source broker, produce one {@link GlobalRtDivState} (carrying the latest consumed
+   *       RT position, LCRP) to the local VT via {@link #sendGlobalRtDivMessage}. Its callback already chains the VT DIV
+   *       + LCVP sync, so the RT produce covers both halves. After the produce persists, a waitable
+   *       {@code SYNC_GLOBAL_RT_DIV} command is enqueued so the aggregate future completes only once the chained VT DIV
+   *       sync (which the single-threaded drainer runs FIFO before this command) has run. Brokers whose LCRP is
+   *       {@link PubSubSymbolicPosition#EARLIEST} are skipped (no RT progress yet).</li>
+   *   <li><b>Follower / leader with no RT progress or no RT brokers:</b> force a single waitable VT DIV snapshot sync.
+   *       RT DIV is already durable in the StorageEngine from when the follower consumed {@link GlobalRtDivState}.</li>
+   * </ul>
+   *
+   * @return a future completing once all produces have persisted and the corresponding VT DIV syncs have run.
+   */
+  @Override
+  protected CompletableFuture<Void> forceGlobalRtDivSync(PartitionConsumptionState pcs) {
+    int partition = pcs.getPartition();
+    PubSubTopicPartition localVtTopicPartition = pcs.getReplicaTopicPartition();
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+    if (pcs.getLeaderFollowerState().equals(LEADER)) {
+      Set<String> realTimeDataSourceKafkaURLs = getRealTimeDataSourceKafkaAddress(pcs);
+      for (String brokerUrl: realTimeDataSourceKafkaURLs) {
+        PubSubPosition lcrp = pcs.getLatestConsumedRtPosition(brokerUrl);
+        // Skip brokers with no RT progress: producing/persisting EARLIEST would force a re-subscribe from EARLIEST on
+        // restart (mirrors the EARLIEST-LCVP guard in sendVtDivSnapshotIfNeeded).
+        if (PubSubSymbolicPosition.EARLIEST.equals(lcrp)) {
+          continue;
+        }
+        // Resolve the cluster id from the canonical url->id reverse map (it also carries alias / _sep-topic url
+        // variants that the forward id->url map lacks), matching how the steady-state RT consume path resolves it.
+        int kafkaClusterId = getServerConfig().getKafkaClusterUrlToIdMap().getOrDefault(brokerUrl, -1);
+        try {
+          LeaderProducerCallback divCallback = sendGlobalRtDivMessage(
+              lcrp,
+              localVtTopicPartition,
+              pcs,
+              partition,
+              brokerUrl,
+              System.nanoTime(),
+              kafkaClusterId);
+          CompletableFuture<Void> persistedToDBFuture =
+              divCallback.getLeaderProducedRecordContext().getPersistedToDBFuture();
+          // After the RT DIV produce persists (its callback already chained the VT DIV sync into the FIFO drainer),
+          // enqueue a waitable VT DIV sync so the aggregate future deterministically covers the chained VT sync too.
+          futures.add(persistedToDBFuture.thenCompose(ignored -> enqueueWaitableVtDivSync(localVtTopicPartition)));
+        } catch (Exception e) {
+          LOGGER.error(
+              "event=globalRtDiv Failed to force Global RT DIV sync for replica: {} broker: {}",
+              localVtTopicPartition,
+              brokerUrl,
+              e);
+        }
+      }
+    }
+
+    // Follower, or leader with no RT progress / no RT brokers: force a waitable VT DIV snapshot sync.
+    if (futures.isEmpty()) {
+      futures.add(enqueueWaitableVtDivSync(localVtTopicPartition));
+    }
+
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+  }
+
+  /**
+   * Enqueues a waitable {@code SYNC_GLOBAL_RT_DIV} drainer command, returning a future that fails (rather than throwing)
+   * if interrupted so the graceful-shutdown await never hangs.
+   */
+  private CompletableFuture<Void> enqueueWaitableVtDivSync(PubSubTopicPartition localVtTopicPartition) {
+    try {
+      return storeBufferService.execSyncGlobalRtDivCommandAsync(localVtTopicPartition, this);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      CompletableFuture<Void> failed = new CompletableFuture<>();
+      failed.completeExceptionally(e);
+      return failed;
+    }
   }
 
   @Override
@@ -4351,21 +4434,25 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    * Upon completion, the {@link LeaderProducerCallback} will write the {@link GlobalRtDivState} to the StorageEngine.
    * When the drainer receives a Global RT DIV, that is the signal to sync the VT DIV to the OffsetRecord.
    * NOTE: This method is called per-broker. The broker url is included in the key.
-   * @param previousMessage the last RT message that was validated and produced to kafka before this GlobalRtDiv
-   *                        will be produced.
+   * @param previousPosition the latest consumed RT position (LCRP) up to which the RT DIV has been validated;
+   *                         serialized into the {@link GlobalRtDivState} and stamped on the produced record.
+   * @param topicPartition the topic-partition of the record that triggered this produce (used for routing/logging).
+   * @return the {@link LeaderProducerCallback} installed on the produce, whose
+   *         {@link LeaderProducerCallback#getLeaderProducedRecordContext()} exposes the persist future; callers in the
+   *         steady-state path may ignore it.
    */
-  void sendGlobalRtDivMessage(
-      DefaultPubSubMessage previousMessage,
+  LeaderProducerCallback sendGlobalRtDivMessage(
+      PubSubPosition previousPosition,
+      PubSubTopicPartition topicPartition,
       PartitionConsumptionState pcs,
       int partition,
       String brokerUrl,
       long beforeProcessingRecordTimestampNs,
       int kafkaClusterId) {
     final byte[] keyBytes = getGlobalRtDivKeyBytes(partition, brokerUrl);
-    final PubSubTopicPartition topicPartition = previousMessage.getTopicPartition();
     TopicType realTimeTopicType = TopicType.of(REALTIME_TOPIC_TYPE, brokerUrl);
     LeaderMetadataWrapper leaderMetadataWrapper =
-        new LeaderMetadataWrapper(previousMessage.getPosition(), kafkaClusterId, DEFAULT_TERM_ID);
+        new LeaderMetadataWrapper(previousPosition, kafkaClusterId, DEFAULT_TERM_ID);
 
     // Snapshot the RT DIV (single broker URL) in preparation to be produced
     // VT DIV contains the latest consumed VT position (LCVP)
@@ -4375,11 +4462,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     Map<CharSequence, ProducerPartitionState> rtDivPartitionStates = rtDiv.getPartitionStates(realTimeTopicType);
 
     // Create GlobalRtDivState (RT DIV + LCRP) and serialize into a byte array. Try compression.
-    final byte[] valueBytes = createGlobalRtDivValueBytes(previousMessage, brokerUrl, rtDivPartitionStates);
+    final byte[] valueBytes =
+        createGlobalRtDivValueBytes(previousPosition, topicPartition, brokerUrl, rtDivPartitionStates);
 
     // The callback onCompletionFunction sends the VT DIV + LCVP to the drainer after producing to VT successfully
     final LeaderProducerCallback divCallback = createGlobalRtDivCallback(
-        previousMessage,
+        previousPosition,
         pcs,
         partition,
         brokerUrl,
@@ -4407,7 +4495,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         "event=globalRtDiv Sending Global RT DIV message for topic-partition: {} versionTopic: {} LCRP: {} broker: {} producerCount: {}, valueSize: {}",
         topicPartition,
         versionTopic,
-        previousMessage.getPosition(),
+        previousPosition,
         brokerUrl,
         rtDivPartitionStates.size(),
         valueBytes.length);
@@ -4429,13 +4517,14 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             true);
 
     pcs.resetConsumedBytesSinceLastGlobalRtDivSync(brokerUrl);
+    return divCallback;
   }
 
   private byte[] createGlobalRtDivValueBytes(
-      DefaultPubSubMessage previousMessage,
+      PubSubPosition previousPosition,
+      PubSubTopicPartition topicPartition,
       String brokerUrl,
       Map<CharSequence, ProducerPartitionState> rtDivPartitionStates) {
-    final PubSubPosition previousPosition = previousMessage.getPosition();
     GlobalRtDivState globalRtDiv =
         new GlobalRtDivState(brokerUrl, rtDivPartitionStates, previousPosition.toWireFormatBuffer());
     byte[] valueBytes = ByteUtils.extractByteArray(globalRtDivStateSerializer.serialize(globalRtDiv));
@@ -4444,7 +4533,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     } catch (IOException e) {
       LOGGER.error(
           "Failed to compress GlobalRtDivState for replica: {}. Will proceed without {} compression.",
-          previousMessage.getTopicPartition(),
+          topicPartition,
           compressionStrategy,
           e);
     }
@@ -4452,7 +4541,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   private LeaderProducerCallback createGlobalRtDivCallback(
-      DefaultPubSubMessage prevMessage,
+      PubSubPosition previousPosition,
       PartitionConsumptionState pcs,
       int partition,
       String brokerUrl,
@@ -4481,11 +4570,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         divKey,
         divEnvelope,
         topicPartition,
-        prevMessage.getPosition(),
+        previousPosition,
         System.currentTimeMillis(),
         divKey.getKeyLength() + valueBytes.length);
     LeaderProducedRecordContext context =
-        LeaderProducedRecordContext.newPutRecord(kafkaClusterId, prevMessage.getPosition(), keyBytes, put);
+        LeaderProducedRecordContext.newPutRecord(kafkaClusterId, previousPosition, keyBytes, put);
     LeaderProducerCallback divCallback =
         createProducerCallback(divMessage, pcs, context, partition, brokerUrl, beforeProcessingRecordTimestampNs);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3894,6 +3894,20 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     pcs.setLatestConsumedRtPosition(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, pubSubPosition);
   }
 
+  /**
+   * Store the DIV RT checkpoint position (LCRP) loaded from a per-broker GlobalRtDivState during the F->L transition.
+   * Keyed under the single {@link OffsetRecord#NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY} for non-A/A: that is the key
+   * the leader-start path reads back via {@link PartitionConsumptionState#getLeaderPosition} to resume from the
+   * checkpoint. Writing it under the broker URL instead would never be read for non-A/A. A/A overrides this to key by
+   * broker URL, matching its per-broker leader-start read.
+   */
+  protected void updateDivRtCheckpointPosition(
+      PartitionConsumptionState pcs,
+      String ignoredPubSubBrokerAddress,
+      PubSubPosition divRtCheckpointPosition) {
+    pcs.setDivRtCheckpointPosition(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, divRtCheckpointPosition);
+  }
+
   @Override
   protected void consumerBatchUnsubscribeAllTopics() {
     Set<PubSubTopicPartition> allPartitions = new HashSet<>();
@@ -4811,7 +4825,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     ByteBuffer checkpointBytes = globalRtDivState.getLatestPubSubPosition(); // LCRP
     PubSubPosition divRtCheckpointPosition =
         getPubSubContext().getPubSubPositionDeserializer().toPosition(checkpointBytes);
-    pcs.setDivRtCheckpointPosition(brokerUrl, divRtCheckpointPosition);
+    // Store under the per-mode key the leader-start path reads back (non-A/A: NON_AA key; A/A: broker URL). A direct
+    // setDivRtCheckpointPosition(brokerUrl, ...) would never be read for non-A/A, so the F->L resume would fall back to
+    // a rewind-based start instead of the persisted checkpoint.
+    updateDivRtCheckpointPosition(pcs, brokerUrl, divRtCheckpointPosition);
 
     producerStates.forEach((producer, pps) -> {
       // TODO: remove. this is a temporary log for debugging while the feature is in its infancy

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2472,7 +2472,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     if (pcs.getLeaderFollowerState().equals(LEADER)) {
       Set<String> realTimeDataSourceKafkaURLs = getRealTimeDataSourceKafkaAddress(pcs);
       for (String brokerUrl: realTimeDataSourceKafkaURLs) {
-        PubSubPosition lcrp = pcs.getLatestConsumedRtPosition(brokerUrl);
+        // Read the LCRP through the per-mode accessor (same one the steady-state RT consume path uses): A/A keys the
+        // latestConsumedRtPositions map by broker URL, but non-A/A (incl. all system stores) keys it by
+        // NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY. A direct getLatestConsumedRtPosition(brokerUrl) would always miss
+        // for non-A/A and return EARLIEST, silently skipping the leader RT DIV flush.
+        PubSubPosition lcrp = getLatestConsumedUpstreamPositionForHybridOffsetLagMeasurement(pcs, brokerUrl);
         // Skip brokers with no RT progress: producing/persisting EARLIEST would force a re-subscribe from EARLIEST on
         // restart (mirrors the EARLIEST-LCVP guard in sendVtDivSnapshotIfNeeded).
         if (PubSubSymbolicPosition.EARLIEST.equals(lcrp)) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2412,20 +2412,38 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    * Shared by {@link #createGlobalRtDivCallback} (leader-RT-source) and
    * {@link #addVtDivToProducerCallbackIfNeeded} (leader-VT-source).
    */
-  private void sendVtDivSnapshotOnCompletion(
+  private CompletableFuture<Void> sendVtDivSnapshotOnCompletion(
       LeaderProducerCallback callback,
       PubSubTopicPartition topicPartition,
       PartitionTracker vtDiv,
       CompletableFuture<Void> persistedToDBFuture) {
+    // Relay future the leader graceful-shutdown path awaits. It completes when the drainer-side VT DIV sync node has
+    // run. The leader-produce callback only fires on produce success, so also fail the relay if the produce/persist
+    // fails — otherwise the shutdown await would hang until its timeout instead of completing promptly.
+    CompletableFuture<Void> vtDivSyncedFuture = new CompletableFuture<>();
+    persistedToDBFuture.whenComplete((ignored, throwable) -> {
+      if (throwable != null) {
+        vtDivSyncedFuture.completeExceptionally(throwable);
+      }
+    });
     callback.setOnCompletionCallback(produceResult -> {
       try {
         vtDiv.updateLatestConsumedVtPosition(produceResult.getPubSubPosition());
-        storeBufferService.execSyncOffsetFromSnapshotAsync(topicPartition, vtDiv, persistedToDBFuture, this);
+        storeBufferService.execSyncOffsetFromSnapshotAsync(topicPartition, vtDiv, persistedToDBFuture, this)
+            .whenComplete((ignored, throwable) -> {
+              if (throwable != null) {
+                vtDivSyncedFuture.completeExceptionally(throwable);
+              } else {
+                vtDivSyncedFuture.complete(null);
+              }
+            });
       } catch (InterruptedException e) {
         LOGGER.error("event=globalRtDiv Failed to async VT DIV OffsetRecord sync for replica: {}", topicPartition, e);
         Thread.currentThread().interrupt();
+        vtDivSyncedFuture.completeExceptionally(e);
       }
     });
+    return vtDivSyncedFuture;
   }
 
   /**
@@ -2434,10 +2452,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    *
    * <ul>
    *   <li><b>Leader:</b> for each RT source broker, produce one {@link GlobalRtDivState} (carrying the latest consumed
-   *       RT position, LCRP) to the local VT via {@link #sendGlobalRtDivMessage}. Its callback already chains the VT DIV
-   *       + LCVP sync, so the RT produce covers both halves. After the produce persists, a waitable Global RT DIV sync
-   *       node is enqueued so the aggregate future completes only once the chained VT DIV sync (which the single-threaded
-   *       drainer runs FIFO before this node) has run. Brokers whose LCRP is
+   *       RT position, LCRP) to the local VT via {@link #sendGlobalRtDivMessage}. Its produce-completion callback enqueues
+   *       a single waitable VT DIV + LCVP sync node into the FIFO drainer (carrying the produced LCVP), so the RT produce
+   *       covers both halves; {@code sendGlobalRtDivMessage} returns that node's future, which completes only after the RT
+   *       DIV produce has persisted and the VT DIV sync has run. Brokers whose LCRP is
    *       {@link PubSubSymbolicPosition#EARLIEST} are skipped (no RT progress yet).</li>
    *   <li><b>Follower / leader with no RT progress or no RT brokers:</b> force a single waitable VT DIV snapshot sync.
    *       RT DIV is already durable in the StorageEngine from when the follower consumed {@link GlobalRtDivState}.</li>
@@ -2464,19 +2482,19 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         // variants that the forward id->url map lacks), matching how the steady-state RT consume path resolves it.
         int kafkaClusterId = getServerConfig().getKafkaClusterUrlToIdMap().getOrDefault(brokerUrl, -1);
         try {
-          LeaderProducerCallback divCallback = sendGlobalRtDivMessage(
-              lcrp,
-              localVtTopicPartition,
-              pcs,
-              partition,
-              brokerUrl,
-              System.nanoTime(),
-              kafkaClusterId);
-          CompletableFuture<Void> persistedToDBFuture =
-              divCallback.getLeaderProducedRecordContext().getPersistedToDBFuture();
-          // After the RT DIV produce persists (its callback already chained the VT DIV sync into the FIFO drainer),
-          // enqueue a waitable VT DIV sync so the aggregate future deterministically covers the chained VT sync too.
-          futures.add(persistedToDBFuture.thenCompose(ignored -> enqueueWaitableVtDivSync(localVtTopicPartition)));
+          // sendGlobalRtDivMessage's produce-completion callback enqueues the waitable VT DIV sync node (carrying the
+          // produced LCVP) into the FIFO drainer. Await that node's future directly: it completes only after the RT DIV
+          // produce has persisted and the VT DIV + LCVP have been synced to the OffsetRecord — no second redundant
+          // sync.
+          futures.add(
+              sendGlobalRtDivMessage(
+                  lcrp,
+                  localVtTopicPartition,
+                  pcs,
+                  partition,
+                  brokerUrl,
+                  System.nanoTime(),
+                  kafkaClusterId));
         } catch (Exception e) {
           LOGGER.error(
               "event=globalRtDiv Failed to force Global RT DIV sync for replica: {} broker: {}",
@@ -4437,11 +4455,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    * @param previousPosition the latest consumed RT position (LCRP) up to which the RT DIV has been validated;
    *                         serialized into the {@link GlobalRtDivState} and stamped on the produced record.
    * @param topicPartition the topic-partition of the record that triggered this produce (used for routing/logging).
-   * @return the {@link LeaderProducerCallback} installed on the produce, whose
-   *         {@link LeaderProducerCallback#getLeaderProducedRecordContext()} exposes the persist future; callers in the
-   *         steady-state path may ignore it.
+   * @return a future that completes once the produce has persisted and the chained VT DIV + LCVP sync node has run on
+   *         the drainer; the graceful-shutdown leader path awaits it, while steady-state callers ignore it.
    */
-  LeaderProducerCallback sendGlobalRtDivMessage(
+  CompletableFuture<Void> sendGlobalRtDivMessage(
       PubSubPosition previousPosition,
       PubSubTopicPartition topicPartition,
       PartitionConsumptionState pcs,
@@ -4465,7 +4482,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     final byte[] valueBytes =
         createGlobalRtDivValueBytes(previousPosition, topicPartition, brokerUrl, rtDivPartitionStates);
 
-    // The callback onCompletionFunction sends the VT DIV + LCVP to the drainer after producing to VT successfully
     final LeaderProducerCallback divCallback = createGlobalRtDivCallback(
         previousPosition,
         pcs,
@@ -4475,8 +4491,17 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         kafkaClusterId,
         keyBytes,
         valueBytes,
+        topicPartition);
+
+    // Install the produce-completion callback that sends the VT DIV + LCVP to the drainer after producing to VT
+    // successfully. Must be set before the produce below so the callback is registered before the produce can complete.
+    // The returned future completes once that drainer-side VT DIV sync has run; the graceful-shutdown leader path
+    // awaits it while steady-state callers ignore it.
+    CompletableFuture<Void> vtDivSyncedFuture = sendVtDivSnapshotOnCompletion(
+        divCallback,
         topicPartition,
-        vtDiv);
+        vtDiv,
+        divCallback.getLeaderProducedRecordContext().getPersistedToDBFuture());
 
     // Read the old manifest (if any) so VeniceWriter can delete orphaned old chunks in Kafka.
     ChunkedValueManifestContainer valueManifestContainer = new ChunkedValueManifestContainer();
@@ -4517,7 +4542,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             true);
 
     pcs.resetConsumedBytesSinceLastGlobalRtDivSync(brokerUrl);
-    return divCallback;
+    return vtDivSyncedFuture;
   }
 
   private byte[] createGlobalRtDivValueBytes(
@@ -4549,8 +4574,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       int kafkaClusterId,
       byte[] keyBytes,
       byte[] valueBytes,
-      PubSubTopicPartition topicPartition,
-      PartitionTracker vtDiv) {
+      PubSubTopicPartition topicPartition) {
     final int schemaId = AvroProtocolDefinition.GLOBAL_RT_DIV_STATE.getCurrentProtocolVersion();
     KafkaKey divKey = new KafkaKey(MessageType.GLOBAL_RT_DIV, keyBytes);
     KafkaMessageEnvelope divEnvelope = getVeniceWriter(pcs).get()
@@ -4575,13 +4599,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         divKey.getKeyLength() + valueBytes.length);
     LeaderProducedRecordContext context =
         LeaderProducedRecordContext.newPutRecord(kafkaClusterId, previousPosition, keyBytes, put);
-    LeaderProducerCallback divCallback =
-        createProducerCallback(divMessage, pcs, context, partition, brokerUrl, beforeProcessingRecordTimestampNs);
-
-    // After producing the RT DIV to local VT, the drainer should sync the VT DIV + LCVP within the OffsetRecord
-    sendVtDivSnapshotOnCompletion(divCallback, topicPartition, vtDiv, context.getPersistedToDBFuture());
-
-    return divCallback;
+    return createProducerCallback(divMessage, pcs, context, partition, brokerUrl, beforeProcessingRecordTimestampNs);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2435,9 +2435,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    * <ul>
    *   <li><b>Leader:</b> for each RT source broker, produce one {@link GlobalRtDivState} (carrying the latest consumed
    *       RT position, LCRP) to the local VT via {@link #sendGlobalRtDivMessage}. Its callback already chains the VT DIV
-   *       + LCVP sync, so the RT produce covers both halves. After the produce persists, a waitable
-   *       {@code SYNC_GLOBAL_RT_DIV} command is enqueued so the aggregate future completes only once the chained VT DIV
-   *       sync (which the single-threaded drainer runs FIFO before this command) has run. Brokers whose LCRP is
+   *       + LCVP sync, so the RT produce covers both halves. After the produce persists, a waitable Global RT DIV sync
+   *       node is enqueued so the aggregate future completes only once the chained VT DIV sync (which the single-threaded
+   *       drainer runs FIFO before this node) has run. Brokers whose LCRP is
    *       {@link PubSubSymbolicPosition#EARLIEST} are skipped (no RT progress yet).</li>
    *   <li><b>Follower / leader with no RT progress or no RT brokers:</b> force a single waitable VT DIV snapshot sync.
    *       RT DIV is already durable in the StorageEngine from when the follower consumed {@link GlobalRtDivState}.</li>
@@ -2496,12 +2496,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   /**
-   * Enqueues a waitable {@code SYNC_GLOBAL_RT_DIV} drainer command, returning a future that fails (rather than throwing)
-   * if interrupted so the graceful-shutdown await never hangs.
+   * Enqueues a waitable Global RT DIV sync on the drainer, returning a future that fails (rather than throwing) if
+   * interrupted so the graceful-shutdown await never hangs.
    */
   private CompletableFuture<Void> enqueueWaitableVtDivSync(PubSubTopicPartition localVtTopicPartition) {
     try {
-      return storeBufferService.execSyncGlobalRtDivCommandAsync(localVtTopicPartition, this);
+      return storeBufferService.execSyncGlobalRtDivAsync(localVtTopicPartition, this);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       CompletableFuture<Void> failed = new CompletableFuture<>();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -93,6 +93,10 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
             sourceConsumerRecord.getTopicPartition(),
             e);
       }
+      // Produce failed: complete the persisted-to-DB future exceptionally so waiters fail fast instead of blocking
+      // indefinitely (e.g. leader topic-switch's getLastLeaderPersistFuture().get(), and the graceful-shutdown Global
+      // RT DIV sync relay, which keys its fail-fast off this future). On success it is completed in the drainer.
+      leaderProducedRecordContext.completePersistedToDBFuture(e);
     } else {
       long currentTimeForMetricsMs = System.currentTimeMillis();
       /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -76,6 +76,10 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
     this.beforeProcessingRecordTimestampNs = beforeProcessingRecordTimestampNs;
   }
 
+  LeaderProducedRecordContext getLeaderProducedRecordContext() {
+    return leaderProducedRecordContext;
+  }
+
   @Override
   public void onCompletion(PubSubProduceResult produceResult, Exception e) {
     this.onCompletionFunction.accept(produceResult);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferService.java
@@ -103,10 +103,10 @@ public class SeparatedStoreBufferService extends AbstractStoreBufferService {
   }
 
   @Override
-  public CompletableFuture<Void> execSyncGlobalRtDivCommandAsync(
+  public CompletableFuture<Void> execSyncGlobalRtDivAsync(
       PubSubTopicPartition topicPartition,
       StoreIngestionTask ingestionTask) throws InterruptedException {
-    return getDelegate(ingestionTask).execSyncGlobalRtDivCommandAsync(topicPartition, ingestionTask);
+    return getDelegate(ingestionTask).execSyncGlobalRtDivAsync(topicPartition, ingestionTask);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferService.java
@@ -110,12 +110,12 @@ public class SeparatedStoreBufferService extends AbstractStoreBufferService {
   }
 
   @Override
-  public void execSyncOffsetFromSnapshotAsync(
+  public CompletableFuture<Void> execSyncOffsetFromSnapshotAsync(
       PubSubTopicPartition topicPartition,
       PartitionTracker vtDivSnapshot,
       CompletableFuture<Void> lastRecordPersistedFuture,
       StoreIngestionTask ingestionTask) throws InterruptedException {
-    getDelegate(ingestionTask)
+    return getDelegate(ingestionTask)
         .execSyncOffsetFromSnapshotAsync(topicPartition, vtDivSnapshot, lastRecordPersistedFuture, ingestionTask);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferService.java
@@ -103,6 +103,13 @@ public class SeparatedStoreBufferService extends AbstractStoreBufferService {
   }
 
   @Override
+  public CompletableFuture<Void> execSyncGlobalRtDivCommandAsync(
+      PubSubTopicPartition topicPartition,
+      StoreIngestionTask ingestionTask) throws InterruptedException {
+    return getDelegate(ingestionTask).execSyncGlobalRtDivCommandAsync(topicPartition, ingestionTask);
+  }
+
+  @Override
   public void execSyncOffsetFromSnapshotAsync(
       PubSubTopicPartition topicPartition,
       PartitionTracker vtDivSnapshot,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -277,9 +277,10 @@ public class StoreBufferService extends AbstractStoreBufferService {
       CommandQueueNode cmd,
       StoreIngestionTask ingestionTask,
       PartitionConsumptionState pcs) {
-    // We only support SYNC_OFFSET command for now.
-    if (cmd.getCommandType() != CommandQueueNode.CommandType.SYNC_OFFSET) {
-      throw new VeniceException("Unsupported command type: " + cmd.getCommandType());
+    CommandQueueNode.CommandType commandType = cmd.getCommandType();
+    if (commandType != CommandQueueNode.CommandType.SYNC_OFFSET
+        && commandType != CommandQueueNode.CommandType.SYNC_GLOBAL_RT_DIV) {
+      throw new VeniceException("Unsupported command type: " + commandType);
     }
 
     cmd.executeSync(() -> {
@@ -287,7 +288,9 @@ public class StoreBufferService extends AbstractStoreBufferService {
         LOGGER.warn(
             "PCS for topic-partition: {} is null. Skipping {} command in StoreBufferDrainer.",
             cmd.getConsumerRecord().getTopicPartition(),
-            cmd.getCommandType());
+            commandType);
+      } else if (commandType == CommandQueueNode.CommandType.SYNC_GLOBAL_RT_DIV) {
+        ingestionTask.syncGlobalRtDivFromSnapshot(cmd.getConsumerRecord().getTopicPartition());
       } else {
         ingestionTask.updateOffsetMetadataAndSyncOffset(pcs);
       }
@@ -335,11 +338,33 @@ public class StoreBufferService extends AbstractStoreBufferService {
   public CompletableFuture<Void> execSyncOffsetCommandAsync(
       PubSubTopicPartition topicPartition,
       StoreIngestionTask ingestionTask) throws InterruptedException {
+    return execCommandAsync(CommandQueueNode.CommandType.SYNC_OFFSET, topicPartition, ingestionTask);
+  }
+
+  /**
+   * Enqueues a waitable {@code SYNC_GLOBAL_RT_DIV} command. The drainer snapshots the VT DIV and syncs it to the
+   * OffsetRecord (see {@link StoreIngestionTask#syncGlobalRtDivFromSnapshot}). Unlike the fire-and-forget
+   * {@link SyncVtDivNode}, the returned future lets the graceful-shutdown path await completion deterministically.
+   */
+  @Override
+  public CompletableFuture<Void> execSyncGlobalRtDivCommandAsync(
+      PubSubTopicPartition topicPartition,
+      StoreIngestionTask ingestionTask) throws InterruptedException {
+    return execCommandAsync(CommandQueueNode.CommandType.SYNC_GLOBAL_RT_DIV, topicPartition, ingestionTask);
+  }
+
+  /**
+   * Enqueues a waitable drainer {@link CommandQueueNode} of the given {@code commandType} for the partition and returns
+   * its executed-future.
+   */
+  private CompletableFuture<Void> execCommandAsync(
+      CommandQueueNode.CommandType commandType,
+      PubSubTopicPartition topicPartition,
+      StoreIngestionTask ingestionTask) throws InterruptedException {
     DefaultPubSubMessage fakeRecord = new FakePubSubMessage(topicPartition);
-    CommandQueueNode syncOffsetCmd =
-        new CommandQueueNode(CommandQueueNode.CommandType.SYNC_OFFSET, fakeRecord, ingestionTask);
-    getDrainerForConsumerRecord(fakeRecord, topicPartition.getPartitionNumber()).put(syncOffsetCmd);
-    return syncOffsetCmd.getCmdExecutedFuture();
+    CommandQueueNode commandNode = new CommandQueueNode(commandType, fakeRecord, ingestionTask);
+    getDrainerForConsumerRecord(fakeRecord, topicPartition.getPartitionNumber()).put(commandNode);
+    return commandNode.getCmdExecutedFuture();
   }
 
   /**
@@ -627,8 +652,11 @@ public class StoreBufferService extends AbstractStoreBufferService {
         getClassOverhead(CommandQueueNode.class) + getClassOverhead(LockAssistedCompletableFuture.class);
 
     enum CommandType {
-      // only supports SYNC_OFFSET command today.
-      SYNC_OFFSET
+      // SYNC_OFFSET: drain-side OffsetRecord sync used by the non-Global-RT-DIV graceful-shutdown path.
+      SYNC_OFFSET,
+      // SYNC_GLOBAL_RT_DIV: snapshot VT DIV in the drainer thread and sync it to the OffsetRecord. Used by the
+      // Global-RT-DIV graceful-shutdown path for followers / leaders with no RT progress.
+      SYNC_GLOBAL_RT_DIV
     }
 
     private final LockAssistedCompletableFuture<Void> cmdExecutedFuture;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -362,8 +362,13 @@ public class StoreBufferService extends AbstractStoreBufferService {
    * 1. From the follower code path, it is lastQueuedRecordPersistedFuture from the PCS set in putConsumeRecord().
    * 2. From the leader side, it is the persistedToDBFuture from the LeaderProducedRecordContext from when the
    *    LeaderProducerCallback was created.
+   *
+   * <p>Returns the node's completion future. Steady-state callers ignore it (fire-and-forget); the graceful-shutdown
+   * leader path awaits it so the aggregate shutdown future deterministically covers this VT DIV sync without enqueuing a
+   * second redundant {@link SyncGlobalRtDivNode}.
    */
-  public void execSyncOffsetFromSnapshotAsync(
+  @Override
+  public CompletableFuture<Void> execSyncOffsetFromSnapshotAsync(
       PubSubTopicPartition topicPartition,
       PartitionTracker vtDivSnapshot,
       CompletableFuture<Void> lastRecordPersistedFuture,
@@ -371,6 +376,7 @@ public class StoreBufferService extends AbstractStoreBufferService {
     DefaultPubSubMessage fakeRecord = new FakePubSubMessage(topicPartition);
     SyncVtDivNode syncDivNode = new SyncVtDivNode(fakeRecord, vtDivSnapshot, lastRecordPersistedFuture, ingestionTask);
     getDrainerForConsumerRecord(fakeRecord, topicPartition.getPartitionNumber()).put(syncDivNode);
+    return syncDivNode.getExecutedFuture();
   }
 
   @Override
@@ -758,10 +764,14 @@ public class StoreBufferService extends AbstractStoreBufferService {
   }
 
   /**
-   * Allows the ConsumptionTask to command the Drainer to sync the VT DIV to the OffsetRecord.
+   * Allows the ConsumptionTask to command the Drainer to sync the VT DIV to the OffsetRecord. Waitable: the leader
+   * graceful-shutdown path ({@link StoreIngestionTask#forceGlobalRtDivSync}) awaits {@link #getExecutedFuture()} on the
+   * node enqueued by the leader-produce completion callback, so it does not need to enqueue a second redundant
+   * {@link SyncGlobalRtDivNode}. Steady-state callers enqueue it fire-and-forget and ignore the future.
    */
-  static class SyncVtDivNode extends QueueNode {
-    private static final int PARTIAL_CLASS_OVERHEAD = getClassOverhead(SyncVtDivNode.class);
+  static class SyncVtDivNode extends WaitableQueueNode {
+    private static final int PARTIAL_CLASS_OVERHEAD =
+        getClassOverhead(SyncVtDivNode.class) + getClassOverhead(LockAssistedCompletableFuture.class);
 
     private final PartitionTracker vtDivSnapshot;
     private final CompletableFuture<Void> lastRecordPersistedFuture;
@@ -771,21 +781,23 @@ public class StoreBufferService extends AbstractStoreBufferService {
         PartitionTracker vtDivSnapshot,
         CompletableFuture<Void> lastRecordPersistedFuture,
         StoreIngestionTask ingestionTask) {
-      super(consumerRecord, ingestionTask, StringUtils.EMPTY, 0);
+      super(consumerRecord, ingestionTask);
       this.vtDivSnapshot = vtDivSnapshot;
       this.lastRecordPersistedFuture = lastRecordPersistedFuture;
     }
 
     public void execute() {
-      if (!lastRecordPersistedFuture.isDone() || lastRecordPersistedFuture.isCompletedExceptionally()) {
-        LOGGER.warn(
-            "event=globalRtDiv Skipping SyncVtDivNode for {} because preceding record failed (done={} exception={})",
-            getConsumerRecord().getTopicPartition(),
-            lastRecordPersistedFuture.isDone(),
-            lastRecordPersistedFuture.isCompletedExceptionally());
-        return;
-      }
-      getIngestionTask().updateAndSyncOffsetFromSnapshot(vtDivSnapshot, getConsumerRecord().getTopicPartition());
+      executeGuarded(() -> {
+        if (!lastRecordPersistedFuture.isDone() || lastRecordPersistedFuture.isCompletedExceptionally()) {
+          LOGGER.warn(
+              "event=globalRtDiv Skipping SyncVtDivNode for {} because preceding record failed (done={} exception={})",
+              getConsumerRecord().getTopicPartition(),
+              lastRecordPersistedFuture.isDone(),
+              lastRecordPersistedFuture.isCompletedExceptionally());
+          return;
+        }
+        getIngestionTask().updateAndSyncOffsetFromSnapshot(vtDivSnapshot, getConsumerRecord().getTopicPartition());
+      });
     }
 
     @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -277,20 +277,17 @@ public class StoreBufferService extends AbstractStoreBufferService {
       CommandQueueNode cmd,
       StoreIngestionTask ingestionTask,
       PartitionConsumptionState pcs) {
-    CommandQueueNode.CommandType commandType = cmd.getCommandType();
-    if (commandType != CommandQueueNode.CommandType.SYNC_OFFSET
-        && commandType != CommandQueueNode.CommandType.SYNC_GLOBAL_RT_DIV) {
-      throw new VeniceException("Unsupported command type: " + commandType);
+    // We only support SYNC_OFFSET command for now.
+    if (cmd.getCommandType() != CommandQueueNode.CommandType.SYNC_OFFSET) {
+      throw new VeniceException("Unsupported command type: " + cmd.getCommandType());
     }
 
-    cmd.executeSync(() -> {
+    cmd.executeGuarded(() -> {
       if (pcs == null) {
         LOGGER.warn(
             "PCS for topic-partition: {} is null. Skipping {} command in StoreBufferDrainer.",
             cmd.getConsumerRecord().getTopicPartition(),
-            commandType);
-      } else if (commandType == CommandQueueNode.CommandType.SYNC_GLOBAL_RT_DIV) {
-        ingestionTask.syncGlobalRtDivFromSnapshot(cmd.getConsumerRecord().getTopicPartition());
+            cmd.getCommandType());
       } else {
         ingestionTask.updateOffsetMetadataAndSyncOffset(pcs);
       }
@@ -338,33 +335,26 @@ public class StoreBufferService extends AbstractStoreBufferService {
   public CompletableFuture<Void> execSyncOffsetCommandAsync(
       PubSubTopicPartition topicPartition,
       StoreIngestionTask ingestionTask) throws InterruptedException {
-    return execCommandAsync(CommandQueueNode.CommandType.SYNC_OFFSET, topicPartition, ingestionTask);
+    DefaultPubSubMessage fakeRecord = new FakePubSubMessage(topicPartition);
+    CommandQueueNode syncOffsetCmd =
+        new CommandQueueNode(CommandQueueNode.CommandType.SYNC_OFFSET, fakeRecord, ingestionTask);
+    getDrainerForConsumerRecord(fakeRecord, topicPartition.getPartitionNumber()).put(syncOffsetCmd);
+    return syncOffsetCmd.getExecutedFuture();
   }
 
   /**
-   * Enqueues a waitable {@code SYNC_GLOBAL_RT_DIV} command. The drainer snapshots the VT DIV and syncs it to the
-   * OffsetRecord (see {@link StoreIngestionTask#syncGlobalRtDivFromSnapshot}). Unlike the fire-and-forget
-   * {@link SyncVtDivNode}, the returned future lets the graceful-shutdown path await completion deterministically.
+   * Enqueues a waitable {@link SyncGlobalRtDivNode}. The drainer snapshots the VT DIV and syncs it to the OffsetRecord
+   * (see {@link StoreIngestionTask#syncGlobalRtDivFromSnapshot}). Unlike the fire-and-forget {@link SyncVtDivNode}, the
+   * returned future lets the graceful-shutdown path await completion deterministically.
    */
   @Override
-  public CompletableFuture<Void> execSyncGlobalRtDivCommandAsync(
-      PubSubTopicPartition topicPartition,
-      StoreIngestionTask ingestionTask) throws InterruptedException {
-    return execCommandAsync(CommandQueueNode.CommandType.SYNC_GLOBAL_RT_DIV, topicPartition, ingestionTask);
-  }
-
-  /**
-   * Enqueues a waitable drainer {@link CommandQueueNode} of the given {@code commandType} for the partition and returns
-   * its executed-future.
-   */
-  private CompletableFuture<Void> execCommandAsync(
-      CommandQueueNode.CommandType commandType,
+  public CompletableFuture<Void> execSyncGlobalRtDivAsync(
       PubSubTopicPartition topicPartition,
       StoreIngestionTask ingestionTask) throws InterruptedException {
     DefaultPubSubMessage fakeRecord = new FakePubSubMessage(topicPartition);
-    CommandQueueNode commandNode = new CommandQueueNode(commandType, fakeRecord, ingestionTask);
-    getDrainerForConsumerRecord(fakeRecord, topicPartition.getPartitionNumber()).put(commandNode);
-    return commandNode.getCmdExecutedFuture();
+    SyncGlobalRtDivNode syncGlobalRtDivNode = new SyncGlobalRtDivNode(fakeRecord, ingestionTask);
+    getDrainerForConsumerRecord(fakeRecord, topicPartition.getPartitionNumber()).put(syncGlobalRtDivNode);
+    return syncGlobalRtDivNode.getExecutedFuture();
   }
 
   /**
@@ -643,7 +633,56 @@ public class StoreBufferService extends AbstractStoreBufferService {
     }
   }
 
-  private static class CommandQueueNode extends QueueNode {
+  /**
+   * A {@link QueueNode} whose drainer-side execution is awaitable. It exposes a {@link LockAssistedCompletableFuture}
+   * that completes once the drainer has run the node's action, guaranteeing that a {@link CompletableFuture#cancel}
+   * cannot abort an action that is already executing (cancel and execution synchronize on the same lock).
+   */
+  private abstract static class WaitableQueueNode extends QueueNode {
+    private final LockAssistedCompletableFuture<Void> executedFuture;
+
+    WaitableQueueNode(DefaultPubSubMessage consumerRecord, StoreIngestionTask ingestionTask) {
+      super(consumerRecord, ingestionTask, StringUtils.EMPTY, 0);
+      this.executedFuture = new LockAssistedCompletableFuture<>(this);
+    }
+
+    public CompletableFuture<Void> getExecutedFuture() {
+      return executedFuture;
+    }
+
+    /**
+     * Runs {@code action} under the future's lock (so it cannot race a {@link CompletableFuture#cancel}), completing the
+     * future on success or failure. A no-op if the future was already cancelled or completed.
+     */
+    protected void executeGuarded(Runnable action) {
+      synchronized (executedFuture.getLock()) {
+        if (executedFuture.isDone() || executedFuture.isCancelled()) {
+          LOGGER.warn(
+              "Drainer node {} for {} is already done or cancelled",
+              getClass().getSimpleName(),
+              getConsumerRecord().getTopicPartition());
+          return;
+        }
+        try {
+          action.run();
+          executedFuture.complete(null);
+        } catch (Exception e) {
+          executedFuture.completeExceptionally(e);
+          LOGGER.error(
+              "Drainer node {} for {} failed",
+              getClass().getSimpleName(),
+              getConsumerRecord().getTopicPartition(),
+              e);
+        }
+      }
+    }
+  }
+
+  /**
+   * Issues a command to the drainer thread. Today the only command is {@link CommandType#SYNC_OFFSET}, the
+   * non-Global-RT-DIV graceful-shutdown OffsetRecord sync.
+   */
+  private static class CommandQueueNode extends WaitableQueueNode {
     /**
      * N.B.: We don't want to recurse fully into the {@link CompletableFuture}, but we do want to take into account an
      * "empty" one.
@@ -652,14 +691,9 @@ public class StoreBufferService extends AbstractStoreBufferService {
         getClassOverhead(CommandQueueNode.class) + getClassOverhead(LockAssistedCompletableFuture.class);
 
     enum CommandType {
-      // SYNC_OFFSET: drain-side OffsetRecord sync used by the non-Global-RT-DIV graceful-shutdown path.
-      SYNC_OFFSET,
-      // SYNC_GLOBAL_RT_DIV: snapshot VT DIV in the drainer thread and sync it to the OffsetRecord. Used by the
-      // Global-RT-DIV graceful-shutdown path for followers / leaders with no RT progress.
-      SYNC_GLOBAL_RT_DIV
+      // only supports SYNC_OFFSET command today.
+      SYNC_OFFSET
     }
-
-    private final LockAssistedCompletableFuture<Void> cmdExecutedFuture;
 
     private final CommandType commandType;
 
@@ -667,48 +701,45 @@ public class StoreBufferService extends AbstractStoreBufferService {
         CommandType commandType,
         DefaultPubSubMessage consumerRecord,
         StoreIngestionTask ingestionTask) {
-      super(consumerRecord, ingestionTask, StringUtils.EMPTY, 0);
+      super(consumerRecord, ingestionTask);
       this.commandType = commandType;
-      this.cmdExecutedFuture = new LockAssistedCompletableFuture<>(this);
-    }
-
-    public CompletableFuture<Void> getCmdExecutedFuture() {
-      return cmdExecutedFuture;
     }
 
     public CommandType getCommandType() {
       return commandType;
     }
 
-    /*
-     * This method is used to execute the command synchronously. We use a customized LockAssistedCompletableFuture to
-     * ensure that once it is in execution, it cannot be cancelled.
-     */
-    public void executeSync(Runnable runnable) {
-      synchronized (cmdExecutedFuture.getLock()) {
-        if (cmdExecutedFuture.isDone() || cmdExecutedFuture.isCancelled()) {
-          LOGGER.warn(
-              "Command {} for {} in drainer queue is already done or cancelled",
-              commandType,
-              getConsumerRecord().getTopicPartition());
-          return;
-        }
-        try {
-          runnable.run();
-          cmdExecutedFuture.complete(null);
-          LOGGER.info(
-              "Command {} for {} in drainer queue is executed successfully",
-              commandType,
-              getConsumerRecord().getTopicPartition());
-        } catch (Exception e) {
-          cmdExecutedFuture.completeExceptionally(e);
-          LOGGER.error(
-              "Command {} for {} in drainer queue failed",
-              commandType,
-              getConsumerRecord().getTopicPartition(),
-              e);
-        }
-      }
+    @Override
+    public int hashCode() {
+      return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return super.equals(o);
+    }
+
+    protected int getBaseClassOverhead() {
+      return PARTIAL_CLASS_OVERHEAD;
+    }
+  }
+
+  /**
+   * Waitable drainer node that snapshots the VT DIV in the drainer thread and syncs it to the OffsetRecord (see
+   * {@link StoreIngestionTask#syncGlobalRtDivFromSnapshot}). Used by the Global-RT-DIV graceful-shutdown path for
+   * followers / leaders with no RT progress. Mirrors the fire-and-forget {@link SyncVtDivNode} but exposes a completion
+   * future so the shutdown path can await it.
+   */
+  private static class SyncGlobalRtDivNode extends WaitableQueueNode {
+    private static final int PARTIAL_CLASS_OVERHEAD =
+        getClassOverhead(SyncGlobalRtDivNode.class) + getClassOverhead(LockAssistedCompletableFuture.class);
+
+    public SyncGlobalRtDivNode(DefaultPubSubMessage consumerRecord, StoreIngestionTask ingestionTask) {
+      super(consumerRecord, ingestionTask);
+    }
+
+    public void execute() {
+      executeGuarded(() -> getIngestionTask().syncGlobalRtDivFromSnapshot(getConsumerRecord().getTopicPartition()));
     }
 
     @Override
@@ -825,6 +856,9 @@ public class StoreBufferService extends AbstractStoreBufferService {
             continue;
           } else if (node instanceof SyncVtDivNode) {
             ((SyncVtDivNode) node).execute();
+            continue;
+          } else if (node instanceof SyncGlobalRtDivNode) {
+            ((SyncGlobalRtDivNode) node).execute();
             continue;
           }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2301,14 +2301,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * Snapshots the VT DIV (and the latest consumed VT position) inside the drainer thread and syncs it to the
    * OffsetRecord. Because the single-threaded drainer guarantees that all previously-queued records for this partition
    * have already been processed by the time this runs, the snapshot is consistent without an explicit
-   * {@code lastQueuedRecordPersistedFuture} dependency. Invoked by {@link StoreBufferService}'s
-   * {@code SYNC_GLOBAL_RT_DIV} command for the follower / no-RT-progress shutdown path.
+   * {@code lastQueuedRecordPersistedFuture} dependency. Invoked by {@link StoreBufferService}'s waitable Global RT DIV
+   * sync node for the follower / no-RT-progress shutdown path.
    */
   protected void syncGlobalRtDivFromSnapshot(PubSubTopicPartition topicPartition) {
     int partition = topicPartition.getPartitionNumber();
     PartitionConsumptionState pcs = getPartitionConsumptionState(partition);
     if (pcs == null) {
-      LOGGER.warn("event=globalRtDiv No PCS found for {}. Skipping SYNC_GLOBAL_RT_DIV.", topicPartition);
+      LOGGER.warn("event=globalRtDiv No PCS found for {}. Skipping Global RT DIV sync.", topicPartition);
       return;
     }
     PartitionTracker vtDivSnapshot =
@@ -2318,7 +2318,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     // EARLIEST to the OffsetRecord, causing the consumer to re-subscribe from EARLIEST on restart.
     if (PubSubSymbolicPosition.EARLIEST.equals(vtDivSnapshot.getLatestConsumedVtPosition())) {
       LOGGER.info(
-          "event=globalRtDiv Skipping SYNC_GLOBAL_RT_DIV for {} because no VT progress has been made (LCVP=EARLIEST).",
+          "event=globalRtDiv Skipping Global RT DIV sync for {} because no VT progress has been made (LCVP=EARLIEST).",
           topicPartition);
       return;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2214,12 +2214,18 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       ExecutorService shutdownExecutor) {
     Runnable shutdownRunnable = () -> {
       // If the ingestion task is stopped gracefully (server stops), persist processed offset to disk.
-      // The Global RT DIV feature is entirely driven by consumer, so any drainer sync must be disabled to not interfere
-      if (getServerConfig().isServerIngestionCheckpointDuringGracefulShutdownEnabled() && !isGlobalRtDivEnabled()) {
+      if (getServerConfig().isServerIngestionCheckpointDuringGracefulShutdownEnabled()) {
         try {
           PubSubTopicPartition topicPartition = partitionConsumptionState.getReplicaTopicPartition();
-          CompletableFuture<Void> cmdFuture = getStoreBufferService().execSyncOffsetCommandAsync(topicPartition, this);
-          waitForSyncOffsetCmd(cmdFuture, topicPartition);
+          // Global RT DIV is consumer-driven, so its drainer SYNC_OFFSET path is disabled to not interfere. Instead,
+          // flush the accumulated RT/VT DIV deltas on-demand via forceGlobalRtDivSync. We are inside
+          // shutdownPartitionConsumptionStates() (after consumerBatchUnsubscribeAllTopics, before closeVeniceWriters),
+          // so the VeniceWriter is alive and no new RT records are arriving. Both paths await with the shutdown
+          // sync-offset timeout, reusing waitForSyncOffsetCmd's timeout/cancel semantics so shutdown never hangs.
+          CompletableFuture<Void> syncFuture = isGlobalRtDivEnabled()
+              ? forceGlobalRtDivSync(partitionConsumptionState)
+              : getStoreBufferService().execSyncOffsetCommandAsync(topicPartition, this);
+          waitForSyncOffsetCmd(syncFuture, topicPartition);
           waitForAllMessageToBeProcessedFromTopicPartition(topicPartition, partitionConsumptionState);
         } catch (InterruptedException e) {
           throw new VeniceException(e);
@@ -2289,6 +2295,34 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     vtDivSnapshot.updateOffsetRecord(PartitionTracker.VERSION_TOPIC, pcs.getOffsetRecord());
     updateOffsetMetadataInOffsetRecord(pcs);
     syncOffset(pcs);
+  }
+
+  /**
+   * Snapshots the VT DIV (and the latest consumed VT position) inside the drainer thread and syncs it to the
+   * OffsetRecord. Because the single-threaded drainer guarantees that all previously-queued records for this partition
+   * have already been processed by the time this runs, the snapshot is consistent without an explicit
+   * {@code lastQueuedRecordPersistedFuture} dependency. Invoked by {@link StoreBufferService}'s
+   * {@code SYNC_GLOBAL_RT_DIV} command for the follower / no-RT-progress shutdown path.
+   */
+  protected void syncGlobalRtDivFromSnapshot(PubSubTopicPartition topicPartition) {
+    int partition = topicPartition.getPartitionNumber();
+    PartitionConsumptionState pcs = getPartitionConsumptionState(partition);
+    if (pcs == null) {
+      LOGGER.warn("event=globalRtDiv No PCS found for {}. Skipping SYNC_GLOBAL_RT_DIV.", topicPartition);
+      return;
+    }
+    PartitionTracker vtDivSnapshot =
+        getDataIntegrityValidator().cloneVtProducerStates(partition, true, pcs.getLatestMessageTimeInMs());
+
+    // Skip sync if no real VT progress has been made yet. Syncing with EARLIEST would persist
+    // EARLIEST to the OffsetRecord, causing the consumer to re-subscribe from EARLIEST on restart.
+    if (PubSubSymbolicPosition.EARLIEST.equals(vtDivSnapshot.getLatestConsumedVtPosition())) {
+      LOGGER.info(
+          "event=globalRtDiv Skipping SYNC_GLOBAL_RT_DIV for {} because no VT progress has been made (LCVP=EARLIEST).",
+          topicPartition);
+      return;
+    }
+    updateAndSyncOffsetFromSnapshot(vtDivSnapshot, topicPartition);
   }
 
   private void handleIngestionException(Exception e, VeniceIngestionFailureReason reason, int errorPartitionId) {
@@ -3519,6 +3553,16 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   abstract void sendVtDivSnapshotIfNeeded(DefaultPubSubMessage record, PubSubTopicPartition topicPartition);
+
+  /**
+   * On-demand Global RT DIV flush invoked at graceful shutdown (see {@link #executeShutdownRunnable}). Flushes both the
+   * RT and VT DIV state that has accumulated since the last byte-threshold-triggered sync, returning a future that
+   * completes once the flush has fully persisted. The base implementation is a no-op (returns an already-completed
+   * future); only {@link LeaderFollowerStoreIngestionTask} performs real work.
+   */
+  protected CompletableFuture<Void> forceGlobalRtDivSync(PartitionConsumptionState pcs) {
+    return CompletableFuture.completedFuture(null);
+  }
 
   /**
    * Update the offset metadata in OffsetRecord in the following cases:

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2292,6 +2292,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    */
   protected void updateAndSyncOffsetFromSnapshot(PartitionTracker vtDivSnapshot, PubSubTopicPartition topicPartition) {
     PartitionConsumptionState pcs = getPartitionConsumptionState(topicPartition.getPartitionNumber());
+    if (pcs == null) {
+      // The PCS can be removed between the sync node being enqueued and executed (e.g. during shutdown/unsubscribe).
+      // Skip cleanly rather than NPE so the drainer node completes normally and the shutdown await stays deterministic.
+      LOGGER.warn("event=globalRtDiv No PCS found for {}. Skipping VT DIV OffsetRecord sync.", topicPartition);
+      return;
+    }
     vtDivSnapshot.updateOffsetRecord(PartitionTracker.VERSION_TOPIC, pcs.getOffsetRecord());
     updateOffsetMetadataInOffsetRecord(pcs);
     syncOffset(pcs);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -314,6 +314,10 @@ public class LeaderFollowerStoreIngestionTaskTest {
     when(builder.getSchemaRepo().getKeySchema(storeName)).thenReturn(new SchemaEntry(1, "\"string\""));
     mockStore = builder.getMetadataRepo().getStoreOrThrow(storeName);
     mockStoreBufferService = (StoreBufferService) builder.getStoreBufferService();
+    // execSyncOffsetFromSnapshotAsync now returns the waitable node's future; default it to a completed future so the
+    // produce-completion callback's .whenComplete(...) has a non-null future to chain (tests may override).
+    doReturn(CompletableFuture.completedFuture(null)).when(mockStoreBufferService)
+        .execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
     Version version = mockStore.getVersion(versionNumber);
     assert version != null; // helps the IDE understand that version is not null, so it won't complain
     version.setCompressionStrategy(CompressionStrategy.GZIP);
@@ -807,15 +811,11 @@ public class LeaderFollowerStoreIngestionTaskTest {
     urlToIdMap.put(brokerB, 1);
     doReturn(urlToIdMap).when(mockVeniceServerConfig).getKafkaClusterUrlToIdMap();
 
-    // Stub sendGlobalRtDivMessage to return a callback whose persisted-to-DB future is already complete.
-    LeaderProducerCallback mockCallback = mock(LeaderProducerCallback.class);
-    LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
-    doReturn(CompletableFuture.completedFuture(null)).when(mockContext).getPersistedToDBFuture();
-    doReturn(mockContext).when(mockCallback).getLeaderProducedRecordContext();
-    doReturn(mockCallback).when(leaderFollowerStoreIngestionTask)
+    // sendGlobalRtDivMessage returns the future that completes once the produce has persisted and its chained VT DIV
+    // sync node has run; stub it to an already-completed future (the produce + drainer wiring is covered by
+    // testSendGlobalRtDivMessage).
+    doReturn(CompletableFuture.completedFuture(null)).when(leaderFollowerStoreIngestionTask)
         .sendGlobalRtDivMessage(any(), any(), any(), anyInt(), anyString(), anyLong(), anyInt());
-    doReturn(CompletableFuture.completedFuture(null)).when(mockStoreBufferService)
-        .execSyncGlobalRtDivAsync(eq(localVtTp), eq(leaderFollowerStoreIngestionTask));
 
     CompletableFuture<Void> future =
         leaderFollowerStoreIngestionTask.forceGlobalRtDivSync(mockPartitionConsumptionState);
@@ -839,8 +839,9 @@ public class LeaderFollowerStoreIngestionTaskTest {
         eq(brokerB),
         anyLong(),
         eq(1));
-    // The waitable VT DIV sync (chained after each persist) runs once per produced broker.
-    verify(mockStoreBufferService, times(2)).execSyncGlobalRtDivAsync(localVtTp, leaderFollowerStoreIngestionTask);
+    // The leader awaits the produce-completion VT DIV sync via sendGlobalRtDivMessage's returned future, so it does NOT
+    // enqueue a second redundant SyncGlobalRtDivNode.
+    verify(mockStoreBufferService, never()).execSyncGlobalRtDivAsync(any(), any());
   }
 
   /**
@@ -872,14 +873,8 @@ public class LeaderFollowerStoreIngestionTaskTest {
     urlToIdMap.put(progressedBroker, 1);
     doReturn(urlToIdMap).when(mockVeniceServerConfig).getKafkaClusterUrlToIdMap();
 
-    LeaderProducerCallback mockCallback = mock(LeaderProducerCallback.class);
-    LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
-    doReturn(CompletableFuture.completedFuture(null)).when(mockContext).getPersistedToDBFuture();
-    doReturn(mockContext).when(mockCallback).getLeaderProducedRecordContext();
-    doReturn(mockCallback).when(leaderFollowerStoreIngestionTask)
+    doReturn(CompletableFuture.completedFuture(null)).when(leaderFollowerStoreIngestionTask)
         .sendGlobalRtDivMessage(any(), any(), any(), anyInt(), anyString(), anyLong(), anyInt());
-    doReturn(CompletableFuture.completedFuture(null)).when(mockStoreBufferService)
-        .execSyncGlobalRtDivAsync(any(), any());
 
     CompletableFuture<Void> future =
         leaderFollowerStoreIngestionTask.forceGlobalRtDivSync(mockPartitionConsumptionState);
@@ -897,6 +892,9 @@ public class LeaderFollowerStoreIngestionTaskTest {
         eq(progressedBroker),
         anyLong(),
         eq(1));
+    // The progressed broker produced (futures non-empty), so the leader does not fall back to a redundant
+    // SyncGlobalRtDivNode.
+    verify(mockStoreBufferService, never()).execSyncGlobalRtDivAsync(any(), any());
   }
 
   /**
@@ -3365,6 +3363,10 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     mockStore = builder.getMetadataRepo().getStoreOrThrow(storeName);
     mockStoreBufferService = (StoreBufferService) builder.getStoreBufferService();
+    // execSyncOffsetFromSnapshotAsync now returns the waitable node's future; default it to a completed future so the
+    // produce-completion callback's .whenComplete(...) has a non-null future to chain (tests may override).
+    doReturn(CompletableFuture.completedFuture(null)).when(mockStoreBufferService)
+        .execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
     Version version = mockStore.getVersion(versionNumber);
     assert version != null;
     version.setCompressionStrategy(CompressionStrategy.GZIP);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -132,7 +132,9 @@ import com.linkedin.venice.views.MaterializedView;
 import com.linkedin.venice.writer.VeniceWriter;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -142,6 +144,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -714,14 +717,9 @@ public class LeaderFollowerStoreIngestionTaskTest {
     setUp();
     int partition = 1;
     long offset = 3L;
-    long messageTime = 5;
-    DefaultPubSubMessage mockMessage = mock(DefaultPubSubMessage.class);
     PubSubTopicPartition mockTopicPartition = mock(PubSubTopicPartition.class);
     PubSubPosition p3 = ApacheKafkaOffsetPosition.of(offset);
     doReturn(partition).when(mockTopicPartition).getPartitionNumber();
-    doReturn(p3).when(mockMessage).getPosition();
-    doReturn(mockTopicPartition).when(mockMessage).getTopicPartition();
-    doReturn(messageTime).when(mockMessage).getPubSubMessageTime();
     VeniceWriter mockWriter = mock(VeniceWriter.class);
     Lazy<VeniceWriter<byte[], byte[], byte[]>> lazyMockWriter = Lazy.of(() -> mockWriter);
     doReturn(lazyMockWriter).when(mockPartitionConsumptionState).getVeniceWriterLazyRef();
@@ -735,7 +733,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(mockOffsetRecord).when(mockPartitionConsumptionState).getOffsetRecord();
 
     leaderFollowerStoreIngestionTask
-        .sendGlobalRtDivMessage(mockMessage, mockPartitionConsumptionState, partition, brokerUrl, 0L, 0);
+        .sendGlobalRtDivMessage(p3, mockTopicPartition, mockPartitionConsumptionState, partition, brokerUrl, 0L, 0);
 
     ArgumentCaptor<byte[]> valueBytesArgumentCaptor = ArgumentCaptor.forClass(byte[].class);
     ArgumentCaptor<LeaderProducerCallback> callbackArgumentCaptor =
@@ -777,6 +775,157 @@ public class LeaderFollowerStoreIngestionTaskTest {
     // Verify that completing the future from put() causes execSyncOffsetFromSnapshotAsync to be called
     // and that produceResult should override the LCVP of the VT DIV sent to the drainer
     fireProduceCallbackAndAssertLcvpSynced(callback, InMemoryPubSubPosition.of(11L));
+  }
+
+  /**
+   * AC 1: a LEADER's {@link LeaderFollowerStoreIngestionTask#forceGlobalRtDivSync} produces exactly one
+   * GlobalRtDivState per RT source broker (LCRP != EARLIEST), carrying that broker's getLatestConsumedRtPosition, and
+   * the aggregate future completes once each produce has persisted and the chained waitable VT DIV sync has run.
+   */
+  @Test
+  public void testForceGlobalRtDivSyncLeaderProducesPerBroker() throws Exception {
+    setUp();
+    int partition = 0;
+    PubSubTopicPartition localVtTp = mock(PubSubTopicPartition.class);
+    doReturn(partition).when(localVtTp).getPartitionNumber();
+    doReturn(localVtTp).when(mockPartitionConsumptionState).getReplicaTopicPartition();
+    doReturn(partition).when(mockPartitionConsumptionState).getPartition();
+    doReturn(LeaderFollowerStateType.LEADER).when(mockPartitionConsumptionState).getLeaderFollowerState();
+
+    String brokerA = "brokerA:1234";
+    String brokerB = "brokerB:1234";
+    PubSubPosition lcrpA = InMemoryPubSubPosition.of(5L);
+    PubSubPosition lcrpB = InMemoryPubSubPosition.of(9L);
+    doReturn(lcrpA).when(mockPartitionConsumptionState).getLatestConsumedRtPosition(brokerA);
+    doReturn(lcrpB).when(mockPartitionConsumptionState).getLatestConsumedRtPosition(brokerB);
+
+    Set<String> brokers = new LinkedHashSet<>(Arrays.asList(brokerA, brokerB));
+    doReturn(brokers).when(leaderFollowerStoreIngestionTask)
+        .getRealTimeDataSourceKafkaAddress(mockPartitionConsumptionState);
+    Object2IntMap<String> urlToIdMap = new Object2IntOpenHashMap<>();
+    urlToIdMap.put(brokerA, 0);
+    urlToIdMap.put(brokerB, 1);
+    doReturn(urlToIdMap).when(mockVeniceServerConfig).getKafkaClusterUrlToIdMap();
+
+    // Stub sendGlobalRtDivMessage to return a callback whose persisted-to-DB future is already complete.
+    LeaderProducerCallback mockCallback = mock(LeaderProducerCallback.class);
+    LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
+    doReturn(CompletableFuture.completedFuture(null)).when(mockContext).getPersistedToDBFuture();
+    doReturn(mockContext).when(mockCallback).getLeaderProducedRecordContext();
+    doReturn(mockCallback).when(leaderFollowerStoreIngestionTask)
+        .sendGlobalRtDivMessage(any(), any(), any(), anyInt(), anyString(), anyLong(), anyInt());
+    doReturn(CompletableFuture.completedFuture(null)).when(mockStoreBufferService)
+        .execSyncGlobalRtDivCommandAsync(eq(localVtTp), eq(leaderFollowerStoreIngestionTask));
+
+    CompletableFuture<Void> future =
+        leaderFollowerStoreIngestionTask.forceGlobalRtDivSync(mockPartitionConsumptionState);
+    future.get(30, TimeUnit.SECONDS);
+    assertTrue(future.isDone());
+
+    // One produce per broker, each carrying that broker's LCRP and the local VT topic-partition.
+    verify(leaderFollowerStoreIngestionTask, times(1)).sendGlobalRtDivMessage(
+        eq(lcrpA),
+        eq(localVtTp),
+        eq(mockPartitionConsumptionState),
+        eq(partition),
+        eq(brokerA),
+        anyLong(),
+        eq(0));
+    verify(leaderFollowerStoreIngestionTask, times(1)).sendGlobalRtDivMessage(
+        eq(lcrpB),
+        eq(localVtTp),
+        eq(mockPartitionConsumptionState),
+        eq(partition),
+        eq(brokerB),
+        anyLong(),
+        eq(1));
+    // The waitable VT DIV sync (chained after each persist) runs once per produced broker.
+    verify(mockStoreBufferService, times(2))
+        .execSyncGlobalRtDivCommandAsync(localVtTp, leaderFollowerStoreIngestionTask);
+  }
+
+  /**
+   * AC 3: brokers whose LCRP is EARLIEST are skipped (no produce). When every broker is EARLIEST, the leader falls back
+   * to a single waitable VT DIV snapshot sync (no GlobalRtDivState produce).
+   */
+  @Test
+  public void testForceGlobalRtDivSyncLeaderSkipsEarliestBrokers() throws Exception {
+    setUp();
+    int partition = 0;
+    PubSubTopicPartition localVtTp = mock(PubSubTopicPartition.class);
+    doReturn(partition).when(localVtTp).getPartitionNumber();
+    doReturn(localVtTp).when(mockPartitionConsumptionState).getReplicaTopicPartition();
+    doReturn(partition).when(mockPartitionConsumptionState).getPartition();
+    doReturn(LeaderFollowerStateType.LEADER).when(mockPartitionConsumptionState).getLeaderFollowerState();
+
+    String earliestBroker = "earliest:1234";
+    String progressedBroker = "progressed:1234";
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(mockPartitionConsumptionState)
+        .getLatestConsumedRtPosition(earliestBroker);
+    PubSubPosition lcrp = InMemoryPubSubPosition.of(7L);
+    doReturn(lcrp).when(mockPartitionConsumptionState).getLatestConsumedRtPosition(progressedBroker);
+
+    Set<String> brokers = new LinkedHashSet<>(Arrays.asList(earliestBroker, progressedBroker));
+    doReturn(brokers).when(leaderFollowerStoreIngestionTask)
+        .getRealTimeDataSourceKafkaAddress(mockPartitionConsumptionState);
+    Object2IntMap<String> urlToIdMap = new Object2IntOpenHashMap<>();
+    urlToIdMap.put(earliestBroker, 0);
+    urlToIdMap.put(progressedBroker, 1);
+    doReturn(urlToIdMap).when(mockVeniceServerConfig).getKafkaClusterUrlToIdMap();
+
+    LeaderProducerCallback mockCallback = mock(LeaderProducerCallback.class);
+    LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
+    doReturn(CompletableFuture.completedFuture(null)).when(mockContext).getPersistedToDBFuture();
+    doReturn(mockContext).when(mockCallback).getLeaderProducedRecordContext();
+    doReturn(mockCallback).when(leaderFollowerStoreIngestionTask)
+        .sendGlobalRtDivMessage(any(), any(), any(), anyInt(), anyString(), anyLong(), anyInt());
+    doReturn(CompletableFuture.completedFuture(null)).when(mockStoreBufferService)
+        .execSyncGlobalRtDivCommandAsync(any(), any());
+
+    CompletableFuture<Void> future =
+        leaderFollowerStoreIngestionTask.forceGlobalRtDivSync(mockPartitionConsumptionState);
+    future.get(30, TimeUnit.SECONDS);
+    assertTrue(future.isDone());
+
+    // EARLIEST broker is skipped; only the progressed broker produces.
+    verify(leaderFollowerStoreIngestionTask, never())
+        .sendGlobalRtDivMessage(any(), any(), any(), anyInt(), eq(earliestBroker), anyLong(), anyInt());
+    verify(leaderFollowerStoreIngestionTask, times(1)).sendGlobalRtDivMessage(
+        eq(lcrp),
+        eq(localVtTp),
+        eq(mockPartitionConsumptionState),
+        eq(partition),
+        eq(progressedBroker),
+        anyLong(),
+        eq(1));
+  }
+
+  /**
+   * AC 2: a FOLLOWER forces a single waitable VT DIV snapshot sync and produces no GlobalRtDivState (RT DIV is already
+   * durable from when the follower consumed it). Also covers a leader with no RT brokers (batch-only) via the same
+   * VT-snapshot-only fallback.
+   */
+  @Test
+  public void testForceGlobalRtDivSyncFollowerSyncsVtOnly() throws Exception {
+    setUp();
+    int partition = 0;
+    PubSubTopicPartition localVtTp = mock(PubSubTopicPartition.class);
+    doReturn(partition).when(localVtTp).getPartitionNumber();
+    doReturn(localVtTp).when(mockPartitionConsumptionState).getReplicaTopicPartition();
+    doReturn(partition).when(mockPartitionConsumptionState).getPartition();
+    doReturn(LeaderFollowerStateType.STANDBY).when(mockPartitionConsumptionState).getLeaderFollowerState();
+    doReturn(CompletableFuture.completedFuture(null)).when(mockStoreBufferService)
+        .execSyncGlobalRtDivCommandAsync(eq(localVtTp), eq(leaderFollowerStoreIngestionTask));
+
+    CompletableFuture<Void> future =
+        leaderFollowerStoreIngestionTask.forceGlobalRtDivSync(mockPartitionConsumptionState);
+    future.get(30, TimeUnit.SECONDS);
+    assertTrue(future.isDone());
+
+    verify(leaderFollowerStoreIngestionTask, never())
+        .sendGlobalRtDivMessage(any(), any(), any(), anyInt(), anyString(), anyLong(), anyInt());
+    verify(mockStoreBufferService, times(1))
+        .execSyncGlobalRtDivCommandAsync(localVtTp, leaderFollowerStoreIngestionTask);
   }
 
   /**
@@ -1229,6 +1378,39 @@ public class LeaderFollowerStoreIngestionTaskTest {
     Thread.interrupted(); // clear any pre-existing flag
     invokeSendVtDivSnapshotIfNeeded(mockVtSnapshot(ApacheKafkaOffsetPosition.of(10L)));
     assertTrue(Thread.interrupted(), "Interrupt flag should be restored after InterruptedException"); // also clears
+  }
+
+  /**
+   * Follower / no-RT-progress shutdown sync: when the cloned VT snapshot's LCVP is EARLIEST (no VT progress yet),
+   * {@code syncGlobalRtDivFromSnapshot} must NOT call {@code updateAndSyncOffsetFromSnapshot} — otherwise EARLIEST
+   * gets stamped into the OffsetRecord and the replica re-subscribes from EARLIEST on restart. A non-EARLIEST LCVP
+   * must proceed with the sync.
+   */
+  @Test
+  public void testSyncGlobalRtDivFromSnapshotSkipsWhenLcvpIsEarliest() throws InterruptedException {
+    setUp();
+    int partition = 0;
+    PubSubTopicPartition tp = new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("test_topic_v1"), partition);
+
+    doReturn(true).when(leaderFollowerStoreIngestionTask).isGlobalRtDivEnabled();
+    doReturn(mockPartitionConsumptionState).when(leaderFollowerStoreIngestionTask)
+        .getPartitionConsumptionState(partition);
+    doReturn(0L).when(mockPartitionConsumptionState).getLatestMessageTimeInMs();
+    DataIntegrityValidator mockConsumerDiv = mock(DataIntegrityValidator.class);
+    doReturn(mockConsumerDiv).when(leaderFollowerStoreIngestionTask).getDataIntegrityValidator();
+    doNothing().when(leaderFollowerStoreIngestionTask).updateAndSyncOffsetFromSnapshot(any(), any());
+
+    // EARLIEST LCVP: must skip the sync but still complete normally so the drainer command future completes.
+    doReturn(mockVtSnapshot(PubSubSymbolicPosition.EARLIEST)).when(mockConsumerDiv)
+        .cloneVtProducerStates(anyInt(), anyBoolean(), anyLong());
+    leaderFollowerStoreIngestionTask.syncGlobalRtDivFromSnapshot(tp);
+    verify(leaderFollowerStoreIngestionTask, never()).updateAndSyncOffsetFromSnapshot(any(), any());
+
+    // Non-EARLIEST LCVP: must proceed with the sync.
+    doReturn(mockVtSnapshot(ApacheKafkaOffsetPosition.of(10L))).when(mockConsumerDiv)
+        .cloneVtProducerStates(anyInt(), anyBoolean(), anyLong());
+    leaderFollowerStoreIngestionTask.syncGlobalRtDivFromSnapshot(tp);
+    verify(leaderFollowerStoreIngestionTask, times(1)).updateAndSyncOffsetFromSnapshot(any(), eq(tp));
   }
 
   /** Opens the gate for {@code sendVtDivSnapshotIfNeeded} and routes consumerDiv to return {@code snapshot}. */

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -815,7 +815,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(mockCallback).when(leaderFollowerStoreIngestionTask)
         .sendGlobalRtDivMessage(any(), any(), any(), anyInt(), anyString(), anyLong(), anyInt());
     doReturn(CompletableFuture.completedFuture(null)).when(mockStoreBufferService)
-        .execSyncGlobalRtDivCommandAsync(eq(localVtTp), eq(leaderFollowerStoreIngestionTask));
+        .execSyncGlobalRtDivAsync(eq(localVtTp), eq(leaderFollowerStoreIngestionTask));
 
     CompletableFuture<Void> future =
         leaderFollowerStoreIngestionTask.forceGlobalRtDivSync(mockPartitionConsumptionState);
@@ -840,8 +840,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
         anyLong(),
         eq(1));
     // The waitable VT DIV sync (chained after each persist) runs once per produced broker.
-    verify(mockStoreBufferService, times(2))
-        .execSyncGlobalRtDivCommandAsync(localVtTp, leaderFollowerStoreIngestionTask);
+    verify(mockStoreBufferService, times(2)).execSyncGlobalRtDivAsync(localVtTp, leaderFollowerStoreIngestionTask);
   }
 
   /**
@@ -880,7 +879,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(mockCallback).when(leaderFollowerStoreIngestionTask)
         .sendGlobalRtDivMessage(any(), any(), any(), anyInt(), anyString(), anyLong(), anyInt());
     doReturn(CompletableFuture.completedFuture(null)).when(mockStoreBufferService)
-        .execSyncGlobalRtDivCommandAsync(any(), any());
+        .execSyncGlobalRtDivAsync(any(), any());
 
     CompletableFuture<Void> future =
         leaderFollowerStoreIngestionTask.forceGlobalRtDivSync(mockPartitionConsumptionState);
@@ -915,7 +914,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
     doReturn(partition).when(mockPartitionConsumptionState).getPartition();
     doReturn(LeaderFollowerStateType.STANDBY).when(mockPartitionConsumptionState).getLeaderFollowerState();
     doReturn(CompletableFuture.completedFuture(null)).when(mockStoreBufferService)
-        .execSyncGlobalRtDivCommandAsync(eq(localVtTp), eq(leaderFollowerStoreIngestionTask));
+        .execSyncGlobalRtDivAsync(eq(localVtTp), eq(leaderFollowerStoreIngestionTask));
 
     CompletableFuture<Void> future =
         leaderFollowerStoreIngestionTask.forceGlobalRtDivSync(mockPartitionConsumptionState);
@@ -924,8 +923,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     verify(leaderFollowerStoreIngestionTask, never())
         .sendGlobalRtDivMessage(any(), any(), any(), anyInt(), anyString(), anyLong(), anyInt());
-    verify(mockStoreBufferService, times(1))
-        .execSyncGlobalRtDivCommandAsync(localVtTp, leaderFollowerStoreIngestionTask);
+    verify(mockStoreBufferService, times(1)).execSyncGlobalRtDivAsync(localVtTp, leaderFollowerStoreIngestionTask);
   }
 
   /**
@@ -1384,7 +1382,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
    * Follower / no-RT-progress shutdown sync: when the cloned VT snapshot's LCVP is EARLIEST (no VT progress yet),
    * {@code syncGlobalRtDivFromSnapshot} must NOT call {@code updateAndSyncOffsetFromSnapshot} — otherwise EARLIEST
    * gets stamped into the OffsetRecord and the replica re-subscribes from EARLIEST on restart. A non-EARLIEST LCVP
-   * must proceed with the sync.
+   * must proceed with the sync, and a null PCS must skip entirely without cloning or syncing.
    */
   @Test
   public void testSyncGlobalRtDivFromSnapshotSkipsWhenLcvpIsEarliest() throws InterruptedException {
@@ -1411,6 +1409,13 @@ public class LeaderFollowerStoreIngestionTaskTest {
         .cloneVtProducerStates(anyInt(), anyBoolean(), anyLong());
     leaderFollowerStoreIngestionTask.syncGlobalRtDivFromSnapshot(tp);
     verify(leaderFollowerStoreIngestionTask, times(1)).updateAndSyncOffsetFromSnapshot(any(), eq(tp));
+
+    // Null PCS: must skip entirely (no clone, no sync) and still return normally so shutdown does not hang.
+    clearInvocations(leaderFollowerStoreIngestionTask, mockConsumerDiv);
+    doReturn(null).when(leaderFollowerStoreIngestionTask).getPartitionConsumptionState(partition);
+    leaderFollowerStoreIngestionTask.syncGlobalRtDivFromSnapshot(tp);
+    verify(mockConsumerDiv, never()).cloneVtProducerStates(anyInt(), anyBoolean(), anyLong());
+    verify(leaderFollowerStoreIngestionTask, never()).updateAndSyncOffsetFromSnapshot(any(), any());
   }
 
   /** Opens the gate for {@code sendVtDivSnapshotIfNeeded} and routes consumerDiv to return {@code snapshot}. */

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask.VIEW_WRITER_CLOSE_TIMEOUT_IN_MS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.offsets.OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyDouble;
@@ -800,8 +801,12 @@ public class LeaderFollowerStoreIngestionTaskTest {
     String brokerB = "brokerB:1234";
     PubSubPosition lcrpA = InMemoryPubSubPosition.of(5L);
     PubSubPosition lcrpB = InMemoryPubSubPosition.of(9L);
-    doReturn(lcrpA).when(mockPartitionConsumptionState).getLatestConsumedRtPosition(brokerA);
-    doReturn(lcrpB).when(mockPartitionConsumptionState).getLatestConsumedRtPosition(brokerB);
+    // A/A-style topology: multiple RT sources, each with its own per-URL LCRP. forceGlobalRtDivSync reads the LCRP
+    // through the per-mode accessor (the A/A override keys by broker URL), so stub that accessor per broker.
+    doReturn(lcrpA).when(leaderFollowerStoreIngestionTask)
+        .getLatestConsumedUpstreamPositionForHybridOffsetLagMeasurement(mockPartitionConsumptionState, brokerA);
+    doReturn(lcrpB).when(leaderFollowerStoreIngestionTask)
+        .getLatestConsumedUpstreamPositionForHybridOffsetLagMeasurement(mockPartitionConsumptionState, brokerB);
 
     Set<String> brokers = new LinkedHashSet<>(Arrays.asList(brokerA, brokerB));
     doReturn(brokers).when(leaderFollowerStoreIngestionTask)
@@ -860,10 +865,14 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     String earliestBroker = "earliest:1234";
     String progressedBroker = "progressed:1234";
-    doReturn(PubSubSymbolicPosition.EARLIEST).when(mockPartitionConsumptionState)
-        .getLatestConsumedRtPosition(earliestBroker);
+    // A/A-style topology: per-URL LCRP read through the per-mode accessor.
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(leaderFollowerStoreIngestionTask)
+        .getLatestConsumedUpstreamPositionForHybridOffsetLagMeasurement(mockPartitionConsumptionState, earliestBroker);
     PubSubPosition lcrp = InMemoryPubSubPosition.of(7L);
-    doReturn(lcrp).when(mockPartitionConsumptionState).getLatestConsumedRtPosition(progressedBroker);
+    doReturn(lcrp).when(leaderFollowerStoreIngestionTask)
+        .getLatestConsumedUpstreamPositionForHybridOffsetLagMeasurement(
+            mockPartitionConsumptionState,
+            progressedBroker);
 
     Set<String> brokers = new LinkedHashSet<>(Arrays.asList(earliestBroker, progressedBroker));
     doReturn(brokers).when(leaderFollowerStoreIngestionTask)
@@ -894,6 +903,58 @@ public class LeaderFollowerStoreIngestionTaskTest {
         eq(1));
     // The progressed broker produced (futures non-empty), so the leader does not fall back to a redundant
     // SyncGlobalRtDivNode.
+    verify(mockStoreBufferService, never()).execSyncGlobalRtDivAsync(any(), any());
+  }
+
+  /**
+   * Regression for the non-A/A map-key mismatch: a non-A/A leader keys its latest-consumed-RT-position map by
+   * {@link com.linkedin.venice.offsets.OffsetRecord#NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY}, not by broker URL.
+   * forceGlobalRtDivSync must read the LCRP through the per-mode accessor (here the real non-A/A override, NOT stubbed)
+   * so it resolves the NON_AA key; a direct getLatestConsumedRtPosition(brokerUrl) would miss, return EARLIEST, and
+   * silently skip the leader RT DIV flush — falling back to a VT-only sync that never persists the RT DIV deltas.
+   */
+  @Test
+  public void testForceGlobalRtDivSyncNonAaLeaderResolvesNonAaKey() throws Exception {
+    setUp();
+    int partition = 0;
+    PubSubTopicPartition localVtTp = mock(PubSubTopicPartition.class);
+    doReturn(partition).when(localVtTp).getPartitionNumber();
+    doReturn(localVtTp).when(mockPartitionConsumptionState).getReplicaTopicPartition();
+    doReturn(partition).when(mockPartitionConsumptionState).getPartition();
+    doReturn(LeaderFollowerStateType.LEADER).when(mockPartitionConsumptionState).getLeaderFollowerState();
+
+    // Non-A/A has a single RT source. The LCRP is stored under the NON_AA key, not the broker URL. Let the real non-A/A
+    // accessor (leaderFollowerStoreIngestionTask is a non-A/A spy) run so it reads the NON_AA-keyed value.
+    String broker = "broker:1234";
+    PubSubPosition lcrp = InMemoryPubSubPosition.of(7L);
+    doReturn(lcrp).when(mockPartitionConsumptionState)
+        .getLatestConsumedRtPosition(NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY);
+
+    doReturn(Collections.singleton(broker)).when(leaderFollowerStoreIngestionTask)
+        .getRealTimeDataSourceKafkaAddress(mockPartitionConsumptionState);
+    Object2IntMap<String> urlToIdMap = new Object2IntOpenHashMap<>();
+    urlToIdMap.put(broker, 3);
+    doReturn(urlToIdMap).when(mockVeniceServerConfig).getKafkaClusterUrlToIdMap();
+
+    doReturn(CompletableFuture.completedFuture(null)).when(leaderFollowerStoreIngestionTask)
+        .sendGlobalRtDivMessage(any(), any(), any(), anyInt(), anyString(), anyLong(), anyInt());
+
+    CompletableFuture<Void> future =
+        leaderFollowerStoreIngestionTask.forceGlobalRtDivSync(mockPartitionConsumptionState);
+    future.get(30, TimeUnit.SECONDS);
+    assertTrue(future.isDone());
+
+    // The NON_AA-keyed LCRP is resolved (not EARLIEST), so the single RT source produces a GlobalRtDivState carrying
+    // it.
+    verify(leaderFollowerStoreIngestionTask, times(1)).sendGlobalRtDivMessage(
+        eq(lcrp),
+        eq(localVtTp),
+        eq(mockPartitionConsumptionState),
+        eq(partition),
+        eq(broker),
+        anyLong(),
+        eq(3));
+    // A produce happened, so the leader does NOT fall back to the VT-only SyncGlobalRtDivNode.
     verify(mockStoreBufferService, never()).execSyncGlobalRtDivAsync(any(), any());
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallbackTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallbackTest.java
@@ -11,18 +11,24 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import com.linkedin.davinci.stats.AggVersionedDIVStats;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.InMemoryLogAppender;
 import com.linkedin.venice.utils.Utils;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -226,6 +232,54 @@ public class LeaderProducerCallbackTest {
       }
       ctx.updateLoggers();
       inMemoryLogAppender.stop();
+    }
+  }
+
+  /**
+   * On a produce failure, onCompletion(produceResult, e) with a non-null exception must complete the
+   * persistedToDBFuture exceptionally. Otherwise waiters block forever: the leader topic-switch's
+   * getLastLeaderPersistFuture().get() and the graceful-shutdown Global RT DIV sync relay both key their fail-fast off
+   * this future, and would hang until the shutdown timeout.
+   */
+  @Test
+  public void testOnCompletionCompletesPersistedToDBFutureExceptionallyOnProduceFailure() {
+    LeaderFollowerStoreIngestionTask ingestionTaskMock = mock(LeaderFollowerStoreIngestionTask.class);
+    DefaultPubSubMessage sourceConsumerRecordMock = mock(DefaultPubSubMessage.class);
+    PartitionConsumptionState partitionConsumptionStateMock = mock(PartitionConsumptionState.class);
+    AggVersionedDIVStats statsMock = mock(AggVersionedDIVStats.class);
+    String storeName = Utils.getUniqueString("test-store");
+
+    when(ingestionTaskMock.getStoreName()).thenReturn(storeName);
+    when(ingestionTaskMock.getVersionedDIVStats()).thenReturn(statsMock);
+    when(sourceConsumerRecordMock.getTopicName()).thenReturn("test_topic_v1");
+    when(sourceConsumerRecordMock.getPartition()).thenReturn(1);
+
+    // Real context backed by a real future so we can observe how onCompletion completes it on produce failure.
+    CompletableFuture<Void> persistedToDBFuture = new CompletableFuture<>();
+    LeaderProducedRecordContext leaderProducedRecordContext = LeaderProducedRecordContext
+        .newPutRecordWithFuture(0, mock(PubSubPosition.class), "key".getBytes(), mock(Put.class), persistedToDBFuture);
+
+    LeaderProducerCallback leaderProducerCallback = new LeaderProducerCallback(
+        ingestionTaskMock,
+        sourceConsumerRecordMock,
+        partitionConsumptionStateMock,
+        leaderProducedRecordContext,
+        5,
+        "dc-0.kafka.venice.org",
+        0);
+
+    VeniceException produceFailure = new VeniceException("Producer is closed forcefully");
+    leaderProducerCallback.onCompletion(null, produceFailure);
+
+    assertTrue(persistedToDBFuture.isCompletedExceptionally(), "persistedToDBFuture must fail fast on produce failure");
+    try {
+      persistedToDBFuture.get();
+      fail("Expected persistedToDBFuture to complete exceptionally");
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      fail("Unexpected InterruptedException");
+    } catch (ExecutionException e) {
+      assertEquals(e.getCause(), produceFailure, "The original produce failure must propagate to waiters");
     }
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
@@ -417,4 +417,42 @@ public class StoreBufferServiceTest {
 
     bufferService.stop();
   }
+
+  /**
+   * The waitable SYNC_GLOBAL_RT_DIV command routes to {@link StoreIngestionTask#syncGlobalRtDivFromSnapshot} in the
+   * drainer thread and completes the returned future. When the PCS is null, the command is skipped (no snapshot sync)
+   * but the future still completes so the shutdown path never hangs.
+   */
+  @Test
+  public void testExecSyncGlobalRtDivCommandAsync() throws Exception {
+    StoreBufferService bufferService = new StoreBufferService(1, 10000, 1000, false, mockedStats, null);
+    StoreIngestionTask mockTask = mock(StoreIngestionTask.class);
+    int partition = 1;
+    String topic = Utils.getUniqueString("test_topic") + "_v1";
+    PubSubTopic pubSubTopic = pubSubTopicRepository.getTopic(topic);
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(pubSubTopic, partition);
+    PartitionConsumptionState mockPcs = mock(PartitionConsumptionState.class);
+    when(mockTask.getPartitionConsumptionState(partition)).thenReturn(mockPcs);
+    bufferService.start();
+
+    // Case 1: PCS present -> drainer invokes syncGlobalRtDivFromSnapshot and the command future completes.
+    // syncGlobalRtDivFromSnapshot is mocked here (its real snapshot logic is covered in StoreIngestionTaskTest);
+    // this test asserts only the command routing.
+    CompletableFuture<Void> cmdFuture = bufferService.execSyncGlobalRtDivCommandAsync(topicPartition, mockTask);
+    cmdFuture.get(SECONDS.toMillis(30), MILLISECONDS);
+    Assert.assertTrue(cmdFuture.isDone());
+    verify(mockTask, timeout(TIMEOUT_IN_MS).times(1)).syncGlobalRtDivFromSnapshot(topicPartition);
+    // Base SYNC_OFFSET path must not be used for this command type.
+    verify(mockTask, never()).updateOffsetMetadataAndSyncOffset(any());
+
+    // Case 2: PCS null -> command is skipped but the future still completes (shutdown must not hang).
+    clearInvocations(mockTask);
+    when(mockTask.getPartitionConsumptionState(partition)).thenReturn(null);
+    CompletableFuture<Void> nullPcsFuture = bufferService.execSyncGlobalRtDivCommandAsync(topicPartition, mockTask);
+    nullPcsFuture.get(SECONDS.toMillis(30), MILLISECONDS);
+    Assert.assertTrue(nullPcsFuture.isDone());
+    verify(mockTask, never()).syncGlobalRtDivFromSnapshot(any());
+
+    bufferService.stop();
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
@@ -419,39 +419,38 @@ public class StoreBufferServiceTest {
   }
 
   /**
-   * The waitable SYNC_GLOBAL_RT_DIV command routes to {@link StoreIngestionTask#syncGlobalRtDivFromSnapshot} in the
-   * drainer thread and completes the returned future. When the PCS is null, the command is skipped (no snapshot sync)
-   * but the future still completes so the shutdown path never hangs.
+   * The waitable {@code SyncGlobalRtDivNode} routes to {@link StoreIngestionTask#syncGlobalRtDivFromSnapshot} in the
+   * drainer thread and completes the returned future (the null/EARLIEST guards live inside that method and are covered
+   * at the ingestion-task level). If the snapshot sync throws, the future still completes exceptionally so the
+   * graceful-shutdown await never hangs.
    */
   @Test
-  public void testExecSyncGlobalRtDivCommandAsync() throws Exception {
+  public void testExecSyncGlobalRtDivAsync() throws Exception {
     StoreBufferService bufferService = new StoreBufferService(1, 10000, 1000, false, mockedStats, null);
     StoreIngestionTask mockTask = mock(StoreIngestionTask.class);
     int partition = 1;
     String topic = Utils.getUniqueString("test_topic") + "_v1";
     PubSubTopic pubSubTopic = pubSubTopicRepository.getTopic(topic);
     PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(pubSubTopic, partition);
-    PartitionConsumptionState mockPcs = mock(PartitionConsumptionState.class);
-    when(mockTask.getPartitionConsumptionState(partition)).thenReturn(mockPcs);
     bufferService.start();
 
-    // Case 1: PCS present -> drainer invokes syncGlobalRtDivFromSnapshot and the command future completes.
+    // Case 1: the drainer invokes syncGlobalRtDivFromSnapshot and the returned future completes.
     // syncGlobalRtDivFromSnapshot is mocked here (its real snapshot logic is covered in StoreIngestionTaskTest);
-    // this test asserts only the command routing.
-    CompletableFuture<Void> cmdFuture = bufferService.execSyncGlobalRtDivCommandAsync(topicPartition, mockTask);
-    cmdFuture.get(SECONDS.toMillis(30), MILLISECONDS);
-    Assert.assertTrue(cmdFuture.isDone());
+    // this test asserts only the routing.
+    CompletableFuture<Void> syncFuture = bufferService.execSyncGlobalRtDivAsync(topicPartition, mockTask);
+    syncFuture.get(SECONDS.toMillis(30), MILLISECONDS);
+    Assert.assertTrue(syncFuture.isDone());
     verify(mockTask, timeout(TIMEOUT_IN_MS).times(1)).syncGlobalRtDivFromSnapshot(topicPartition);
-    // Base SYNC_OFFSET path must not be used for this command type.
+    // The SYNC_OFFSET command path must not be used for this node.
     verify(mockTask, never()).updateOffsetMetadataAndSyncOffset(any());
 
-    // Case 2: PCS null -> command is skipped but the future still completes (shutdown must not hang).
+    // Case 2: if the snapshot sync throws, the future still completes (exceptionally) so shutdown never hangs.
     clearInvocations(mockTask);
-    when(mockTask.getPartitionConsumptionState(partition)).thenReturn(null);
-    CompletableFuture<Void> nullPcsFuture = bufferService.execSyncGlobalRtDivCommandAsync(topicPartition, mockTask);
-    nullPcsFuture.get(SECONDS.toMillis(30), MILLISECONDS);
-    Assert.assertTrue(nullPcsFuture.isDone());
-    verify(mockTask, never()).syncGlobalRtDivFromSnapshot(any());
+    doThrow(new VeniceException("boom")).when(mockTask).syncGlobalRtDivFromSnapshot(topicPartition);
+    CompletableFuture<Void> failedFuture = bufferService.execSyncGlobalRtDivAsync(topicPartition, mockTask);
+    Throwable error = failedFuture.handle((result, throwable) -> throwable).get(SECONDS.toMillis(30), MILLISECONDS);
+    Assert.assertNotNull(error, "Future should complete exceptionally when the snapshot sync throws");
+    Assert.assertTrue(failedFuture.isCompletedExceptionally());
 
     bufferService.stop();
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
@@ -396,9 +396,11 @@ public class StoreBufferServiceTest {
     when(mockTask.getPartitionConsumptionState(partition)).thenReturn(null);
     bufferService.start();
 
-    // Case 1: PCS is null -> updateAndSyncOffsetFromSnapshot() should be called
-    bufferService.execSyncOffsetFromSnapshotAsync(topicPartition, mockSnapshot, future, mockTask);
+    // Case 1: PCS is null -> updateAndSyncOffsetFromSnapshot() should be called, returned future completes
+    CompletableFuture<Void> case1 =
+        bufferService.execSyncOffsetFromSnapshotAsync(topicPartition, mockSnapshot, future, mockTask);
     verify(mockTask, timeout(TIMEOUT_IN_MS).times(1)).updateAndSyncOffsetFromSnapshot(mockSnapshot, topicPartition);
+    case1.get(TIMEOUT_IN_MS, MILLISECONDS);
 
     // Case 2: Future is null
     bufferService.execSyncOffsetFromSnapshotAsync(topicPartition, mockSnapshot, future, mockTask);
@@ -408,11 +410,14 @@ public class StoreBufferServiceTest {
     bufferService.execSyncOffsetFromSnapshotAsync(topicPartition, mockSnapshot, future, mockTask);
     verify(mockTask, timeout(TIMEOUT_IN_MS).times(3)).updateAndSyncOffsetFromSnapshot(mockSnapshot, topicPartition);
 
-    // Case 4: Previous message's future is completed exceptionally -> updateAndSyncOffsetFromSnapshot() not be called
+    // Case 4: Previous message's future is completed exceptionally -> updateAndSyncOffsetFromSnapshot() not called, but
+    // the waitable node's future still completes (normally) so the graceful-shutdown leader await never hangs.
     clearInvocations(mockTask);
     CompletableFuture<Void> failedFuture = new CompletableFuture<>();
     failedFuture.completeExceptionally(new RuntimeException("Test exception"));
-    bufferService.execSyncOffsetFromSnapshotAsync(topicPartition, mockSnapshot, failedFuture, mockTask);
+    CompletableFuture<Void> case4 =
+        bufferService.execSyncOffsetFromSnapshotAsync(topicPartition, mockSnapshot, failedFuture, mockTask);
+    case4.get(TIMEOUT_IN_MS, MILLISECONDS);
     verify(mockTask, never()).updateAndSyncOffsetFromSnapshot(mockSnapshot, topicPartition);
 
     bufferService.stop();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -6345,6 +6345,9 @@ public abstract class StoreIngestionTaskTest {
     doCallRealMethod().when(ingestionTask).restoreProducerStatesForLeaderConsumption(anyInt());
     doCallRealMethod().when(ingestionTask).loadGlobalRtDiv(anyInt());
     doCallRealMethod().when(ingestionTask).loadGlobalRtDiv(anyInt(), anyString());
+    // Drive the real non-A/A accessor so the checkpoint is stored under the NON_AA key (the key the leader-start path
+    // reads back), not the broker URL.
+    doCallRealMethod().when(ingestionTask).updateDivRtCheckpointPosition(any(), anyString(), any());
     doReturn(true).when(ingestionTask).isGlobalRtDivEnabled();
 
     InMemoryPubSubPosition p1 = InMemoryPubSubPosition.of(11);
@@ -6381,6 +6384,9 @@ public abstract class StoreIngestionTaskTest {
     assertEquals(capturedUrls.size(), brokerIdToUrlMap.size());
 
     for (int i = 0; i < capturedUrls.size(); i++) {
+      // Non-A/A keys the in-memory DIV RT checkpoint by the NON_AA key (not the broker URL), so the leader-start read
+      // via getLeaderPosition(NON_AA_KEY, ...) resolves the persisted checkpoint instead of falling back to EARLIEST.
+      assertEquals(capturedUrls.get(i), OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY);
       PubSubPosition position = capturedPositions.get(i);
       assertEquals(position, p1);
       assertTrue(position instanceof InMemoryPubSubPosition);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -118,6 +118,7 @@ import com.linkedin.davinci.store.record.ValueRecord;
 import com.linkedin.davinci.store.rocksdb.RocksDBServerConfig;
 import com.linkedin.davinci.transformer.TestStringRecordTransformer;
 import com.linkedin.davinci.validation.DataIntegrityValidator;
+import com.linkedin.davinci.validation.PartitionTracker;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceIngestionTaskKilledException;
@@ -7625,5 +7626,29 @@ public abstract class StoreIngestionTaskTest {
         Optional.of(new HybridStoreConfigImpl(100, 100, 100, BufferReplayPolicy.REWIND_FROM_SOP)));
 
     runTest(config);
+  }
+
+  /**
+   * The waitable VT DIV sync node ({@code StoreBufferService.SyncVtDivNode}) routes through
+   * {@link StoreIngestionTask#updateAndSyncOffsetFromSnapshot}. The PCS can be removed between the node being enqueued
+   * and executed (e.g. during shutdown/unsubscribe). The null guard must skip cleanly rather than NPE so the drainer
+   * node completes normally and the graceful-shutdown await stays deterministic.
+   */
+  @Test
+  public void testUpdateAndSyncOffsetFromSnapshotSkipsWhenPcsIsNull() {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    PartitionTracker vtDivSnapshot = mock(PartitionTracker.class);
+    int partition = 0;
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(new PubSubTopicImpl("test_topic_v1"), partition);
+
+    when(storeIngestionTask.getPartitionConsumptionState(partition)).thenReturn(null);
+    doCallRealMethod().when(storeIngestionTask).updateAndSyncOffsetFromSnapshot(vtDivSnapshot, topicPartition);
+
+    // Must not throw even though the PCS is gone.
+    storeIngestionTask.updateAndSyncOffsetFromSnapshot(vtDivSnapshot, topicPartition);
+
+    // The early return skips the OffsetRecord write entirely; nothing is dereferenced off the null PCS.
+    verify(vtDivSnapshot, never()).updateOffsetRecord(any(), any());
+    verify(storeIngestionTask, never()).updateOffsetMetadataInOffsetRecord(any());
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -6696,6 +6696,68 @@ public abstract class StoreIngestionTaskTest {
     shutdownExecutor.shutdown();
   }
 
+  /**
+   * With Global RT DIV enabled, the graceful-shutdown path must drive {@link StoreIngestionTask#forceGlobalRtDivSync}
+   * (instead of the drainer SYNC_OFFSET command) and await it before returning, then drain messages. It must NOT call
+   * the non-global execSyncOffsetCommandAsync path. Covers AC 4 (flush completes before shutdown proceeds).
+   */
+  @Test
+  public void testExecuteShutdownRunnableGlobalRtDivEnabled() throws InterruptedException {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    List<CompletableFuture<Void>> shutdownFutures = new ArrayList<>();
+
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    when(serverConfig.isServerIngestionCheckpointDuringGracefulShutdownEnabled()).thenReturn(true);
+    when(serverConfig.getShutdownSyncOffsetTimeoutMs()).thenReturn(2000L);
+    when(storeIngestionTask.getServerConfig()).thenReturn(serverConfig);
+    when(storeIngestionTask.isGlobalRtDivEnabled()).thenReturn(true);
+
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(new PubSubTopicImpl("test_topic_v1"), 0);
+    when(pcs.getReplicaTopicPartition()).thenReturn(topicPartition);
+    when(storeIngestionTask.forceGlobalRtDivSync(pcs)).thenReturn(CompletableFuture.completedFuture(null));
+
+    doCallRealMethod().when(storeIngestionTask).executeShutdownRunnable(any(), anyList(), any());
+    storeIngestionTask.executeShutdownRunnable(pcs, shutdownFutures, null);
+
+    verify(storeIngestionTask).forceGlobalRtDivSync(pcs);
+    verify(storeIngestionTask).waitForAllMessageToBeProcessedFromTopicPartition(topicPartition, pcs);
+    // The Global RT DIV path must not use the non-global drainer SYNC_OFFSET command.
+    verify(storeIngestionTask, never()).getStoreBufferService();
+  }
+
+  /**
+   * A produce/await failure during the Global RT DIV shutdown sync must never hang shutdown: the bounded
+   * getShutdownSyncOffsetTimeoutMs() wait swallows the timeout, then message draining still proceeds. Covers AC 5.
+   */
+  @Test
+  public void testExecuteShutdownRunnableGlobalRtDivTimeoutDoesNotHang() throws InterruptedException {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    List<CompletableFuture<Void>> shutdownFutures = new ArrayList<>();
+
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    when(serverConfig.isServerIngestionCheckpointDuringGracefulShutdownEnabled()).thenReturn(true);
+    // Short timeout so the never-completing future is abandoned quickly.
+    when(serverConfig.getShutdownSyncOffsetTimeoutMs()).thenReturn(100L);
+    when(storeIngestionTask.getServerConfig()).thenReturn(serverConfig);
+    when(storeIngestionTask.isGlobalRtDivEnabled()).thenReturn(true);
+
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(new PubSubTopicImpl("test_topic_v1"), 0);
+    when(pcs.getReplicaTopicPartition()).thenReturn(topicPartition);
+    // A future that never completes simulates a produce/await failure stalling the sync.
+    when(storeIngestionTask.forceGlobalRtDivSync(pcs)).thenReturn(new CompletableFuture<>());
+
+    doCallRealMethod().when(storeIngestionTask).executeShutdownRunnable(any(), anyList(), any());
+    long start = System.currentTimeMillis();
+    storeIngestionTask.executeShutdownRunnable(pcs, shutdownFutures, null);
+    long elapsed = System.currentTimeMillis() - start;
+
+    assertTrue(elapsed < 30_000L, "Shutdown must not hang on a stalled Global RT DIV sync; elapsed=" + elapsed + "ms");
+    // Even after timing out the sync, draining must still run so shutdown completes.
+    verify(storeIngestionTask).waitForAllMessageToBeProcessedFromTopicPartition(topicPartition, pcs);
+  }
+
   @Test
   public void testShutdownPartitionConsumptionStatesUsesConfiguredPoolSize() throws Exception {
     int configuredPoolSize = 4;


### PR DESCRIPTION
## Problem Statement

Venice's **Global RT DIV** feature persists DIV (Data Integrity Validation) state through two consumer/leader-driven paths, both gated by byte-count thresholds during steady-state ingestion (the RT DIV produce-to-VT path and the VT DIV snapshot path).

On a **graceful shutdown**, `executeShutdownRunnable()` and `updateOffsetMetadataAndSyncOffset()` both explicitly bail when `isGlobalRtDivEnabled()` (deliberately deferred — Global RT DIV is consumer-driven, so any drainer sync must be disabled to not interfere). As a result, nothing flushes the in-memory RT/VT DIV deltas accumulated since the last threshold-triggered sync. On restart the server replays from the last synced point, causing a **post-restart bootstrap slowdown**. The non-Global-RT-DIV (OffsetRecord) path already closes this gap via the drainer `SYNC_OFFSET` command.

## Solution

Add a single on-demand DIV sync, `forceGlobalRtDivSync(pcs)`, that flushes **both** the RT and VT DIV state, invoked during graceful shutdown — mirroring what the OffsetRecord path already does. It is gated by the **existing** `isServerIngestionCheckpointDuringGracefulShutdownEnabled` server config (no new flag).

- **Leader:** for each RT source broker whose latest-consumed RT position (LCRP) is not `EARLIEST`, produce a `GlobalRtDivState` via a position-based `sendGlobalRtDivMessage` variant. The produce callback already chains the VT DIV + LCVP sync, so both halves are covered.
- **Follower / no-RT-progress:** enqueue a new **waitable** `SYNC_GLOBAL_RT_DIV` drainer command that snapshots VT DIV in the drainer thread and syncs it to the OffsetRecord, guarded against persisting `EARLIEST`. RT DIV is already durable from when the follower consumed `GlobalRtDivState`.

`forceGlobalRtDivSync` returns an aggregate `CompletableFuture`. The shutdown await reuses `waitForSyncOffsetCmd`'s timeout/cancel semantics (bounded by `getShutdownSyncOffsetTimeoutMs()`), so shutdown never hangs on a produce/await failure. The flush runs inside `shutdownPartitionConsumptionStates()` — after `consumerBatchUnsubscribeAllTopics` (no new RT records arriving) and before `closeVeniceWriters` (VeniceWriter still alive) — exactly the window where the "don't interfere" concern no longer applies.

**Trade-offs:** the work is bounded by RT broker count, runs only on graceful shutdown (not a steady-state hot path), and is best-effort (failures are logged, never thrown, and capped by the shutdown timeout).

### Code changes
- [x] Added new code behind **a config**. Reuses the existing `isServerIngestionCheckpointDuringGracefulShutdownEnabled` (no new config introduced).
- [ ] Introduced new **log lines**. One best-effort error log on per-broker produce failure (shutdown path, not rate-limit sensitive).

### **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. The VT DIV snapshot is taken inside the single-threaded drainer; ordering relies on the drainer's FIFO guarantee.
- [x] Proper **synchronization mechanisms** are used where needed (drainer command queue + completion future).
- [x] No **blocking calls** inside critical sections that could lead to deadlocks; the shutdown await is bounded by the sync-offset timeout.
- [x] Verified **thread-safe collections** are used.
- [x] Validated proper exception handling — interrupts complete the future exceptionally (rather than throwing) so the shutdown await never hangs.

## How was this PR tested?

- [x] New unit tests added (leader per-broker produce, follower VT-only sync, EARLIEST-skip, follower EARLIEST-LCVP guard, shutdown wiring, timeout-does-not-hang, drainer `SYNC_GLOBAL_RT_DIV` routing).
- [x] Modified or extended existing tests (`sendGlobalRtDivMessage` updated to the position-based signature; steady-state values unchanged).
- [x] Verified backward compatibility — steady-state behavior is unchanged; the position-based refactor passes the same values it did before.

Test runs (clients/da-vinci-client): `LeaderFollowerStoreIngestionTaskTest` (149), `StoreBufferServiceTest` (22), and the `SITWith*` subclasses covering `StoreIngestionTask` (322 each) — all green, 0 failures.

## Does this PR introduce any user-facing or breaking changes?
- [x] No.
