### PR TITLE
[admin-tool][controller] Fix update-admin-operation-protocol-version silently ignoring -1

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminToolEndToEnd.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestAdminToolEndToEnd.java
@@ -76,6 +76,56 @@ public class TestAdminToolEndToEnd {
     venice.close();
   }
 
+  /**
+   * Verifies that passing -1 as the admin operation protocol version resets an existing pinned version in ZK.
+   * Before the fix, -1 was treated as UNDEFINED_VALUE in the merge guard and the ZK write was silently skipped,
+   * leaving the previously pinned version in place.
+   */
+  @Test(timeOut = 4 * TEST_TIMEOUT)
+  public void testUpdateAdminOperationVersionToNegativeOne() throws Exception {
+    long pinnedVersion = 80L;
+    try (VeniceTwoLayerMultiRegionMultiClusterWrapper venice =
+        ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+            new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(1)
+                .numberOfClusters(1)
+                .numberOfParentControllers(1)
+                .numberOfChildControllers(1)
+                .numberOfServers(1)
+                .numberOfRouters(1)
+                .replicationFactor(1)
+                .build())) {
+      String clusterName = venice.getClusterNames()[0];
+      VeniceControllerWrapper parentController = venice.getParentControllers().get(0);
+      ControllerClient parentControllerClient = new ControllerClient(clusterName, parentController.getControllerUrl());
+
+      // Pin the version to a known non-(-1) value first
+      AdminTool.main(
+          new String[] { "--update-admin-operation-protocol-version", "--url", parentController.getControllerUrl(),
+              "--cluster", clusterName, "--admin-operation-protocol-version", String.valueOf(pinnedVersion) });
+
+      TestUtils.waitForNonDeterministicAssertion(
+          30,
+          TimeUnit.SECONDS,
+          () -> Assert.assertEquals(
+              parentControllerClient.getAdminTopicMetadata(Optional.empty()).getAdminOperationProtocolVersion(),
+              pinnedVersion));
+
+      // Now reset to -1 (unpinned). Before the fix this was silently dropped.
+      AdminTool.main(
+          new String[] { "--update-admin-operation-protocol-version", "--url", parentController.getControllerUrl(),
+              "--cluster", clusterName, "--admin-operation-protocol-version", "-1" });
+
+      TestUtils.waitForNonDeterministicAssertion(
+          30,
+          TimeUnit.SECONDS,
+          () -> Assert.assertEquals(
+              parentControllerClient.getAdminTopicMetadata(Optional.empty()).getAdminOperationProtocolVersion(),
+              -1L,
+              "Protocol version should be reset to -1; if still " + pinnedVersion
+                  + " the ZK write was silently skipped"));
+    }
+  }
+
   @Test(timeOut = TEST_TIMEOUT)
   public void testNodeReplicasReadinessCommand() throws Exception {
     VeniceServerWrapper server = venice.getVeniceServers().get(0);

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/admin/InMemoryAdminTopicMetadataAccessor.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/admin/InMemoryAdminTopicMetadataAccessor.java
@@ -19,7 +19,7 @@ public class InMemoryAdminTopicMetadataAccessor extends AdminTopicMetadataAccess
   public void updateMetadata(String clusterName, AdminMetadata metadataDelta) {
     PubSubPosition newPosition = metadataDelta.getPosition();
     PubSubPosition newUpstreamPosition = metadataDelta.getUpstreamPosition();
-    if (metadataDelta.hasExecutionId()) {
+    if (!metadataDelta.getExecutionId().equals(UNDEFINED_VALUE)) {
       inMemoryMetadata.setExecutionId(metadataDelta.getExecutionId());
     }
     if (metadataDelta.hasAdminOperationProtocolVersion()) {

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/admin/InMemoryAdminTopicMetadataAccessor.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/admin/InMemoryAdminTopicMetadataAccessor.java
@@ -22,7 +22,7 @@ public class InMemoryAdminTopicMetadataAccessor extends AdminTopicMetadataAccess
     if (metadataDelta.getExecutionId() != null) {
       inMemoryMetadata.setExecutionId(metadataDelta.getExecutionId());
     }
-    if (!metadataDelta.getAdminOperationProtocolVersion().equals(UNDEFINED_VALUE)) {
+    if (metadataDelta.hasAdminOperationProtocolVersion()) {
       inMemoryMetadata.setAdminOperationProtocolVersion(metadataDelta.getAdminOperationProtocolVersion());
     }
     if (!PubSubSymbolicPosition.EARLIEST.equals(newPosition)) {

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/admin/InMemoryAdminTopicMetadataAccessor.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/admin/InMemoryAdminTopicMetadataAccessor.java
@@ -19,7 +19,7 @@ public class InMemoryAdminTopicMetadataAccessor extends AdminTopicMetadataAccess
   public void updateMetadata(String clusterName, AdminMetadata metadataDelta) {
     PubSubPosition newPosition = metadataDelta.getPosition();
     PubSubPosition newUpstreamPosition = metadataDelta.getUpstreamPosition();
-    if (metadataDelta.getExecutionId() != null) {
+    if (metadataDelta.hasExecutionId()) {
       inMemoryMetadata.setExecutionId(metadataDelta.getExecutionId());
     }
     if (metadataDelta.hasAdminOperationProtocolVersion()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkAdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkAdminTopicMetadataAccessor.java
@@ -81,7 +81,7 @@ public class ZkAdminTopicMetadataAccessor extends AdminTopicMetadataAccessor {
           metadata);
 
       // Merge the metadata objects
-      if (!metadata.getExecutionId().equals(UNDEFINED_VALUE)) {
+      if (metadata.hasExecutionId()) {
         currentMetadata.setExecutionId(metadata.getExecutionId());
       }
       if (metadata.hasAdminOperationProtocolVersion()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkAdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkAdminTopicMetadataAccessor.java
@@ -81,7 +81,7 @@ public class ZkAdminTopicMetadataAccessor extends AdminTopicMetadataAccessor {
           metadata);
 
       // Merge the metadata objects
-      if (metadata.hasExecutionId()) {
+      if (!metadata.getExecutionId().equals(UNDEFINED_VALUE)) {
         currentMetadata.setExecutionId(metadata.getExecutionId());
       }
       if (metadata.hasAdminOperationProtocolVersion()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkAdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkAdminTopicMetadataAccessor.java
@@ -84,7 +84,7 @@ public class ZkAdminTopicMetadataAccessor extends AdminTopicMetadataAccessor {
       if (!metadata.getExecutionId().equals(UNDEFINED_VALUE)) {
         currentMetadata.setExecutionId(metadata.getExecutionId());
       }
-      if (!metadata.getAdminOperationProtocolVersion().equals(UNDEFINED_VALUE)) {
+      if (metadata.hasAdminOperationProtocolVersion()) {
         currentMetadata.setAdminOperationProtocolVersion(metadata.getAdminOperationProtocolVersion());
       }
       if (metadata.getPosition() != null && !metadata.getPosition().equals(PubSubSymbolicPosition.EARLIEST)) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminMetadata.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminMetadata.java
@@ -83,6 +83,10 @@ public class AdminMetadata {
     return adminOperationProtocolVersion == null ? UNDEFINED_VALUE : adminOperationProtocolVersion;
   }
 
+  public boolean hasAdminOperationProtocolVersion() {
+    return adminOperationProtocolVersion != null;
+  }
+
   public void setAdminOperationProtocolVersion(Long adminOperationProtocolVersion) {
     this.adminOperationProtocolVersion = adminOperationProtocolVersion;
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminMetadata.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminMetadata.java
@@ -75,6 +75,10 @@ public class AdminMetadata {
     return executionId == null ? UNDEFINED_VALUE : executionId;
   }
 
+  public boolean hasExecutionId() {
+    return executionId != null;
+  }
+
   public void setExecutionId(Long executionId) {
     this.executionId = executionId;
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkAdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkAdminTopicMetadataAccessor.java
@@ -150,6 +150,40 @@ public class TestZkAdminTopicMetadataAccessor {
   }
 
   @Test
+  public void testDeltaWithoutExecutionIdPreservesExistingValue() {
+    String clusterName = "test-cluster";
+    InMemoryPubSubPosition originalPosition = InMemoryPubSubPosition.of(1L);
+
+    // Existing metadata with a set executionId
+    AdminMetadata currentMetadata = new AdminMetadata();
+    currentMetadata.setPubSubPosition(originalPosition);
+    currentMetadata.setExecutionId(42L);
+    currentMetadata.setAdminOperationProtocolVersion(97L);
+
+    // Delta that only updates the protocol version — executionId is intentionally absent
+    AdminMetadata metadataDelta = new AdminMetadata();
+    metadataDelta.setAdminOperationProtocolVersion(98L);
+
+    String v2MetadataPath = ZkAdminTopicMetadataAccessor.getAdminTopicV2MetadataNodePath(clusterName);
+
+    try (MockedStatic<DataTree> dataTreeMockedStatic = Mockito.mockStatic(DataTree.class)) {
+      dataTreeMockedStatic.when(() -> DataTree.copyStat(any(), any())).thenAnswer(invocation -> null);
+      Stat readStat = new Stat();
+      when(zkClient.readData(v2MetadataPath, readStat)).thenReturn(currentMetadata);
+
+      zkAdminTopicMetadataAccessor.updateMetadata(clusterName, metadataDelta);
+
+      // executionId must be retained from the existing metadata (42), not overwritten with UNDEFINED_VALUE (-1)
+      AdminMetadata expectedMetadata = new AdminMetadata();
+      expectedMetadata.setPubSubPosition(originalPosition);
+      expectedMetadata.setExecutionId(42L);
+      expectedMetadata.setAdminOperationProtocolVersion(98L);
+
+      verify(zkClient, times(1)).writeDataGetStat(eq(v2MetadataPath), eq(expectedMetadata), eq(0));
+    }
+  }
+
+  @Test
   public void testGetMetadata() {
     String clusterName = "test-cluster";
     AdminMetadata currentV2Metadata = new AdminMetadata();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkAdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkAdminTopicMetadataAccessor.java
@@ -150,36 +150,54 @@ public class TestZkAdminTopicMetadataAccessor {
   }
 
   @Test
-  public void testDeltaWithoutExecutionIdPreservesExistingValue() {
+  public void testExecutionIdIsNeverOverwrittenWithUndefinedValue() {
     String clusterName = "test-cluster";
     InMemoryPubSubPosition originalPosition = InMemoryPubSubPosition.of(1L);
 
-    // Existing metadata with a set executionId
     AdminMetadata currentMetadata = new AdminMetadata();
     currentMetadata.setPubSubPosition(originalPosition);
     currentMetadata.setExecutionId(42L);
     currentMetadata.setAdminOperationProtocolVersion(97L);
 
-    // Delta that only updates the protocol version — executionId is intentionally absent
-    AdminMetadata metadataDelta = new AdminMetadata();
-    metadataDelta.setAdminOperationProtocolVersion(98L);
-
     String v2MetadataPath = ZkAdminTopicMetadataAccessor.getAdminTopicV2MetadataNodePath(clusterName);
+
+    // Case 1: delta with executionId absent (null field) must not overwrite existing value
+    AdminMetadata deltaWithoutExecutionId = new AdminMetadata();
+    deltaWithoutExecutionId.setAdminOperationProtocolVersion(98L);
 
     try (MockedStatic<DataTree> dataTreeMockedStatic = Mockito.mockStatic(DataTree.class)) {
       dataTreeMockedStatic.when(() -> DataTree.copyStat(any(), any())).thenAnswer(invocation -> null);
       Stat readStat = new Stat();
       when(zkClient.readData(v2MetadataPath, readStat)).thenReturn(currentMetadata);
 
-      zkAdminTopicMetadataAccessor.updateMetadata(clusterName, metadataDelta);
+      zkAdminTopicMetadataAccessor.updateMetadata(clusterName, deltaWithoutExecutionId);
 
-      // executionId must be retained from the existing metadata (42), not overwritten with UNDEFINED_VALUE (-1)
-      AdminMetadata expectedMetadata = new AdminMetadata();
-      expectedMetadata.setPubSubPosition(originalPosition);
-      expectedMetadata.setExecutionId(42L);
-      expectedMetadata.setAdminOperationProtocolVersion(98L);
+      AdminMetadata expected = new AdminMetadata();
+      expected.setPubSubPosition(originalPosition);
+      expected.setExecutionId(42L);
+      expected.setAdminOperationProtocolVersion(98L);
+      verify(zkClient, times(1)).writeDataGetStat(eq(v2MetadataPath), eq(expected), eq(0));
+    }
 
-      verify(zkClient, times(1)).writeDataGetStat(eq(v2MetadataPath), eq(expectedMetadata), eq(0));
+    // Case 2: delta with executionId explicitly set to -1 must also not overwrite existing value
+    Mockito.clearInvocations(zkClient);
+
+    AdminMetadata deltaWithNegativeOneExecutionId = new AdminMetadata();
+    deltaWithNegativeOneExecutionId.setExecutionId(AdminTopicMetadataAccessor.UNDEFINED_VALUE);
+    deltaWithNegativeOneExecutionId.setAdminOperationProtocolVersion(99L);
+
+    try (MockedStatic<DataTree> dataTreeMockedStatic = Mockito.mockStatic(DataTree.class)) {
+      dataTreeMockedStatic.when(() -> DataTree.copyStat(any(), any())).thenAnswer(invocation -> null);
+      Stat readStat = new Stat();
+      when(zkClient.readData(v2MetadataPath, readStat)).thenReturn(currentMetadata);
+
+      zkAdminTopicMetadataAccessor.updateMetadata(clusterName, deltaWithNegativeOneExecutionId);
+
+      AdminMetadata expected = new AdminMetadata();
+      expected.setPubSubPosition(originalPosition);
+      expected.setExecutionId(42L); // must remain 42, not -1
+      expected.setAdminOperationProtocolVersion(99L);
+      verify(zkClient, times(1)).writeDataGetStat(eq(v2MetadataPath), eq(expected), eq(0));
     }
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkAdminTopicMetadataAccessor.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkAdminTopicMetadataAccessor.java
@@ -116,6 +116,40 @@ public class TestZkAdminTopicMetadataAccessor {
   }
 
   @Test
+  public void testUpdateAdminOperationProtocolVersionToNegativeOne() {
+    String clusterName = "test-cluster";
+    InMemoryPubSubPosition originalPosition = InMemoryPubSubPosition.of(1L);
+
+    // Existing metadata with a pinned protocol version
+    AdminMetadata currentMetadata = new AdminMetadata();
+    currentMetadata.setPubSubPosition(originalPosition);
+    currentMetadata.setExecutionId(1L);
+    currentMetadata.setAdminOperationProtocolVersion(97L);
+
+    // Delta that resets the protocol version to -1 (unpinned / use latest)
+    AdminMetadata metadataDelta = new AdminMetadata();
+    metadataDelta.setAdminOperationProtocolVersion(-1L);
+
+    String v2MetadataPath = ZkAdminTopicMetadataAccessor.getAdminTopicV2MetadataNodePath(clusterName);
+
+    try (MockedStatic<DataTree> dataTreeMockedStatic = Mockito.mockStatic(DataTree.class)) {
+      dataTreeMockedStatic.when(() -> DataTree.copyStat(any(), any())).thenAnswer(invocation -> null);
+      Stat readStat = new Stat();
+      when(zkClient.readData(v2MetadataPath, readStat)).thenReturn(currentMetadata);
+
+      zkAdminTopicMetadataAccessor.updateMetadata(clusterName, metadataDelta);
+
+      // The written metadata must have -1 (not 97 — the old value must not be retained)
+      AdminMetadata expectedMetadata = new AdminMetadata();
+      expectedMetadata.setPubSubPosition(originalPosition);
+      expectedMetadata.setExecutionId(1L);
+      expectedMetadata.setAdminOperationProtocolVersion(-1L);
+
+      verify(zkClient, times(1)).writeDataGetStat(eq(v2MetadataPath), eq(expectedMetadata), eq(0));
+    }
+  }
+
+  @Test
   public void testGetMetadata() {
     String clusterName = "test-cluster";
     AdminMetadata currentV2Metadata = new AdminMetadata();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminMetadata.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminMetadata.java
@@ -211,6 +211,32 @@ public class TestAdminMetadata {
   }
 
   @Test
+  public void testHasExecutionIdAndHasAdminOperationProtocolVersion() {
+    AdminMetadata metadata = new AdminMetadata();
+
+    // Neither field set — both has* methods must return false
+    assertFalse(metadata.hasExecutionId());
+    assertFalse(metadata.hasAdminOperationProtocolVersion());
+
+    // Getters return UNDEFINED_VALUE (-1) when unset
+    assertEquals(metadata.getExecutionId(), UNDEFINED_VALUE);
+    assertEquals(metadata.getAdminOperationProtocolVersion(), UNDEFINED_VALUE);
+
+    // Set executionId — hasExecutionId becomes true, other stays false
+    metadata.setExecutionId(42L);
+    assertTrue(metadata.hasExecutionId());
+    assertFalse(metadata.hasAdminOperationProtocolVersion());
+
+    // Explicitly set to -1 (UNDEFINED_VALUE) — has* must still return true
+    // (distinguishes "field present with value -1" from "field absent")
+    metadata.setExecutionId(UNDEFINED_VALUE);
+    assertTrue(metadata.hasExecutionId());
+
+    metadata.setAdminOperationProtocolVersion(UNDEFINED_VALUE);
+    assertTrue(metadata.hasAdminOperationProtocolVersion());
+  }
+
+  @Test
   public void testToString() {
     AdminMetadata metadata = new AdminMetadata();
     metadata.setExecutionId(123L);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminMetadata.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminMetadata.java
@@ -222,18 +222,22 @@ public class TestAdminMetadata {
     assertEquals(metadata.getExecutionId(), UNDEFINED_VALUE);
     assertEquals(metadata.getAdminOperationProtocolVersion(), UNDEFINED_VALUE);
 
-    // Set executionId — hasExecutionId becomes true, other stays false
+    // Set executionId to a positive value — hasExecutionId becomes true
     metadata.setExecutionId(42L);
     assertTrue(metadata.hasExecutionId());
     assertFalse(metadata.hasAdminOperationProtocolVersion());
 
-    // Explicitly set to -1 (UNDEFINED_VALUE) — has* must still return true
-    // (distinguishes "field present with value -1" from "field absent")
-    metadata.setExecutionId(UNDEFINED_VALUE);
-    assertTrue(metadata.hasExecutionId());
-
+    // hasAdminOperationProtocolVersion() returns true even when set to -1:
+    // -1 is a valid target for adminOperationProtocolVersion (means "unpinned / use latest").
+    // The merge guard uses hasAdminOperationProtocolVersion() so -1 is written to ZK.
     metadata.setAdminOperationProtocolVersion(UNDEFINED_VALUE);
     assertTrue(metadata.hasAdminOperationProtocolVersion());
+
+    // hasExecutionId() also returns true when set to -1, but the merge guard for executionId
+    // uses !getExecutionId().equals(UNDEFINED_VALUE) — so -1 is never written to ZK for executionId.
+    metadata.setExecutionId(UNDEFINED_VALUE);
+    assertTrue(metadata.hasExecutionId());
+    assertEquals(metadata.getExecutionId(), UNDEFINED_VALUE); // getter confirms -1
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandlerTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ClusterAdminOpsRequestHandlerTest.java
@@ -291,6 +291,20 @@ public class ClusterAdminOpsRequestHandlerTest {
   }
 
   @Test
+  public void testUpdateAdminOperationProtocolVersionWithNegativeOne() {
+    String clusterName = "test-cluster";
+    UpdateAdminOperationProtocolVersionGrpcRequest request = UpdateAdminOperationProtocolVersionGrpcRequest.newBuilder()
+        .setClusterName(clusterName)
+        .setAdminOperationProtocolVersion(-1L)
+        .build();
+    AdminTopicMetadataGrpcResponse response = handler.updateAdminOperationProtocolVersion(request);
+
+    assertNotNull(response);
+    assertEquals(response.getMetadata().getClusterName(), clusterName);
+    assertEquals(response.getMetadata().getAdminOperationProtocolVersion(), -1L);
+  }
+
+  @Test
   public void testUpdateAdminOperationProtocolVersionInvalidInputs() {
     String clusterName = "test-cluster";
     long version = 12345L;


### PR DESCRIPTION
## Problem Statement

`--update-admin-operation-protocol-version --admin-operation-protocol-version -1` via the admin tool was silently dropped. The command returned HTTP 200 but the ZooKeeper node was never updated.

Root cause: `-1L` (`UNDEFINED_VALUE`) served two conflicting roles in the `AdminMetadata` merge logic:
1. A valid target value meaning "unpinned — use the latest protocol version supported by the running code" (allowed by `ControllerRequestParamValidator`).
2. The "this field was not set in this delta" sentinel used by the merge guards in `ZkAdminTopicMetadataAccessor` and `InMemoryAdminTopicMetadataAccessor`.

The same structural bug also affected `executionId`: `InMemoryAdminTopicMetadataAccessor` guarded with `getExecutionId() != null`, but the getter never returns `null` (it maps a missing field to `-1L`), so the guard was always `true` and could unintentionally overwrite a stored `executionId`. `ZkAdminTopicMetadataAccessor` used `!getExecutionId().equals(UNDEFINED_VALUE)` which had the symmetric problem — it could not distinguish an absent field from one explicitly set to `-1`.

## Solution

Added `AdminMetadata.hasAdminOperationProtocolVersion()` and `AdminMetadata.hasExecutionId()`, which check the raw nullable `Long` fields directly (`field != null`). This cleanly distinguishes "not provided in this delta" (`null`) from "explicitly set to `-1`".

All three merge-guard sites now use these presence-check methods:
- `ZkAdminTopicMetadataAccessor` — both `executionId` and `adminOperationProtocolVersion`
- `InMemoryAdminTopicMetadataAccessor` — both fields

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [x] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

Unit tests:
- `TestAdminMetadata.testHasExecutionIdAndHasAdminOperationProtocolVersion` — verifies `has*()` returns `false` when field is absent and `true` when set, including when explicitly set to `-1`.
- `TestZkAdminTopicMetadataAccessor.testUpdateAdminOperationProtocolVersionToNegativeOne` — verifies a delta with `adminOperationProtocolVersion = -1` overwrites an existing pinned version in ZK (would have failed before this fix).
- `TestZkAdminTopicMetadataAccessor.testDeltaWithoutExecutionIdPreservesExistingValue` — verifies a delta that omits `executionId` does not overwrite an existing value in ZK.
- `ClusterAdminOpsRequestHandlerTest.testUpdateAdminOperationProtocolVersionWithNegativeOne` — verifies the handler layer accepts and returns `-1`.

Integration test:
- `TestAdminToolEndToEnd.testUpdateAdminOperationVersionToNegativeOne` — pins the version to `80`, then resets to `-1` via `AdminTool.main`, and asserts the ZK-backed metadata reflects `-1`.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
