### PR TITLE
[controller][test]: Extract schema services from Helix admins

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ParentSchemaOrchestrator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ParentSchemaOrchestrator.java
@@ -1,0 +1,523 @@
+package com.linkedin.venice.controller;
+
+import com.linkedin.venice.controller.kafka.protocol.admin.AdminOperation;
+import com.linkedin.venice.controller.kafka.protocol.admin.DerivedSchemaCreation;
+import com.linkedin.venice.controller.kafka.protocol.admin.MetadataSchemaCreation;
+import com.linkedin.venice.controller.kafka.protocol.admin.SchemaMeta;
+import com.linkedin.venice.controller.kafka.protocol.admin.SupersetSchemaCreation;
+import com.linkedin.venice.controller.kafka.protocol.admin.ValueSchemaCreation;
+import com.linkedin.venice.controller.kafka.protocol.enums.AdminMessageType;
+import com.linkedin.venice.controller.kafka.protocol.enums.SchemaType;
+import com.linkedin.venice.controller.supersetschema.DefaultSupersetSchemaGenerator;
+import com.linkedin.venice.controller.supersetschema.SupersetSchemaGenerator;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.schema.AvroSchemaParseUtils;
+import com.linkedin.venice.schema.SchemaData;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.avro.DirectionalSchemaCompatibilityType;
+import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
+import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
+import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
+import com.linkedin.venice.utils.AvroSchemaUtils;
+import java.util.Collection;
+import java.util.Optional;
+import org.apache.avro.Schema;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Orchestrates schema-related operations (value schema, superset schema, derived/write-compute schema and replication
+ * metadata schema) on the parent controller. The orchestration involves sending admin messages and waiting for them to
+ * be consumed, plus reading back from the child {@link VeniceHelixAdmin}.
+ *
+ * <p>This class is intentionally package-private and reaches the parent's package-private methods through the injected
+ * {@link VeniceParentHelixAdmin} back-reference, since a same-package reference cannot read the parent's private
+ * fields.</p>
+ */
+class ParentSchemaOrchestrator {
+  private static final Logger LOGGER = LogManager.getLogger(ParentSchemaOrchestrator.class);
+
+  private final VeniceParentHelixAdmin parent;
+  private final WriteComputeSchemaConverter writeComputeSchemaConverter;
+  private final Optional<SupersetSchemaGenerator> externalSupersetSchemaGenerator;
+  private final SupersetSchemaGenerator defaultSupersetSchemaGenerator = new DefaultSupersetSchemaGenerator();
+
+  ParentSchemaOrchestrator(
+      VeniceParentHelixAdmin parent,
+      WriteComputeSchemaConverter writeComputeSchemaConverter,
+      Optional<SupersetSchemaGenerator> externalSupersetSchemaGenerator) {
+    this.parent = parent;
+    this.writeComputeSchemaConverter = writeComputeSchemaConverter;
+    this.externalSupersetSchemaGenerator = externalSupersetSchemaGenerator;
+  }
+
+  SupersetSchemaGenerator getSupersetSchemaGenerator(String clusterName) {
+    if (externalSupersetSchemaGenerator.isPresent() && parent.getMultiClusterConfigs()
+        .getControllerConfig(clusterName)
+        .isParentExternalSupersetSchemaGenerationEnabled()) {
+      return externalSupersetSchemaGenerator.get();
+    }
+    return defaultSupersetSchemaGenerator;
+  }
+
+  void addSupersetSchemaForStore(String clusterName, String storeName, boolean activeActiveReplicationEnabled) {
+    // Generate a superset schema and add it.
+    SchemaEntry supersetSchemaEntry = getSupersetSchemaGenerator(clusterName)
+        .generateSupersetSchemaFromSchemas(parent.getVeniceHelixAdmin().getValueSchemas(clusterName, storeName));
+    final Schema supersetSchema = supersetSchemaEntry.getSchema();
+    final int supersetSchemaID = supersetSchemaEntry.getId();
+    addValueSchemaEntry(clusterName, storeName, supersetSchema.toString(), supersetSchemaID, true);
+
+    if (activeActiveReplicationEnabled) {
+      updateReplicationMetadataSchema(clusterName, storeName, supersetSchema, supersetSchemaID);
+    }
+  }
+
+  SchemaEntry addValueSchema(
+      String clusterName,
+      String storeName,
+      String newValueSchemaStr,
+      DirectionalSchemaCompatibilityType expectedCompatibilityType) {
+    parent.acquireAdminMessageLock(clusterName, storeName);
+    try {
+      final int newValueSchemaId = parent.getVeniceHelixAdmin()
+          .checkPreConditionForAddValueSchemaAndGetNewSchemaId(
+              clusterName,
+              storeName,
+              newValueSchemaStr,
+              expectedCompatibilityType);
+
+      /**
+       * If we find this is an exactly duplicate schema, return the existing schema id;
+       * else add the schema with possible doc field change.
+       */
+      if (newValueSchemaId == SchemaData.DUPLICATE_VALUE_SCHEMA_CODE) {
+        return new SchemaEntry(
+            parent.getVeniceHelixAdmin().getValueSchemaId(clusterName, storeName, newValueSchemaStr),
+            newValueSchemaStr);
+      }
+
+      return addValueSchema(clusterName, storeName, newValueSchemaStr, newValueSchemaId, expectedCompatibilityType);
+    } finally {
+      parent.releaseAdminMessageLock(clusterName, storeName);
+    }
+  }
+
+  private SchemaEntry addValueAndSupersetSchemaEntries(
+      String clusterName,
+      String storeName,
+      SchemaEntry newValueSchemaEntry,
+      SchemaEntry newSupersetSchemaEntry,
+      final boolean isWriteComputationEnabled) {
+    validateNewSupersetAndValueSchemaEntries(storeName, clusterName, newValueSchemaEntry, newSupersetSchemaEntry);
+    LOGGER.info(
+        "Adding value schema {} and superset schema {} to store: {} in cluster: {}",
+        newValueSchemaEntry,
+        newSupersetSchemaEntry,
+        storeName,
+        clusterName);
+
+    SupersetSchemaCreation supersetSchemaCreation =
+        (SupersetSchemaCreation) AdminMessageType.SUPERSET_SCHEMA_CREATION.getNewInstance();
+    supersetSchemaCreation.clusterName = clusterName;
+    supersetSchemaCreation.storeName = storeName;
+    SchemaMeta valueSchemaMeta = new SchemaMeta();
+    valueSchemaMeta.definition = newValueSchemaEntry.getSchemaStr();
+    valueSchemaMeta.schemaType = SchemaType.AVRO_1_4.getValue();
+    supersetSchemaCreation.valueSchema = valueSchemaMeta;
+    supersetSchemaCreation.valueSchemaId = newValueSchemaEntry.getId();
+
+    SchemaMeta supersetSchemaMeta = new SchemaMeta();
+    supersetSchemaMeta.definition = newSupersetSchemaEntry.getSchemaStr();
+    supersetSchemaMeta.schemaType = SchemaType.AVRO_1_4.getValue();
+    supersetSchemaCreation.supersetSchema = supersetSchemaMeta;
+    supersetSchemaCreation.supersetSchemaId = newSupersetSchemaEntry.getId();
+
+    AdminOperation message = new AdminOperation();
+    message.operationType = AdminMessageType.SUPERSET_SCHEMA_CREATION.getValue();
+    message.payloadUnion = supersetSchemaCreation;
+
+    parent.sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
+    // Need to add RMD schemas for both new value schema and new superset schema.
+    updateReplicationMetadataSchema(
+        clusterName,
+        storeName,
+        newValueSchemaEntry.getSchema(),
+        newValueSchemaEntry.getId());
+    updateReplicationMetadataSchema(
+        clusterName,
+        storeName,
+        newSupersetSchemaEntry.getSchema(),
+        newSupersetSchemaEntry.getId());
+    if (isWriteComputationEnabled) {
+      Schema newValueWriteComputeSchema =
+          writeComputeSchemaConverter.convertFromValueRecordSchema(newValueSchemaEntry.getSchema());
+      Schema newSuperSetWriteComputeSchema =
+          writeComputeSchemaConverter.convertFromValueRecordSchema(newSupersetSchemaEntry.getSchema());
+      addDerivedSchema(clusterName, storeName, newValueSchemaEntry.getId(), newValueWriteComputeSchema.toString());
+      addDerivedSchema(
+          clusterName,
+          storeName,
+          newSupersetSchemaEntry.getId(),
+          newSuperSetWriteComputeSchema.toString());
+    }
+    parent.updateStore(
+        clusterName,
+        storeName,
+        new UpdateStoreQueryParams().setLatestSupersetSchemaId(newSupersetSchemaEntry.getId()));
+    return newValueSchemaEntry;
+  }
+
+  private void validateNewSupersetAndValueSchemaEntries(
+      String storeName,
+      String clusterName,
+      SchemaEntry newValueSchemaEntry,
+      SchemaEntry newSupersetSchemaEntry) {
+    if (newValueSchemaEntry.getId() == newSupersetSchemaEntry.getId()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Superset schema ID and value schema ID are expected to be different for store %s in cluster %s. "
+                  + "Got ID: %d",
+              storeName,
+              clusterName,
+              newValueSchemaEntry.getId()));
+    }
+    if (AvroSchemaUtils
+        .compareSchemaIgnoreFieldOrder(newValueSchemaEntry.getSchema(), newSupersetSchemaEntry.getSchema())) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Superset and value schemas are expected to be different for store %s in cluster %s. Got schema: %s",
+              storeName,
+              clusterName,
+              newValueSchemaEntry.getSchema()));
+    }
+  }
+
+  private SchemaEntry addValueSchemaEntry(
+      String clusterName,
+      String storeName,
+      String valueSchemaStr,
+      final int newValueSchemaId,
+      final boolean doUpdateSupersetSchemaID) {
+    LOGGER.info("Adding value schema: {} to store: {} in cluster: {}", valueSchemaStr, storeName, clusterName);
+
+    ValueSchemaCreation valueSchemaCreation =
+        (ValueSchemaCreation) AdminMessageType.VALUE_SCHEMA_CREATION.getNewInstance();
+    valueSchemaCreation.clusterName = clusterName;
+    valueSchemaCreation.storeName = storeName;
+    SchemaMeta schemaMeta = new SchemaMeta();
+    schemaMeta.definition = valueSchemaStr;
+    schemaMeta.schemaType = SchemaType.AVRO_1_4.getValue();
+    valueSchemaCreation.schema = schemaMeta;
+    valueSchemaCreation.schemaId = newValueSchemaId;
+
+    AdminOperation message = new AdminOperation();
+    message.operationType = AdminMessageType.VALUE_SCHEMA_CREATION.getValue();
+    message.payloadUnion = valueSchemaCreation;
+    parent.sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
+
+    // defensive code checking
+    int actualValueSchemaId = parent.getVeniceHelixAdmin().getValueSchemaId(clusterName, storeName, valueSchemaStr);
+    if (actualValueSchemaId != newValueSchemaId) {
+      throw new VeniceException(
+          "Something bad happens, the expected new value schema id is: " + newValueSchemaId + ", but got: "
+              + actualValueSchemaId);
+    }
+
+    if (doUpdateSupersetSchemaID) {
+      parent.updateStore(
+          clusterName,
+          storeName,
+          new UpdateStoreQueryParams().setLatestSupersetSchemaId(newValueSchemaId));
+    }
+
+    return new SchemaEntry(actualValueSchemaId, valueSchemaStr);
+  }
+
+  SchemaEntry addValueSchema(
+      String clusterName,
+      String storeName,
+      String newValueSchemaStr,
+      int schemaId,
+      DirectionalSchemaCompatibilityType expectedCompatibilityType) {
+    parent.acquireAdminMessageLock(clusterName, storeName);
+    try {
+      Schema newValueSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(newValueSchemaStr);
+
+      final Store store = parent.getVeniceHelixAdmin().getStore(clusterName, storeName);
+      Schema existingValueSchema = parent.getVeniceHelixAdmin().getSupersetOrLatestValueSchema(clusterName, store);
+
+      // Update superset schema if:
+      // 1. Compute is enabled (existing behavior), OR
+      // 2. A superset schema already exists (always keep it updated even if compute is disabled)
+      // Check if a superset schema already exists for this store
+      final boolean doUpdateSupersetSchemaID;
+      boolean supersetSchemaAlreadyExists =
+          store.getLatestSuperSetValueSchemaId() != SchemaData.INVALID_VALUE_SCHEMA_ID;
+      if (existingValueSchema != null
+          && (store.isReadComputationEnabled() || store.isWriteComputationEnabled() || supersetSchemaAlreadyExists)) {
+        SupersetSchemaGenerator supersetSchemaGenerator = getSupersetSchemaGenerator(clusterName);
+        Schema newSuperSetSchema = supersetSchemaGenerator.generateSupersetSchema(existingValueSchema, newValueSchema);
+        String newSuperSetSchemaStr = newSuperSetSchema.toString();
+        if (supersetSchemaGenerator.compareSchema(newSuperSetSchema, newValueSchema)) {
+          doUpdateSupersetSchemaID = true;
+
+        } else if (supersetSchemaGenerator.compareSchema(newSuperSetSchema, existingValueSchema)) {
+          doUpdateSupersetSchemaID = false;
+
+        } else if (store.isSystemStore()) {
+          /**
+           * Do not register superset schema for system store for now. Because some system stores specify the schema ID
+           * explicitly, which may conflict with the superset schema generated internally, the new value schema registration
+           * could fail.
+           *
+           * TODO: Design a long-term plan.
+           */
+          doUpdateSupersetSchemaID = false;
+
+        } else {
+          // Register superset schema only if it does not match with existing or new schema.
+
+          // validate compatibility of the new superset schema
+          parent.getVeniceHelixAdmin()
+              .checkPreConditionForAddValueSchemaAndGetNewSchemaId(
+                  clusterName,
+                  storeName,
+                  newSuperSetSchemaStr,
+                  expectedCompatibilityType);
+          // Check if the superset schema already exists or not. If exists use the same ID, else bump the value ID by
+          // one.
+          int supersetSchemaId = parent.getVeniceHelixAdmin()
+              .getValueSchemaIdIgnoreFieldOrder(
+                  clusterName,
+                  storeName,
+                  newSuperSetSchemaStr,
+                  (s1, s2) -> supersetSchemaGenerator.compareSchema(s1, s2) ? 0 : 1);
+          if (supersetSchemaId == SchemaData.INVALID_VALUE_SCHEMA_ID) {
+            supersetSchemaId = schemaId + 1;
+          }
+          return addValueAndSupersetSchemaEntries(
+              clusterName,
+              storeName,
+              new SchemaEntry(schemaId, newValueSchema),
+              new SchemaEntry(supersetSchemaId, newSuperSetSchema),
+              store.isWriteComputationEnabled());
+        }
+      } else {
+        doUpdateSupersetSchemaID = false;
+      }
+      SchemaEntry addedSchemaEntry =
+          addValueSchemaEntry(clusterName, storeName, newValueSchemaStr, schemaId, doUpdateSupersetSchemaID);
+
+      /**
+       * if active-active replication is enabled for the store then generate and register the new Replication metadata schema
+       * for this newly added value schema.
+       */
+      if (store.isActiveActiveReplicationEnabled()) {
+        Schema latestValueSchema = parent.getVeniceHelixAdmin().getSupersetOrLatestValueSchema(clusterName, store);
+        final int valueSchemaId =
+            parent.getVeniceHelixAdmin().getValueSchemaId(clusterName, storeName, latestValueSchema.toString());
+        updateReplicationMetadataSchema(clusterName, storeName, latestValueSchema, valueSchemaId);
+      }
+      if (store.isWriteComputationEnabled()) {
+        Schema newWriteComputeSchema =
+            writeComputeSchemaConverter.convertFromValueRecordSchema(addedSchemaEntry.getSchema());
+        addDerivedSchema(clusterName, storeName, addedSchemaEntry.getId(), newWriteComputeSchema.toString());
+      }
+
+      return addedSchemaEntry;
+    } finally {
+      parent.releaseAdminMessageLock(clusterName, storeName);
+    }
+  }
+
+  DerivedSchemaEntry addDerivedSchema(
+      String clusterName,
+      String storeName,
+      int valueSchemaId,
+      String derivedSchemaStr) {
+    parent.acquireAdminMessageLock(clusterName, storeName);
+    try {
+      int newDerivedSchemaId = parent.getVeniceHelixAdmin()
+          .checkPreConditionForAddDerivedSchemaAndGetNewSchemaId(
+              clusterName,
+              storeName,
+              valueSchemaId,
+              derivedSchemaStr);
+
+      // if we find this is a duplicate schema, return the existing schema id
+      if (newDerivedSchemaId == SchemaData.DUPLICATE_VALUE_SCHEMA_CODE) {
+        return new DerivedSchemaEntry(
+            valueSchemaId,
+            parent.getVeniceHelixAdmin()
+                .getDerivedSchemaId(clusterName, storeName, derivedSchemaStr)
+                .getGeneratedSchemaVersion(),
+            derivedSchemaStr);
+      }
+
+      LOGGER.info(
+          "Adding derived schema: {} to store: {}, version: {} in cluster: {}",
+          derivedSchemaStr,
+          storeName,
+          valueSchemaId,
+          clusterName);
+
+      DerivedSchemaCreation derivedSchemaCreation =
+          (DerivedSchemaCreation) AdminMessageType.DERIVED_SCHEMA_CREATION.getNewInstance();
+      derivedSchemaCreation.clusterName = clusterName;
+      derivedSchemaCreation.storeName = storeName;
+      SchemaMeta schemaMeta = new SchemaMeta();
+      schemaMeta.definition = derivedSchemaStr;
+      schemaMeta.schemaType = SchemaType.AVRO_1_4.getValue();
+      derivedSchemaCreation.schema = schemaMeta;
+      derivedSchemaCreation.valueSchemaId = valueSchemaId;
+      derivedSchemaCreation.derivedSchemaId = newDerivedSchemaId;
+
+      AdminOperation message = new AdminOperation();
+      message.operationType = AdminMessageType.DERIVED_SCHEMA_CREATION.getValue();
+      message.payloadUnion = derivedSchemaCreation;
+
+      parent.sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
+
+      return new DerivedSchemaEntry(valueSchemaId, newDerivedSchemaId, derivedSchemaStr);
+    } finally {
+      parent.releaseAdminMessageLock(clusterName, storeName);
+    }
+  }
+
+  RmdSchemaEntry addReplicationMetadataSchema(
+      String clusterName,
+      String storeName,
+      int valueSchemaId,
+      int replicationMetadataVersionId,
+      String replicationMetadataSchemaStr) {
+    parent.acquireAdminMessageLock(clusterName, storeName);
+    try {
+      RmdSchemaEntry rmdSchemaEntry =
+          new RmdSchemaEntry(valueSchemaId, replicationMetadataVersionId, replicationMetadataSchemaStr);
+      final boolean replicationMetadataSchemaAlreadyPresent = parent.getVeniceHelixAdmin()
+          .checkIfMetadataSchemaAlreadyPresent(clusterName, storeName, valueSchemaId, rmdSchemaEntry);
+      if (replicationMetadataSchemaAlreadyPresent) {
+        LOGGER.info(
+            "Replication metadata schema already exists for store: {} in cluster: {} metadataSchema: {} "
+                + "replicationMetadataVersionId: {} valueSchemaId: {}",
+            storeName,
+            clusterName,
+            replicationMetadataSchemaStr,
+            replicationMetadataVersionId,
+            valueSchemaId);
+        return rmdSchemaEntry;
+      }
+
+      LOGGER.info(
+          "Adding Replication metadata schema for store: {} in cluster: {} metadataSchema: {} "
+              + "replicationMetadataVersionId: {} valueSchemaId: {}",
+          storeName,
+          clusterName,
+          replicationMetadataSchemaStr,
+          replicationMetadataVersionId,
+          valueSchemaId);
+
+      MetadataSchemaCreation replicationMetadataSchemaCreation =
+          (MetadataSchemaCreation) AdminMessageType.REPLICATION_METADATA_SCHEMA_CREATION.getNewInstance();
+      replicationMetadataSchemaCreation.clusterName = clusterName;
+      replicationMetadataSchemaCreation.storeName = storeName;
+      replicationMetadataSchemaCreation.valueSchemaId = valueSchemaId;
+      SchemaMeta schemaMeta = new SchemaMeta();
+      schemaMeta.definition = replicationMetadataSchemaStr;
+      schemaMeta.schemaType = SchemaType.AVRO_1_4.getValue();
+      replicationMetadataSchemaCreation.metadataSchema = schemaMeta;
+      replicationMetadataSchemaCreation.timestampMetadataVersionId = replicationMetadataVersionId;
+
+      AdminOperation message = new AdminOperation();
+      message.operationType = AdminMessageType.REPLICATION_METADATA_SCHEMA_CREATION.getValue();
+      message.payloadUnion = replicationMetadataSchemaCreation;
+
+      parent.sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
+
+      // Be defensive and check that RMD schema has been added indeed. Do a loose validation parsing as stores can have
+      // older schemas considered wrong with respect to the current avro version
+      final Schema expectedRmdSchema =
+          AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(replicationMetadataSchemaStr);
+      validateRmdSchemaIsAddedAsExpected(
+          clusterName,
+          storeName,
+          valueSchemaId,
+          replicationMetadataVersionId,
+          expectedRmdSchema);
+      return new RmdSchemaEntry(valueSchemaId, replicationMetadataVersionId, replicationMetadataSchemaStr);
+    } catch (Exception e) {
+      LOGGER.error(
+          "Error when adding replication metadata schema for store: {}, value schema id: {}",
+          storeName,
+          valueSchemaId,
+          e);
+      throw e;
+    } finally {
+      parent.releaseAdminMessageLock(clusterName, storeName);
+    }
+  }
+
+  private void validateRmdSchemaIsAddedAsExpected(
+      String clusterName,
+      String storeName,
+      int valueSchemaID,
+      int rmdVersionID,
+      Schema expectedRmdSchema) {
+    final Schema addedRmdSchema = parent.getVeniceHelixAdmin()
+        .getReplicationMetadataSchema(clusterName, storeName, valueSchemaID, rmdVersionID)
+        .orElse(null);
+    if (addedRmdSchema == null) {
+      throw new VeniceException(
+          String.format(
+              "No replication metadata schema found for store %s in cluster %s with value "
+                  + "schema ID %s and RMD protocol version ID %d",
+              storeName,
+              clusterName,
+              valueSchemaID,
+              rmdVersionID));
+    }
+    if (!AvroSchemaUtils.compareSchemaIgnoreFieldOrder(addedRmdSchema, expectedRmdSchema)) {
+      throw new VeniceException(
+          String.format(
+              "For store %s in cluster %s with value schema ID %d and RMD protocol"
+                  + " version ID %d. Expected RMD schema %s. But got RMD schema: %s",
+              storeName,
+              clusterName,
+              valueSchemaID,
+              rmdVersionID,
+              expectedRmdSchema.toString(true),
+              addedRmdSchema.toString(true)));
+    }
+  }
+
+  void updateReplicationMetadataSchemaForAllValueSchema(String clusterName, String storeName) {
+    final Collection<SchemaEntry> valueSchemas = parent.getVeniceHelixAdmin().getValueSchemas(clusterName, storeName);
+    for (SchemaEntry valueSchemaEntry: valueSchemas) {
+      updateReplicationMetadataSchema(clusterName, storeName, valueSchemaEntry.getSchema(), valueSchemaEntry.getId());
+    }
+  }
+
+  void updateReplicationMetadataSchema(String clusterName, String storeName, Schema valueSchema, int valueSchemaId) {
+    final int rmdVersionId = parent.getRmdVersionID(storeName, clusterName);
+    final boolean valueSchemaAlreadyHasRmdSchema = parent.getVeniceHelixAdmin()
+        .checkIfValueSchemaAlreadyHasRmdSchema(clusterName, storeName, valueSchemaId, rmdVersionId);
+    if (valueSchemaAlreadyHasRmdSchema) {
+      LOGGER.info(
+          "Store {} in cluster {} already has a replication metadata schema for its value schema with ID {} and "
+              + "replication metadata version ID {}. So skip updating this value schema's RMD schema.",
+          storeName,
+          clusterName,
+          valueSchemaId,
+          rmdVersionId);
+      return;
+    }
+    String replicationMetadataSchemaStr =
+        RmdSchemaGenerator.generateMetadataSchema(valueSchema, rmdVersionId).toString();
+    addReplicationMetadataSchema(clusterName, storeName, valueSchemaId, rmdVersionId, replicationMetadataSchemaStr);
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreSchemaService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreSchemaService.java
@@ -1,0 +1,466 @@
+package com.linkedin.venice.controller;
+
+import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_STORE_NAME;
+import static com.linkedin.venice.utils.AvroSchemaUtils.isValidAvroSchema;
+
+import com.linkedin.avroutil1.compatibility.AvroIncompatibleSchemaException;
+import com.linkedin.avroutil1.compatibility.RandomRecordGenerator;
+import com.linkedin.avroutil1.compatibility.RecordGenerationConfig;
+import com.linkedin.venice.exceptions.InvalidVeniceSchemaException;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.ReadWriteSchemaRepository;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.schema.AvroSchemaParseUtils;
+import com.linkedin.venice.schema.GeneratedSchemaID;
+import com.linkedin.venice.schema.SchemaData;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.avro.DirectionalSchemaCompatibilityType;
+import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
+import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
+import com.linkedin.venice.serializer.AvroSerializer;
+import com.linkedin.venice.serializer.RecordDeserializer;
+import com.linkedin.venice.serializer.SerializerDeserializerFactory;
+import com.linkedin.venice.system.store.MetaStoreDataType;
+import com.linkedin.venice.system.store.MetaStoreWriter;
+import com.linkedin.venice.systemstore.schemas.StoreMetaKey;
+import com.linkedin.venice.systemstore.schemas.StoreMetaValue;
+import com.linkedin.venice.utils.AvroSchemaUtils;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.avro.Schema;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Encapsulates the (child controller) store schema operations: key/value/derived/replication-metadata schema
+ * registration, reads, validation, and value-schema cleanup. Extracted from {@link VeniceHelixAdmin} to keep schema
+ * concerns cohesive and independently testable. The public {@code Admin} schema methods on {@link VeniceHelixAdmin}
+ * delegate here; this class reaches back into the admin only for the cluster-leadership check and per-cluster
+ * resources/meta-store accessors.
+ */
+class StoreSchemaService {
+  private static final Logger LOGGER = LogManager.getLogger(StoreSchemaService.class);
+  private static final int RECORD_COUNT = 10;
+
+  private final VeniceHelixAdmin admin;
+
+  StoreSchemaService(VeniceHelixAdmin admin) {
+    this.admin = admin;
+  }
+
+  Optional<Schema> getReplicationMetadataSchema(
+      String clusterName,
+      String storeName,
+      int valueSchemaID,
+      int rmdVersionID) {
+    admin.checkControllerLeadershipFor(clusterName);
+    ReadWriteSchemaRepository schemaRepo = admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+    SchemaEntry schemaEntry = schemaRepo.getReplicationMetadataSchema(storeName, valueSchemaID, rmdVersionID);
+    if (schemaEntry == null) {
+      return Optional.empty();
+    } else {
+      return Optional.of(schemaEntry.getSchema());
+    }
+  }
+
+  Set<Integer> getInUseValueSchemaIds(String clusterName, String storeName) {
+    if (admin.isParent()) {
+      return Collections.emptySet();
+    }
+
+    Store store = admin.getStore(clusterName, storeName);
+    Set<Integer> schemaIds = new HashSet<>();
+
+    // Fetch value schema id used by all existing store version
+    for (Version version: store.getVersions()) {
+      Map<String, String> map = new HashMap<>(2);
+      map.put(KEY_STRING_STORE_NAME, storeName);
+      map.put(MetaStoreWriter.KEY_STRING_VERSION_NUMBER, Integer.toString(version.getNumber()));
+      StoreMetaKey key = MetaStoreDataType.VALUE_SCHEMAS_WRITTEN_PER_STORE_VERSION.getStoreMetaKey(map);
+      StoreMetaValue metaValue = admin.getMetaStoreValue(key, storeName);
+
+      if (metaValue == null) {
+        String msg = "Could not find in-use value schema for store " + storeName;
+        LOGGER.warn(msg);
+        throw new VeniceException(msg);
+      }
+      schemaIds.addAll(metaValue.storeValueSchemaIdsWrittenPerStoreVersion);
+    }
+    return schemaIds;
+  }
+
+  void deleteValueSchemas(String clusterName, String storeName, Set<Integer> unusedValueSchemaIds) {
+    Set<Integer> inuseValueSchemaIds = getInUseValueSchemaIds(clusterName, storeName);
+    boolean isCommon = unusedValueSchemaIds.stream().anyMatch(inuseValueSchemaIds::contains);
+    if (isCommon) {
+      String msg = "For store " + storeName + " cannot delete value schema ids they being used. schema ids: "
+          + unusedValueSchemaIds;
+      LOGGER.error(msg);
+      throw new VeniceException(msg);
+    }
+    // delete the unused schemas.
+    unusedValueSchemaIds.forEach(id -> {
+      admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository().removeValueSchema(storeName, id);
+      LOGGER.info("Removed value schema with ID " + id + " for store " + storeName);
+    });
+  }
+
+  SchemaEntry getKeySchema(String clusterName, String storeName) {
+    admin.checkControllerLeadershipFor(clusterName);
+    ReadWriteSchemaRepository schemaRepo = admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+    return schemaRepo.getKeySchema(storeName);
+  }
+
+  Collection<SchemaEntry> getValueSchemas(String clusterName, String storeName) {
+    admin.checkControllerLeadershipFor(clusterName);
+    ReadWriteSchemaRepository schemaRepo = admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+    return schemaRepo.getValueSchemas(storeName);
+  }
+
+  Collection<DerivedSchemaEntry> getDerivedSchemas(String clusterName, String storeName) {
+    admin.checkControllerLeadershipFor(clusterName);
+    ReadWriteSchemaRepository schemaRepo = admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+    return schemaRepo.getDerivedSchemas(storeName);
+  }
+
+  int getValueSchemaId(String clusterName, String storeName, String valueSchemaStr) {
+    admin.checkControllerLeadershipFor(clusterName);
+    ReadWriteSchemaRepository schemaRepo = admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+    int schemaId = schemaRepo.getValueSchemaId(storeName, valueSchemaStr);
+    // validate the schema as VPJ uses this method to fetch the value schema. Fail loudly if the schema user trying
+    // to push is bad.
+    if (schemaId != SchemaData.INVALID_VALUE_SCHEMA_ID) {
+      AvroSchemaUtils.validateAvroSchemaStr(valueSchemaStr);
+    }
+    return schemaId;
+  }
+
+  GeneratedSchemaID getDerivedSchemaId(String clusterName, String storeName, String schemaStr) {
+    admin.checkControllerLeadershipFor(clusterName);
+    ReadWriteSchemaRepository schemaRepo = admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+    GeneratedSchemaID schemaID = schemaRepo.getDerivedSchemaId(storeName, schemaStr);
+    // validate the schema as VPJ uses this method to fetch the value schema. Fail loudly if the schema user trying
+    // to push is bad.
+    if (schemaID.isValid()) {
+      AvroSchemaUtils.validateAvroSchemaStr(schemaStr);
+    }
+    return schemaID;
+  }
+
+  SchemaEntry getValueSchema(String clusterName, String storeName, int id) {
+    admin.checkControllerLeadershipFor(clusterName);
+    ReadWriteSchemaRepository schemaRepo = admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+    return schemaRepo.getValueSchema(storeName, id);
+  }
+
+  private void validateValueSchemaUsingRandomGenerator(String schemaStr, String clusterName, String storeName) {
+    VeniceControllerClusterConfig config = admin.getHelixVeniceClusterResources(clusterName).getConfig();
+    if (!config.isControllerSchemaValidationEnabled()) {
+      return;
+    }
+
+    ReadWriteSchemaRepository schemaRepository =
+        admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+    Collection<SchemaEntry> schemaEntries = schemaRepository.getValueSchemas(storeName);
+    AvroSerializer serializer;
+    Schema existingSchema = null;
+
+    Schema newSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr);
+    RandomRecordGenerator recordGenerator = new RandomRecordGenerator();
+    RecordGenerationConfig genConfig = RecordGenerationConfig.newConfig().withAvoidNulls(true);
+
+    for (int i = 0; i < RECORD_COUNT; i++) {
+      // check if new records written with new schema can be read using existing older schema
+      // Object record =
+      Object record = recordGenerator.randomGeneric(newSchema, genConfig);
+      serializer = new AvroSerializer<>(newSchema);
+      byte[] bytes = serializer.serialize(record);
+      for (SchemaEntry schemaEntry: schemaEntries) {
+        try {
+          existingSchema = schemaEntry.getSchema();
+          if (!isValidAvroSchema(existingSchema)) {
+            LOGGER.warn("Skip validating ill-formed schema for store: {}", storeName);
+            continue;
+          }
+          RecordDeserializer<Object> deserializer =
+              SerializerDeserializerFactory.getAvroGenericDeserializer(newSchema, existingSchema);
+          deserializer.deserialize(bytes);
+        } catch (Exception e) {
+          if (e instanceof AvroIncompatibleSchemaException) {
+            LOGGER.warn("Found incompatible avro schema with bad union branch for store: {}", storeName, e);
+            continue;
+          }
+          throw new InvalidVeniceSchemaException(
+              "Error while trying to add new schema: " + schemaStr + "  for store " + storeName
+                  + " as it is incompatible with existing schema: " + existingSchema,
+              e);
+        }
+      }
+    }
+
+    // check if records written with older schema can be read using the new schema
+    for (int i = 0; i < RECORD_COUNT; i++) {
+      for (SchemaEntry schemaEntry: schemaEntries) {
+        try {
+          Object record = recordGenerator.randomGeneric(schemaEntry.getSchema(), genConfig);
+          serializer = new AvroSerializer(schemaEntry.getSchema());
+          byte[] bytes = serializer.serialize(record);
+          existingSchema = schemaEntry.getSchema();
+          if (!isValidAvroSchema(existingSchema)) {
+            LOGGER.warn("Skip validating ill-formed schema for store: {}", storeName);
+            continue;
+          }
+          RecordDeserializer<Object> deserializer =
+              SerializerDeserializerFactory.getAvroGenericDeserializer(existingSchema, newSchema);
+          deserializer.deserialize(bytes);
+        } catch (Exception e) {
+          if (e instanceof AvroIncompatibleSchemaException) {
+            LOGGER.warn("Found incompatible avro schema with bad union branch for store: {}", storeName, e);
+            continue;
+          }
+          throw new InvalidVeniceSchemaException(
+              "Error while trying to add new schema: " + schemaStr + "  for store " + storeName
+                  + " as it is incompatible with existing schema: " + existingSchema,
+              e);
+        }
+      }
+    }
+  }
+
+  SchemaEntry addValueSchema(
+      String clusterName,
+      String storeName,
+      String valueSchemaStr,
+      DirectionalSchemaCompatibilityType expectedCompatibilityType) {
+    admin.checkControllerLeadershipFor(clusterName);
+    ReadWriteSchemaRepository schemaRepository =
+        admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+    SchemaEntry schemaEntry = schemaRepository.addValueSchema(storeName, valueSchemaStr, expectedCompatibilityType);
+    // For duplicates, addValueSchema returns DUPLICATE_VALUE_SCHEMA_CODE; look up the real id so callers
+    // (e.g. SchemaRoutes) always receive a concrete schema id in the response.
+    int returnId = schemaEntry.getId() == SchemaData.DUPLICATE_VALUE_SCHEMA_CODE
+        ? schemaRepository.getValueSchemaId(storeName, valueSchemaStr)
+        : schemaEntry.getId();
+    return new SchemaEntry(returnId, valueSchemaStr);
+  }
+
+  SchemaEntry addValueSchema(
+      String clusterName,
+      String storeName,
+      String valueSchemaStr,
+      int schemaId,
+      DirectionalSchemaCompatibilityType compatibilityType) {
+    admin.checkControllerLeadershipFor(clusterName);
+    ReadWriteSchemaRepository schemaRepository =
+        admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+    int newValueSchemaId =
+        schemaRepository.preCheckValueSchemaAndGetNextAvailableId(storeName, valueSchemaStr, compatibilityType);
+    if (newValueSchemaId != SchemaData.DUPLICATE_VALUE_SCHEMA_CODE && newValueSchemaId != schemaId) {
+      throw new VeniceException(
+          "Inconsistent value schema id between the caller and the local schema repository."
+              + " Expected new schema id of " + schemaId + " but the next available id from the local repository is "
+              + newValueSchemaId + " for store " + storeName + " in cluster " + clusterName + " Schema: "
+              + valueSchemaStr);
+    }
+    return schemaRepository.addValueSchema(storeName, valueSchemaStr, newValueSchemaId);
+  }
+
+  DerivedSchemaEntry addDerivedSchema(
+      String clusterName,
+      String storeName,
+      int valueSchemaId,
+      String derivedSchemaStr) {
+    admin.checkControllerLeadershipFor(clusterName);
+    ReadWriteSchemaRepository schemaRepository =
+        admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+    schemaRepository.addDerivedSchema(storeName, derivedSchemaStr, valueSchemaId);
+
+    return new DerivedSchemaEntry(
+        valueSchemaId,
+        schemaRepository.getDerivedSchemaId(storeName, derivedSchemaStr).getGeneratedSchemaVersion(),
+        derivedSchemaStr);
+  }
+
+  DerivedSchemaEntry addDerivedSchema(
+      String clusterName,
+      String storeName,
+      int valueSchemaId,
+      int derivedSchemaId,
+      String derivedSchemaStr) {
+    admin.checkControllerLeadershipFor(clusterName);
+    return admin.getHelixVeniceClusterResources(clusterName)
+        .getSchemaRepository()
+        .addDerivedSchema(storeName, derivedSchemaStr, valueSchemaId, derivedSchemaId);
+  }
+
+  DerivedSchemaEntry removeDerivedSchema(String clusterName, String storeName, int valueSchemaId, int derivedSchemaId) {
+    admin.checkControllerLeadershipFor(clusterName);
+    return admin.getHelixVeniceClusterResources(clusterName)
+        .getSchemaRepository()
+        .removeDerivedSchema(storeName, valueSchemaId, derivedSchemaId);
+  }
+
+  SchemaEntry addSupersetSchema(
+      String clusterName,
+      String storeName,
+      String valueSchema,
+      int valueSchemaId,
+      String supersetSchemaStr,
+      int supersetSchemaId) {
+    admin.checkControllerLeadershipFor(clusterName);
+    ReadWriteSchemaRepository schemaRepository =
+        admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+
+    final SchemaEntry existingSupersetSchemaEntry = schemaRepository.getValueSchema(storeName, supersetSchemaId);
+    if (existingSupersetSchemaEntry == null) {
+      // If the new superset schema does not exist in the schema repo, add it
+      LOGGER.info("Adding superset schema: {} for store: {}", supersetSchemaStr, storeName);
+      schemaRepository.addValueSchema(storeName, supersetSchemaStr, supersetSchemaId);
+
+    } else {
+      final Schema newSupersetSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(supersetSchemaStr);
+      if (!AvroSchemaUtils.compareSchemaIgnoreFieldOrder(existingSupersetSchemaEntry.getSchema(), newSupersetSchema)) {
+        throw new VeniceException(
+            "Existing schema with id " + existingSupersetSchemaEntry.getId() + " does not match with new schema "
+                + supersetSchemaStr);
+      }
+    }
+
+    // add the value schema
+    return schemaRepository.addValueSchema(storeName, valueSchema, valueSchemaId);
+  }
+
+  int getValueSchemaIdIgnoreFieldOrder(
+      String clusterName,
+      String storeName,
+      String valueSchemaStr,
+      Comparator<Schema> schemaComparator) {
+    admin.checkControllerLeadershipFor(clusterName);
+    SchemaEntry valueSchemaEntry = new SchemaEntry(SchemaData.UNKNOWN_SCHEMA_ID, valueSchemaStr);
+
+    for (SchemaEntry schemaEntry: getValueSchemas(clusterName, storeName)) {
+      if (schemaComparator.compare(schemaEntry.getSchema(), valueSchemaEntry.getSchema()) == 0) {
+        return schemaEntry.getId();
+      }
+    }
+    return SchemaData.INVALID_VALUE_SCHEMA_ID;
+
+  }
+
+  int checkPreConditionForAddValueSchemaAndGetNewSchemaId(
+      String clusterName,
+      String storeName,
+      String valueSchemaStr,
+      DirectionalSchemaCompatibilityType expectedCompatibilityType) {
+    AvroSchemaUtils.validateAvroSchemaStr(valueSchemaStr);
+    AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(valueSchemaStr);
+    validateValueSchemaUsingRandomGenerator(valueSchemaStr, clusterName, storeName);
+    admin.checkControllerLeadershipFor(clusterName);
+    return admin.getHelixVeniceClusterResources(clusterName)
+        .getSchemaRepository()
+        .preCheckValueSchemaAndGetNextAvailableId(storeName, valueSchemaStr, expectedCompatibilityType);
+  }
+
+  int checkPreConditionForAddDerivedSchemaAndGetNewSchemaId(
+      String clusterName,
+      String storeName,
+      int valueSchemaId,
+      String derivedSchemaStr) {
+    admin.checkControllerLeadershipFor(clusterName);
+    return admin.getHelixVeniceClusterResources(clusterName)
+        .getSchemaRepository()
+        .preCheckDerivedSchemaAndGetNextAvailableId(storeName, valueSchemaId, derivedSchemaStr);
+  }
+
+  Collection<RmdSchemaEntry> getReplicationMetadataSchemas(String clusterName, String storeName) {
+    admin.checkControllerLeadershipFor(clusterName);
+    ReadWriteSchemaRepository schemaRepo = admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+    return schemaRepo.getReplicationMetadataSchemas(storeName);
+  }
+
+  boolean checkIfValueSchemaAlreadyHasRmdSchema(
+      String clusterName,
+      String storeName,
+      final int valueSchemaID,
+      final int replicationMetadataVersionId) {
+    admin.checkControllerLeadershipFor(clusterName);
+    Collection<RmdSchemaEntry> schemaEntries = admin.getHelixVeniceClusterResources(clusterName)
+        .getSchemaRepository()
+        .getReplicationMetadataSchemas(storeName);
+    for (RmdSchemaEntry rmdSchemaEntry: schemaEntries) {
+      if (rmdSchemaEntry.getValueSchemaID() == valueSchemaID
+          && rmdSchemaEntry.getId() == replicationMetadataVersionId) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  boolean checkIfMetadataSchemaAlreadyPresent(
+      String clusterName,
+      String storeName,
+      int valueSchemaId,
+      RmdSchemaEntry rmdSchemaEntry) {
+    admin.checkControllerLeadershipFor(clusterName);
+    try {
+      Collection<RmdSchemaEntry> schemaEntries = admin.getHelixVeniceClusterResources(clusterName)
+          .getSchemaRepository()
+          .getReplicationMetadataSchemas(storeName);
+      for (RmdSchemaEntry schemaEntry: schemaEntries) {
+        if (schemaEntry.equals(rmdSchemaEntry)) {
+          return true;
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Exception in checkIfMetadataSchemaAlreadyPresent ", e);
+    }
+    return false;
+  }
+
+  RmdSchemaEntry addReplicationMetadataSchema(
+      String clusterName,
+      String storeName,
+      int valueSchemaId,
+      int replicationMetadataVersionId,
+      String replicationMetadataSchemaStr) {
+    admin.checkControllerLeadershipFor(clusterName);
+
+    RmdSchemaEntry rmdSchemaEntry =
+        new RmdSchemaEntry(valueSchemaId, replicationMetadataVersionId, replicationMetadataSchemaStr);
+    if (checkIfMetadataSchemaAlreadyPresent(clusterName, storeName, valueSchemaId, rmdSchemaEntry)) {
+      LOGGER.info(
+          "Timestamp metadata schema Already present: for store: {} in cluster: {} metadataSchema: {} "
+              + "replicationMetadataVersionId: {} valueSchemaId: {}",
+          storeName,
+          clusterName,
+          replicationMetadataSchemaStr,
+          replicationMetadataVersionId,
+          valueSchemaId);
+      return rmdSchemaEntry;
+    }
+
+    return admin.getHelixVeniceClusterResources(clusterName)
+        .getSchemaRepository()
+        .addReplicationMetadataSchema(
+            storeName,
+            valueSchemaId,
+            replicationMetadataSchemaStr,
+            replicationMetadataVersionId);
+  }
+
+  Schema getSupersetOrLatestValueSchema(String clusterName, Store store) {
+    ReadWriteSchemaRepository schemaRepository =
+        admin.getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+    // If already a superset schema exists, try to generate the new superset from that and the input value schema
+    SchemaEntry existingSchema = schemaRepository.getSupersetOrLatestValueSchema(store.getName());
+    return existingSchema == null ? null : existingSchema.getSchema();
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -28,8 +28,6 @@ import static com.linkedin.venice.meta.VersionStatus.ROLLED_BACK;
 import static com.linkedin.venice.meta.VersionStatus.STARTED;
 import static com.linkedin.venice.pushmonitor.OfflinePushStatus.HELIX_ASSIGNMENT_COMPLETED;
 import static com.linkedin.venice.serialization.avro.AvroProtocolDefinition.PARTICIPANT_MESSAGE_SYSTEM_STORE_VALUE;
-import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_STORE_NAME;
-import static com.linkedin.venice.utils.AvroSchemaUtils.isValidAvroSchema;
 import static com.linkedin.venice.utils.RegionUtils.isRegionPartOfRegionsFilterList;
 import static com.linkedin.venice.utils.RegionUtils.parseRegionsFilterList;
 import static com.linkedin.venice.views.ViewUtils.ETERNAL_TOPIC_RETENTION_ENABLED;
@@ -37,9 +35,6 @@ import static com.linkedin.venice.views.ViewUtils.LOG_COMPACTION_ENABLED;
 import static com.linkedin.venice.views.ViewUtils.PARTITION_COUNT;
 import static com.linkedin.venice.views.ViewUtils.USE_FAST_KAFKA_OPERATION_TIMEOUT;
 
-import com.linkedin.avroutil1.compatibility.AvroIncompatibleSchemaException;
-import com.linkedin.avroutil1.compatibility.RandomRecordGenerator;
-import com.linkedin.avroutil1.compatibility.RecordGenerationConfig;
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.D2.D2ClientUtils;
@@ -103,7 +98,6 @@ import com.linkedin.venice.controllerapi.UpdateStoragePersonaQueryParams;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionResponse;
 import com.linkedin.venice.exceptions.ErrorType;
-import com.linkedin.venice.exceptions.InvalidVeniceSchemaException;
 import com.linkedin.venice.exceptions.ResourceStillExistsException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceHttpException;
@@ -228,9 +222,6 @@ import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
-import com.linkedin.venice.serializer.AvroSerializer;
-import com.linkedin.venice.serializer.RecordDeserializer;
-import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.stats.AbstractVeniceAggStats;
 import com.linkedin.venice.stats.ZkClientStatusStats;
@@ -242,7 +233,6 @@ import com.linkedin.venice.status.protocol.BatchJobHeartbeatValue;
 import com.linkedin.venice.status.protocol.PushJobDetails;
 import com.linkedin.venice.status.protocol.PushJobDetailsStatusTuple;
 import com.linkedin.venice.status.protocol.PushJobStatusRecordKey;
-import com.linkedin.venice.system.store.MetaStoreDataType;
 import com.linkedin.venice.system.store.MetaStoreReader;
 import com.linkedin.venice.system.store.MetaStoreWriter;
 import com.linkedin.venice.systemstore.schemas.StoreMetaKey;
@@ -359,7 +349,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       RedundantExceptionFilter.getRedundantExceptionFilter();
 
   private static final Logger LOGGER = LogManager.getLogger(VeniceHelixAdmin.class);
-  private static final int RECORD_COUNT = 10;
   public static final List<Class<? extends Throwable>> RETRY_FAILURE_TYPES = Collections.singletonList(Exception.class);
 
   private final VeniceControllerMultiClusterConfig multiClusterConfigs;
@@ -414,6 +403,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   private final Lazy<PushStatusStoreWriter> pushStatusStoreWriter;
   private final SharedHelixReadOnlyZKSharedSystemStoreRepository zkSharedSystemStoreRepository;
   private final SharedHelixReadOnlyZKSharedSchemaRepository zkSharedSchemaRepository;
+  private final StoreSchemaService storeSchemaService;
   private final MetaStoreWriter metaStoreWriter;
   private final MetaStoreReader metaStoreReader;
   private final D2Client d2Client;
@@ -647,6 +637,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         commonConfig.getSystemSchemaClusterName(),
         commonConfig.getRefreshAttemptsForZkReconnect(),
         commonConfig.getRefreshIntervalForZkReconnectInMs());
+    storeSchemaService = new StoreSchemaService(this);
     metaStoreWriter = new MetaStoreWriter(
         topicManagerRepository.getLocalTopicManager(),
         veniceWriterFactory,
@@ -3862,14 +3853,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       int valueSchemaID,
       int rmdVersionID) {
-    checkControllerLeadershipFor(clusterName);
-    ReadWriteSchemaRepository schemaRepo = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-    SchemaEntry schemaEntry = schemaRepo.getReplicationMetadataSchema(storeName, valueSchemaID, rmdVersionID);
-    if (schemaEntry == null) {
-      return Optional.empty();
-    } else {
-      return Optional.of(schemaEntry.getSchema());
-    }
+    return storeSchemaService.getReplicationMetadataSchema(clusterName, storeName, valueSchemaID, rmdVersionID);
   }
 
   @Override
@@ -5380,45 +5364,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   @Override
   public Set<Integer> getInUseValueSchemaIds(String clusterName, String storeName) {
-    if (isParent()) {
-      return Collections.emptySet();
-    }
-
-    Store store = getStore(clusterName, storeName);
-    Set<Integer> schemaIds = new HashSet<>();
-
-    // Fetch value schema id used by all existing store version
-    for (Version version: store.getVersions()) {
-      Map<String, String> map = new HashMap<>(2);
-      map.put(KEY_STRING_STORE_NAME, storeName);
-      map.put(MetaStoreWriter.KEY_STRING_VERSION_NUMBER, Integer.toString(version.getNumber()));
-      StoreMetaKey key = MetaStoreDataType.VALUE_SCHEMAS_WRITTEN_PER_STORE_VERSION.getStoreMetaKey(map);
-      StoreMetaValue metaValue = getMetaStoreValue(key, storeName);
-
-      if (metaValue == null) {
-        String msg = "Could not find in-use value schema for store " + storeName;
-        LOGGER.warn(msg);
-        throw new VeniceException(msg);
-      }
-      schemaIds.addAll(metaValue.storeValueSchemaIdsWrittenPerStoreVersion);
-    }
-    return schemaIds;
+    return storeSchemaService.getInUseValueSchemaIds(clusterName, storeName);
   }
 
   public void deleteValueSchemas(String clusterName, String storeName, Set<Integer> unusedValueSchemaIds) {
-    Set<Integer> inuseValueSchemaIds = getInUseValueSchemaIds(clusterName, storeName);
-    boolean isCommon = unusedValueSchemaIds.stream().anyMatch(inuseValueSchemaIds::contains);
-    if (isCommon) {
-      String msg = "For store " + storeName + " cannot delete value schema ids they being used. schema ids: "
-          + unusedValueSchemaIds;
-      LOGGER.error(msg);
-      throw new VeniceException(msg);
-    }
-    // delete the unused schemas.
-    unusedValueSchemaIds.forEach(id -> {
-      getHelixVeniceClusterResources(clusterName).getSchemaRepository().removeValueSchema(storeName, id);
-      LOGGER.info("Removed value schema with ID " + id + " for store " + storeName);
-    });
+    storeSchemaService.deleteValueSchemas(clusterName, storeName, unusedValueSchemaIds);
   }
 
   private void setStoreCompressionStrategy(
@@ -6962,9 +6912,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public SchemaEntry getKeySchema(String clusterName, String storeName) {
-    checkControllerLeadershipFor(clusterName);
-    ReadWriteSchemaRepository schemaRepo = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-    return schemaRepo.getKeySchema(storeName);
+    return storeSchemaService.getKeySchema(clusterName, storeName);
   }
 
   /**
@@ -6972,9 +6920,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public Collection<SchemaEntry> getValueSchemas(String clusterName, String storeName) {
-    checkControllerLeadershipFor(clusterName);
-    ReadWriteSchemaRepository schemaRepo = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-    return schemaRepo.getValueSchemas(storeName);
+    return storeSchemaService.getValueSchemas(clusterName, storeName);
   }
 
   /**
@@ -6982,9 +6928,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public Collection<DerivedSchemaEntry> getDerivedSchemas(String clusterName, String storeName) {
-    checkControllerLeadershipFor(clusterName);
-    ReadWriteSchemaRepository schemaRepo = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-    return schemaRepo.getDerivedSchemas(storeName);
+    return storeSchemaService.getDerivedSchemas(clusterName, storeName);
   }
 
   /**
@@ -6992,15 +6936,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public int getValueSchemaId(String clusterName, String storeName, String valueSchemaStr) {
-    checkControllerLeadershipFor(clusterName);
-    ReadWriteSchemaRepository schemaRepo = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-    int schemaId = schemaRepo.getValueSchemaId(storeName, valueSchemaStr);
-    // validate the schema as VPJ uses this method to fetch the value schema. Fail loudly if the schema user trying
-    // to push is bad.
-    if (schemaId != SchemaData.INVALID_VALUE_SCHEMA_ID) {
-      AvroSchemaUtils.validateAvroSchemaStr(valueSchemaStr);
-    }
-    return schemaId;
+    return storeSchemaService.getValueSchemaId(clusterName, storeName, valueSchemaStr);
   }
 
   /**
@@ -7008,15 +6944,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public GeneratedSchemaID getDerivedSchemaId(String clusterName, String storeName, String schemaStr) {
-    checkControllerLeadershipFor(clusterName);
-    ReadWriteSchemaRepository schemaRepo = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-    GeneratedSchemaID schemaID = schemaRepo.getDerivedSchemaId(storeName, schemaStr);
-    // validate the schema as VPJ uses this method to fetch the value schema. Fail loudly if the schema user trying
-    // to push is bad.
-    if (schemaID.isValid()) {
-      AvroSchemaUtils.validateAvroSchemaStr(schemaStr);
-    }
-    return schemaID;
+    return storeSchemaService.getDerivedSchemaId(clusterName, storeName, schemaStr);
   }
 
   /**
@@ -7024,82 +6952,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public SchemaEntry getValueSchema(String clusterName, String storeName, int id) {
-    checkControllerLeadershipFor(clusterName);
-    ReadWriteSchemaRepository schemaRepo = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-    return schemaRepo.getValueSchema(storeName, id);
-  }
-
-  private void validateValueSchemaUsingRandomGenerator(String schemaStr, String clusterName, String storeName) {
-    VeniceControllerClusterConfig config = getHelixVeniceClusterResources(clusterName).getConfig();
-    if (!config.isControllerSchemaValidationEnabled()) {
-      return;
-    }
-
-    ReadWriteSchemaRepository schemaRepository = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-    Collection<SchemaEntry> schemaEntries = schemaRepository.getValueSchemas(storeName);
-    AvroSerializer serializer;
-    Schema existingSchema = null;
-
-    Schema newSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr);
-    RandomRecordGenerator recordGenerator = new RandomRecordGenerator();
-    RecordGenerationConfig genConfig = RecordGenerationConfig.newConfig().withAvoidNulls(true);
-
-    for (int i = 0; i < RECORD_COUNT; i++) {
-      // check if new records written with new schema can be read using existing older schema
-      // Object record =
-      Object record = recordGenerator.randomGeneric(newSchema, genConfig);
-      serializer = new AvroSerializer<>(newSchema);
-      byte[] bytes = serializer.serialize(record);
-      for (SchemaEntry schemaEntry: schemaEntries) {
-        try {
-          existingSchema = schemaEntry.getSchema();
-          if (!isValidAvroSchema(existingSchema)) {
-            LOGGER.warn("Skip validating ill-formed schema for store: {}", storeName);
-            continue;
-          }
-          RecordDeserializer<Object> deserializer =
-              SerializerDeserializerFactory.getAvroGenericDeserializer(newSchema, existingSchema);
-          deserializer.deserialize(bytes);
-        } catch (Exception e) {
-          if (e instanceof AvroIncompatibleSchemaException) {
-            LOGGER.warn("Found incompatible avro schema with bad union branch for store: {}", storeName, e);
-            continue;
-          }
-          throw new InvalidVeniceSchemaException(
-              "Error while trying to add new schema: " + schemaStr + "  for store " + storeName
-                  + " as it is incompatible with existing schema: " + existingSchema,
-              e);
-        }
-      }
-    }
-
-    // check if records written with older schema can be read using the new schema
-    for (int i = 0; i < RECORD_COUNT; i++) {
-      for (SchemaEntry schemaEntry: schemaEntries) {
-        try {
-          Object record = recordGenerator.randomGeneric(schemaEntry.getSchema(), genConfig);
-          serializer = new AvroSerializer(schemaEntry.getSchema());
-          byte[] bytes = serializer.serialize(record);
-          existingSchema = schemaEntry.getSchema();
-          if (!isValidAvroSchema(existingSchema)) {
-            LOGGER.warn("Skip validating ill-formed schema for store: {}", storeName);
-            continue;
-          }
-          RecordDeserializer<Object> deserializer =
-              SerializerDeserializerFactory.getAvroGenericDeserializer(existingSchema, newSchema);
-          deserializer.deserialize(bytes);
-        } catch (Exception e) {
-          if (e instanceof AvroIncompatibleSchemaException) {
-            LOGGER.warn("Found incompatible avro schema with bad union branch for store: {}", storeName, e);
-            continue;
-          }
-          throw new InvalidVeniceSchemaException(
-              "Error while trying to add new schema: " + schemaStr + "  for store " + storeName
-                  + " as it is incompatible with existing schema: " + existingSchema,
-              e);
-        }
-      }
-    }
+    return storeSchemaService.getValueSchema(clusterName, storeName, id);
   }
 
   /**
@@ -7111,15 +6964,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       String valueSchemaStr,
       DirectionalSchemaCompatibilityType expectedCompatibilityType) {
-    checkControllerLeadershipFor(clusterName);
-    ReadWriteSchemaRepository schemaRepository = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-    SchemaEntry schemaEntry = schemaRepository.addValueSchema(storeName, valueSchemaStr, expectedCompatibilityType);
-    // For duplicates, addValueSchema returns DUPLICATE_VALUE_SCHEMA_CODE; look up the real id so callers
-    // (e.g. SchemaRoutes) always receive a concrete schema id in the response.
-    int returnId = schemaEntry.getId() == SchemaData.DUPLICATE_VALUE_SCHEMA_CODE
-        ? schemaRepository.getValueSchemaId(storeName, valueSchemaStr)
-        : schemaEntry.getId();
-    return new SchemaEntry(returnId, valueSchemaStr);
+    return storeSchemaService.addValueSchema(clusterName, storeName, valueSchemaStr, expectedCompatibilityType);
   }
 
   /**
@@ -7134,18 +6979,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String valueSchemaStr,
       int schemaId,
       DirectionalSchemaCompatibilityType compatibilityType) {
-    checkControllerLeadershipFor(clusterName);
-    ReadWriteSchemaRepository schemaRepository = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-    int newValueSchemaId =
-        schemaRepository.preCheckValueSchemaAndGetNextAvailableId(storeName, valueSchemaStr, compatibilityType);
-    if (newValueSchemaId != SchemaData.DUPLICATE_VALUE_SCHEMA_CODE && newValueSchemaId != schemaId) {
-      throw new VeniceException(
-          "Inconsistent value schema id between the caller and the local schema repository."
-              + " Expected new schema id of " + schemaId + " but the next available id from the local repository is "
-              + newValueSchemaId + " for store " + storeName + " in cluster " + clusterName + " Schema: "
-              + valueSchemaStr);
-    }
-    return schemaRepository.addValueSchema(storeName, valueSchemaStr, newValueSchemaId);
+    return storeSchemaService.addValueSchema(clusterName, storeName, valueSchemaStr, schemaId, compatibilityType);
   }
 
   /**
@@ -7159,14 +6993,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       int valueSchemaId,
       String derivedSchemaStr) {
-    checkControllerLeadershipFor(clusterName);
-    ReadWriteSchemaRepository schemaRepository = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-    schemaRepository.addDerivedSchema(storeName, derivedSchemaStr, valueSchemaId);
-
-    return new DerivedSchemaEntry(
-        valueSchemaId,
-        schemaRepository.getDerivedSchemaId(storeName, derivedSchemaStr).getGeneratedSchemaVersion(),
-        derivedSchemaStr);
+    return storeSchemaService.addDerivedSchema(clusterName, storeName, valueSchemaId, derivedSchemaStr);
   }
 
   /**
@@ -7180,9 +7007,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       int valueSchemaId,
       int derivedSchemaId,
       String derivedSchemaStr) {
-    checkControllerLeadershipFor(clusterName);
-    return getHelixVeniceClusterResources(clusterName).getSchemaRepository()
-        .addDerivedSchema(storeName, derivedSchemaStr, valueSchemaId, derivedSchemaId);
+    return storeSchemaService
+        .addDerivedSchema(clusterName, storeName, valueSchemaId, derivedSchemaId, derivedSchemaStr);
   }
 
   /**
@@ -7194,9 +7020,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       int valueSchemaId,
       int derivedSchemaId) {
-    checkControllerLeadershipFor(clusterName);
-    return getHelixVeniceClusterResources(clusterName).getSchemaRepository()
-        .removeDerivedSchema(storeName, valueSchemaId, derivedSchemaId);
+    return storeSchemaService.removeDerivedSchema(clusterName, storeName, valueSchemaId, derivedSchemaId);
   }
 
   /**
@@ -7213,26 +7037,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       int valueSchemaId,
       String supersetSchemaStr,
       int supersetSchemaId) {
-    checkControllerLeadershipFor(clusterName);
-    ReadWriteSchemaRepository schemaRepository = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-
-    final SchemaEntry existingSupersetSchemaEntry = schemaRepository.getValueSchema(storeName, supersetSchemaId);
-    if (existingSupersetSchemaEntry == null) {
-      // If the new superset schema does not exist in the schema repo, add it
-      LOGGER.info("Adding superset schema: {} for store: {}", supersetSchemaStr, storeName);
-      schemaRepository.addValueSchema(storeName, supersetSchemaStr, supersetSchemaId);
-
-    } else {
-      final Schema newSupersetSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(supersetSchemaStr);
-      if (!AvroSchemaUtils.compareSchemaIgnoreFieldOrder(existingSupersetSchemaEntry.getSchema(), newSupersetSchema)) {
-        throw new VeniceException(
-            "Existing schema with id " + existingSupersetSchemaEntry.getId() + " does not match with new schema "
-                + supersetSchemaStr);
-      }
-    }
-
-    // add the value schema
-    return schemaRepository.addValueSchema(storeName, valueSchema, valueSchemaId);
+    return storeSchemaService
+        .addSupersetSchema(clusterName, storeName, valueSchema, valueSchemaId, supersetSchemaStr, supersetSchemaId);
   }
 
   int getValueSchemaIdIgnoreFieldOrder(
@@ -7240,16 +7046,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       String valueSchemaStr,
       Comparator<Schema> schemaComparator) {
-    checkControllerLeadershipFor(clusterName);
-    SchemaEntry valueSchemaEntry = new SchemaEntry(SchemaData.UNKNOWN_SCHEMA_ID, valueSchemaStr);
-
-    for (SchemaEntry schemaEntry: getValueSchemas(clusterName, storeName)) {
-      if (schemaComparator.compare(schemaEntry.getSchema(), valueSchemaEntry.getSchema()) == 0) {
-        return schemaEntry.getId();
-      }
-    }
-    return SchemaData.INVALID_VALUE_SCHEMA_ID;
-
+    return storeSchemaService
+        .getValueSchemaIdIgnoreFieldOrder(clusterName, storeName, valueSchemaStr, schemaComparator);
   }
 
   int checkPreConditionForAddValueSchemaAndGetNewSchemaId(
@@ -7257,12 +7055,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       String valueSchemaStr,
       DirectionalSchemaCompatibilityType expectedCompatibilityType) {
-    AvroSchemaUtils.validateAvroSchemaStr(valueSchemaStr);
-    AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(valueSchemaStr);
-    validateValueSchemaUsingRandomGenerator(valueSchemaStr, clusterName, storeName);
-    checkControllerLeadershipFor(clusterName);
-    return getHelixVeniceClusterResources(clusterName).getSchemaRepository()
-        .preCheckValueSchemaAndGetNextAvailableId(storeName, valueSchemaStr, expectedCompatibilityType);
+    return storeSchemaService.checkPreConditionForAddValueSchemaAndGetNewSchemaId(
+        clusterName,
+        storeName,
+        valueSchemaStr,
+        expectedCompatibilityType);
   }
 
   int checkPreConditionForAddDerivedSchemaAndGetNewSchemaId(
@@ -7270,9 +7067,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       int valueSchemaId,
       String derivedSchemaStr) {
-    checkControllerLeadershipFor(clusterName);
-    return getHelixVeniceClusterResources(clusterName).getSchemaRepository()
-        .preCheckDerivedSchemaAndGetNextAvailableId(storeName, valueSchemaId, derivedSchemaStr);
+    return storeSchemaService
+        .checkPreConditionForAddDerivedSchemaAndGetNewSchemaId(clusterName, storeName, valueSchemaId, derivedSchemaStr);
   }
 
   /**
@@ -7280,9 +7076,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public Collection<RmdSchemaEntry> getReplicationMetadataSchemas(String clusterName, String storeName) {
-    checkControllerLeadershipFor(clusterName);
-    ReadWriteSchemaRepository schemaRepo = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-    return schemaRepo.getReplicationMetadataSchemas(storeName);
+    return storeSchemaService.getReplicationMetadataSchemas(clusterName, storeName);
   }
 
   boolean checkIfValueSchemaAlreadyHasRmdSchema(
@@ -7290,16 +7084,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       final int valueSchemaID,
       final int replicationMetadataVersionId) {
-    checkControllerLeadershipFor(clusterName);
-    Collection<RmdSchemaEntry> schemaEntries =
-        getHelixVeniceClusterResources(clusterName).getSchemaRepository().getReplicationMetadataSchemas(storeName);
-    for (RmdSchemaEntry rmdSchemaEntry: schemaEntries) {
-      if (rmdSchemaEntry.getValueSchemaID() == valueSchemaID
-          && rmdSchemaEntry.getId() == replicationMetadataVersionId) {
-        return true;
-      }
-    }
-    return false;
+    return storeSchemaService
+        .checkIfValueSchemaAlreadyHasRmdSchema(clusterName, storeName, valueSchemaID, replicationMetadataVersionId);
   }
 
   boolean checkIfMetadataSchemaAlreadyPresent(
@@ -7307,19 +7093,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       int valueSchemaId,
       RmdSchemaEntry rmdSchemaEntry) {
-    checkControllerLeadershipFor(clusterName);
-    try {
-      Collection<RmdSchemaEntry> schemaEntries =
-          getHelixVeniceClusterResources(clusterName).getSchemaRepository().getReplicationMetadataSchemas(storeName);
-      for (RmdSchemaEntry schemaEntry: schemaEntries) {
-        if (schemaEntry.equals(rmdSchemaEntry)) {
-          return true;
-        }
-      }
-    } catch (Exception e) {
-      LOGGER.warn("Exception in checkIfMetadataSchemaAlreadyPresent ", e);
-    }
-    return false;
+    return storeSchemaService
+        .checkIfMetadataSchemaAlreadyPresent(clusterName, storeName, valueSchemaId, rmdSchemaEntry);
   }
 
   /**
@@ -7334,28 +7109,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       int valueSchemaId,
       int replicationMetadataVersionId,
       String replicationMetadataSchemaStr) {
-    checkControllerLeadershipFor(clusterName);
-
-    RmdSchemaEntry rmdSchemaEntry =
-        new RmdSchemaEntry(valueSchemaId, replicationMetadataVersionId, replicationMetadataSchemaStr);
-    if (checkIfMetadataSchemaAlreadyPresent(clusterName, storeName, valueSchemaId, rmdSchemaEntry)) {
-      LOGGER.info(
-          "Timestamp metadata schema Already present: for store: {} in cluster: {} metadataSchema: {} "
-              + "replicationMetadataVersionId: {} valueSchemaId: {}",
-          storeName,
-          clusterName,
-          replicationMetadataSchemaStr,
-          replicationMetadataVersionId,
-          valueSchemaId);
-      return rmdSchemaEntry;
-    }
-
-    return getHelixVeniceClusterResources(clusterName).getSchemaRepository()
-        .addReplicationMetadataSchema(
-            storeName,
-            valueSchemaId,
-            replicationMetadataSchemaStr,
-            replicationMetadataVersionId);
+    return storeSchemaService.addReplicationMetadataSchema(
+        clusterName,
+        storeName,
+        valueSchemaId,
+        replicationMetadataVersionId,
+        replicationMetadataSchemaStr);
   }
 
   /**
@@ -7469,10 +7228,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   Schema getSupersetOrLatestValueSchema(String clusterName, Store store) {
-    ReadWriteSchemaRepository schemaRepository = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-    // If already a superset schema exists, try to generate the new superset from that and the input value schema
-    SchemaEntry existingSchema = schemaRepository.getSupersetOrLatestValueSchema(store.getName());
-    return existingSchema == null ? null : existingSchema.getSchema();
+    return storeSchemaService.getSupersetOrLatestValueSchema(clusterName, store);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -129,13 +129,11 @@ import com.linkedin.venice.controller.kafka.protocol.admin.DeleteOldVersion;
 import com.linkedin.venice.controller.kafka.protocol.admin.DeleteStoragePersona;
 import com.linkedin.venice.controller.kafka.protocol.admin.DeleteStore;
 import com.linkedin.venice.controller.kafka.protocol.admin.DeleteUnusedValueSchemas;
-import com.linkedin.venice.controller.kafka.protocol.admin.DerivedSchemaCreation;
 import com.linkedin.venice.controller.kafka.protocol.admin.DisableStoreRead;
 import com.linkedin.venice.controller.kafka.protocol.admin.ETLStoreConfigRecord;
 import com.linkedin.venice.controller.kafka.protocol.admin.EnableStoreRead;
 import com.linkedin.venice.controller.kafka.protocol.admin.KillOfflinePushJob;
 import com.linkedin.venice.controller.kafka.protocol.admin.MetaSystemStoreAutoCreationValidation;
-import com.linkedin.venice.controller.kafka.protocol.admin.MetadataSchemaCreation;
 import com.linkedin.venice.controller.kafka.protocol.admin.MigrateStore;
 import com.linkedin.venice.controller.kafka.protocol.admin.PartitionerConfigRecord;
 import com.linkedin.venice.controller.kafka.protocol.admin.PauseStore;
@@ -148,10 +146,8 @@ import com.linkedin.venice.controller.kafka.protocol.admin.SetStorePartitionCoun
 import com.linkedin.venice.controller.kafka.protocol.admin.StoreCreation;
 import com.linkedin.venice.controller.kafka.protocol.admin.StoreLifecycleHooksRecord;
 import com.linkedin.venice.controller.kafka.protocol.admin.StoreViewConfigRecord;
-import com.linkedin.venice.controller.kafka.protocol.admin.SupersetSchemaCreation;
 import com.linkedin.venice.controller.kafka.protocol.admin.UpdateStoragePersona;
 import com.linkedin.venice.controller.kafka.protocol.admin.UpdateStore;
-import com.linkedin.venice.controller.kafka.protocol.admin.ValueSchemaCreation;
 import com.linkedin.venice.controller.kafka.protocol.enums.AdminMessageType;
 import com.linkedin.venice.controller.kafka.protocol.enums.SchemaType;
 import com.linkedin.venice.controller.kafka.protocol.serializer.AdminOperationSerializer;
@@ -160,7 +156,6 @@ import com.linkedin.venice.controller.lingeringjob.LingeringStoreVersionChecker;
 import com.linkedin.venice.controller.logcompaction.CompactionManager;
 import com.linkedin.venice.controller.migration.MigrationPushStrategyZKAccessor;
 import com.linkedin.venice.controller.repush.RepushJobRequest;
-import com.linkedin.venice.controller.supersetschema.DefaultSupersetSchemaGenerator;
 import com.linkedin.venice.controller.supersetschema.SupersetSchemaGenerator;
 import com.linkedin.venice.controller.util.ParentControllerConfigUpdateUtils;
 import com.linkedin.venice.controller.versionlifecycle.VersionLifecyclePolicy;
@@ -245,13 +240,11 @@ import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreWriter;
-import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.schema.GeneratedSchemaID;
 import com.linkedin.venice.schema.SchemaData;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.avro.DirectionalSchemaCompatibilityType;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
-import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.security.SSLFactory;
@@ -263,7 +256,6 @@ import com.linkedin.venice.system.store.MetaStoreReader;
 import com.linkedin.venice.system.store.MetaStoreWriter;
 import com.linkedin.venice.systemstore.schemas.StoreMetaKey;
 import com.linkedin.venice.systemstore.schemas.StoreMetaValue;
-import com.linkedin.venice.utils.AvroSchemaUtils;
 import com.linkedin.venice.utils.CollectionUtils;
 import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.ObjectMapperFactory;
@@ -361,7 +353,6 @@ public class VeniceParentHelixAdmin implements Admin {
   private final TerminalStateTopicCheckerForParentController terminalStateTopicChecker;
   private final SystemStoreAclSynchronizationTask systemStoreAclSynchronizationTask;
   private final UserSystemStoreLifeCycleHelper systemStoreLifeCycleHelper;
-  private final WriteComputeSchemaConverter writeComputeSchemaConverter;
 
   private Time timer = new SystemTime();
   private Optional<SSLFactory> sslFactory = Optional.empty();
@@ -395,9 +386,7 @@ public class VeniceParentHelixAdmin implements Admin {
 
   private final LingeringStoreVersionChecker lingeringStoreVersionChecker;
 
-  private final Optional<SupersetSchemaGenerator> externalSupersetSchemaGenerator;
-
-  private final SupersetSchemaGenerator defaultSupersetSchemaGenerator = new DefaultSupersetSchemaGenerator();
+  private final ParentSchemaOrchestrator parentSchemaOrchestrator;
 
   private final IdentityParser identityParser;
   private final LogContext logContext;
@@ -494,7 +483,6 @@ public class VeniceParentHelixAdmin implements Admin {
     this.asyncSetupEnabledMap = new VeniceConcurrentHashMap<>();
     this.accessController = accessController;
     this.authorizerService = authorizerService;
-    this.externalSupersetSchemaGenerator = externalSupersetSchemaGenerator;
     this.pubSubTopicRepository = pubSubTopicRepository;
     this.systemStoreAclSynchronizationExecutor =
         authorizerService.map(service -> Executors.newSingleThreadExecutor()).orElse(null);
@@ -544,7 +532,8 @@ public class VeniceParentHelixAdmin implements Admin {
     }
     this.lingeringStoreVersionChecker = lingeringStoreVersionChecker;
     systemStoreLifeCycleHelper = new UserSystemStoreLifeCycleHelper(this, authorizerService, multiClusterConfigs);
-    this.writeComputeSchemaConverter = writeComputeSchemaConverter;
+    this.parentSchemaOrchestrator =
+        new ParentSchemaOrchestrator(this, writeComputeSchemaConverter, externalSupersetSchemaGenerator);
     Class<IdentityParser> identityParserClass =
         ReflectUtils.loadClass(multiClusterConfigs.getCommonConfig().getIdentityParserClassName());
     this.identityParser = ReflectUtils.callConstructor(identityParserClass, new Class[0], new Object[0]);
@@ -1262,7 +1251,7 @@ public class VeniceParentHelixAdmin implements Admin {
         replicationMetadataVersionId,
         largestUsedRTVersionNumber);
     if (version.isActiveActiveReplicationEnabled()) {
-      updateReplicationMetadataSchemaForAllValueSchema(clusterName, storeName);
+      parentSchemaOrchestrator.updateReplicationMetadataSchemaForAllValueSchema(clusterName, storeName);
     }
     acquireAdminMessageLock(clusterName, storeName);
     try {
@@ -1281,7 +1270,7 @@ public class VeniceParentHelixAdmin implements Admin {
     }
   }
 
-  private int getRmdVersionID(final String storeName, final String clusterName) {
+  int getRmdVersionID(final String storeName, final String clusterName) {
     final Store store = getVeniceHelixAdmin().getStore(clusterName, storeName);
     if (store == null) {
       LOGGER.warn(
@@ -2119,7 +2108,7 @@ public class VeniceParentHelixAdmin implements Admin {
     Version newVersion = result.getSecond();
     if (result.getFirst()) {
       if (newVersion.isActiveActiveReplicationEnabled()) {
-        updateReplicationMetadataSchemaForAllValueSchema(clusterName, storeName);
+        parentSchemaOrchestrator.updateReplicationMetadataSchemaForAllValueSchema(clusterName, storeName);
       }
       // Send admin message if the version is newly created.
       acquireAdminMessageLock(clusterName, storeName);
@@ -3585,7 +3574,7 @@ public class VeniceParentHelixAdmin implements Admin {
           !currStore.isSystemStore() && (readComputeJustEnabled || partialUpdateJustEnabled);
       if (needToGenerateSupersetSchema) {
         // dry run to make sure superset schema generation can work
-        getSupersetSchemaGenerator(clusterName)
+        parentSchemaOrchestrator.getSupersetSchemaGenerator(clusterName)
             .generateSupersetSchemaFromSchemas(getValueSchemas(clusterName, storeName));
       }
 
@@ -3595,7 +3584,8 @@ public class VeniceParentHelixAdmin implements Admin {
       sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
 
       if (needToGenerateSupersetSchema) {
-        addSupersetSchemaForStore(clusterName, storeName, currStore.isActiveActiveReplicationEnabled());
+        parentSchemaOrchestrator
+            .addSupersetSchemaForStore(clusterName, storeName, currStore.isActiveActiveReplicationEnabled());
       }
       if (partialUpdateJustEnabled) {
         LOGGER.info("Enabling partial update for the first time on store: {} in cluster: {}", storeName, clusterName);
@@ -3609,7 +3599,7 @@ public class VeniceParentHelixAdmin implements Admin {
       final boolean activeActiveReplicationJustEnabled =
           activeActiveReplicationEnabled.orElse(false) && !currStore.isActiveActiveReplicationEnabled();
       if (activeActiveReplicationJustEnabled) {
-        updateReplicationMetadataSchemaForAllValueSchema(clusterName, storeName);
+        parentSchemaOrchestrator.updateReplicationMetadataSchemaForAllValueSchema(clusterName, storeName);
       }
     } finally {
       releaseAdminMessageLock(clusterName, storeName);
@@ -3658,27 +3648,6 @@ public class VeniceParentHelixAdmin implements Admin {
         viewConfig.getViewParameters());
     view.validateConfigs(store);
     return viewConfig;
-  }
-
-  private SupersetSchemaGenerator getSupersetSchemaGenerator(String clusterName) {
-    if (externalSupersetSchemaGenerator.isPresent() && getMultiClusterConfigs().getControllerConfig(clusterName)
-        .isParentExternalSupersetSchemaGenerationEnabled()) {
-      return externalSupersetSchemaGenerator.get();
-    }
-    return defaultSupersetSchemaGenerator;
-  }
-
-  private void addSupersetSchemaForStore(String clusterName, String storeName, boolean activeActiveReplicationEnabled) {
-    // Generate a superset schema and add it.
-    SchemaEntry supersetSchemaEntry = getSupersetSchemaGenerator(clusterName)
-        .generateSupersetSchemaFromSchemas(getValueSchemas(clusterName, storeName));
-    final Schema supersetSchema = supersetSchemaEntry.getSchema();
-    final int supersetSchemaID = supersetSchemaEntry.getId();
-    addValueSchemaEntry(clusterName, storeName, supersetSchema.toString(), supersetSchemaID, true);
-
-    if (activeActiveReplicationEnabled) {
-      updateReplicationMetadataSchema(clusterName, storeName, supersetSchema, supersetSchemaID);
-    }
   }
 
   /**
@@ -3839,156 +3808,8 @@ public class VeniceParentHelixAdmin implements Admin {
       String storeName,
       String newValueSchemaStr,
       DirectionalSchemaCompatibilityType expectedCompatibilityType) {
-    acquireAdminMessageLock(clusterName, storeName);
-    try {
-      final int newValueSchemaId = getVeniceHelixAdmin().checkPreConditionForAddValueSchemaAndGetNewSchemaId(
-          clusterName,
-          storeName,
-          newValueSchemaStr,
-          expectedCompatibilityType);
-
-      /**
-       * If we find this is an exactly duplicate schema, return the existing schema id;
-       * else add the schema with possible doc field change.
-       */
-      if (newValueSchemaId == SchemaData.DUPLICATE_VALUE_SCHEMA_CODE) {
-        return new SchemaEntry(
-            getVeniceHelixAdmin().getValueSchemaId(clusterName, storeName, newValueSchemaStr),
-            newValueSchemaStr);
-      }
-
-      return addValueSchema(clusterName, storeName, newValueSchemaStr, newValueSchemaId, expectedCompatibilityType);
-    } finally {
-      releaseAdminMessageLock(clusterName, storeName);
-    }
-  }
-
-  private SchemaEntry addValueAndSupersetSchemaEntries(
-      String clusterName,
-      String storeName,
-      SchemaEntry newValueSchemaEntry,
-      SchemaEntry newSupersetSchemaEntry,
-      final boolean isWriteComputationEnabled) {
-    validateNewSupersetAndValueSchemaEntries(storeName, clusterName, newValueSchemaEntry, newSupersetSchemaEntry);
-    LOGGER.info(
-        "Adding value schema {} and superset schema {} to store: {} in cluster: {}",
-        newValueSchemaEntry,
-        newSupersetSchemaEntry,
-        storeName,
-        clusterName);
-
-    SupersetSchemaCreation supersetSchemaCreation =
-        (SupersetSchemaCreation) AdminMessageType.SUPERSET_SCHEMA_CREATION.getNewInstance();
-    supersetSchemaCreation.clusterName = clusterName;
-    supersetSchemaCreation.storeName = storeName;
-    SchemaMeta valueSchemaMeta = new SchemaMeta();
-    valueSchemaMeta.definition = newValueSchemaEntry.getSchemaStr();
-    valueSchemaMeta.schemaType = SchemaType.AVRO_1_4.getValue();
-    supersetSchemaCreation.valueSchema = valueSchemaMeta;
-    supersetSchemaCreation.valueSchemaId = newValueSchemaEntry.getId();
-
-    SchemaMeta supersetSchemaMeta = new SchemaMeta();
-    supersetSchemaMeta.definition = newSupersetSchemaEntry.getSchemaStr();
-    supersetSchemaMeta.schemaType = SchemaType.AVRO_1_4.getValue();
-    supersetSchemaCreation.supersetSchema = supersetSchemaMeta;
-    supersetSchemaCreation.supersetSchemaId = newSupersetSchemaEntry.getId();
-
-    AdminOperation message = new AdminOperation();
-    message.operationType = AdminMessageType.SUPERSET_SCHEMA_CREATION.getValue();
-    message.payloadUnion = supersetSchemaCreation;
-
-    sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
-    // Need to add RMD schemas for both new value schema and new superset schema.
-    updateReplicationMetadataSchema(
-        clusterName,
-        storeName,
-        newValueSchemaEntry.getSchema(),
-        newValueSchemaEntry.getId());
-    updateReplicationMetadataSchema(
-        clusterName,
-        storeName,
-        newSupersetSchemaEntry.getSchema(),
-        newSupersetSchemaEntry.getId());
-    if (isWriteComputationEnabled) {
-      Schema newValueWriteComputeSchema =
-          writeComputeSchemaConverter.convertFromValueRecordSchema(newValueSchemaEntry.getSchema());
-      Schema newSuperSetWriteComputeSchema =
-          writeComputeSchemaConverter.convertFromValueRecordSchema(newSupersetSchemaEntry.getSchema());
-      addDerivedSchema(clusterName, storeName, newValueSchemaEntry.getId(), newValueWriteComputeSchema.toString());
-      addDerivedSchema(
-          clusterName,
-          storeName,
-          newSupersetSchemaEntry.getId(),
-          newSuperSetWriteComputeSchema.toString());
-    }
-    updateStore(
-        clusterName,
-        storeName,
-        new UpdateStoreQueryParams().setLatestSupersetSchemaId(newSupersetSchemaEntry.getId()));
-    return newValueSchemaEntry;
-  }
-
-  private void validateNewSupersetAndValueSchemaEntries(
-      String storeName,
-      String clusterName,
-      SchemaEntry newValueSchemaEntry,
-      SchemaEntry newSupersetSchemaEntry) {
-    if (newValueSchemaEntry.getId() == newSupersetSchemaEntry.getId()) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Superset schema ID and value schema ID are expected to be different for store %s in cluster %s. "
-                  + "Got ID: %d",
-              storeName,
-              clusterName,
-              newValueSchemaEntry.getId()));
-    }
-    if (AvroSchemaUtils
-        .compareSchemaIgnoreFieldOrder(newValueSchemaEntry.getSchema(), newSupersetSchemaEntry.getSchema())) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Superset and value schemas are expected to be different for store %s in cluster %s. Got schema: %s",
-              storeName,
-              clusterName,
-              newValueSchemaEntry.getSchema()));
-    }
-  }
-
-  private SchemaEntry addValueSchemaEntry(
-      String clusterName,
-      String storeName,
-      String valueSchemaStr,
-      final int newValueSchemaId,
-      final boolean doUpdateSupersetSchemaID) {
-    LOGGER.info("Adding value schema: {} to store: {} in cluster: {}", valueSchemaStr, storeName, clusterName);
-
-    ValueSchemaCreation valueSchemaCreation =
-        (ValueSchemaCreation) AdminMessageType.VALUE_SCHEMA_CREATION.getNewInstance();
-    valueSchemaCreation.clusterName = clusterName;
-    valueSchemaCreation.storeName = storeName;
-    SchemaMeta schemaMeta = new SchemaMeta();
-    schemaMeta.definition = valueSchemaStr;
-    schemaMeta.schemaType = SchemaType.AVRO_1_4.getValue();
-    valueSchemaCreation.schema = schemaMeta;
-    valueSchemaCreation.schemaId = newValueSchemaId;
-
-    AdminOperation message = new AdminOperation();
-    message.operationType = AdminMessageType.VALUE_SCHEMA_CREATION.getValue();
-    message.payloadUnion = valueSchemaCreation;
-    sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
-
-    // defensive code checking
-    int actualValueSchemaId = getValueSchemaId(clusterName, storeName, valueSchemaStr);
-    if (actualValueSchemaId != newValueSchemaId) {
-      throw new VeniceException(
-          "Something bad happens, the expected new value schema id is: " + newValueSchemaId + ", but got: "
-              + actualValueSchemaId);
-    }
-
-    if (doUpdateSupersetSchemaID) {
-      updateStore(clusterName, storeName, new UpdateStoreQueryParams().setLatestSupersetSchemaId(newValueSchemaId));
-    }
-
-    return new SchemaEntry(actualValueSchemaId, valueSchemaStr);
+    return parentSchemaOrchestrator
+        .addValueSchema(clusterName, storeName, newValueSchemaStr, expectedCompatibilityType);
   }
 
   /**
@@ -4012,92 +3833,8 @@ public class VeniceParentHelixAdmin implements Admin {
       String newValueSchemaStr,
       int schemaId,
       DirectionalSchemaCompatibilityType expectedCompatibilityType) {
-    acquireAdminMessageLock(clusterName, storeName);
-    try {
-      Schema newValueSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(newValueSchemaStr);
-
-      final Store store = getVeniceHelixAdmin().getStore(clusterName, storeName);
-      Schema existingValueSchema = getVeniceHelixAdmin().getSupersetOrLatestValueSchema(clusterName, store);
-
-      // Update superset schema if:
-      // 1. Compute is enabled (existing behavior), OR
-      // 2. A superset schema already exists (always keep it updated even if compute is disabled)
-      // Check if a superset schema already exists for this store
-      final boolean doUpdateSupersetSchemaID;
-      boolean supersetSchemaAlreadyExists =
-          store.getLatestSuperSetValueSchemaId() != SchemaData.INVALID_VALUE_SCHEMA_ID;
-      if (existingValueSchema != null
-          && (store.isReadComputationEnabled() || store.isWriteComputationEnabled() || supersetSchemaAlreadyExists)) {
-        SupersetSchemaGenerator supersetSchemaGenerator = getSupersetSchemaGenerator(clusterName);
-        Schema newSuperSetSchema = supersetSchemaGenerator.generateSupersetSchema(existingValueSchema, newValueSchema);
-        String newSuperSetSchemaStr = newSuperSetSchema.toString();
-        if (supersetSchemaGenerator.compareSchema(newSuperSetSchema, newValueSchema)) {
-          doUpdateSupersetSchemaID = true;
-
-        } else if (supersetSchemaGenerator.compareSchema(newSuperSetSchema, existingValueSchema)) {
-          doUpdateSupersetSchemaID = false;
-
-        } else if (store.isSystemStore()) {
-          /**
-           * Do not register superset schema for system store for now. Because some system stores specify the schema ID
-           * explicitly, which may conflict with the superset schema generated internally, the new value schema registration
-           * could fail.
-           *
-           * TODO: Design a long-term plan.
-           */
-          doUpdateSupersetSchemaID = false;
-
-        } else {
-          // Register superset schema only if it does not match with existing or new schema.
-
-          // validate compatibility of the new superset schema
-          getVeniceHelixAdmin().checkPreConditionForAddValueSchemaAndGetNewSchemaId(
-              clusterName,
-              storeName,
-              newSuperSetSchemaStr,
-              expectedCompatibilityType);
-          // Check if the superset schema already exists or not. If exists use the same ID, else bump the value ID by
-          // one.
-          int supersetSchemaId = getVeniceHelixAdmin().getValueSchemaIdIgnoreFieldOrder(
-              clusterName,
-              storeName,
-              newSuperSetSchemaStr,
-              (s1, s2) -> supersetSchemaGenerator.compareSchema(s1, s2) ? 0 : 1);
-          if (supersetSchemaId == SchemaData.INVALID_VALUE_SCHEMA_ID) {
-            supersetSchemaId = schemaId + 1;
-          }
-          return addValueAndSupersetSchemaEntries(
-              clusterName,
-              storeName,
-              new SchemaEntry(schemaId, newValueSchema),
-              new SchemaEntry(supersetSchemaId, newSuperSetSchema),
-              store.isWriteComputationEnabled());
-        }
-      } else {
-        doUpdateSupersetSchemaID = false;
-      }
-      SchemaEntry addedSchemaEntry =
-          addValueSchemaEntry(clusterName, storeName, newValueSchemaStr, schemaId, doUpdateSupersetSchemaID);
-
-      /**
-       * if active-active replication is enabled for the store then generate and register the new Replication metadata schema
-       * for this newly added value schema.
-       */
-      if (store.isActiveActiveReplicationEnabled()) {
-        Schema latestValueSchema = getVeniceHelixAdmin().getSupersetOrLatestValueSchema(clusterName, store);
-        final int valueSchemaId = getValueSchemaId(clusterName, storeName, latestValueSchema.toString());
-        updateReplicationMetadataSchema(clusterName, storeName, latestValueSchema, valueSchemaId);
-      }
-      if (store.isWriteComputationEnabled()) {
-        Schema newWriteComputeSchema =
-            writeComputeSchemaConverter.convertFromValueRecordSchema(addedSchemaEntry.getSchema());
-        addDerivedSchema(clusterName, storeName, addedSchemaEntry.getId(), newWriteComputeSchema.toString());
-      }
-
-      return addedSchemaEntry;
-    } finally {
-      releaseAdminMessageLock(clusterName, storeName);
-    }
+    return parentSchemaOrchestrator
+        .addValueSchema(clusterName, storeName, newValueSchemaStr, schemaId, expectedCompatibilityType);
   }
 
   /**
@@ -4111,51 +3848,7 @@ public class VeniceParentHelixAdmin implements Admin {
       String storeName,
       int valueSchemaId,
       String derivedSchemaStr) {
-    acquireAdminMessageLock(clusterName, storeName);
-    try {
-      int newDerivedSchemaId = veniceHelixAdmin.checkPreConditionForAddDerivedSchemaAndGetNewSchemaId(
-          clusterName,
-          storeName,
-          valueSchemaId,
-          derivedSchemaStr);
-
-      // if we find this is a duplicate schema, return the existing schema id
-      if (newDerivedSchemaId == SchemaData.DUPLICATE_VALUE_SCHEMA_CODE) {
-        return new DerivedSchemaEntry(
-            valueSchemaId,
-            getVeniceHelixAdmin().getDerivedSchemaId(clusterName, storeName, derivedSchemaStr)
-                .getGeneratedSchemaVersion(),
-            derivedSchemaStr);
-      }
-
-      LOGGER.info(
-          "Adding derived schema: {} to store: {}, version: {} in cluster: {}",
-          derivedSchemaStr,
-          storeName,
-          valueSchemaId,
-          clusterName);
-
-      DerivedSchemaCreation derivedSchemaCreation =
-          (DerivedSchemaCreation) AdminMessageType.DERIVED_SCHEMA_CREATION.getNewInstance();
-      derivedSchemaCreation.clusterName = clusterName;
-      derivedSchemaCreation.storeName = storeName;
-      SchemaMeta schemaMeta = new SchemaMeta();
-      schemaMeta.definition = derivedSchemaStr;
-      schemaMeta.schemaType = SchemaType.AVRO_1_4.getValue();
-      derivedSchemaCreation.schema = schemaMeta;
-      derivedSchemaCreation.valueSchemaId = valueSchemaId;
-      derivedSchemaCreation.derivedSchemaId = newDerivedSchemaId;
-
-      AdminOperation message = new AdminOperation();
-      message.operationType = AdminMessageType.DERIVED_SCHEMA_CREATION.getValue();
-      message.payloadUnion = derivedSchemaCreation;
-
-      sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
-
-      return new DerivedSchemaEntry(valueSchemaId, newDerivedSchemaId, derivedSchemaStr);
-    } finally {
-      releaseAdminMessageLock(clusterName, storeName);
-    }
+    return parentSchemaOrchestrator.addDerivedSchema(clusterName, storeName, valueSchemaId, derivedSchemaStr);
   }
 
   /**
@@ -4214,103 +3907,12 @@ public class VeniceParentHelixAdmin implements Admin {
       int valueSchemaId,
       int replicationMetadataVersionId,
       String replicationMetadataSchemaStr) {
-    acquireAdminMessageLock(clusterName, storeName);
-    try {
-      RmdSchemaEntry rmdSchemaEntry =
-          new RmdSchemaEntry(valueSchemaId, replicationMetadataVersionId, replicationMetadataSchemaStr);
-      final boolean replicationMetadataSchemaAlreadyPresent = getVeniceHelixAdmin()
-          .checkIfMetadataSchemaAlreadyPresent(clusterName, storeName, valueSchemaId, rmdSchemaEntry);
-      if (replicationMetadataSchemaAlreadyPresent) {
-        LOGGER.info(
-            "Replication metadata schema already exists for store: {} in cluster: {} metadataSchema: {} "
-                + "replicationMetadataVersionId: {} valueSchemaId: {}",
-            storeName,
-            clusterName,
-            replicationMetadataSchemaStr,
-            replicationMetadataVersionId,
-            valueSchemaId);
-        return rmdSchemaEntry;
-      }
-
-      LOGGER.info(
-          "Adding Replication metadata schema for store: {} in cluster: {} metadataSchema: {} "
-              + "replicationMetadataVersionId: {} valueSchemaId: {}",
-          storeName,
-          clusterName,
-          replicationMetadataSchemaStr,
-          replicationMetadataVersionId,
-          valueSchemaId);
-
-      MetadataSchemaCreation replicationMetadataSchemaCreation =
-          (MetadataSchemaCreation) AdminMessageType.REPLICATION_METADATA_SCHEMA_CREATION.getNewInstance();
-      replicationMetadataSchemaCreation.clusterName = clusterName;
-      replicationMetadataSchemaCreation.storeName = storeName;
-      replicationMetadataSchemaCreation.valueSchemaId = valueSchemaId;
-      SchemaMeta schemaMeta = new SchemaMeta();
-      schemaMeta.definition = replicationMetadataSchemaStr;
-      schemaMeta.schemaType = SchemaType.AVRO_1_4.getValue();
-      replicationMetadataSchemaCreation.metadataSchema = schemaMeta;
-      replicationMetadataSchemaCreation.timestampMetadataVersionId = replicationMetadataVersionId;
-
-      AdminOperation message = new AdminOperation();
-      message.operationType = AdminMessageType.REPLICATION_METADATA_SCHEMA_CREATION.getValue();
-      message.payloadUnion = replicationMetadataSchemaCreation;
-
-      sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
-
-      // Be defensive and check that RMD schema has been added indeed. Do a loose validation parsing as stores can have
-      // older schemas considered wrong with respect to the current avro version
-      final Schema expectedRmdSchema =
-          AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(replicationMetadataSchemaStr);
-      validateRmdSchemaIsAddedAsExpected(
-          clusterName,
-          storeName,
-          valueSchemaId,
-          replicationMetadataVersionId,
-          expectedRmdSchema);
-      return new RmdSchemaEntry(valueSchemaId, replicationMetadataVersionId, replicationMetadataSchemaStr);
-    } catch (Exception e) {
-      LOGGER.error(
-          "Error when adding replication metadata schema for store: {}, value schema id: {}",
-          storeName,
-          valueSchemaId,
-          e);
-      throw e;
-    } finally {
-      releaseAdminMessageLock(clusterName, storeName);
-    }
-  }
-
-  private void validateRmdSchemaIsAddedAsExpected(
-      String clusterName,
-      String storeName,
-      int valueSchemaID,
-      int rmdVersionID,
-      Schema expectedRmdSchema) {
-    final Schema addedRmdSchema =
-        getReplicationMetadataSchema(clusterName, storeName, valueSchemaID, rmdVersionID).orElse(null);
-    if (addedRmdSchema == null) {
-      throw new VeniceException(
-          String.format(
-              "No replication metadata schema found for store %s in cluster %s with value "
-                  + "schema ID %s and RMD protocol version ID %d",
-              storeName,
-              clusterName,
-              valueSchemaID,
-              rmdVersionID));
-    }
-    if (!AvroSchemaUtils.compareSchemaIgnoreFieldOrder(addedRmdSchema, expectedRmdSchema)) {
-      throw new VeniceException(
-          String.format(
-              "For store %s in cluster %s with value schema ID %d and RMD protocol"
-                  + " version ID %d. Expected RMD schema %s. But got RMD schema: %s",
-              storeName,
-              clusterName,
-              valueSchemaID,
-              rmdVersionID,
-              expectedRmdSchema.toString(true),
-              addedRmdSchema.toString(true)));
-    }
+    return parentSchemaOrchestrator.addReplicationMetadataSchema(
+        clusterName,
+        storeName,
+        valueSchemaId,
+        replicationMetadataVersionId,
+        replicationMetadataSchemaStr);
   }
 
   /**
@@ -4322,36 +3924,6 @@ public class VeniceParentHelixAdmin implements Admin {
       String storeName,
       VeniceSystemStoreType veniceSystemStoreType) {
     throw new VeniceUnsupportedOperationException("validateAndMaybeRetrySystemStoreAutoCreation");
-  }
-
-  private void updateReplicationMetadataSchemaForAllValueSchema(String clusterName, String storeName) {
-    final Collection<SchemaEntry> valueSchemas = getValueSchemas(clusterName, storeName);
-    for (SchemaEntry valueSchemaEntry: valueSchemas) {
-      updateReplicationMetadataSchema(clusterName, storeName, valueSchemaEntry.getSchema(), valueSchemaEntry.getId());
-    }
-  }
-
-  private void updateReplicationMetadataSchema(
-      String clusterName,
-      String storeName,
-      Schema valueSchema,
-      int valueSchemaId) {
-    final int rmdVersionId = getRmdVersionID(storeName, clusterName);
-    final boolean valueSchemaAlreadyHasRmdSchema = getVeniceHelixAdmin()
-        .checkIfValueSchemaAlreadyHasRmdSchema(clusterName, storeName, valueSchemaId, rmdVersionId);
-    if (valueSchemaAlreadyHasRmdSchema) {
-      LOGGER.info(
-          "Store {} in cluster {} already has a replication metadata schema for its value schema with ID {} and "
-              + "replication metadata version ID {}. So skip updating this value schema's RMD schema.",
-          storeName,
-          clusterName,
-          valueSchemaId,
-          rmdVersionId);
-      return;
-    }
-    String replicationMetadataSchemaStr =
-        RmdSchemaGenerator.generateMetadataSchema(valueSchema, rmdVersionId).toString();
-    addReplicationMetadataSchema(clusterName, storeName, valueSchemaId, rmdVersionId, replicationMetadataSchemaStr);
   }
 
   /**

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -614,6 +614,65 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     assertEquals(valueSchemaCreationMessage.schemaId, valueSchemaId);
   }
 
+  /**
+   * Regression guard: when write computation is enabled, {@code addValueSchema} must also broadcast a
+   * {@link AdminMessageType#DERIVED_SCHEMA_CREATION} admin message so the derived (write-compute) schema is replicated
+   * to child fabrics. A local schema-repo write would not propagate, leaving child controllers without the derived
+   * schema.
+   */
+  @Test
+  public void testAddValueSchemaWithWriteComputePropagatesDerivedSchema() {
+    String storeName = "test-store-wc";
+    Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
+    store.setWriteComputationEnabled(true);
+    doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
+    // No existing superset/latest value schema, so the superset-generation branch is skipped.
+    doReturn(null).when(internalAdmin).getSupersetOrLatestValueSchema(eq(clusterName), any(Store.class));
+
+    int valueSchemaId = 1;
+    String valueSchemaStr =
+        "{\"type\":\"record\",\"name\":\"TestRecord\",\"fields\":[{\"name\":\"field1\",\"type\":\"int\",\"default\":0}]}";
+    doReturn(valueSchemaId).when(internalAdmin)
+        .checkPreConditionForAddValueSchemaAndGetNewSchemaId(
+            clusterName,
+            storeName,
+            valueSchemaStr,
+            DirectionalSchemaCompatibilityType.FULL);
+    doReturn(valueSchemaId).when(internalAdmin).getValueSchemaId(clusterName, storeName, valueSchemaStr);
+    doReturn(1).when(internalAdmin)
+        .checkPreConditionForAddDerivedSchemaAndGetNewSchemaId(
+            eq(clusterName),
+            eq(storeName),
+            eq(valueSchemaId),
+            anyString());
+
+    parentAdmin.initStorageCluster(clusterName);
+    parentAdmin.addValueSchema(clusterName, storeName, valueSchemaStr, DirectionalSchemaCompatibilityType.FULL);
+
+    ArgumentCaptor<byte[]> valueCaptor = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<Integer> schemaCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(veniceWriter, atLeast(2))
+        .put(any(), valueCaptor.capture(), schemaCaptor.capture(), any(), any(), anyLong(), any(), any(), any(), any());
+
+    boolean sawValueSchemaCreation = false;
+    boolean sawDerivedSchemaCreation = false;
+    List<byte[]> values = valueCaptor.getAllValues();
+    List<Integer> schemas = schemaCaptor.getAllValues();
+    for (int i = 0; i < values.size(); i++) {
+      AdminOperation adminMessage =
+          adminOperationSerializer.deserialize(ByteBuffer.wrap(values.get(i)), schemas.get(i));
+      if (adminMessage.operationType == AdminMessageType.VALUE_SCHEMA_CREATION.getValue()) {
+        sawValueSchemaCreation = true;
+      } else if (adminMessage.operationType == AdminMessageType.DERIVED_SCHEMA_CREATION.getValue()) {
+        sawDerivedSchemaCreation = true;
+      }
+    }
+    assertTrue(sawValueSchemaCreation, "Expected a VALUE_SCHEMA_CREATION admin message");
+    assertTrue(
+        sawDerivedSchemaCreation,
+        "addValueSchema with write computation enabled must broadcast a DERIVED_SCHEMA_CREATION admin message");
+  }
+
   @Test
   public void testAddDerivedSchema() {
     String storeName = "test-store";


### PR DESCRIPTION
 ## Problem Statement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  Schema-related logic was spread across two already-large controller classes. `VeniceHelixAdmin` carried the child-controller store schema operations (key/value/derived/replication-metadata schema reads, registration, validation, and value-schema cleanup) while `VeniceParentHelixAdmin` carried the parent-controller schema orchestration (admin-message-driven value/superset/derived/RMD schema creation). Mixing these schema concerns into the broader admin classes makes them harder to read, reason about, and unit-test
  in isolation, and continues to grow two files that are already among the largest in the module.                                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  ## Solution                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  Extract the schema concerns into two cohesive, package-private, independently-testable classes, keeping the public `Admin` schema methods as thin delegators so external call sites and the `Admin` interface are unaffected.                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  - `StoreSchemaService` (extracted from `VeniceHelixAdmin`): child-controller store schema operations — key/value/derived/RMD schema reads, registration, `validateValueSchemaUsingRandomGenerator`, `deleteValueSchemas`, and `getInUseValueSchemaIds`. It reaches back into `VeniceHelixAdmin` only for the cluster-leadership check and per-cluster resource/meta-store accessors.                                                                                                                                                  
  - `ParentSchemaOrchestrator` (extracted from `VeniceParentHelixAdmin`): parent-controller schema orchestration — value/superset/derived/RMD schema creation via admin messages, superset-generator selection, and RMD-for-all-value-schemas. It reaches the parent's package-private methods through an injected `VeniceParentHelixAdmin` back-reference.                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  This is a behavior-preserving refactor. Method bodies, log lines, exception types/messages, admin-message construction, and the `acquireAdminMessageLock`/`releaseAdminMessageLock` re-entrant locking semantics are unchanged. The only visibility change is `VeniceParentHelixAdmin.getRmdVersionID`, narrowed from `private` to package-private so the orchestrator can call it. Re-routed reads (e.g. `parent.getVeniceHelixAdmin().getValueSchemas(...)`) are equivalent because the corresponding parent methods were already   
  pure pass-throughs to `getVeniceHelixAdmin()`. No new configs and no new log lines are introduced. Verified via `compileJava` + `compileTestJava` and by running the full `TestVeniceParentHelixAdmin` suite with the build cache disabled.                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  ###  Code changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
  - [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.                                                                                                                                                                                                                                                                                                                                                                                                                 
  - [ ] Introduced new **log lines**.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
    - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.                                                                                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  ###  **Concurrency-Specific Checks**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
  Both reviewer and PR author to verify                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
  - [x] Code has **no race conditions** or **thread safety issues**.                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
  - [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.                                                                                                                                                                                                                                                                                                                                                                                                                                   
  - [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.                                                                                                                                                                                                                                                                                                                                                                                                                         
  - [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).                                                                                                                                                                                                                                                                                                                                                                                                                              
  - [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.                                                                                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  (The admin-message lock acquire/release boundaries and their re-entrant nesting are carried over verbatim from the original code; no locking, collection, or exception-handling behavior was altered by the extraction.)                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  ## How was this PR tested?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  - [x] New unit tests added.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
  - [ ] New integration tests added.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
  - [ ] Modified or extended existing tests.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
  - [x] Verified backward compatibility (if applicable).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  Added `testAddValueSchemaWithWriteComputePropagatesDerivedSchema` to `TestVeniceParentHelixAdmin`, a regression guard verifying that `addValueSchema` still broadcasts a `DERIVED_SCHEMA_CREATION` admin message when write computation is enabled — the cross-fabric propagation behavior most at risk in this refactor. The existing `TestVeniceParentHelixAdmin` suite (including `testAddValueSchema`, `testAddDerivedSchema`, and the schema/superset/RMD tests) passes, and both main and test sources compile cleanly.         
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  ## Does this PR introduce any user-facing or breaking changes?                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  - [x] No. You can skip the rest of this section.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
  - [ ] Yes. Clearly explain the behavior change and its impact.       