### PR TITLE
[server] Add lkc heartbeat header for active-key-count consistency check across replicas

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -71,6 +71,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_AA_WC_WORKLOAD_PARALLEL_PROC
 import static com.linkedin.venice.ConfigKeys.SERVER_AA_WC_WORKLOAD_PARALLEL_PROCESSING_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_ACTIVE_KEY_COUNT_FOR_ALL_BATCH_PUSH_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_ACTIVE_KEY_COUNT_FOR_HYBRID_STORE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_ACTIVE_KEY_COUNT_REPLICA_CONSISTENCY_CHECK_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_ADAPTIVE_THROTTLER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_ADAPTIVE_THROTTLER_MULTI_GET_LATENCY_THRESHOLD;
 import static com.linkedin.venice.ConfigKeys.SERVER_ADAPTIVE_THROTTLER_READ_COMPUTE_GET_LATENCY_THRESHOLD;
@@ -738,6 +739,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final boolean addRmdToBatchPushForHybridStores;
   private final boolean activeKeyCountForAllBatchPushEnabled;
   private final boolean activeKeyCountForHybridStoreEnabled;
+  private final boolean activeKeyCountReplicaConsistencyCheckEnabled;
   private final int partialUpdateLargeResultLogThresholdBytes;
   private final long partialUpdateAmplificationReportIntervalMs;
 
@@ -1290,6 +1292,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getBoolean(SERVER_ACTIVE_KEY_COUNT_FOR_ALL_BATCH_PUSH_ENABLED, false);
     this.activeKeyCountForHybridStoreEnabled =
         serverProperties.getBoolean(SERVER_ACTIVE_KEY_COUNT_FOR_HYBRID_STORE_ENABLED, false);
+    this.activeKeyCountReplicaConsistencyCheckEnabled =
+        serverProperties.getBoolean(SERVER_ACTIVE_KEY_COUNT_REPLICA_CONSISTENCY_CHECK_ENABLED, false);
     this.partialUpdateLargeResultLogThresholdBytes =
         serverProperties.getInt(PARTIAL_UPDATE_LARGE_RESULT_LOG_THRESHOLD_BYTES, 100 * 1024);
     this.partialUpdateAmplificationReportIntervalMs =
@@ -2335,6 +2339,15 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isActiveKeyCountForHybridStoreEnabled() {
     return activeKeyCountForHybridStoreEnabled;
+  }
+
+  /**
+   * @return {@code true} when the replica-consistency check will actually run — i.e. both the check flag
+   *         ({@code server.active.key.count.replica.consistency.check.enabled}) AND its hybrid-tracking
+   *         prerequisite ({@link #isActiveKeyCountForHybridStoreEnabled()}) are on.
+   */
+  public boolean isActiveKeyCountReplicaConsistencyCheckEnabled() {
+    return activeKeyCountForHybridStoreEnabled && activeKeyCountReplicaConsistencyCheckEnabled;
   }
 
   public boolean isAnyActiveKeyCountTrackingEnabled() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -113,12 +113,14 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
   static final byte KEY_CREATED_SIGNAL_VALUE = 1;
   static final byte KEY_DELETED_SIGNAL_VALUE = -1;
   static final byte KEY_COUNT_INVALIDATE_SIGNAL_VALUE = 0;
-  static final PubSubMessageHeader KEY_CREATED_SIGNAL =
-      new PubSubMessageHeader(StoreIngestionTask.KEY_COUNT_SIGNAL_HEADER, new byte[] { KEY_CREATED_SIGNAL_VALUE });
-  static final PubSubMessageHeader KEY_DELETED_SIGNAL =
-      new PubSubMessageHeader(StoreIngestionTask.KEY_COUNT_SIGNAL_HEADER, new byte[] { KEY_DELETED_SIGNAL_VALUE });
+  static final PubSubMessageHeader KEY_CREATED_SIGNAL = new PubSubMessageHeader(
+      PubSubMessageHeaders.VENICE_KEY_COUNT_SIGNAL_HEADER,
+      new byte[] { KEY_CREATED_SIGNAL_VALUE });
+  static final PubSubMessageHeader KEY_DELETED_SIGNAL = new PubSubMessageHeader(
+      PubSubMessageHeaders.VENICE_KEY_COUNT_SIGNAL_HEADER,
+      new byte[] { KEY_DELETED_SIGNAL_VALUE });
   static final PubSubMessageHeader KEY_COUNT_INVALIDATE_SIGNAL = new PubSubMessageHeader(
-      StoreIngestionTask.KEY_COUNT_SIGNAL_HEADER,
+      PubSubMessageHeaders.VENICE_KEY_COUNT_SIGNAL_HEADER,
       new byte[] { KEY_COUNT_INVALIDATE_SIGNAL_VALUE });
 
   /** RMD bytes (ts=0) with superset schema ID prepended. For chunk manifests (superset schema ID known at construction). */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountInvalidationReason.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountInvalidationReason.java
@@ -1,20 +1,30 @@
 package com.linkedin.davinci.kafka.consumer;
 
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_ACTIVE_KEY_COUNT_INVALIDATION_REASON;
+
+import com.linkedin.venice.stats.dimensions.VeniceDimensionInterface;
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+
+
 /**
  * Reasons for invalidating a partition's active-key-count tracking. Each value carries a message
  * template (some with a {@code %d} placeholder for runtime detail like the offending signal value
  * or header length) that becomes the prefix of the operator-visible ERROR log emitted by
  * {@link StoreIngestionTask#invalidateActiveKeyCount}.
+ *
+ * <p>Also serves as an OTel dimension on
+ * {@link com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity#ACTIVE_KEY_COUNT_INVALIDATION}.
+ * The Tehuti sensor remains a flat total.
  */
-public enum ActiveKeyCountInvalidationReason {
+public enum ActiveKeyCountInvalidationReason implements VeniceDimensionInterface {
   /** Follower received {@code kcs=-1} but its count was already zero (count drifted). */
   FOLLOWER_DECREMENT_UNDERFLOW("Decrement underflow on follower from kcs=-1"),
   /** Follower received {@code kcs=0} (leader-propagated invalidation signal). */
   LEADER_PROPAGATED_INVALIDATION("Leader propagated invalidation signal"),
   /** Follower received a single-byte {@code kcs} value outside the {-1, 0, +1} contract. */
-  CORRUPT_KCS_SIGNAL_VALUE("Unexpected kcs signal value %d"),
-  /** Follower received a multi-byte {@code kcs} header (corrupt or future producer). */
-  CORRUPT_MULTI_BYTE_KCS_SIGNAL("Unexpected multi-byte kcs signal (length=%d)"),
+  CORRUPT_KEY_COUNT_SIGNAL_HEADER_VALUE("Unexpected kcs signal value %d"),
+  /** Follower received a {@code kcs} header with the wrong byte length (expected 1; corrupt or future producer). */
+  CORRUPT_KEY_COUNT_SIGNAL_HEADER_LENGTH("Unexpected kcs header length=%d"),
   /** Leader detected an underflow during DCR (count was zero but a delete was processed). */
   LEADER_DCR_UNDERFLOW("Decrement underflow on leader during DCR"),
   /**
@@ -23,19 +33,40 @@ public enum ActiveKeyCountInvalidationReason {
    * The transient I/O failure must not stop ingestion or leave the active count in a wrong state —
    * invalidate so we stop publishing a stale value.
    */
-  KEY_EXISTS_FAILURE("RocksDB value column family lookup failed");
+  KEY_EXISTS_FAILURE("RocksDB value column family lookup failed"),
+  /** Follower received an {@code lkc} header with the wrong byte length (expected 8; corrupt or future producer). */
+  CORRUPT_LEADER_KEY_COUNT_HEADER_LENGTH("Unexpected lkc header length=%d");
 
   private final String messageTemplate;
+  private final boolean templateWithExtraData;
 
   ActiveKeyCountInvalidationReason(String messageTemplate) {
     this.messageTemplate = messageTemplate;
+    this.templateWithExtraData = messageTemplate.contains("%d");
   }
 
   String getMessage() {
+    if (templateWithExtraData) {
+      throw new IllegalStateException(
+          "Reason " + name() + " carries a '%d' placeholder; caller must use getMessage(int detail).");
+    }
     return messageTemplate;
   }
 
   String getMessage(int detail) {
+    if (!templateWithExtraData) {
+      throw new IllegalStateException(
+          "Reason " + name() + " has no '%d' placeholder; caller must use the no-arg getMessage().");
+    }
     return String.format(messageTemplate, detail);
+  }
+
+  /**
+   * All instances of this enum share the same dimension name.
+   * Refer to {@link VeniceDimensionInterface#getDimensionName()} for more details.
+   */
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VENICE_ACTIVE_KEY_COUNT_INVALIDATION_REASON;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -10,6 +10,7 @@ import static com.linkedin.davinci.validation.PartitionTracker.TopicType.REALTIM
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.END_OF_PUSH;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
 import static com.linkedin.venice.kafka.protocol.enums.MessageType.UPDATE;
+import static com.linkedin.venice.offsets.OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED;
 import static com.linkedin.venice.offsets.OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY;
 import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_LEADER_COMPLETION_STATE_HEADER;
 import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
@@ -386,33 +387,37 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
   @Override
   protected void closeVeniceViewWriters(boolean doFlush) {
+    long gracefulCloseDeadline = time.getMilliseconds() + VIEW_WRITER_CLOSE_TIMEOUT_IN_MS;
     if (!viewWriters.isEmpty()) {
-      long gracefulCloseDeadline = time.getMilliseconds() + VIEW_WRITER_CLOSE_TIMEOUT_IN_MS;
       viewWriters.forEach((k, v) -> v.close(doFlush));
-      // Short circuit last VT produce call future if it's incomplete to unblock any consumer thread(s) that are waiting
-      for (PartitionConsumptionState pcs: partitionConsumptionStateMap.values()) {
-        CompletableFuture<Void> lastVTProduceCallFuture = pcs.getLastVTProduceCallFuture();
-        if (!lastVTProduceCallFuture.isDone()) {
-          if (doFlush) {
-            long timeout = gracefulCloseDeadline - time.getMilliseconds();
-            if (timeout <= 0) {
+    }
+    /*
+     * Short-circuit the chain head to unblock waiters. Hybrid A/A with the active-key-count replica
+     * consistency check pushes an hbProduceFuture even when viewWriters is empty, so run unconditionally;
+     * the isDone() guard makes it a no-op on partitions whose head is already complete.
+     */
+    for (PartitionConsumptionState pcs: partitionConsumptionStateMap.values()) {
+      CompletableFuture<Void> lastVTProduceCallFuture = pcs.getLastVTProduceCallFuture();
+      if (!lastVTProduceCallFuture.isDone()) {
+        if (doFlush) {
+          long timeout = gracefulCloseDeadline - time.getMilliseconds();
+          if (timeout <= 0) {
+            lastVTProduceCallFuture.completeExceptionally(
+                new VeniceException(
+                    "Completing the future forcefully since we exceeded the view writer graceful close timeout for: "
+                        + kafkaVersionTopic));
+          } else {
+            try {
+              lastVTProduceCallFuture.get(timeout, MILLISECONDS);
+            } catch (Exception e) {
               lastVTProduceCallFuture.completeExceptionally(
                   new VeniceException(
-                      "Completing the future forcefully since we exceeded the view writer graceful close timeout for: "
-                          + kafkaVersionTopic));
-            } else {
-              try {
-                lastVTProduceCallFuture.get(timeout, MILLISECONDS);
-              } catch (Exception e) {
-                lastVTProduceCallFuture.completeExceptionally(
-                    new VeniceException(
-                        "Exception caught when closing the view writer in ingestion task for: " + kafkaVersionTopic,
-                        e));
-              }
+                      "Exception caught when closing the view writer in ingestion task for: " + kafkaVersionTopic,
+                      e));
             }
-          } else {
-            lastVTProduceCallFuture.complete(null);
           }
+        } else {
+          lastVTProduceCallFuture.complete(null);
         }
       }
     }
@@ -3037,6 +3042,56 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           : getServerConfig().getKafkaClusterUrlToAliasMap().get(kafkaUrl);
       HeartbeatKey cachedKey = partitionConsumptionState.getOrCreateCachedHeartbeatKey(region);
       hbService.recordFollowerHeartbeat(cachedKey, timestamp, isComplete);
+      compareLeaderActiveKeyCountOnHeartbeat(partitionConsumptionState, consumerRecord);
+    }
+  }
+
+  /**
+   * Compare the leader's active-key-count carried on the {@code lkc} heartbeat header against this
+   * follower's own count. VT ordering guarantees all prior {@code kcs} signals are applied before the
+   * heartbeat is processed, so a difference is a real divergence across replicas.
+   *
+   * <p>Mismatch is diagnostic-only: bumps {@code ingestion.key.active_count_mismatch_across_replicas}
+   * and emits a WARN log; the follower's count is left intact. A malformed header (wrong byte length)
+   * is treated as producer corruption and DOES invalidate with
+   * {@link ActiveKeyCountInvalidationReason#CORRUPT_LEADER_KEY_COUNT_HEADER_LENGTH}.
+   *
+   * <p>Skips when {@link #activeKeyCountReplicaConsistencyCheckEnabled} is off, pre-EOP, the follower's
+   * count is {@link OffsetRecord#ACTIVE_KEY_COUNT_NOT_TRACKED}, or the leader did not attach the header.
+   */
+  void compareLeaderActiveKeyCountOnHeartbeat(
+      PartitionConsumptionState partitionConsumptionState,
+      DefaultPubSubMessage consumerRecord) {
+    if (!activeKeyCountReplicaConsistencyCheckEnabled) {
+      return;
+    }
+    if (!partitionConsumptionState.isEndOfPushReceived()) {
+      // HB and lkc header are post EOP
+      return;
+    }
+    long followerCount = partitionConsumptionState.getActiveKeyCount();
+    if (followerCount == ACTIVE_KEY_COUNT_NOT_TRACKED) {
+      return;
+    }
+    PubSubMessageHeader header =
+        consumerRecord.getPubSubMessageHeaders().get(PubSubMessageHeaders.VENICE_LEADER_KEY_COUNT_HEADER);
+    if (header == null || header.value() == null) {
+      return; // Legacy/disabled leader — no comparison possible.
+    }
+    if (header.value().length != Long.BYTES) {
+      invalidateActiveKeyCount(
+          partitionConsumptionState,
+          ActiveKeyCountInvalidationReason.CORRUPT_LEADER_KEY_COUNT_HEADER_LENGTH,
+          header.value().length);
+      return;
+    }
+    long leaderCount = decodeLeaderKeyCountHeaderValue(header);
+    if (leaderCount == ACTIVE_KEY_COUNT_NOT_TRACKED) {
+      // Leader was not tracking at HB emission time — nothing to compare.
+      return;
+    }
+    if (leaderCount != followerCount) {
+      recordActiveKeyCountMismatchAcrossReplicas(partitionConsumptionState, leaderCount, followerCount);
     }
   }
 
@@ -3331,7 +3386,19 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             // CMs then in the VT we might get out of order messages and with pass-through DIV that's going to be an
             // issue. e.g. a PUT record belonging to seg:0 can come after the EOS of seg:0 due to view writer delays.
             // Since SOP and EOP are rare we can simply wait for the last VT produce future.
-            checkAndWaitForLastVTProduceFuture(partitionConsumptionState);
+            try {
+              checkAndWaitForLastVTProduceFuture(partitionConsumptionState);
+            } catch (TimeoutException e) {
+              /*
+               * The chain head is stuck (likely common-pool starvation blocking an hbProduceFuture or a
+               * slow view-writer ack). Re-raise with explicit attribution so the operator-visible message
+               * names the failure mode instead of presenting as a generic ingestion error.
+               */
+              throw new VeniceException(
+                  "Timed out waiting for the VT produce-call chain to drain before EOP for replica "
+                      + partitionConsumptionState.getReplicaId(),
+                  e);
+            }
             /*
              * Forward only the "prc" partition-record-count header from the EOP to the local VT.
              */
@@ -4856,23 +4923,21 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     partitionConsumptionStateMap.put(partition, pcs);
   }
 
-  /**
-   * Log ingestion heartbeat propagated from upstream topic to version topic
-   */
-  private void logIngestionHeartbeat(PubSubTopicPartition topicPartition, Exception exception) {
+  /** Log ingestion heartbeat propagated from upstream topic to version topic */
+  private void logIngestionHeartbeat(PubSubTopicPartition topicPartition, Throwable cause) {
     String topicPartitionName = topicPartition.getPubSubTopic().getName();
     int partitionId = topicPartition.getPartitionNumber();
 
     String logMessage = String.format(
         "Forward ingestion heartbeat from upstream topic to version topic-partition: %s %s.",
         Utils.getReplicaId(topicPartitionName, partitionId),
-        exception != null ? "failed" : "succeeded");
+        cause != null ? "failed" : "succeeded");
 
     // using a redundant filter in case if the configured duration to send heartbeat
     // is too frequent for logging purposes
     if (!REDUNDANT_LOGGING_FILTER.isRedundantException(logMessage)) {
-      if (exception != null) {
-        LOGGER.error(logMessage, exception);
+      if (cause != null) {
+        LOGGER.error(logMessage, cause);
       } else {
         LOGGER.debug(logMessage);
       }
@@ -4888,7 +4953,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         false, // maybeSendIngestionHeartbeat logs for this case
         false,
         LeaderCompleteState.LEADER_NOT_COMPLETED,
-        System.currentTimeMillis());
+        System.currentTimeMillis(),
+        null); // RT heartbeats are consumed by leaders in other regions, not local followers — skip lkc.
   }
 
   private void sendIngestionHeartbeatToVT(
@@ -4898,15 +4964,97 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       LeaderMetadataWrapper leaderMetadataWrapper,
       LeaderCompleteState leaderCompleteState,
       long originTimeStampMs) {
-    sendIngestionHeartbeat(
-        partitionConsumptionState,
-        topicPartition,
-        callback,
-        leaderMetadataWrapper,
-        true,
-        true,
-        leaderCompleteState,
-        originTimeStampMs);
+    if (activeKeyCountReplicaConsistencyCheckEnabled) {
+      /*
+       * Capture lkc on SIT (NOT inside the deferred callback — that would pick up later SIT increments and
+       * emit an lkc the follower hasn't reached yet). Chain the HB send behind the previous VT produce.
+       */
+      PubSubMessageHeader extraHeader = buildLeaderActiveKeyCountHeader(partitionConsumptionState);
+      CompletableFuture<Void> hbProduceFuture = new CompletableFuture<>();
+      CompletableFuture<Void> previousVtWrite = partitionConsumptionState.swapLastVTProduceCallFuture(hbProduceFuture);
+      boolean callbackScheduled = false;
+      try {
+        previousVtWrite.whenCompleteAsync((value, exception) -> {
+          if (exception != null) {
+            // Prior chain entry failed; don't emit the HB (its lkc would reflect records that never landed).
+            hbProduceFuture.completeExceptionally(exception);
+            return;
+          }
+          try {
+            CompletableFuture<PubSubProduceResult> heartBeatFuture = sendIngestionHeartbeat(
+                partitionConsumptionState,
+                topicPartition,
+                callback,
+                leaderMetadataWrapper,
+                true,
+                true,
+                leaderCompleteState,
+                originTimeStampMs,
+                extraHeader);
+            /*
+             * Surface sync send failure (swallowed into the returned future) so the chain reflects reality.
+             * Async broker rejections are logged separately and don't gate the chain. exceptionally() runs
+             * synchronously here since heartBeatFuture is already done, so it's just a cause extractor.
+             */
+            if (heartBeatFuture.isCompletedExceptionally()) {
+              heartBeatFuture.exceptionally(cause -> {
+                hbProduceFuture.completeExceptionally(cause);
+                return null;
+              });
+            } else {
+              hbProduceFuture.complete(null);
+            }
+          } catch (Throwable t) {
+            hbProduceFuture.completeExceptionally(t);
+          }
+        });
+        callbackScheduled = true;
+      } finally {
+        if (!callbackScheduled) {
+          // whenCompleteAsync registration itself threw — fail the head so chained writes unblock.
+          hbProduceFuture.completeExceptionally(
+              new VeniceException("Aborted HB VT-produce setup before the chained callback was scheduled"));
+        }
+      }
+    } else {
+      sendIngestionHeartbeat(
+          partitionConsumptionState,
+          topicPartition,
+          callback,
+          leaderMetadataWrapper,
+          true,
+          true,
+          leaderCompleteState,
+          originTimeStampMs,
+          null);
+    }
+  }
+
+  /**
+   * Build the {@code lkc} PubSub header carrying the leader's current active key count, or {@code null} when
+   * not warranted (check disabled, pre-EOP, or count is {@link OffsetRecord#ACTIVE_KEY_COUNT_NOT_TRACKED}).
+   * Followers compare against their own count on HB-process; absent header = no comparison.
+   *
+   * <p>Call on the SIT/AAWC thread at swap-time, NOT from inside the chained callback — reading the count
+   * later picks up SIT increments for records queued AFTER this HB and produces false-positive mismatches.
+   *
+   * <p>Gated on {@link #activeKeyCountReplicaConsistencyCheckEnabled} so operators can toggle the check
+   * independently of underlying active-key-count tracking.
+   */
+  PubSubMessageHeader buildLeaderActiveKeyCountHeader(PartitionConsumptionState partitionConsumptionState) {
+    if (!activeKeyCountReplicaConsistencyCheckEnabled) {
+      return null;
+    }
+    if (partitionConsumptionState == null || !partitionConsumptionState.isEndOfPushReceived()) {
+      return null;
+    }
+    long count = partitionConsumptionState.getActiveKeyCount();
+    if (count == ACTIVE_KEY_COUNT_NOT_TRACKED) {
+      return null;
+    }
+    return new PubSubMessageHeader(
+        PubSubMessageHeaders.VENICE_LEADER_KEY_COUNT_HEADER,
+        encodeLeaderKeyCountHeaderValue(count));
   }
 
   private CompletableFuture<PubSubProduceResult> sendIngestionHeartbeat(
@@ -4917,7 +5065,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       boolean shouldLog,
       boolean addLeaderCompleteState,
       LeaderCompleteState leaderCompleteState,
-      long originTimeStampMs) {
+      long originTimeStampMs,
+      PubSubMessageHeader extraHeader) {
     CompletableFuture<PubSubProduceResult> heartBeatFuture;
     try {
       heartBeatFuture = partitionConsumptionState.getVeniceWriterLazyRef()
@@ -4928,10 +5077,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
               leaderMetadataWrapper,
               addLeaderCompleteState,
               leaderCompleteState,
-              originTimeStampMs);
+              originTimeStampMs,
+              extraHeader);
       if (shouldLog) {
-        heartBeatFuture
-            .whenComplete((ignore, throwable) -> logIngestionHeartbeat(topicPartition, (Exception) throwable));
+        heartBeatFuture.whenComplete((ignore, throwable) -> logIngestionHeartbeat(topicPartition, throwable));
       }
     } catch (Exception e) {
       heartBeatFuture = new CompletableFuture<>();
@@ -5111,39 +5260,64 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       Runnable versionTopicWrite) {
     long preprocessingTime = System.currentTimeMillis();
     CompletableFuture<Void> currentVersionTopicWrite = new CompletableFuture<>();
+    /*
+     * Swap our future in as the chain head and stash the previous head in viewWriterFutures[0]. Once we're
+     * the head, downstream writers chain behind us — so the try/finally must always complete
+     * currentVersionTopicWrite, even if setup throws, or the chain hangs forever.
+     */
     CompletableFuture[] viewWriterFutures = new CompletableFuture[this.viewWriters.size() + 1];
     int index = 0;
-    // The first future is for the previous write to VT
-    viewWriterFutures[index++] = partitionConsumptionState.getLastVTProduceCallFuture();
-    for (VeniceViewWriter writer: viewWriters.values()) {
-      Set<Integer> viewPartitionSet = null;
-      if (viewPartitionMap != null && writer.getViewWriterType() == VeniceViewWriter.ViewWriterType.MATERIALIZED_VIEW) {
-        MaterializedViewWriter mvWriter = (MaterializedViewWriter) writer;
-        viewPartitionSet = viewPartitionMap.get(mvWriter.getViewName());
-        if (viewPartitionSet == null) {
-          throw new VeniceException("Unable to find view partition set for view: " + mvWriter.getViewName());
+    viewWriterFutures[index++] = partitionConsumptionState.swapLastVTProduceCallFuture(currentVersionTopicWrite);
+    boolean allOfScheduled = false;
+    try {
+      for (VeniceViewWriter writer: viewWriters.values()) {
+        Set<Integer> viewPartitionSet = null;
+        if (viewPartitionMap != null
+            && writer.getViewWriterType() == VeniceViewWriter.ViewWriterType.MATERIALIZED_VIEW) {
+          MaterializedViewWriter mvWriter = (MaterializedViewWriter) writer;
+          viewPartitionSet = viewPartitionMap.get(mvWriter.getViewName());
+          if (viewPartitionSet == null) {
+            throw new VeniceException("Unable to find view partition set for view: " + mvWriter.getViewName());
+          }
         }
+        viewWriterFutures[index++] = viewWriterRecordProcessor.apply(writer, viewPartitionSet);
       }
-      viewWriterFutures[index++] = viewWriterRecordProcessor.apply(writer, viewPartitionSet);
+      double viewProduceLatency = LatencyUtils.getElapsedTimeFromMsToMs(preprocessingTime);
+      hostLevelIngestionStats.recordViewProducerLatency(viewProduceLatency);
+      versionedIngestionStats.recordViewWriterProduceTime(storeName, versionNumber, viewProduceLatency);
+      CompletableFuture.allOf(viewWriterFutures).whenCompleteAsync((value, exception) -> {
+        double viewAckLatency = LatencyUtils.getElapsedTimeFromMsToMs(preprocessingTime);
+        try {
+          if (exception == null) {
+            versionTopicWrite.run();
+            currentVersionTopicWrite.complete(null);
+          } else {
+            VeniceException veniceException = new VeniceException(exception);
+            // Complete the future BEFORE the side-effecting setIngestionException so a throw in the
+            // latter can't strand the chain.
+            currentVersionTopicWrite.completeExceptionally(veniceException);
+            this.setIngestionException(partitionConsumptionState.getPartition(), veniceException);
+          }
+        } catch (Throwable t) {
+          /*
+           * Same protection as the setup try/finally: never leave currentVersionTopicWrite incomplete on a
+           * throw inside versionTopicWrite.run() — strict chaining behind us would block forever otherwise.
+           * Complete the future BEFORE setIngestionException for the same reason.
+           */
+          currentVersionTopicWrite.completeExceptionally(t);
+          this.setIngestionException(partitionConsumptionState.getPartition(), new VeniceException(t));
+        }
+        hostLevelIngestionStats.recordViewProducerAckLatency(viewAckLatency);
+        versionedIngestionStats.recordViewWriterAckTime(storeName, versionNumber, viewAckLatency);
+      });
+      allOfScheduled = true;
+    } finally {
+      if (!allOfScheduled) {
+        // Setup threw before we wired the allOf callback; fail the future so subsequent chained writes unblock.
+        currentVersionTopicWrite
+            .completeExceptionally(new VeniceException("Aborted VT-produce setup before allOf was scheduled"));
+      }
     }
-    double viewProduceLatency = LatencyUtils.getElapsedTimeFromMsToMs(preprocessingTime);
-    hostLevelIngestionStats.recordViewProducerLatency(viewProduceLatency);
-    versionedIngestionStats.recordViewWriterProduceTime(storeName, versionNumber, viewProduceLatency);
-    CompletableFuture.allOf(viewWriterFutures).whenCompleteAsync((value, exception) -> {
-      double viewAckLatency = LatencyUtils.getElapsedTimeFromMsToMs(preprocessingTime);
-      if (exception == null) {
-        versionTopicWrite.run();
-        currentVersionTopicWrite.complete(null);
-      } else {
-        VeniceException veniceException = new VeniceException(exception);
-        this.setIngestionException(partitionConsumptionState.getPartition(), veniceException);
-        currentVersionTopicWrite.completeExceptionally(veniceException);
-      }
-      hostLevelIngestionStats.recordViewProducerAckLatency(viewAckLatency);
-      versionedIngestionStats.recordViewWriterAckTime(storeName, versionNumber, viewAckLatency);
-    });
-
-    partitionConsumptionState.setLastVTProduceCallFuture(currentVersionTopicWrite);
   }
 
   /**
@@ -5173,8 +5347,16 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   private void checkAndWaitForLastVTProduceFuture(PartitionConsumptionState partitionConsumptionState)
-      throws ExecutionException, InterruptedException {
-    partitionConsumptionState.getLastVTProduceCallFuture().get();
+      throws ExecutionException, InterruptedException, TimeoutException {
+    /*
+     * The chain head can now be an {@code hbProduceFuture} whose completion depends on a
+     * {@code whenCompleteAsync} callback queued on {@link java.util.concurrent.ForkJoinPool#commonPool()}.
+     * An unbounded {@code .get()} on this future would park the SIT thread indefinitely if the common pool
+     * is starved (unrelated parallel-stream load, deadlock-inducing chained callback, etc.). Cap the wait at
+     * {@link #VIEW_WRITER_CLOSE_TIMEOUT_IN_MS} so a stuck chain surfaces as a {@link TimeoutException} the
+     * caller can attribute, instead of an opaque ingestion hang.
+     */
+    partitionConsumptionState.getLastVTProduceCallFuture().get(VIEW_WRITER_CLOSE_TIMEOUT_IN_MS, MILLISECONDS);
   }
 
   protected boolean hasViewWriters() {
@@ -5186,17 +5368,41 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       Runnable produceCall) {
     if (hasViewWriters()) {
       CompletableFuture<Void> propagateSegmentCMWrite = new CompletableFuture<>();
-      partitionConsumptionState.getLastVTProduceCallFuture().whenCompleteAsync((value, exception) -> {
-        if (exception == null) {
-          produceCall.run();
-          propagateSegmentCMWrite.complete(null);
-        } else {
-          VeniceException veniceException = new VeniceException(exception);
-          this.setIngestionException(partitionConsumptionState.getPartition(), veniceException);
-          propagateSegmentCMWrite.completeExceptionally(veniceException);
+      CompletableFuture<Void> previousVtWrite =
+          partitionConsumptionState.swapLastVTProduceCallFuture(propagateSegmentCMWrite);
+      boolean callbackScheduled = false;
+      try {
+        previousVtWrite.whenCompleteAsync((value, exception) -> {
+          try {
+            if (exception == null) {
+              produceCall.run();
+              propagateSegmentCMWrite.complete(null);
+            } else {
+              VeniceException veniceException = new VeniceException(exception);
+              // Complete the future BEFORE recording the ingestion exception — if setIngestionException
+              // itself throws, downstream chained writers must still unblock.
+              propagateSegmentCMWrite.completeExceptionally(veniceException);
+              this.setIngestionException(partitionConsumptionState.getPartition(), veniceException);
+            }
+          } catch (Throwable t) {
+            /*
+             * Under strict chaining a throw inside produceCall.run() would block every subsequent write —
+             * make sure propagateSegmentCMWrite always reaches a terminal state. Complete the future
+             * BEFORE the side-effecting setIngestionException so any throw in the latter can't strand
+             * the chain.
+             */
+            propagateSegmentCMWrite.completeExceptionally(t);
+            this.setIngestionException(partitionConsumptionState.getPartition(), new VeniceException(t));
+          }
+        });
+        callbackScheduled = true;
+      } finally {
+        if (!callbackScheduled) {
+          // whenCompleteAsync registration itself threw — fail the future so the chain unblocks.
+          propagateSegmentCMWrite.completeExceptionally(
+              new VeniceException("Aborted CM VT-produce setup before the chained callback was scheduled"));
         }
-      });
-      partitionConsumptionState.setLastVTProduceCallFuture(propagateSegmentCMWrite);
+      }
     } else {
       produceCall.run();
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -103,10 +103,19 @@ public class PartitionConsumptionState {
   private LeaderFollowerStateType leaderFollowerState;
 
   /**
-   * The VT produce future should be read/set by the same consumer thread during normal operation. Making it volatile
-   * since the SIT thread might want to shortcircuit this future when closing {@link LeaderFollowerStoreIngestionTask}.
+   * Head of the VT produce-call chain. All swaps from the ingestion loop (data writes via
+   * {@code queueUpVersionTopicWritesWithViewWriters}, CMs via {@code maybeQueueCMWritesToVersionTopic}, HBs
+   * via {@code sendIngestionHeartbeatToVT}) execute on the SIT main thread today — AAWC workers only build
+   * MCRs; the SIT main thread iterates batch results and does the actual swap. The concurrent reader is the
+   * close/kill thread ({@code closeVeniceViewWriters}), which reads the current head and may complete it
+   * exceptionally — close does NOT install a new head.
+   *
+   * <p>{@link AtomicReference} is forward-compatibility insurance: a future refactor that moves swaps into
+   * worker threads (e.g. parallelizing the per-key VT produce) would race read-modify-write on this field;
+   * {@code getAndSet} keeps the linked-chain invariant intact without additional synchronization.
    */
-  private volatile CompletableFuture<Void> lastVTProduceCallFuture;
+  private final AtomicReference<CompletableFuture<Void>> lastVTProduceCallFuture =
+      new AtomicReference<>(CompletableFuture.completedFuture(null));
 
   /**
    * State machine that can only transition to LATCH_CREATED if LatchStatus is NONE, and transition to LATCH_RELEASED
@@ -467,7 +476,6 @@ public class PartitionConsumptionState {
     this.latestProcessedRemoteVtPosition = offsetRecord.getCheckpointedRemoteVtPosition();
     this.leaderHostId = offsetRecord.getLeaderHostId();
     this.leaderGUID = offsetRecord.getLeaderGUID();
-    this.lastVTProduceCallFuture = CompletableFuture.completedFuture(null);
     this.leaderCompleteState = LeaderCompleteState.LEADER_NOT_COMPLETED;
     this.lastLeaderCompleteStateUpdateInMs = 0;
     this.pendingReportIncPushVersionList = offsetRecord.getPendingReportIncPushVersionList();
@@ -654,11 +662,23 @@ public class PartitionConsumptionState {
   }
 
   public CompletableFuture<Void> getLastVTProduceCallFuture() {
-    return this.lastVTProduceCallFuture;
+    return this.lastVTProduceCallFuture.get();
   }
 
-  public void setLastVTProduceCallFuture(CompletableFuture<Void> lastVTProduceCallFuture) {
-    this.lastVTProduceCallFuture = lastVTProduceCallFuture;
+  /**
+   * Atomically install {@code next} as the new head of the VT produce-call chain and return the previous head.
+   * Callers must wire a callback on the returned future before completing {@code next} — that callback is what
+   * runs the actual produce when the previous future completes. Replaces the prior non-atomic
+   * {@code getLastVTProduceCallFuture + setLastVTProduceCallFuture} pattern, which lost updates under concurrent
+   * callers and could leave a writer's future orphaned (no subsequent write waiting for it).
+   *
+   * <p>{@code next} must be non-null — installing null would permanently break the chain (every subsequent
+   * {@code getLastVTProduceCallFuture().whenCompleteAsync(...)} would NPE, and {@code closeVeniceViewWriters}
+   * would NPE on {@code .isDone()}). Surface a caller bug here rather than as an obscure NPE in close/shutdown.
+   */
+  public CompletableFuture<Void> swapLastVTProduceCallFuture(CompletableFuture<Void> next) {
+    Objects.requireNonNull(next, "next chain head must be non-null");
+    return this.lastVTProduceCallFuture.getAndSet(next);
   }
 
   public void setCurrentVersionSupplier(BooleanSupplier isCurrentVersion) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -253,8 +253,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return schemaId == CHUNK_MANIFEST_SCHEMA_ID;
   }
 
-  /** VT header: +1 (key created), -1 (key deleted), or 0 (invalidate). Absent = no change. Produced by A/A leader, consumed by followers. */
-  static final String KEY_COUNT_SIGNAL_HEADER = "kcs";
   public static final String GLOBAL_RT_DIV_KEY_PREFIX = "GLOBAL_RT_DIV_KEY.";
 
   protected static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER =
@@ -437,6 +435,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected final boolean activeKeyCountForAllBatchPushEnabled;
   /** @see ConfigKeys#SERVER_ACTIVE_KEY_COUNT_FOR_HYBRID_STORE_ENABLED */
   protected final boolean activeKeyCountForHybridStoreEnabled;
+  /**
+   * Effective flag for the active-key-count replica-consistency check on this version. Only ON when both
+   * {@link ConfigKeys#SERVER_ACTIVE_KEY_COUNT_REPLICA_CONSISTENCY_CHECK_ENABLED} and
+   * {@link #activeKeyCountForHybridStoreEnabled} are true — the check is meaningless without the underlying
+   * count tracking, so the gating is computed once at construction and reused on every heartbeat send/receive.
+   */
+  protected final boolean activeKeyCountReplicaConsistencyCheckEnabled;
 
   private final boolean offsetLagDeltaRelaxEnabled;
   private final boolean timeLagRelaxEnabled;
@@ -600,6 +605,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         && hybridStoreConfig.isPresent() && version.isActiveActiveReplicationEnabled();
     this.activeKeyCountForAllBatchPushEnabled =
         serverConfig.isActiveKeyCountForAllBatchPushEnabled() || activeKeyCountForHybridStoreEnabled;
+    // The replica-consistency check requires the underlying count tracking; see field Javadoc for details.
+    this.activeKeyCountReplicaConsistencyCheckEnabled =
+        activeKeyCountForHybridStoreEnabled && serverConfig.isActiveKeyCountReplicaConsistencyCheckEnabled();
     if (activeKeyCountForHybridStoreEnabled && !serverConfig.isActiveKeyCountForAllBatchPushEnabled()) {
       LOGGER.warn(
           "Store version {}: {} is enabled without {}. Batch counting forced ON implicitly"
@@ -4914,7 +4922,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         && partitionConsumptionState.getActiveKeyCount() != ACTIVE_KEY_COUNT_NOT_TRACKED
         && partitionConsumptionState.isEndOfPushReceived() && leaderProducedRecordContext == null
         && (messageType == MessageType.PUT ? !isChunkFragment(writerSchemaId) : messageType == MessageType.DELETE)) {
-      PubSubMessageHeader signalHeader = consumerRecord.getPubSubMessageHeaders().get(KEY_COUNT_SIGNAL_HEADER);
+      PubSubMessageHeader signalHeader =
+          consumerRecord.getPubSubMessageHeaders().get(PubSubMessageHeaders.VENICE_KEY_COUNT_SIGNAL_HEADER);
       if (signalHeader != null && signalHeader.value() != null && signalHeader.value().length == 1) {
         int signal = signalHeader.value()[0];
         if (signal == ActiveActiveStoreIngestionTask.KEY_CREATED_SIGNAL_VALUE) {
@@ -4932,16 +4941,39 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         } else {
           invalidateActiveKeyCount(
               partitionConsumptionState,
-              ActiveKeyCountInvalidationReason.CORRUPT_KCS_SIGNAL_VALUE,
+              ActiveKeyCountInvalidationReason.CORRUPT_KEY_COUNT_SIGNAL_HEADER_VALUE,
               signal);
         }
       } else if (signalHeader != null && signalHeader.value() != null && signalHeader.value().length > 1) {
         invalidateActiveKeyCount(
             partitionConsumptionState,
-            ActiveKeyCountInvalidationReason.CORRUPT_MULTI_BYTE_KCS_SIGNAL,
+            ActiveKeyCountInvalidationReason.CORRUPT_KEY_COUNT_SIGNAL_HEADER_LENGTH,
             signalHeader.value().length);
       }
     }
+  }
+
+  /** Encode the leader's active key count as the 8-byte big-endian value of the {@code lkc} HB header. */
+  static byte[] encodeLeaderKeyCountHeaderValue(long count) {
+    return ByteBuffer.allocate(Long.BYTES).putLong(count).array();
+  }
+
+  /**
+   * Decode the {@code lkc} HB header value. Returns the encoded long, or {@link OffsetRecord#ACTIVE_KEY_COUNT_NOT_TRACKED}
+   * if the header is null/absent. Throws {@link IllegalArgumentException} on wrong-length payloads — callers must
+   * length-check before invoking and treat any throw here as producer corruption. We do not return a numeric
+   * sentinel for malformed length: {@link Long#MIN_VALUE} (or any other) would collide with a legitimately
+   * round-trippable {@code lkc} value once a future maintainer drops the length pre-check.
+   */
+  static long decodeLeaderKeyCountHeaderValue(PubSubMessageHeader header) {
+    if (header == null || header.value() == null) {
+      return ACTIVE_KEY_COUNT_NOT_TRACKED;
+    }
+    if (header.value().length != Long.BYTES) {
+      throw new IllegalArgumentException(
+          "Malformed lkc header — expected " + Long.BYTES + " bytes, got " + header.value().length);
+    }
+    return ByteBuffer.wrap(header.value()).getLong();
   }
 
   /**
@@ -4952,7 +4984,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   final void invalidateActiveKeyCount(
       PartitionConsumptionState partitionConsumptionState,
       ActiveKeyCountInvalidationReason reason) {
-    invalidateActiveKeyCountAndLog(partitionConsumptionState, reason.getMessage(), null);
+    invalidateActiveKeyCountAndLog(partitionConsumptionState, reason, reason.getMessage(), null);
   }
 
   /**
@@ -4962,7 +4994,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       PartitionConsumptionState partitionConsumptionState,
       ActiveKeyCountInvalidationReason reason,
       Throwable cause) {
-    invalidateActiveKeyCountAndLog(partitionConsumptionState, reason.getMessage(), cause);
+    invalidateActiveKeyCountAndLog(partitionConsumptionState, reason, reason.getMessage(), cause);
   }
 
   /**
@@ -4972,16 +5004,17 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       PartitionConsumptionState partitionConsumptionState,
       ActiveKeyCountInvalidationReason reason,
       int detail) {
-    invalidateActiveKeyCountAndLog(partitionConsumptionState, reason.getMessage(detail), null);
+    invalidateActiveKeyCountAndLog(partitionConsumptionState, reason, reason.getMessage(detail), null);
   }
 
   private void invalidateActiveKeyCountAndLog(
       PartitionConsumptionState partitionConsumptionState,
+      ActiveKeyCountInvalidationReason reason,
       String reasonText,
       Throwable cause) {
     try {
       partitionConsumptionState.setActiveKeyCount(ACTIVE_KEY_COUNT_NOT_TRACKED);
-      recordActiveKeyCountInvalidation();
+      recordActiveKeyCountInvalidation(reason);
     } finally {
       String msg =
           reasonText + " for replica " + partitionConsumptionState.getReplicaId() + "; invalidating activeKeyCount.";
@@ -5022,10 +5055,42 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     partitionConsumptionState.incrementBatchPushRecordCount();
   }
 
-  /** Records active-key-count invalidation on both the OTel (per-version) and Tehuti (host-level) paths. */
-  protected final void recordActiveKeyCountInvalidation() {
-    versionedIngestionStats.recordActiveKeyCountInvalidation(storeName, versionNumber);
+  /**
+   * Records active-key-count invalidation on both the OTel (per-version) and Tehuti (host-level) paths.
+   * The {@code reason} is recorded as an OTel dimension so operators can break invalidation counts down by
+   * cause; the Tehuti sensor stays a flat total (Tehuti does not natively support dimensions like OTel).
+   */
+  protected final void recordActiveKeyCountInvalidation(ActiveKeyCountInvalidationReason reason) {
+    versionedIngestionStats.recordActiveKeyCountInvalidation(storeName, versionNumber, reason);
     hostLevelIngestionStats.recordActiveKeyCountInvalidation();
+  }
+
+  /**
+   * Diagnostic-only path for active-key-count divergence across replicas detected on heartbeats. Bumps the
+   * dedicated {@code ingestion.key.active_count_mismatch_across_replicas} counter on both OTel and Tehuti,
+   * and emits a rate-limited WARN log carrying the leader and follower counts. Does NOT mutate
+   * {@link PartitionConsumptionState#getActiveKeyCount()} — the count stays as-is so operators can investigate
+   * a real-time divergence without losing the data.
+   *
+   * <p>Wrapped in try/finally so the WARN log fires even if the metric path throws.
+   */
+  protected final void recordActiveKeyCountMismatchAcrossReplicas(
+      PartitionConsumptionState partitionConsumptionState,
+      long leaderCount,
+      long followerCount) {
+    try {
+      versionedIngestionStats.recordActiveKeyCountMismatchAcrossReplicas(storeName, versionNumber);
+      hostLevelIngestionStats.recordActiveKeyCountMismatchAcrossReplicas();
+    } finally {
+      String msg = String.format(
+          "Active key count divergence across replicas on heartbeat: leader=%d, follower=%d for replica %s",
+          leaderCount,
+          followerCount,
+          partitionConsumptionState.getReplicaId());
+      if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
+        LOGGER.warn(msg);
+      }
+    }
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.stats;
 
 import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.davinci.kafka.consumer.ActiveKeyCountInvalidationReason;
 import com.linkedin.davinci.kafka.consumer.StoreIngestionTask;
 import com.linkedin.davinci.stats.ingestion.IngestionOtelStats;
 import com.linkedin.davinci.stats.ingestion.NoOpIngestionOtelStats;
@@ -44,6 +45,7 @@ public class AggVersionedIngestionStats
   private final boolean emitOtelIngestionStats;
   private final boolean uniqueIngestedKeyCountHllEnabled;
   private final boolean activeKeyCountEnabled;
+  private final boolean mismatchCheckEnabled;
 
   public AggVersionedIngestionStats(
       MetricsRepository metricsRepository,
@@ -60,6 +62,11 @@ public class AggVersionedIngestionStats
     this.emitOtelIngestionStats = serverConfig.isIngestionOtelStatsEnabled();
     this.uniqueIngestedKeyCountHllEnabled = serverConfig.isUniqueIngestedKeyCountHllEnabled();
     this.activeKeyCountEnabled = serverConfig.isAnyActiveKeyCountTrackingEnabled();
+    /*
+     * Tracks the recording-site gate (see StoreIngestionTask#activeKeyCountReplicaConsistencyCheckEnabled)
+     * so the OTel metric isn't registered when the recording path will never fire.
+     */
+    this.mismatchCheckEnabled = serverConfig.isActiveKeyCountReplicaConsistencyCheckEnabled();
   }
 
   /** Updates version info for existing OTel stats only. Null guard needed because eager loading
@@ -123,7 +130,8 @@ public class AggVersionedIngestionStats
           localRegionName,
           emitOtelIngestionStats,
           uniqueIngestedKeyCountHllEnabled,
-          activeKeyCountEnabled);
+          activeKeyCountEnabled,
+          mismatchCheckEnabled);
       stats.updateVersionInfo(currentVersion, futureVersion);
       return stats;
     });
@@ -586,7 +594,11 @@ public class AggVersionedIngestionStats
     getIngestionOtelStats(storeName).recordPartialUpdateAmplificationAlertCount(version, 1);
   }
 
-  public void recordActiveKeyCountInvalidation(String storeName, int version) {
-    getIngestionOtelStats(storeName).recordActiveKeyCountInvalidation(version);
+  public void recordActiveKeyCountInvalidation(String storeName, int version, ActiveKeyCountInvalidationReason reason) {
+    getIngestionOtelStats(storeName).recordActiveKeyCountInvalidation(version, reason);
+  }
+
+  public void recordActiveKeyCountMismatchAcrossReplicas(String storeName, int version) {
+    getIngestionOtelStats(storeName).recordActiveKeyCountMismatchAcrossReplicas(version);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -165,6 +165,12 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
    */
   private final LongAdderRateGauge totalTombstoneCreationDCRRate;
   private final LongAdderRateGauge totalActiveKeyCountInvalidationRate;
+  /**
+   * Diagnostic-only counter for active-key-count divergence across replicas detected on heartbeats.
+   * Separate from {@link #totalActiveKeyCountInvalidationRate} because mismatch does not invalidate — it is
+   * a pure observation. Operators alert on this rate, then investigate.
+   */
+  private final LongAdderRateGauge totalActiveKeyCountMismatchAcrossReplicasRate;
 
   private final Sensor leaderProduceLatencySensor;
   private final Sensor leaderCompressLatencySensor;
@@ -256,6 +262,17 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
             "active_key_count_invalidation",
             totalStats,
             () -> totalStats.totalActiveKeyCountInvalidationRate,
+            time)
+        : null;
+    /*
+     * Sensor registration tracks the recording-site gate so a batch-only operator that flips on the check
+     * doesn't see a sensor stuck at zero (false-negative monitoring).
+     */
+    this.totalActiveKeyCountMismatchAcrossReplicasRate = serverConfig.isActiveKeyCountReplicaConsistencyCheckEnabled()
+        ? registerOnlyTotalRate(
+            "active_key_count_mismatch_across_replicas",
+            totalStats,
+            () -> totalStats.totalActiveKeyCountMismatchAcrossReplicasRate,
             time)
         : null;
 
@@ -735,6 +752,12 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   public void recordActiveKeyCountInvalidation() {
     if (totalActiveKeyCountInvalidationRate != null) {
       totalActiveKeyCountInvalidationRate.record();
+    }
+  }
+
+  public void recordActiveKeyCountMismatchAcrossReplicas() {
+    if (totalActiveKeyCountMismatchAcrossReplicasRate != null) {
+      totalActiveKeyCountMismatchAcrossReplicasRate.record();
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelMetricEntity.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.stats.ingestion;
 
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_ACTIVE_KEY_COUNT_INVALIDATION_REASON;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_DCR_EVENT;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_DCR_OPERATION;
@@ -408,7 +409,19 @@ public enum IngestionOtelMetricEntity implements ModuleMetricEntityInterface {
 
   ACTIVE_KEY_COUNT_INVALIDATION(
       "ingestion.key.active_count_invalidation", MetricType.COUNTER, MetricUnit.NUMBER,
-      "Count of active key count invalidations due to underflow drift, keyExists failures, leader-propagated invalidation, or corrupt kcs signals",
+      "Count of active key count invalidations on this host, broken down by the "
+          + "venice.active_key_count.invalidation_reason dimension; see ActiveKeyCountInvalidationReason for the "
+          + "full set of causes",
+      setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_VERSION_ROLE, VENICE_ACTIVE_KEY_COUNT_INVALIDATION_REASON)
+  ),
+
+  ACTIVE_KEY_COUNT_MISMATCH_ACROSS_REPLICAS(
+      "ingestion.key.active_count_mismatch_across_replicas", MetricType.COUNTER, MetricUnit.NUMBER,
+      "Diagnostic-only count of active-key-count divergences across replicas detected on ingestion heartbeats. "
+          + "Follower receives the leader's count via the lkc heartbeat header and compares; a non-zero value "
+          + "indicates divergence at HB-processing time. The follower's count is NOT invalidated — operators "
+          + "alert on this metric and investigate. Kept separate from ACTIVE_KEY_COUNT_INVALIDATION so dashboards "
+          + "distinguish divergence (an observation) from invalidation (a corrective action).",
       setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_VERSION_ROLE)
   );
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStats.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.stats.ingestion;
 
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.ACTIVE_KEY_COUNT;
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.ACTIVE_KEY_COUNT_INVALIDATION;
+import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.ACTIVE_KEY_COUNT_MISMATCH_ACROSS_REPLICAS;
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.BATCH_PROCESSING_REQUEST_COUNT;
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.BATCH_PROCESSING_REQUEST_ERROR_COUNT;
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.BATCH_PROCESSING_REQUEST_RECORD_COUNT;
@@ -60,6 +61,7 @@ import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.VIE
 import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.linkedin.davinci.kafka.consumer.ActiveKeyCountInvalidationReason;
 import com.linkedin.davinci.kafka.consumer.StoreIngestionTask;
 import com.linkedin.davinci.stats.IngestionStatsUtils;
 import com.linkedin.davinci.stats.OtelVersionedStatsUtils;
@@ -185,7 +187,8 @@ public class IngestionOtelStats {
   private final MetricEntityStateOneEnum<VersionRole> partialUpdateCacheHitCountMetric;
   private final MetricEntityStateOneEnum<VersionRole> checksumVerificationFailureCountMetric;
   private final MetricEntityStateOneEnum<VersionRole> partialUpdateAmplificationAlertCountMetric;
-  private final MetricEntityStateOneEnum<VersionRole> activeKeyCountInvalidationMetric;
+  private final MetricEntityStateTwoEnums<VersionRole, ActiveKeyCountInvalidationReason> activeKeyCountInvalidationMetric;
+  private final MetricEntityStateOneEnum<VersionRole> activeKeyCountMismatchAcrossReplicasMetric;
   private final MetricEntityStateOneEnum<VersionRole> batchPushRecordCountMatchMetric;
   private final MetricEntityStateOneEnum<VersionRole> batchPushRecordCountMismatchMetric;
   private final MetricEntityStateOneEnum<VersionRole> recordCountMismatchFailureMetric;
@@ -263,6 +266,7 @@ public class IngestionOtelStats {
     this.checksumVerificationFailureCountMetric = null;
     this.partialUpdateAmplificationAlertCountMetric = null;
     this.activeKeyCountInvalidationMetric = null;
+    this.activeKeyCountMismatchAcrossReplicasMetric = null;
     this.batchPushRecordCountMatchMetric = null;
     this.batchPushRecordCountMismatchMetric = null;
     this.recordCountMismatchFailureMetric = null;
@@ -285,7 +289,8 @@ public class IngestionOtelStats {
       String localRegionName,
       boolean ingestionOtelStatsEnabled,
       boolean uniqueIngestedKeyCountHllEnabled,
-      boolean activeKeyCountEnabled) {
+      boolean activeKeyCountEnabled,
+      boolean mismatchCheckEnabled) {
     OpenTelemetryMetricsSetup.OpenTelemetryMetricsSetupInfo otelSetup =
         OpenTelemetryMetricsSetup.builder(metricsRepository)
             .setOtelEnabledOverride(ingestionOtelStatsEnabled)
@@ -393,8 +398,17 @@ public class IngestionOtelStats {
     checksumVerificationFailureCountMetric = createOneEnumMetric(CHECKSUM_VERIFICATION_FAILURE_COUNT.getMetricEntity());
     partialUpdateAmplificationAlertCountMetric =
         createOneEnumMetric(PARTIAL_UPDATE_AMPLIFICATION_ALERT_COUNT.getMetricEntity());
-    activeKeyCountInvalidationMetric =
-        activeKeyCountEnabled ? createOneEnumMetric(ACTIVE_KEY_COUNT_INVALIDATION.getMetricEntity()) : null;
+    activeKeyCountInvalidationMetric = activeKeyCountEnabled
+        ? createTwoEnumMetric(ACTIVE_KEY_COUNT_INVALIDATION.getMetricEntity(), ActiveKeyCountInvalidationReason.class)
+        : null;
+    /*
+     * The mismatch metric only fires when the replica-consistency check is on (which itself requires hybrid
+     * tracking). Gating wiring on the same condition keeps the registered OTel metric aligned with what the
+     * recording site emits — a batch-only operator that flips on the check config no longer gets a permanently
+     * zero metric (false-negative monitoring).
+     */
+    activeKeyCountMismatchAcrossReplicasMetric =
+        mismatchCheckEnabled ? createOneEnumMetric(ACTIVE_KEY_COUNT_MISMATCH_ACROSS_REPLICAS.getMetricEntity()) : null;
     batchPushRecordCountMatchMetric = createOneEnumMetric(BATCH_PUSH_RECORD_COUNT_MATCH_COUNT.getMetricEntity());
     batchPushRecordCountMismatchMetric = createOneEnumMetric(BATCH_PUSH_RECORD_COUNT_MISMATCH_COUNT.getMetricEntity());
     recordCountMismatchFailureMetric = createOneEnumMetric(RECORD_COUNT_MISMATCH_FAILURE_COUNT.getMetricEntity());
@@ -830,9 +844,15 @@ public class IngestionOtelStats {
     partialUpdateAmplificationAlertCountMetric.record(value, classifyVersion(version, versionInfo));
   }
 
-  public void recordActiveKeyCountInvalidation(int version) {
+  public void recordActiveKeyCountInvalidation(int version, ActiveKeyCountInvalidationReason reason) {
     if (activeKeyCountInvalidationMetric != null) {
-      activeKeyCountInvalidationMetric.record(1, classifyVersion(version, versionInfo));
+      activeKeyCountInvalidationMetric.record(1, classifyVersion(version, versionInfo), reason);
+    }
+  }
+
+  public void recordActiveKeyCountMismatchAcrossReplicas(int version) {
+    if (activeKeyCountMismatchAcrossReplicasMetric != null) {
+      activeKeyCountMismatchAcrossReplicasMetric.record(1, classifyVersion(version, versionInfo));
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/NoOpIngestionOtelStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/NoOpIngestionOtelStats.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.stats.ingestion;
 
+import com.linkedin.davinci.kafka.consumer.ActiveKeyCountInvalidationReason;
 import com.linkedin.davinci.kafka.consumer.StoreIngestionTask;
 import com.linkedin.venice.stats.dimensions.ReplicaType;
 import com.linkedin.venice.stats.dimensions.VeniceDCREvent;
@@ -262,6 +263,10 @@ public class NoOpIngestionOtelStats extends IngestionOtelStats {
   }
 
   @Override
-  public void recordActiveKeyCountInvalidation(int version) {
+  public void recordActiveKeyCountInvalidation(int version, ActiveKeyCountInvalidationReason reason) {
+  }
+
+  @Override
+  public void recordActiveKeyCountMismatchAcrossReplicas(int version) {
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountHeartbeatTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountHeartbeatTest.java
@@ -1,0 +1,568 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import static com.linkedin.davinci.kafka.consumer.ActiveKeyCountTestUtils.findMethod;
+import static com.linkedin.davinci.kafka.consumer.ActiveKeyCountTestUtils.setField;
+import static com.linkedin.venice.offsets.OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
+import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
+import com.linkedin.venice.pubsub.api.PubSubProduceResult;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.utils.lazy.Lazy;
+import com.linkedin.venice.writer.LeaderCompleteState;
+import com.linkedin.venice.writer.LeaderMetadataWrapper;
+import com.linkedin.venice.writer.VeniceWriter;
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for the leader-active-key-count heartbeat header pipeline added to
+ * {@link LeaderFollowerStoreIngestionTask} and {@link StoreIngestionTask}.
+ *
+ * Covers four concerns:
+ * <ol>
+ *   <li>Encode/decode of the 8-byte {@code lkc} header value.</li>
+ *   <li>{@link LeaderFollowerStoreIngestionTask#buildLeaderActiveKeyCountHeader} gating — feature off,
+ *       pre-EOP, untracked count, and the happy path that emits the header.</li>
+ *   <li>{@link LeaderFollowerStoreIngestionTask#compareLeaderActiveKeyCountOnHeartbeat} branches —
+ *       feature off, pre-EOP, follower not tracking, absent header, leader count sentinel, matching counts,
+ *       mismatched counts, and a corrupt header length.</li>
+ *   <li>{@code sendIngestionHeartbeatToVT} ordering — the lkc header attachment must be chained behind
+ *       {@code lastVTProduceCallFuture} so in-flight worker writes have already queued their kcs signals
+ *       before the leader reads the count.</li>
+ * </ol>
+ */
+public class ActiveKeyCountHeartbeatTest {
+  private static final long SAMPLE_FOLLOWER_COUNT = 12345L;
+
+  /* ---------- 1. encode / decode roundtrip ---------- */
+
+  @DataProvider(name = "headerLongValues")
+  public Object[][] headerLongValues() {
+    /*
+     * decodeLeaderKeyCountHeaderValue now throws on wrong-length payloads rather than returning a numeric
+     * sentinel, so every long (including Long.MIN_VALUE and Long.MAX_VALUE) must round-trip cleanly.
+     */
+    return new Object[][] { { 0L }, { 1L }, { 100L }, { 1_000_000L }, { Long.MAX_VALUE },
+        { ACTIVE_KEY_COUNT_NOT_TRACKED }, { Long.MIN_VALUE } };
+  }
+
+  @Test(dataProvider = "headerLongValues")
+  public void testHeaderEncodeDecodeRoundtrip(long value) {
+    byte[] bytes = StoreIngestionTask.encodeLeaderKeyCountHeaderValue(value);
+    assertEquals(bytes.length, Long.BYTES, "lkc header must always be 8 bytes");
+    PubSubMessageHeader header = new PubSubMessageHeader(PubSubMessageHeaders.VENICE_LEADER_KEY_COUNT_HEADER, bytes);
+    assertEquals(StoreIngestionTask.decodeLeaderKeyCountHeaderValue(header), value);
+  }
+
+  @Test
+  public void testDecodeNullHeaderReturnsNotTracked() {
+    assertEquals(StoreIngestionTask.decodeLeaderKeyCountHeaderValue(null), ACTIVE_KEY_COUNT_NOT_TRACKED);
+  }
+
+  @Test
+  public void testDecodeHeaderWithNullValueReturnsNotTracked() {
+    PubSubMessageHeader header = new PubSubMessageHeader(PubSubMessageHeaders.VENICE_LEADER_KEY_COUNT_HEADER, null);
+    assertEquals(StoreIngestionTask.decodeLeaderKeyCountHeaderValue(header), ACTIVE_KEY_COUNT_NOT_TRACKED);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDecodeWrongLengthHeaderThrows() {
+    PubSubMessageHeader header =
+        new PubSubMessageHeader(PubSubMessageHeaders.VENICE_LEADER_KEY_COUNT_HEADER, new byte[] { 1, 2, 3 });
+    StoreIngestionTask.decodeLeaderKeyCountHeaderValue(header);
+  }
+
+  /* ---------- 2. buildLeaderActiveKeyCountHeader gating ---------- */
+
+  @Test
+  public void testBuildReturnsNullWhenConsistencyCheckDisabled() throws Exception {
+    assertBuildReturnsNull(false, true, 100L, false);
+  }
+
+  @Test
+  public void testBuildReturnsNullPreEop() throws Exception {
+    assertBuildReturnsNull(true, false, 100L, false);
+  }
+
+  @Test
+  public void testBuildReturnsNullWhenCountUntracked() throws Exception {
+    assertBuildReturnsNull(true, true, ACTIVE_KEY_COUNT_NOT_TRACKED, false);
+  }
+
+  @Test
+  public void testBuildReturnsNullWhenPcsNull() throws Exception {
+    assertBuildReturnsNull(true, true, 0L /* unused */, true);
+  }
+
+  @Test
+  public void testBuildReturnsEncodedHeaderHappyPath() throws Exception {
+    LeaderFollowerStoreIngestionTask task = mockedTask(true);
+    PartitionConsumptionState pcs = mockPcs(true, 42L);
+    PubSubMessageHeader header = task.buildLeaderActiveKeyCountHeader(pcs);
+    assertNotNull(header);
+    assertEquals(header.key(), PubSubMessageHeaders.VENICE_LEADER_KEY_COUNT_HEADER);
+    assertEquals(StoreIngestionTask.decodeLeaderKeyCountHeaderValue(header), 42L);
+  }
+
+  /* ---------- 3. compareLeaderActiveKeyCountOnHeartbeat branches ---------- */
+
+  @Test
+  public void testCompareNoOpWhenConsistencyCheckDisabled() throws Exception {
+    // Even with a mismatch in the lkc header, the disabled flag short-circuits before reading the header.
+    assertCompareIsNoOp(false, true, SAMPLE_FOLLOWER_COUNT, headersWithLkc(SAMPLE_FOLLOWER_COUNT + 1));
+  }
+
+  @Test
+  public void testCompareNoOpPreEop() throws Exception {
+    assertCompareIsNoOp(true, false, SAMPLE_FOLLOWER_COUNT, headersWithLkc(SAMPLE_FOLLOWER_COUNT + 1));
+  }
+
+  @Test
+  public void testCompareNoOpWhenFollowerNotTracking() throws Exception {
+    assertCompareIsNoOp(true, true, ACTIVE_KEY_COUNT_NOT_TRACKED, headersWithLkc(100L));
+  }
+
+  @Test
+  public void testCompareNoOpWhenLkcHeaderAbsent() throws Exception {
+    // Headers exist but no lkc — legacy / disabled leader scenario.
+    PubSubMessageHeaders headers = new PubSubMessageHeaders();
+    headers.add(new PubSubMessageHeader("some-other", new byte[] { 1 }));
+    assertCompareIsNoOp(true, true, SAMPLE_FOLLOWER_COUNT, headers);
+  }
+
+  @Test
+  public void testCompareNoOpWhenLeaderCountSentinel() throws Exception {
+    assertCompareIsNoOp(true, true, SAMPLE_FOLLOWER_COUNT, headersWithLkc(ACTIVE_KEY_COUNT_NOT_TRACKED));
+  }
+
+  @Test
+  public void testCompareMatchingCountsNoInvalidation() throws Exception {
+    assertCompareIsNoOp(true, true, SAMPLE_FOLLOWER_COUNT, headersWithLkc(SAMPLE_FOLLOWER_COUNT));
+  }
+
+  @Test
+  public void testCompareMismatchRecordsMismatchMetricWithoutInvalidating() throws Exception {
+    LeaderFollowerStoreIngestionTask task = mockedTask(true);
+    PartitionConsumptionState pcs = mockPcs(true, SAMPLE_FOLLOWER_COUNT);
+    long leaderCount = SAMPLE_FOLLOWER_COUNT + 7;
+    DefaultPubSubMessage record = mockHeartbeatRecord(headersWithLkc(leaderCount));
+
+    task.compareLeaderActiveKeyCountOnHeartbeat(pcs, record);
+
+    /*
+     * Mismatch is diagnostic-only: the dedicated cross-replica mismatch helper fires (which bumps the new
+     * counter and emits a WARN log), but no invalidation happens and the follower's count is left untouched.
+     */
+    verify(task).recordActiveKeyCountMismatchAcrossReplicas(pcs, leaderCount, SAMPLE_FOLLOWER_COUNT);
+    verifyNoInvalidation(task);
+    verify(pcs, never()).setActiveKeyCount(anyLong());
+  }
+
+  @Test
+  public void testCompareCorruptHeaderInvalidates() throws Exception {
+    LeaderFollowerStoreIngestionTask task = mockedTask(true);
+    PartitionConsumptionState pcs = mockPcs(true, SAMPLE_FOLLOWER_COUNT);
+    PubSubMessageHeaders headers = new PubSubMessageHeaders();
+    headers.add(new PubSubMessageHeader(PubSubMessageHeaders.VENICE_LEADER_KEY_COUNT_HEADER, new byte[] { 1, 2, 3 }));
+    DefaultPubSubMessage record = mockHeartbeatRecord(headers);
+
+    task.compareLeaderActiveKeyCountOnHeartbeat(pcs, record);
+    verify(task)
+        .invalidateActiveKeyCount(pcs, ActiveKeyCountInvalidationReason.CORRUPT_LEADER_KEY_COUNT_HEADER_LENGTH, 3);
+  }
+
+  /* ---------- 3b. Operator override: consistency check disabled while tracking is on ---------- */
+
+  /**
+   * Exercises the realistic operator-disable scenario: the underlying active-key-count tracking is on
+   * (so the follower has a real count and the leader's count is real too), but the HB consistency check
+   * has been turned off via {@code SERVER_ACTIVE_KEY_COUNT_REPLICA_CONSISTENCY_CHECK_ENABLED=false}. Neither side
+   * should do anything consistency-check-related — leader skips the header, follower skips comparing — even if a
+   * stale {@code lkc} header arrived on the wire from a peer that still has the check on.
+   */
+  @Test
+  public void testLeaderBuildSkippedWhenOperatorDisablesCheckButTrackingIsOn() throws Exception {
+    LeaderFollowerStoreIngestionTask task = mockedTask(true /* tracking */, false /* check off */);
+    assertNull(task.buildLeaderActiveKeyCountHeader(mockPcs(true, 100L)));
+  }
+
+  @Test
+  public void testFollowerCompareSkippedWhenOperatorDisablesCheckButTrackingIsOn() throws Exception {
+    LeaderFollowerStoreIngestionTask task = mockedTask(true /* tracking */, false /* check off */);
+    PartitionConsumptionState pcs = mockPcs(true, SAMPLE_FOLLOWER_COUNT);
+    // Stale peer that still has the check on attaches a mismatching count header — follower must NOT invalidate.
+    DefaultPubSubMessage record = mockHeartbeatRecord(headersWithLkc(SAMPLE_FOLLOWER_COUNT + 99));
+
+    task.compareLeaderActiveKeyCountOnHeartbeat(pcs, record);
+    verifyNoInvalidation(task);
+  }
+
+  /* ---------- 4. ActiveKeyCountInvalidationReason message formatting ---------- */
+
+  @Test
+  public void testCorruptLakcReasonRendersLength() {
+    String msg = ActiveKeyCountInvalidationReason.CORRUPT_LEADER_KEY_COUNT_HEADER_LENGTH.getMessage(5);
+    assertTrue(msg.contains("length=5"), "Expected 'length=5' in message; got: " + msg);
+  }
+
+  /* ---------- Test helpers ---------- */
+
+  /**
+   * Mock a {@link LeaderFollowerStoreIngestionTask} with both gating flags reflectively set. Default is to set
+   * tracking and consistency-check together (production wires them in lockstep — the check is computed as
+   * {@code activeKeyCountForHybridStoreEnabled && serverConfig.isActiveKeyCountReplicaConsistencyCheckEnabled()}).
+   * The 2-arg overload exposes them independently for the operator-disable scenario (tracking on, check off).
+   *
+   * <p>A/A is transitively implied by both flags via the SIT constructor and is therefore not a test parameter.
+   * {@code invalidateActiveKeyCount} overloads are left as Mockito-default no-ops so we can
+   * {@link org.mockito.Mockito#verify} them.
+   */
+  private static LeaderFollowerStoreIngestionTask mockedTask(boolean consistencyCheckEnabled) throws Exception {
+    return mockedTask(consistencyCheckEnabled, consistencyCheckEnabled);
+  }
+
+  private static LeaderFollowerStoreIngestionTask mockedTask(boolean trackingEnabled, boolean consistencyCheckEnabled)
+      throws Exception {
+    LeaderFollowerStoreIngestionTask task = mock(LeaderFollowerStoreIngestionTask.class);
+    doCallRealMethod().when(task).buildLeaderActiveKeyCountHeader(any());
+    doCallRealMethod().when(task).compareLeaderActiveKeyCountOnHeartbeat(any(), any());
+    setField(task, "activeKeyCountForHybridStoreEnabled", trackingEnabled);
+    setField(task, "activeKeyCountReplicaConsistencyCheckEnabled", consistencyCheckEnabled);
+    return task;
+  }
+
+  private static PartitionConsumptionState mockPcs(boolean postEop, long activeKeyCount) {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn(postEop).when(pcs).isEndOfPushReceived();
+    doReturn(activeKeyCount).when(pcs).getActiveKeyCount();
+    return pcs;
+  }
+
+  private static PubSubMessageHeaders headersWithLkc(long encodedCount) {
+    PubSubMessageHeaders headers = new PubSubMessageHeaders();
+    headers.add(
+        new PubSubMessageHeader(
+            PubSubMessageHeaders.VENICE_LEADER_KEY_COUNT_HEADER,
+            StoreIngestionTask.encodeLeaderKeyCountHeaderValue(encodedCount)));
+    return headers;
+  }
+
+  private static DefaultPubSubMessage mockHeartbeatRecord(PubSubMessageHeaders headers) {
+    DefaultPubSubMessage record = mock(DefaultPubSubMessage.class);
+    doReturn(headers).when(record).getPubSubMessageHeaders();
+    return record;
+  }
+
+  /** Reflective handle to the package-private {@code sendIngestionHeartbeatToVT}; identical across ordering tests. */
+  private static Method findSendVtMethod() throws Exception {
+    Method sendVt = findMethod(
+        LeaderFollowerStoreIngestionTask.class,
+        "sendIngestionHeartbeatToVT",
+        PartitionConsumptionState.class,
+        PubSubTopicPartition.class,
+        PubSubProducerCallback.class,
+        LeaderMetadataWrapper.class,
+        LeaderCompleteState.class,
+        long.class);
+    sendVt.setAccessible(true);
+    return sendVt;
+  }
+
+  /**
+   * Drives a {@code compareLeaderActiveKeyCountOnHeartbeat} call and asserts no invalidation fired.
+   * Used by every "skip" branch in section 3 so each test method stays a single-line declaration of its inputs.
+   */
+  private static void assertCompareIsNoOp(
+      boolean consistencyCheckEnabled,
+      boolean postEop,
+      long followerCount,
+      PubSubMessageHeaders headers) throws Exception {
+    LeaderFollowerStoreIngestionTask task = mockedTask(consistencyCheckEnabled);
+    PartitionConsumptionState pcs = mockPcs(postEop, followerCount);
+    DefaultPubSubMessage record = mockHeartbeatRecord(headers);
+    task.compareLeaderActiveKeyCountOnHeartbeat(pcs, record);
+    verifyNoInvalidation(task);
+  }
+
+  /**
+   * Drives a {@code buildLeaderActiveKeyCountHeader} call and asserts {@code null} was returned.
+   * Used by every "skip" branch in section 2.
+   */
+  private static void assertBuildReturnsNull(
+      boolean consistencyCheckEnabled,
+      boolean postEop,
+      long activeKeyCount,
+      boolean pcsNull) throws Exception {
+    LeaderFollowerStoreIngestionTask task = mockedTask(consistencyCheckEnabled);
+    PartitionConsumptionState pcs = pcsNull ? null : mockPcs(postEop, activeKeyCount);
+    assertNull(task.buildLeaderActiveKeyCountHeader(pcs));
+  }
+
+  private static void verifyNoInvalidation(LeaderFollowerStoreIngestionTask task) {
+    verify(task, never())
+        .invalidateActiveKeyCount(any(PartitionConsumptionState.class), any(ActiveKeyCountInvalidationReason.class));
+    verify(task, never()).invalidateActiveKeyCount(
+        any(PartitionConsumptionState.class),
+        any(ActiveKeyCountInvalidationReason.class),
+        anyInt());
+    verify(task, never()).invalidateActiveKeyCount(
+        any(PartitionConsumptionState.class),
+        any(ActiveKeyCountInvalidationReason.class),
+        any(Throwable.class));
+  }
+
+  /* ---------- 5. sendIngestionHeartbeatToVT ordering w.r.t. lastVTProduceCallFuture ---------- */
+
+  /**
+   * Regression test for the chain ordering in {@code sendIngestionHeartbeatToVT}: when
+   * {@code activeKeyCountReplicaConsistencyCheckEnabled} is on, the HB SEND must be deferred behind
+   * {@code partitionConsumptionState.getLastVTProduceCallFuture()}, but the lkc COUNT must be captured
+   * synchronously at swap-time (NOT in the deferred callback). Reading the count from inside the callback
+   * would observe SIT-thread increments for records queued AFTER this HB's swap — those records chain
+   * behind the HB at the broker but their increments already landed in the AtomicLong by the time the
+   * callback fires, so the attached lkc header would reflect state the follower has not yet reached at
+   * HB-process time, causing false-positive mismatches.
+   *
+   * <p>This test installs an incomplete {@code lastVTProduceCallFuture} on the PCS, invokes
+   * {@code sendIngestionHeartbeatToVT}, asserts (a) the count IS read synchronously once (swap-time
+   * capture) and (b) the writer is NOT called yet (SEND is deferred). Then it completes the future and
+   * asserts the writer is called with the swap-time count attached as a header.
+   */
+  @Test
+  public void testSendIngestionHeartbeatToVTOrdersBehindLastVtProduceCallFuture() throws Exception {
+    LeaderFollowerStoreIngestionTask task = mockedTask(true);
+    Method sendVt = findSendVtMethod();
+
+    // PCS with an incomplete previous VT produce future — simulates an in-flight worker write.
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn(true).when(pcs).isEndOfPushReceived();
+    doReturn(99L).when(pcs).getActiveKeyCount();
+    /*
+     * The atomic swap returns the previous head and installs the new one in one call. Stub it to return
+     * the incomplete previousVtWrite — that's what the chained callback will wait on.
+     */
+    CompletableFuture<Void> previousVtWrite = new CompletableFuture<>();
+    doReturn(previousVtWrite).when(pcs).swapLastVTProduceCallFuture(any());
+
+    // VeniceWriter mock that returns a completed produce result so the inner sendHeartbeat call doesn't trip.
+    VeniceWriter<byte[], byte[], byte[]> writer = mock(VeniceWriter.class);
+    PubSubProduceResult produceResult = mock(PubSubProduceResult.class);
+    doReturn(CompletableFuture.completedFuture(produceResult)).when(writer)
+        .sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), any(PubSubMessageHeader.class));
+    doReturn(Lazy.of(() -> writer)).when(pcs).getVeniceWriterLazyRef();
+
+    PubSubTopicPartition topicPartition = mock(PubSubTopicPartition.class);
+    sendVt.invoke(
+        task,
+        pcs,
+        topicPartition,
+        null,
+        VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
+        LeaderCompleteState.LEADER_COMPLETED,
+        123L);
+
+    /*
+     * Pre-completion: the count IS read synchronously on the SIT thread at swap-time (so it reflects only
+     * records queued up to this point — see buildLeaderActiveKeyCountHeader's Javadoc). times(1)
+     * locks the swap-time read in: a future regression that re-reads the count inside the chained callback
+     * would observe two invocations and fail the test. The writer is NOT called yet because the chained
+     * callback waits on previousVtWrite.
+     */
+    verify(pcs, times(1)).getActiveKeyCount();
+    verify(writer, never())
+        .sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), any(PubSubMessageHeader.class));
+
+    // PCS must have had its lastVTProduceCallFuture rotated to a fresh future via the atomic swap.
+    ArgumentCaptor<CompletableFuture<Void>> futureCap = ArgumentCaptor.forClass(CompletableFuture.class);
+    verify(pcs).swapLastVTProduceCallFuture(futureCap.capture());
+    CompletableFuture<Void> hbFuture = futureCap.getValue();
+    assertNotSame(hbFuture, previousVtWrite, "Swapped-in future must be a fresh instance");
+    assertFalse(hbFuture.isDone(), "HB future must remain incomplete until the chained callback fires");
+
+    // Release the previous produce — the chained callback should now call the writer with the captured lkc.
+    previousVtWrite.complete(null);
+    // The whenCompleteAsync runs on the ForkJoinPool common pool; block on the HB future for determinism.
+    hbFuture.get();
+
+    ArgumentCaptor<PubSubMessageHeader> headerCap = ArgumentCaptor.forClass(PubSubMessageHeader.class);
+    verify(writer).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), headerCap.capture());
+    PubSubMessageHeader lkcHeader = headerCap.getValue();
+    assertNotNull(lkcHeader, "Expected lkc header to be attached after ordering completes");
+    assertEquals(lkcHeader.key(), PubSubMessageHeaders.VENICE_LEADER_KEY_COUNT_HEADER);
+    assertEquals(StoreIngestionTask.decodeLeaderKeyCountHeaderValue(lkcHeader), 99L);
+  }
+
+  /**
+   * Companion to the ordering test: when the consistency check is disabled the synchronous path must be preserved —
+   * we must NOT touch {@code lastVTProduceCallFuture} (rotating it on every HB would introduce a needless
+   * dependency for stores that opted out).
+   */
+  @Test
+  public void testSendIngestionHeartbeatToVTDoesNotChainWhenConsistencyCheckDisabled() throws Exception {
+    LeaderFollowerStoreIngestionTask task = mockedTask(false);
+    Method sendVt = findSendVtMethod();
+
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    VeniceWriter<byte[], byte[], byte[]> writer = mock(VeniceWriter.class);
+    doReturn(CompletableFuture.completedFuture(mock(PubSubProduceResult.class))).when(writer)
+        .sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), any());
+    doReturn(Lazy.of(() -> writer)).when(pcs).getVeniceWriterLazyRef();
+
+    PubSubTopicPartition topicPartition = mock(PubSubTopicPartition.class);
+    sendVt.invoke(
+        task,
+        pcs,
+        topicPartition,
+        null,
+        VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
+        LeaderCompleteState.LEADER_COMPLETED,
+        123L);
+
+    // Sync path: writer was invoked with extraHeader=null, lastVTProduceCallFuture was neither read nor swapped.
+    verify(writer).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), isNull());
+    verify(pcs, never()).getLastVTProduceCallFuture();
+    verify(pcs, never()).swapLastVTProduceCallFuture(any());
+  }
+
+  /**
+   * Regression test for the upstream-exception propagation fix in {@code sendIngestionHeartbeatToVT}'s
+   * chained callback. If the previous VT write failed (e.g., close short-circuited the head, or a prior
+   * data write blew up), the HB callback must NOT emit a heartbeat — its lkc would reflect records that
+   * never reached VT and would trigger false-positive divergence on followers. The chain's failure must
+   * propagate to hbProduceFuture instead, so anyone chained behind us fails fast too.
+   */
+  @Test
+  public void testSendIngestionHeartbeatToVTPropagatesPreviousFailureWithoutEmittingHeartbeat() throws Exception {
+    LeaderFollowerStoreIngestionTask task = mockedTask(true);
+    Method sendVt = findSendVtMethod();
+
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn(true).when(pcs).isEndOfPushReceived();
+    doReturn(77L).when(pcs).getActiveKeyCount();
+    CompletableFuture<Void> previousVtWrite = new CompletableFuture<>();
+    doReturn(previousVtWrite).when(pcs).swapLastVTProduceCallFuture(any());
+
+    VeniceWriter<byte[], byte[], byte[]> writer = mock(VeniceWriter.class);
+    doReturn(Lazy.of(() -> writer)).when(pcs).getVeniceWriterLazyRef();
+
+    PubSubTopicPartition topicPartition = mock(PubSubTopicPartition.class);
+    sendVt.invoke(
+        task,
+        pcs,
+        topicPartition,
+        null,
+        VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
+        LeaderCompleteState.LEADER_COMPLETED,
+        123L);
+
+    // Capture the swapped-in future and fail the previous one.
+    ArgumentCaptor<CompletableFuture<Void>> futureCap = ArgumentCaptor.forClass(CompletableFuture.class);
+    verify(pcs).swapLastVTProduceCallFuture(futureCap.capture());
+    CompletableFuture<Void> hbFuture = futureCap.getValue();
+    RuntimeException upstream = new RuntimeException("prior write blew up");
+    previousVtWrite.completeExceptionally(upstream);
+
+    // Block on the chain future and assert it carries the propagated exception.
+    try {
+      hbFuture.get(5, TimeUnit.SECONDS);
+      throw new AssertionError("hbFuture should have completed exceptionally");
+    } catch (java.util.concurrent.ExecutionException expected) {
+      assertEquals(expected.getCause(), upstream);
+    }
+
+    /*
+     * HB must NOT have been emitted — the writer is never called when the prior chain entry failed. The
+     * count IS read once at swap-time (synchronous SIT-thread capture for the lkc header), but that read
+     * is harmless: nothing was sent.
+     */
+    verify(writer, never()).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), any());
+  }
+
+  /**
+   * Regression test for the chained callback in {@link LeaderFollowerStoreIngestionTask#sendIngestionHeartbeatToVT}.
+   * When {@code writer.sendHeartbeat} throws synchronously, sendIngestionHeartbeat catches and wraps the cause
+   * into the returned future — the chain head must reflect that synchronous-enqueue failure rather than
+   * unconditionally completing successfully. Otherwise downstream chained writes proceed under the false
+   * assumption that the HB enqueued, defeating the lkc ordering invariant.
+   *
+   * <p>Stub {@code topicPartition.getPubSubTopic()} with a real PubSubTopic mock so {@code logIngestionHeartbeat}
+   * completes normally instead of NPE'ing — the test must exercise the actual failure-propagation path inside
+   * the chained callback, not rely on an incidental NPE from an under-stubbed mock to make the assertion fire.
+   */
+  @Test
+  public void testSendIngestionHeartbeatToVTCompletesChainExceptionallyWhenSendHeartbeatThrows() throws Exception {
+    LeaderFollowerStoreIngestionTask task = mockedTask(true);
+    Method sendVt = findSendVtMethod();
+
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    doReturn(true).when(pcs).isEndOfPushReceived();
+    doReturn(99L).when(pcs).getActiveKeyCount();
+    CompletableFuture<Void> previousVtWrite = CompletableFuture.completedFuture(null);
+    doReturn(previousVtWrite).when(pcs).swapLastVTProduceCallFuture(any());
+
+    // Writer.sendHeartbeat throws synchronously — simulates an in-bad-state VeniceWriter.
+    VeniceWriter<byte[], byte[], byte[]> writer = mock(VeniceWriter.class);
+    RuntimeException sendFailure = new RuntimeException("writer is closed");
+    org.mockito.Mockito.doThrow(sendFailure)
+        .when(writer)
+        .sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), any(PubSubMessageHeader.class));
+    doReturn(Lazy.of(() -> writer)).when(pcs).getVeniceWriterLazyRef();
+
+    PubSubTopicPartition topicPartition = mock(PubSubTopicPartition.class);
+    PubSubTopic stubTopic = mock(PubSubTopic.class);
+    doReturn("test-store_v1").when(stubTopic).getName();
+    doReturn(stubTopic).when(topicPartition).getPubSubTopic();
+    doReturn(0).when(topicPartition).getPartitionNumber();
+    sendVt.invoke(
+        task,
+        pcs,
+        topicPartition,
+        null,
+        VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
+        LeaderCompleteState.LEADER_COMPLETED,
+        123L);
+
+    ArgumentCaptor<CompletableFuture<Void>> futureCap = ArgumentCaptor.forClass(CompletableFuture.class);
+    verify(pcs).swapLastVTProduceCallFuture(futureCap.capture());
+    CompletableFuture<Void> hbFuture = futureCap.getValue();
+    /*
+     * Block on the chain head FIRST — the inner callback runs on the common pool when previousVtWrite is
+     * already complete (we stubbed it to completedFuture(null)), so it may not have fired yet when sendVt
+     * returns. Then assert the cause is the actual sync writer failure (not an incidental NPE from an
+     * under-stubbed mock — that pattern hid this very bug for an iteration).
+     */
+    try {
+      hbFuture.get(5, TimeUnit.SECONDS);
+      throw new AssertionError("hbFuture should have completed exceptionally");
+    } catch (java.util.concurrent.ExecutionException expected) {
+      assertEquals(expected.getCause(), sendFailure, "Chain head must surface the sync writer.sendHeartbeat failure");
+    }
+    assertTrue(hbFuture.isCompletedExceptionally(), "Chain head must reach a terminal exceptional state");
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountInvalidationReasonTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountInvalidationReasonTest.java
@@ -1,0 +1,40 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import com.linkedin.venice.stats.dimensions.VeniceDimensionTestFixture;
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.utils.CollectionUtils;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+/**
+ * Validates {@link ActiveKeyCountInvalidationReason} as an OTel dimension on
+ * {@link com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity#ACTIVE_KEY_COUNT_INVALIDATION}:
+ * enum value count, dimension name parity across all instances, and per-instance dimension value strings.
+ * Uses raw hardcoded strings on purpose so accidental enum renames are caught.
+ */
+public class ActiveKeyCountInvalidationReasonTest {
+  @Test
+  public void testDimensionInterface() {
+    Map<ActiveKeyCountInvalidationReason, String> expectedValues =
+        CollectionUtils.<ActiveKeyCountInvalidationReason, String>mapBuilder()
+            .put(ActiveKeyCountInvalidationReason.FOLLOWER_DECREMENT_UNDERFLOW, "follower_decrement_underflow")
+            .put(ActiveKeyCountInvalidationReason.LEADER_PROPAGATED_INVALIDATION, "leader_propagated_invalidation")
+            .put(
+                ActiveKeyCountInvalidationReason.CORRUPT_KEY_COUNT_SIGNAL_HEADER_VALUE,
+                "corrupt_key_count_signal_header_value")
+            .put(
+                ActiveKeyCountInvalidationReason.CORRUPT_KEY_COUNT_SIGNAL_HEADER_LENGTH,
+                "corrupt_key_count_signal_header_length")
+            .put(ActiveKeyCountInvalidationReason.LEADER_DCR_UNDERFLOW, "leader_dcr_underflow")
+            .put(ActiveKeyCountInvalidationReason.KEY_EXISTS_FAILURE, "key_exists_failure")
+            .put(
+                ActiveKeyCountInvalidationReason.CORRUPT_LEADER_KEY_COUNT_HEADER_LENGTH,
+                "corrupt_leader_key_count_header_length")
+            .build();
+    new VeniceDimensionTestFixture<>(
+        ActiveKeyCountInvalidationReason.class,
+        VeniceMetricsDimensions.VENICE_ACTIVE_KEY_COUNT_INVALIDATION_REASON,
+        expectedValues).assertAll();
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountScenarioTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountScenarioTest.java
@@ -8,6 +8,8 @@ import static com.linkedin.davinci.kafka.consumer.ActiveKeyCountTestUtils.restor
 import static com.linkedin.davinci.stats.ServerMetricEntity.SERVER_METRIC_ENTITIES;
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.ACTIVE_KEY_COUNT;
 import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.ACTIVE_KEY_COUNT_INVALIDATION;
+import static com.linkedin.davinci.stats.ingestion.IngestionOtelMetricEntity.ACTIVE_KEY_COUNT_MISMATCH_ACROSS_REPLICAS;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_ACTIVE_KEY_COUNT_INVALIDATION_REASON;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REPLICA_TYPE;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
@@ -357,13 +359,15 @@ public class ActiveKeyCountScenarioTest {
 
     try {
       IngestionOtelStats otelStats =
-          new IngestionOtelStats(otelRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, false, true);
+          new IngestionOtelStats(otelRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, false, true, true);
       otelStats.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
 
       VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
       doReturn(Int2ObjectMaps.emptyMap()).when(mockServerConfig).getKafkaClusterIdToAliasMap();
       doReturn(CLUSTER_NAME).when(mockServerConfig).getClusterName();
       doReturn(true).when(mockServerConfig).isAnyActiveKeyCountTrackingEnabled();
+      doReturn(true).when(mockServerConfig).isActiveKeyCountForHybridStoreEnabled();
+      doReturn(true).when(mockServerConfig).isActiveKeyCountReplicaConsistencyCheckEnabled();
       Map<String, StoreIngestionTask> taskMap = new HashMap<>();
       taskMap.put(STORE_NAME, mock(StoreIngestionTask.class));
       AggHostLevelIngestionStats aggStats = new AggHostLevelIngestionStats(
@@ -374,12 +378,16 @@ public class ActiveKeyCountScenarioTest {
           true,
           mockTime);
       aggStats.getStoreStats(STORE_NAME).recordActiveKeyCountInvalidation();
-      otelStats.recordActiveKeyCountInvalidation(CURRENT_VERSION);
+      ActiveKeyCountInvalidationReason reason = ActiveKeyCountInvalidationReason.FOLLOWER_DECREMENT_UNDERFLOW;
+      otelStats.recordActiveKeyCountInvalidation(CURRENT_VERSION, reason);
 
       Attributes invalidationAttrs = Attributes.builder()
           .put(VENICE_STORE_NAME.getDimensionNameInDefaultFormat(), STORE_NAME)
           .put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), CLUSTER_NAME)
           .put(VENICE_VERSION_ROLE.getDimensionNameInDefaultFormat(), VersionRole.CURRENT.getDimensionValue())
+          .put(
+              VENICE_ACTIVE_KEY_COUNT_INVALIDATION_REASON.getDimensionNameInDefaultFormat(),
+              reason.getDimensionValue())
           .build();
       validateLongPointDataFromCounter(
           reader,
@@ -400,6 +408,159 @@ public class ActiveKeyCountScenarioTest {
     } finally {
       otelRepo.close();
       // Do NOT close tehutiRepo — see MetricsTestContext.close() rationale.
+      try {
+        asyncGaugeExecutor.close();
+      } catch (IOException ignored) {
+        // best-effort
+      }
+    }
+  }
+
+  /**
+   * A single mismatch event must increment both the Tehuti rate and the OTel counter exactly once.
+   * Also asserts cross-system isolation: recording one mismatch must not increment the invalidation
+   * counters, since they're different events under different operator interpretations.
+   */
+  @Test
+  public void testMismatchParityRecordsToBothTehutiAndOtelInIsolation() {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    VeniceMetricsRepository otelRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setMetricPrefix(TEST_PREFIX)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(reader)
+            .build());
+    AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
+    TestMockTime mockTime = new TestMockTime();
+    MetricsRepository tehutiRepo =
+        new MetricsRepository(new MetricConfig(asyncGaugeExecutor), Collections.emptyList(), mockTime);
+
+    try {
+      IngestionOtelStats otelStats =
+          new IngestionOtelStats(otelRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, false, true, true);
+      otelStats.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
+
+      VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
+      doReturn(Int2ObjectMaps.emptyMap()).when(mockServerConfig).getKafkaClusterIdToAliasMap();
+      doReturn(CLUSTER_NAME).when(mockServerConfig).getClusterName();
+      doReturn(true).when(mockServerConfig).isAnyActiveKeyCountTrackingEnabled();
+      doReturn(true).when(mockServerConfig).isActiveKeyCountForHybridStoreEnabled();
+      doReturn(true).when(mockServerConfig).isActiveKeyCountReplicaConsistencyCheckEnabled();
+      Map<String, StoreIngestionTask> taskMap = new HashMap<>();
+      taskMap.put(STORE_NAME, mock(StoreIngestionTask.class));
+      AggHostLevelIngestionStats aggStats = new AggHostLevelIngestionStats(
+          tehutiRepo,
+          mockServerConfig,
+          taskMap,
+          mock(ReadOnlyStoreRepository.class),
+          true,
+          mockTime);
+
+      aggStats.getStoreStats(STORE_NAME).recordActiveKeyCountMismatchAcrossReplicas();
+      otelStats.recordActiveKeyCountMismatchAcrossReplicas(CURRENT_VERSION);
+
+      Attributes mismatchAttrs = Attributes.builder()
+          .put(VENICE_STORE_NAME.getDimensionNameInDefaultFormat(), STORE_NAME)
+          .put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), CLUSTER_NAME)
+          .put(VENICE_VERSION_ROLE.getDimensionNameInDefaultFormat(), VersionRole.CURRENT.getDimensionValue())
+          .build();
+      validateLongPointDataFromCounter(
+          reader,
+          1L,
+          mismatchAttrs,
+          ACTIVE_KEY_COUNT_MISMATCH_ACROSS_REPLICAS.getMetricEntity().getMetricName(),
+          TEST_PREFIX);
+
+      // Advance the cached rate window so Tehuti reports the just-recorded event.
+      mockTime.addMilliseconds(LongAdderRateGauge.RATE_GAUGE_CACHE_DURATION_IN_SECONDS * Time.MS_PER_SECOND);
+      assertEquals(
+          tehutiRepo.getMetric(".total--active_key_count_mismatch_across_replicas.Rate").value(),
+          1d / LongAdderRateGauge.RATE_GAUGE_CACHE_DURATION_IN_SECONDS,
+          "Tehuti rate must reflect exactly the one mismatch we recorded");
+
+      // Cross-system isolation: invalidation metrics must NOT have been touched by the mismatch event.
+      assertEquals(
+          tehutiRepo.getMetric(".total--active_key_count_invalidation.Rate").value(),
+          0d,
+          "Mismatch must NOT bump the Tehuti invalidation rate");
+      // No OTel datapoint exists for ACTIVE_KEY_COUNT_INVALIDATION at all (metric never recorded).
+      assertEquals(
+          reader.collectAllMetrics()
+              .stream()
+              .filter(md -> md.getName().endsWith(ACTIVE_KEY_COUNT_INVALIDATION.getMetricEntity().getMetricName()))
+              .count(),
+          0L,
+          "Mismatch must NOT register any OTel invalidation datapoint");
+    } finally {
+      otelRepo.close();
+      try {
+        asyncGaugeExecutor.close();
+      } catch (IOException ignored) {
+        // best-effort
+      }
+    }
+  }
+
+  /**
+   * Inverse cross-system isolation: recording one invalidation must not increment the mismatch counters.
+   */
+  @Test
+  public void testInvalidationDoesNotBumpMismatchMetrics() {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    VeniceMetricsRepository otelRepo = new VeniceMetricsRepository(
+        new VeniceMetricsConfig.Builder().setMetricEntities(SERVER_METRIC_ENTITIES)
+            .setMetricPrefix(TEST_PREFIX)
+            .setEmitOtelMetrics(true)
+            .setOtelAdditionalMetricsReader(reader)
+            .build());
+    AsyncGauge.AsyncGaugeExecutor asyncGaugeExecutor = new AsyncGauge.AsyncGaugeExecutor.Builder().build();
+    TestMockTime mockTime = new TestMockTime();
+    MetricsRepository tehutiRepo =
+        new MetricsRepository(new MetricConfig(asyncGaugeExecutor), Collections.emptyList(), mockTime);
+
+    try {
+      IngestionOtelStats otelStats =
+          new IngestionOtelStats(otelRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, false, true, true);
+      otelStats.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
+
+      VeniceServerConfig mockServerConfig = mock(VeniceServerConfig.class);
+      doReturn(Int2ObjectMaps.emptyMap()).when(mockServerConfig).getKafkaClusterIdToAliasMap();
+      doReturn(CLUSTER_NAME).when(mockServerConfig).getClusterName();
+      doReturn(true).when(mockServerConfig).isAnyActiveKeyCountTrackingEnabled();
+      doReturn(true).when(mockServerConfig).isActiveKeyCountForHybridStoreEnabled();
+      doReturn(true).when(mockServerConfig).isActiveKeyCountReplicaConsistencyCheckEnabled();
+      Map<String, StoreIngestionTask> taskMap = new HashMap<>();
+      taskMap.put(STORE_NAME, mock(StoreIngestionTask.class));
+      AggHostLevelIngestionStats aggStats = new AggHostLevelIngestionStats(
+          tehutiRepo,
+          mockServerConfig,
+          taskMap,
+          mock(ReadOnlyStoreRepository.class),
+          true,
+          mockTime);
+
+      aggStats.getStoreStats(STORE_NAME).recordActiveKeyCountInvalidation();
+      otelStats.recordActiveKeyCountInvalidation(
+          CURRENT_VERSION,
+          ActiveKeyCountInvalidationReason.LEADER_PROPAGATED_INVALIDATION);
+
+      // Cross-system isolation: mismatch metrics must NOT have been touched by the invalidation event.
+      mockTime.addMilliseconds(LongAdderRateGauge.RATE_GAUGE_CACHE_DURATION_IN_SECONDS * Time.MS_PER_SECOND);
+      assertEquals(
+          tehutiRepo.getMetric(".total--active_key_count_mismatch_across_replicas.Rate").value(),
+          0d,
+          "Invalidation must NOT bump the Tehuti mismatch rate");
+      assertEquals(
+          reader.collectAllMetrics()
+              .stream()
+              .filter(
+                  md -> md.getName()
+                      .endsWith(ACTIVE_KEY_COUNT_MISMATCH_ACROSS_REPLICAS.getMetricEntity().getMetricName()))
+              .count(),
+          0L,
+          "Invalidation must NOT register any OTel mismatch datapoint");
+    } finally {
+      otelRepo.close();
       try {
         asyncGaugeExecutor.close();
       } catch (IOException ignored) {
@@ -454,7 +615,7 @@ public class ActiveKeyCountScenarioTest {
             .setOtelAdditionalMetricsReader(reader)
             .build());
     IngestionOtelStats otelStats =
-        new IngestionOtelStats(otelRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, false, true);
+        new IngestionOtelStats(otelRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, false, true, true);
     otelStats.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
     otelStats.setIngestionTask(CURRENT_VERSION, mockTask);
 
@@ -466,6 +627,8 @@ public class ActiveKeyCountScenarioTest {
     doReturn(Int2ObjectMaps.emptyMap()).when(mockServerConfig).getKafkaClusterIdToAliasMap();
     doReturn(CLUSTER_NAME).when(mockServerConfig).getClusterName();
     doReturn(true).when(mockServerConfig).isAnyActiveKeyCountTrackingEnabled();
+    doReturn(true).when(mockServerConfig).isActiveKeyCountForHybridStoreEnabled();
+    doReturn(true).when(mockServerConfig).isActiveKeyCountReplicaConsistencyCheckEnabled();
     Map<String, StoreIngestionTask> taskMap = new HashMap<>();
     taskMap.put(STORE_NAME, mockTask);
     AggHostLevelIngestionStats aggStats = new AggHostLevelIngestionStats(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveKeyCountTest.java
@@ -256,7 +256,8 @@ public class ActiveKeyCountTest {
 
   private PubSubMessageHeaders createSignalHeaders(byte signalValue) {
     PubSubMessageHeaders headers = new PubSubMessageHeaders();
-    headers.add(new PubSubMessageHeader(StoreIngestionTask.KEY_COUNT_SIGNAL_HEADER, new byte[] { signalValue }));
+    headers
+        .add(new PubSubMessageHeader(PubSubMessageHeaders.VENICE_KEY_COUNT_SIGNAL_HEADER, new byte[] { signalValue }));
     return headers;
   }
 
@@ -623,7 +624,8 @@ public class ActiveKeyCountTest {
   @DataProvider(name = "signalInvalidatesCases")
   public Object[][] signalInvalidatesCases() {
     PubSubMessageHeaders multiByteHeaders = new PubSubMessageHeaders();
-    multiByteHeaders.add(new PubSubMessageHeader(StoreIngestionTask.KEY_COUNT_SIGNAL_HEADER, new byte[] { 1, 2 }));
+    multiByteHeaders
+        .add(new PubSubMessageHeader(PubSubMessageHeaders.VENICE_KEY_COUNT_SIGNAL_HEADER, new byte[] { 1, 2 }));
     /* Columns: headers, messageType, simulateUnderflow, expectedLogSubstring, desc */
     return new Object[][] {
         { createSignalHeaders(ActiveActiveStoreIngestionTask.KEY_DELETED_SIGNAL_VALUE), MessageType.DELETE, true,
@@ -632,8 +634,7 @@ public class ActiveKeyCountTest {
             "Leader propagated invalidation signal", "explicit invalidate signal" },
         { createSignalHeaders((byte) 99), MessageType.PUT, false, "Unexpected kcs signal value 99",
             "unexpected single-byte value" },
-        { multiByteHeaders, MessageType.PUT, false, "Unexpected multi-byte kcs signal (length=2)",
-            "multi-byte signal" } };
+        { multiByteHeaders, MessageType.PUT, false, "Unexpected kcs header length=2", "multi-byte signal" } };
   }
 
   @Test(dataProvider = "signalInvalidatesCases")
@@ -721,11 +722,11 @@ public class ActiveKeyCountTest {
     PubSubMessageHeaders[] headerCases =
         new PubSubMessageHeaders[] { new PubSubMessageHeaders(), new PubSubMessageHeaders() {
           {
-            add(new PubSubMessageHeader(StoreIngestionTask.KEY_COUNT_SIGNAL_HEADER, null));
+            add(new PubSubMessageHeader(PubSubMessageHeaders.VENICE_KEY_COUNT_SIGNAL_HEADER, null));
           }
         }, new PubSubMessageHeaders() {
           {
-            add(new PubSubMessageHeader(StoreIngestionTask.KEY_COUNT_SIGNAL_HEADER, new byte[0]));
+            add(new PubSubMessageHeader(PubSubMessageHeaders.VENICE_KEY_COUNT_SIGNAL_HEADER, new byte[0]));
           }
         } };
     for (PubSubMessageHeaders headers: headerCases) {
@@ -841,7 +842,8 @@ public class ActiveKeyCountTest {
 
       verify(localPcs).decrementActiveKeyCount();
       verify(localPcs).setActiveKeyCount(OffsetRecord.ACTIVE_KEY_COUNT_NOT_TRACKED);
-      verify(ingestionTask, times(1)).recordActiveKeyCountInvalidation();
+      verify(ingestionTask, times(1))
+          .recordActiveKeyCountInvalidation(ActiveKeyCountInvalidationReason.LEADER_DCR_UNDERFLOW);
 
       String capturedLog = appender.getLog();
       Assert.assertTrue(
@@ -883,7 +885,8 @@ public class ActiveKeyCountTest {
 
     PartitionConsumptionState recorderFails = mock(PartitionConsumptionState.class);
     doReturn("replica-recorder-fails").when(recorderFails).getReplicaId();
-    doThrow(new RuntimeException("metric explosion")).when(ingestionTask).recordActiveKeyCountInvalidation();
+    doThrow(new RuntimeException("metric explosion")).when(ingestionTask)
+        .recordActiveKeyCountInvalidation(any(ActiveKeyCountInvalidationReason.class));
 
     TestLogAppender appender2 = new TestLogAppender("RecorderFailsAppender", PatternLayout.createDefaultLayout());
     appender2.start();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -135,6 +135,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -153,6 +154,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import org.apache.logging.log4j.LogManager;
@@ -491,7 +493,8 @@ public class LeaderFollowerStoreIngestionTaskTest {
     put.schemaId = 1;
     when(mockResult.getNewPut()).thenReturn(put);
     AtomicBoolean writeToVersionTopic = new AtomicBoolean(false);
-    when(mockPartitionConsumptionState.getLastVTProduceCallFuture())
+    // The atomic swap returns the previous head (already-completed in this test) and installs the new one.
+    when(mockPartitionConsumptionState.swapLastVTProduceCallFuture(any()))
         .thenReturn(CompletableFuture.completedFuture(null));
     leaderFollowerStoreIngestionTask.queueUpVersionTopicWritesWithViewWriters(
         mockPartitionConsumptionState,
@@ -499,9 +502,8 @@ public class LeaderFollowerStoreIngestionTaskTest {
             .processRecord(mock(ByteBuffer.class), new byte[1], 1, viewPartitionSet, Lazy.of(() -> null)),
         null,
         () -> writeToVersionTopic.set(true));
-    verify(mockPartitionConsumptionState, times(1)).getLastVTProduceCallFuture();
     ArgumentCaptor<CompletableFuture> vtWriteFutureCaptor = ArgumentCaptor.forClass(CompletableFuture.class);
-    verify(mockPartitionConsumptionState, times(1)).setLastVTProduceCallFuture(vtWriteFutureCaptor.capture());
+    verify(mockPartitionConsumptionState, times(1)).swapLastVTProduceCallFuture(vtWriteFutureCaptor.capture());
     verify(materializedViewWriter, times(1)).processRecord(any(), any(), anyInt(), any(), any());
     verify(hostLevelIngestionStats, times(1)).recordViewProducerLatency(anyDouble());
     verify(hostLevelIngestionStats, never()).recordViewProducerAckLatency(anyDouble());
@@ -515,6 +517,128 @@ public class LeaderFollowerStoreIngestionTaskTest {
     assertTrue(vtWriteFutureCaptor.getValue().isDone());
     assertFalse(vtWriteFutureCaptor.getValue().isCompletedExceptionally());
     assertTrue(writeToVersionTopic.get());
+  }
+
+  /**
+   * Regression test for the try/finally + try/catch exception-safety added to
+   * {@code queueUpVersionTopicWritesWithViewWriters}. If the {@code viewWriterRecordProcessor.apply}
+   * call throws during setup AFTER the atomic swap installed our future as the head, the future must
+   * be completed exceptionally so subsequent chained writes don't block forever.
+   */
+  @Test
+  public void testQueueUpVersionTopicWritesCompletesChainWhenViewWriterApplyThrows() throws InterruptedException {
+    mockVeniceViewWriterFactory = mock(VeniceViewWriterFactory.class);
+    Map<String, VeniceViewWriter> viewWriterMap = new HashMap<>();
+    MaterializedViewWriter materializedViewWriter = mock(MaterializedViewWriter.class);
+    when(materializedViewWriter.getViewWriterType()).thenReturn(VeniceViewWriter.ViewWriterType.MATERIALIZED_VIEW);
+    viewWriterMap.put("testView", materializedViewWriter);
+    when(mockVeniceViewWriterFactory.buildStoreViewWriters(any(), anyInt())).thenReturn(viewWriterMap);
+    setUp();
+    when(mockPartitionConsumptionState.swapLastVTProduceCallFuture(any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    RuntimeException setupFailure = new RuntimeException("processRecord blew up before allOf was scheduled");
+    /*
+     * The setup-throw propagates out of queueUpVersionTopicWritesWithViewWriters (the try/finally completes
+     * the future exceptionally but doesn't swallow the throw). What we're asserting is that the chain head
+     * was nonetheless put into a terminal state so downstream chained writes can unblock.
+     */
+    try {
+      leaderFollowerStoreIngestionTask
+          .queueUpVersionTopicWritesWithViewWriters(mockPartitionConsumptionState, (viewWriter, viewPartitionSet) -> {
+            throw setupFailure;
+          }, null, () -> { /* never reached */ });
+      fail("Expected setup throw to propagate");
+    } catch (RuntimeException expected) {
+      assertEquals(expected, setupFailure);
+    }
+
+    ArgumentCaptor<CompletableFuture> futureCap = ArgumentCaptor.forClass(CompletableFuture.class);
+    verify(mockPartitionConsumptionState, times(1)).swapLastVTProduceCallFuture(futureCap.capture());
+    CompletableFuture<Void> currentVersionTopicWrite = futureCap.getValue();
+    assertTrue(
+        currentVersionTopicWrite.isDone(),
+        "Chain head must reach a terminal state when setup throws — otherwise downstream blocks forever");
+    assertTrue(currentVersionTopicWrite.isCompletedExceptionally(), "Should be exceptional, not normal");
+  }
+
+  /**
+   * Regression test for the try/catch added inside the allOf callback of
+   * {@code queueUpVersionTopicWritesWithViewWriters}. If the {@code versionTopicWrite.run()} call
+   * throws when allOf eventually fires, the future must still reach a terminal state.
+   */
+  @Test
+  public void testQueueUpVersionTopicWritesCompletesChainWhenVersionTopicWriteThrows() throws Exception {
+    mockVeniceViewWriterFactory = mock(VeniceViewWriterFactory.class);
+    Map<String, VeniceViewWriter> viewWriterMap = new HashMap<>();
+    MaterializedViewWriter materializedViewWriter = mock(MaterializedViewWriter.class);
+    when(materializedViewWriter.getViewWriterType()).thenReturn(VeniceViewWriter.ViewWriterType.MATERIALIZED_VIEW);
+    viewWriterMap.put("testView", materializedViewWriter);
+    when(mockVeniceViewWriterFactory.buildStoreViewWriters(any(), anyInt())).thenReturn(viewWriterMap);
+    CompletableFuture<Void> viewWriterFuture = CompletableFuture.completedFuture(null);
+    when(materializedViewWriter.processRecord(any(), any(), anyInt(), any(), any())).thenReturn(viewWriterFuture);
+    setUp();
+    when(mockPartitionConsumptionState.swapLastVTProduceCallFuture(any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    RuntimeException runFailure = new RuntimeException("VT produce blew up inside allOf callback");
+    leaderFollowerStoreIngestionTask.queueUpVersionTopicWritesWithViewWriters(
+        mockPartitionConsumptionState,
+        (viewWriter, viewPartitionSet) -> viewWriter
+            .processRecord(mock(ByteBuffer.class), new byte[1], 1, viewPartitionSet, Lazy.of(() -> null)),
+        null,
+        () -> {
+          throw runFailure;
+        });
+
+    ArgumentCaptor<CompletableFuture> futureCap = ArgumentCaptor.forClass(CompletableFuture.class);
+    verify(mockPartitionConsumptionState, times(1)).swapLastVTProduceCallFuture(futureCap.capture());
+    CompletableFuture<Void> currentVersionTopicWrite = futureCap.getValue();
+    // The whenCompleteAsync runs on the ForkJoinPool — wait for it to reach the terminal state.
+    try {
+      currentVersionTopicWrite.get(5, TimeUnit.SECONDS);
+      fail("Should have completed exceptionally");
+    } catch (ExecutionException expected) {
+      // Expected — chain reached a terminal exceptional state.
+    }
+    assertTrue(currentVersionTopicWrite.isCompletedExceptionally(), "Should be exceptional");
+  }
+
+  /**
+   * Regression test for the try/catch added to {@code maybeQueueCMWritesToVersionTopic}. If the
+   * {@code produceCall.run()} throws, the chain future must still be completed exceptionally.
+   */
+  @Test
+  public void testMaybeQueueCMWritesCompletesChainWhenProduceCallThrows() throws Exception {
+    mockVeniceViewWriterFactory = mock(VeniceViewWriterFactory.class);
+    Map<String, VeniceViewWriter> viewWriterMap = new HashMap<>();
+    MaterializedViewWriter materializedViewWriter = mock(MaterializedViewWriter.class);
+    viewWriterMap.put("testView", materializedViewWriter);
+    when(mockVeniceViewWriterFactory.buildStoreViewWriters(any(), anyInt())).thenReturn(viewWriterMap);
+    setUp();
+    when(mockPartitionConsumptionState.swapLastVTProduceCallFuture(any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    RuntimeException produceFailure = new RuntimeException("CM produce blew up");
+    // maybeQueueCMWritesToVersionTopic is private — use the public path that calls it for CM-on-VT.
+    // Easier: invoke directly via reflection since it's package-private but the test is in the same package.
+    Method maybeQueueCM = LeaderFollowerStoreIngestionTask.class
+        .getDeclaredMethod("maybeQueueCMWritesToVersionTopic", PartitionConsumptionState.class, Runnable.class);
+    maybeQueueCM.setAccessible(true);
+    maybeQueueCM.invoke(leaderFollowerStoreIngestionTask, mockPartitionConsumptionState, (Runnable) () -> {
+      throw produceFailure;
+    });
+
+    ArgumentCaptor<CompletableFuture> futureCap = ArgumentCaptor.forClass(CompletableFuture.class);
+    verify(mockPartitionConsumptionState, times(1)).swapLastVTProduceCallFuture(futureCap.capture());
+    CompletableFuture<Void> propagateSegmentCMWrite = futureCap.getValue();
+    try {
+      propagateSegmentCMWrite.get(5, TimeUnit.SECONDS);
+      fail("Should have completed exceptionally");
+    } catch (ExecutionException expected) {
+      // Expected.
+    }
+    assertTrue(propagateSegmentCMWrite.isCompletedExceptionally(), "Should be exceptional");
   }
 
   @Test(timeOut = 30000)
@@ -578,6 +702,64 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
+   * Regression: checkAndWaitForLastVTProduceFuture (called from EOP processing) caps its wait at
+   * VIEW_WRITER_CLOSE_TIMEOUT_IN_MS so a stuck chain head — e.g. a common-pool starvation that blocks an
+   * hbProduceFuture's completion — surfaces as a TimeoutException the caller can attribute, rather than
+   * parking the SIT thread indefinitely. We override .get(long, TimeUnit) on a CompletableFuture subclass
+   * to simulate the timeout without making the test wait the production 60-second budget.
+   */
+  @Test(timeOut = 30000, expectedExceptions = TimeoutException.class)
+  public void testCheckAndWaitForLastVTProduceFutureBoundedByTimeout() throws Exception {
+    setUp();
+    CompletableFuture<Void> stuckHead = new CompletableFuture<Void>() {
+      @Override
+      public Void get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        throw new TimeoutException("simulated chain stall");
+      }
+    };
+    doReturn(stuckHead).when(mockPartitionConsumptionState).getLastVTProduceCallFuture();
+    Method check = LeaderFollowerStoreIngestionTask.class
+        .getDeclaredMethod("checkAndWaitForLastVTProduceFuture", PartitionConsumptionState.class);
+    check.setAccessible(true);
+    try {
+      check.invoke(leaderFollowerStoreIngestionTask, mockPartitionConsumptionState);
+    } catch (InvocationTargetException e) {
+      throw (Exception) e.getCause();
+    }
+  }
+
+  /**
+   * Regression: closeVeniceViewWriters must short-circuit the chain head even when viewWriters is empty.
+   * Hybrid A/A with the active-key-count replica consistency check populates the chain via
+   * sendIngestionHeartbeatToVT without any view writers; the prior implementation skipped the entire
+   * short-circuit loop in that configuration, leaving any pending hbProduceFuture orphaned at close.
+   */
+  @Test(timeOut = 30000)
+  public void testCloseVeniceViewWritersShortCircuitsChainWhenViewWritersEmpty() throws InterruptedException {
+    mockVeniceViewWriterFactory = mock(VeniceViewWriterFactory.class);
+    when(mockVeniceViewWriterFactory.buildStoreViewWriters(any(), anyInt())).thenReturn(new HashMap<>());
+    setUp();
+    CompletableFuture<Void> pendingHead = new CompletableFuture<>();
+    doReturn(pendingHead).when(mockPartitionConsumptionState).getLastVTProduceCallFuture();
+
+    // doFlush=false (killed ingestion): the head should be completed normally.
+    leaderFollowerStoreIngestionTask.closeVeniceViewWriters(false);
+    assertTrue(pendingHead.isDone());
+    assertFalse(pendingHead.isCompletedExceptionally());
+
+    // doFlush=true with deadline already exceeded: the head should be completed exceptionally.
+    setUp();
+    Time mockTime = mock(Time.class);
+    when(mockTime.getMilliseconds()).thenReturn(0L).thenReturn(VIEW_WRITER_CLOSE_TIMEOUT_IN_MS + 100L);
+    leaderFollowerStoreIngestionTask.setTime(mockTime);
+    CompletableFuture<Void> forcefullyCompleted = new CompletableFuture<>();
+    doReturn(forcefullyCompleted).when(mockPartitionConsumptionState).getLastVTProduceCallFuture();
+    leaderFollowerStoreIngestionTask.closeVeniceViewWriters(true);
+    assertTrue(forcefullyCompleted.isDone());
+    assertTrue(forcefullyCompleted.isCompletedExceptionally());
+  }
+
+  /**
    * This test is to ensure if there are view writers the CMs produced to the VT don't get out of order due previous
    * writes to the VT getting delayed by corresponding view writers. Since during NR we write to view topic(s) before VT
    */
@@ -593,7 +775,11 @@ public class LeaderFollowerStoreIngestionTaskTest {
     PubSubMessageProcessedResultWrapper secondCM = getMockMessage(2);
     CompletableFuture<Void> lastVTWriteFuture = new CompletableFuture<>();
     CompletableFuture<Void> nextVTWriteFuture = new CompletableFuture<>();
-    when(mockPartitionConsumptionState.getLastVTProduceCallFuture()).thenReturn(lastVTWriteFuture)
+    /*
+     * The atomic swap returns the previous head each time it's called: lastVTWriteFuture for the first CM,
+     * nextVTWriteFuture for the second. The new head is what the caller passes in.
+     */
+    when(mockPartitionConsumptionState.swapLastVTProduceCallFuture(any())).thenReturn(lastVTWriteFuture)
         .thenReturn(nextVTWriteFuture);
     VeniceWriter veniceWriter = mock(VeniceWriter.class);
     doReturn(Lazy.of(() -> veniceWriter)).when(mockPartitionConsumptionState).getVeniceWriterLazyRef();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
@@ -29,7 +29,17 @@ import com.linkedin.venice.writer.WriterChunkingHelper;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -633,5 +643,103 @@ public class PartitionConsumptionStateTest {
       pcs.incrementBatchPushRecordCount();
     }
     assertEquals(pcs.getBatchPushRecordCount(), expectedFinalCount, description);
+  }
+
+  /**
+   * Regression test for the atomic-swap invariant on {@code lastVTProduceCallFuture}.
+   *
+   * <p>Under N concurrent swappers, every thread must observe a distinct {@code previous} value from
+   * {@code swapLastVTProduceCallFuture}, and the union of all observed {@code previous} values plus the
+   * final head must form a strict linked chain (every swapped-in future is "previous" for exactly one
+   * subsequent swap, plus the initial completed future and the final head). Without the AtomicReference
+   * getAndSet, racing get+set would let multiple threads observe the same {@code previous}, leaving one
+   * thread's installed future orphaned — exactly the failure mode the swap was added to prevent.
+   */
+  @Test
+  public void testSwapLastVTProduceCallFutureIsAtomicUnderConcurrentSwaps() throws Exception {
+    final int threadCount = 32;
+    PartitionConsumptionState pcs = new PartitionConsumptionState(
+        TOPIC_PARTITION,
+        new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer(), pubSubContext),
+        pubSubContext,
+        false,
+        false,
+        false,
+        null);
+    CompletableFuture<Void> initialHead = pcs.getLastVTProduceCallFuture();
+    assertNotNull(initialHead, "initial head must be non-null");
+    assertTrue(initialHead.isDone(), "initial head must be a completed future per the field initializer");
+
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(threadCount);
+    Map<Integer, CompletableFuture<Void>> installedByThread = new ConcurrentHashMap<>();
+    Map<Integer, CompletableFuture<Void>> observedPreviousByThread = new ConcurrentHashMap<>();
+    ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+    try {
+      for (int i = 0; i < threadCount; i++) {
+        final int tid = i;
+        pool.submit(() -> {
+          try {
+            start.await();
+            CompletableFuture<Void> mine = new CompletableFuture<>();
+            installedByThread.put(tid, mine);
+            CompletableFuture<Void> previous = pcs.swapLastVTProduceCallFuture(mine);
+            observedPreviousByThread.put(tid, previous);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } finally {
+            done.countDown();
+          }
+        });
+      }
+      start.countDown();
+      assertTrue(done.await(10, TimeUnit.SECONDS), "all swaps must complete within 10s");
+    } finally {
+      pool.shutdownNow();
+    }
+
+    /*
+     * Build the set of futures we expect to be referenced as "previous" exactly once across the run:
+     * the initial completed head + every installed future EXCEPT the one that ends up as the final head.
+     * The final head is what getLastVTProduceCallFuture returns after the storm settles.
+     */
+    CompletableFuture<Void> finalHead = pcs.getLastVTProduceCallFuture();
+    Set<CompletableFuture<Void>> expectedPredecessors = Collections.newSetFromMap(new IdentityHashMap<>());
+    expectedPredecessors.add(initialHead);
+    for (CompletableFuture<Void> installed: installedByThread.values()) {
+      if (installed != finalHead) {
+        expectedPredecessors.add(installed);
+      }
+    }
+    Set<CompletableFuture<Void>> actualPredecessors = Collections.newSetFromMap(new IdentityHashMap<>());
+    actualPredecessors.addAll(observedPreviousByThread.values());
+
+    assertEquals(
+        actualPredecessors.size(),
+        observedPreviousByThread.size(),
+        "every thread must observe a UNIQUE previous head — a duplicate proves two threads swapped against "
+            + "the same head, orphaning one of their futures");
+    assertEquals(
+        actualPredecessors,
+        expectedPredecessors,
+        "the set of observed predecessors must equal initial-head + (installed minus final-head)");
+  }
+
+  /**
+   * swapLastVTProduceCallFuture must reject null at the call site; installing null as the head would
+   * permanently break the chain (every subsequent whenCompleteAsync would NPE) and the close-path
+   * isDone() check would NPE too.
+   */
+  @Test(expectedExceptions = NullPointerException.class)
+  public void testSwapLastVTProduceCallFutureRejectsNull() {
+    PartitionConsumptionState pcs = new PartitionConsumptionState(
+        TOPIC_PARTITION,
+        mock(OffsetRecord.class),
+        pubSubContext,
+        false,
+        false,
+        false,
+        null);
+    pcs.swapLastVTProduceCallFuture(null);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -5355,7 +5355,8 @@ public abstract class StoreIngestionTaskTest {
     VeniceWriterFactory veniceWriterFactory = mock(VeniceWriterFactory.class);
     CompletableFuture heartBeatFuture = new CompletableFuture();
     heartBeatFuture.complete(null);
-    doReturn(heartBeatFuture).when(veniceWriter).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong());
+    doReturn(heartBeatFuture).when(veniceWriter)
+        .sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), any());
     doReturn(veniceWriter).when(veniceWriterFactory).createVeniceWriter(any());
 
     doReturn(Lazy.of(() -> veniceWriter)).when(pcs).getVeniceWriterLazyRef();
@@ -5388,9 +5389,9 @@ public abstract class StoreIngestionTaskTest {
     // Second invocation should be skipped since it shouldn't be time for another heartbeat yet.
     ingestionTask.maybeSendIngestionHeartbeat();
     if (hybridConfig == HYBRID && isRealTimeTopic && nodeType == NodeType.LEADER) {
-      verify(veniceWriter, times(1)).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong());
+      verify(veniceWriter, times(1)).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), any());
     } else {
-      verify(veniceWriter, never()).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong());
+      verify(veniceWriter, never()).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), any());
     }
 
     /**
@@ -5491,17 +5492,18 @@ public abstract class StoreIngestionTaskTest {
     PubSubTopicPartition pubSubTopicPartition1sep = new PubSubTopicPartitionImpl(sepRTtopic, 1);
 
     // all succeeded
-    doReturn(heartBeatFuture).when(veniceWriter).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong());
+    doReturn(heartBeatFuture).when(veniceWriter)
+        .sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong(), any());
     AtomicReference<Set<String>> failedPartitions = new AtomicReference<>(null);
     failedPartitions.set(ingestionTask.maybeSendIngestionHeartbeat());
     assertEquals(failedPartitions.get().size(), 0);
 
     // 1 partition throws exception
     doReturn(heartBeatFuture).when(veniceWriter)
-        .sendHeartbeat(eq(pubSubTopicPartition0), any(), any(), anyBoolean(), any(), anyLong());
+        .sendHeartbeat(eq(pubSubTopicPartition0), any(), any(), anyBoolean(), any(), anyLong(), any());
     doAnswer(invocation -> {
       throw new Exception("mock exception");
-    }).when(veniceWriter).sendHeartbeat(eq(pubSubTopicPartition1), any(), any(), anyBoolean(), any(), anyLong());
+    }).when(veniceWriter).sendHeartbeat(eq(pubSubTopicPartition1), any(), any(), anyBoolean(), any(), anyLong(), any());
     // wait for SERVER_INGESTION_HEARTBEAT_INTERVAL_MS
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       failedPartitions.set(ingestionTask.maybeSendIngestionHeartbeat());
@@ -5516,10 +5518,11 @@ public abstract class StoreIngestionTaskTest {
 
     // 1 partition throws exception
     doReturn(heartBeatFuture).when(veniceWriter)
-        .sendHeartbeat(eq(pubSubTopicPartition0), any(), any(), anyBoolean(), any(), anyLong());
+        .sendHeartbeat(eq(pubSubTopicPartition0), any(), any(), anyBoolean(), any(), anyLong(), any());
     doAnswer(invocation -> {
       throw new Exception("mock exception");
-    }).when(veniceWriter).sendHeartbeat(eq(pubSubTopicPartition1sep), any(), any(), anyBoolean(), any(), anyLong());
+    }).when(veniceWriter)
+        .sendHeartbeat(eq(pubSubTopicPartition1sep), any(), any(), anyBoolean(), any(), anyLong(), any());
     // wait for SERVER_INGESTION_HEARTBEAT_INTERVAL_MS
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       failedPartitions.set(ingestionTask.maybeSendIngestionHeartbeat());
@@ -5535,7 +5538,7 @@ public abstract class StoreIngestionTaskTest {
     // both partition throws exception
     doAnswer(invocation -> {
       throw new Exception("mock exception");
-    }).when(veniceWriter).sendHeartbeat(eq(pubSubTopicPartition0), any(), any(), anyBoolean(), any(), anyLong());
+    }).when(veniceWriter).sendHeartbeat(eq(pubSubTopicPartition0), any(), any(), anyBoolean(), any(), anyLong(), any());
     // wait for SERVER_INGESTION_HEARTBEAT_INTERVAL_MS
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       failedPartitions.set(ingestionTask.maybeSendIngestionHeartbeat());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 185, "Expected 185 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 186, "Expected 186 unique metric entities");
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelMetricEntityTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.stats.ingestion;
 
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_ACTIVE_KEY_COUNT_INVALIDATION_REASON;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_DCR_EVENT;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_DCR_OPERATION;
@@ -63,6 +64,8 @@ public class IngestionOtelMetricEntityTest {
         setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_VERSION_ROLE, VENICE_DCR_OPERATION);
     Set<VeniceMetricsDimensions> storeClusterVersionFailureReason =
         setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_VERSION_ROLE, VENICE_INGESTION_FAILURE_REASON);
+    Set<VeniceMetricsDimensions> storeClusterVersionInvalidationReason =
+        setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_VERSION_ROLE, VENICE_ACTIVE_KEY_COUNT_INVALIDATION_REASON);
 
     // ASYNC_GAUGE metrics
     map.put(
@@ -539,14 +542,30 @@ public class IngestionOtelMetricEntityTest {
             "Count of reporting windows where partial-update amplification was detected (large result values)",
             storeClusterVersion));
 
-    // Active key count invalidation counter
+    // Active key count invalidation counter — dimensioned by reason
     map.put(
         IngestionOtelMetricEntity.ACTIVE_KEY_COUNT_INVALIDATION,
         new MetricEntityExpectation(
             "ingestion.key.active_count_invalidation",
             MetricType.COUNTER,
             MetricUnit.NUMBER,
-            "Count of active key count invalidations due to underflow drift, keyExists failures, leader-propagated invalidation, or corrupt kcs signals",
+            "Count of active key count invalidations on this host, broken down by the "
+                + "venice.active_key_count.invalidation_reason dimension; see ActiveKeyCountInvalidationReason for the "
+                + "full set of causes",
+            storeClusterVersionInvalidationReason));
+
+    // Diagnostic-only cross-replica-mismatch counter — separate from invalidation since mismatch does not mutate state
+    map.put(
+        IngestionOtelMetricEntity.ACTIVE_KEY_COUNT_MISMATCH_ACROSS_REPLICAS,
+        new MetricEntityExpectation(
+            "ingestion.key.active_count_mismatch_across_replicas",
+            MetricType.COUNTER,
+            MetricUnit.NUMBER,
+            "Diagnostic-only count of active-key-count divergences across replicas detected on ingestion heartbeats. "
+                + "Follower receives the leader's count via the lkc heartbeat header and compares; a non-zero value "
+                + "indicates divergence at HB-processing time. The follower's count is NOT invalidated — operators "
+                + "alert on this metric and investigate. Kept separate from ACTIVE_KEY_COUNT_INVALIDATION so dashboards "
+                + "distinguish divergence (an observation) from invalidation (a corrective action).",
             storeClusterVersion));
 
     return map;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/IngestionOtelStatsTest.java
@@ -79,6 +79,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
+import com.linkedin.davinci.kafka.consumer.ActiveKeyCountInvalidationReason;
 import com.linkedin.davinci.kafka.consumer.StoreIngestionTask;
 import com.linkedin.davinci.stats.OtelVersionedStatsUtils;
 import com.linkedin.venice.server.VersionRole;
@@ -135,7 +136,7 @@ public class IngestionOtelStatsTest {
   }
 
   private static IngestionOtelStats createStats(VeniceMetricsRepository repo) {
-    return new IngestionOtelStats(repo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, true);
+    return new IngestionOtelStats(repo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, true, true);
   }
 
   @BeforeMethod
@@ -167,7 +168,7 @@ public class IngestionOtelStatsTest {
             .setOtelAdditionalMetricsReader(localReader)
             .build())) {
       IngestionOtelStats statsDisabled =
-          new IngestionOtelStats(localRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, false);
+          new IngestionOtelStats(localRepo, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, false, false);
       statsDisabled.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
       /*
        * Register a task with a non-trivial active-key-count so that, if the ASYNC_GAUGE were
@@ -178,7 +179,9 @@ public class IngestionOtelStatsTest {
       when(probeTask.getActiveKeyCount(any(ReplicaType.class))).thenReturn(42L);
       statsDisabled.setIngestionTask(CURRENT_VERSION, probeTask);
       // Recorder must be a safe no-op so producers can call it without checking the flag.
-      statsDisabled.recordActiveKeyCountInvalidation(CURRENT_VERSION);
+      statsDisabled.recordActiveKeyCountInvalidation(
+          CURRENT_VERSION,
+          ActiveKeyCountInvalidationReason.LEADER_PROPAGATED_INVALIDATION);
 
       Collection<MetricData> metrics = localReader.collectAllMetrics();
       assertFalse(
@@ -206,8 +209,15 @@ public class IngestionOtelStatsTest {
             .setEmitOtelMetrics(false)
             .setOtelAdditionalMetricsReader(inMemoryMetricReader)
             .build())) {
-      IngestionOtelStats stats =
-          new IngestionOtelStats(disabledMetricsRepository, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, true);
+      IngestionOtelStats stats = new IngestionOtelStats(
+          disabledMetricsRepository,
+          STORE_NAME,
+          CLUSTER_NAME,
+          LOCAL_REGION,
+          true,
+          true,
+          true,
+          true);
       assertFalse(stats.emitOtelMetrics(), "OTel metrics should be disabled when global OTel is off");
     }
   }
@@ -220,8 +230,15 @@ public class IngestionOtelStatsTest {
             .setEmitOtelMetrics(true)
             .setOtelAdditionalMetricsReader(inMemoryMetricReader)
             .build())) {
-      IngestionOtelStats stats =
-          new IngestionOtelStats(enabledMetricsRepository, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, false, true, true);
+      IngestionOtelStats stats = new IngestionOtelStats(
+          enabledMetricsRepository,
+          STORE_NAME,
+          CLUSTER_NAME,
+          LOCAL_REGION,
+          false,
+          true,
+          true,
+          true);
       assertFalse(stats.emitOtelMetrics(), "OTel metrics should be disabled when ingestion override is off");
     }
   }
@@ -230,7 +247,7 @@ public class IngestionOtelStatsTest {
   public void testConstructorWithNonVeniceMetricsRepository() {
     MetricsRepository regularRepository = new MetricsRepository();
     IngestionOtelStats stats =
-        new IngestionOtelStats(regularRepository, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, true);
+        new IngestionOtelStats(regularRepository, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, true, true);
     assertFalse(stats.emitOtelMetrics(), "OTel metrics should be disabled for non-Venice repository");
 
     // RT recording methods should not throw when baseDimensionsMap is null
@@ -1010,8 +1027,15 @@ public class IngestionOtelStatsTest {
             .setEmitOtelMetrics(false)
             .setOtelAdditionalMetricsReader(disabledMetricReader)
             .build())) {
-      IngestionOtelStats stats =
-          new IngestionOtelStats(disabledMetricsRepository, STORE_NAME, CLUSTER_NAME, LOCAL_REGION, true, true, true);
+      IngestionOtelStats stats = new IngestionOtelStats(
+          disabledMetricsRepository,
+          STORE_NAME,
+          CLUSTER_NAME,
+          LOCAL_REGION,
+          true,
+          true,
+          true,
+          true);
       stats.updateVersionInfo(CURRENT_VERSION, FUTURE_VERSION);
       stats.recordRecordsConsumed(CURRENT_VERSION, ReplicaType.LEADER, 10);
       stats.recordIngestionTime(CURRENT_VERSION, 50.0);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -122,6 +122,9 @@ public enum VeniceMetricsDimensions {
   /** {@link VeniceIngestionFailureReason} Categorized reason for ingestion failure */
   VENICE_INGESTION_FAILURE_REASON("venice.ingestion.failure.reason"),
 
+  /** {@code ActiveKeyCountInvalidationReason} Cause of an active-key-count tracking invalidation */
+  VENICE_ACTIVE_KEY_COUNT_INVALIDATION_REASON("venice.active_key_count.invalidation_reason"),
+
   /** {@link VeniceChunkingStatus} */
   VENICE_CHUNKING_STATUS("venice.chunking.status"),
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -124,6 +124,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_INGESTION_FAILURE_REASON:
           assertEquals(dimension.getDimensionName(format), "venice.ingestion.failure.reason");
           break;
+        case VENICE_ACTIVE_KEY_COUNT_INVALIDATION_REASON:
+          assertEquals(dimension.getDimensionName(format), "venice.active_key_count.invalidation_reason");
+          break;
         case VENICE_CHUNKING_STATUS:
           assertEquals(dimension.getDimensionName(format), "venice.chunking.status");
           break;
@@ -312,6 +315,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_INGESTION_FAILURE_REASON:
           assertEquals(dimension.getDimensionName(format), "venice.ingestion.failure.reason");
           break;
+        case VENICE_ACTIVE_KEY_COUNT_INVALIDATION_REASON:
+          assertEquals(dimension.getDimensionName(format), "venice.activeKeyCount.invalidationReason");
+          break;
         case VENICE_CHUNKING_STATUS:
           assertEquals(dimension.getDimensionName(format), "venice.chunking.status");
           break;
@@ -499,6 +505,9 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_INGESTION_FAILURE_REASON:
           assertEquals(dimension.getDimensionName(format), "Venice.Ingestion.Failure.Reason");
+          break;
+        case VENICE_ACTIVE_KEY_COUNT_INVALIDATION_REASON:
+          assertEquals(dimension.getDimensionName(format), "Venice.ActiveKeyCount.InvalidationReason");
           break;
         case VENICE_CHUNKING_STATUS:
           assertEquals(dimension.getDimensionName(format), "Venice.Chunking.Status");

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -3486,6 +3486,19 @@ public class ConfigKeys {
       "server.active.key.count.for.hybrid.store.enabled";
 
   /**
+   * Enables the active-key-count consistency check across replicas. When ON, the A/A leader attaches the
+   * {@code lkc} header carrying its current active key count on every VT heartbeat, and the follower
+   * compares it against its own count when processing the heartbeat. A divergence bumps the diagnostic
+   * {@code ingestion.key.active_count_mismatch_across_replicas} metric and emits a rate-limited WARN log;
+   * the follower's count is NOT invalidated (the check is observation-only during rollout).
+   *
+   * <p>Requires {@link #SERVER_ACTIVE_KEY_COUNT_FOR_HYBRID_STORE_ENABLED} — if hybrid tracking itself is off,
+   * there is no count to compare. Default: {@code false} (opt-in rollout).
+   */
+  public static final String SERVER_ACTIVE_KEY_COUNT_REPLICA_CONSISTENCY_CHECK_ENABLED =
+      "server.active.key.count.replica.consistency.check.enabled";
+
+  /**
    * Partial-update results larger than this threshold (in bytes) are tracked in the per-partition heavy-key map
    * for amplification detection. Default: 100 KB.
    */

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
@@ -48,6 +48,22 @@ public class PubSubMessageHeaders implements Measurable, Iterable<PubSubMessageH
    */
   public static final long PRC_HEADER_UNAVAILABLE_SENTINEL = -1L;
 
+  /**
+   * VT data-record header: single byte carrying {@code +1} (key created), {@code -1} (key deleted),
+   * or {@code 0} (invalidate). Absent = no change. Produced by A/A leader during DCR, consumed by
+   * followers to maintain a per-partition active-key-count.
+   */
+  public static final String VENICE_KEY_COUNT_SIGNAL_HEADER = "kcs";
+
+  /**
+   * VT heartbeat header: 8-byte long carrying the leader's active-key-count at heartbeat-emission
+   * time. Followers compare against their own count when processing the heartbeat — by VT
+   * ordering, all {@link #VENICE_KEY_COUNT_SIGNAL_HEADER} signals on records prior to this heartbeat
+   * have already been applied, so a difference indicates divergence across replicas. Absent = leader
+   * not tracking or feature disabled; follower skips comparison.
+   */
+  public static final String VENICE_LEADER_KEY_COUNT_HEADER = "lkc";
+
   public PubSubMessageHeaders add(PubSubMessageHeader header) {
     headers.put(header.key(), header);
     return this;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -2588,22 +2588,57 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       boolean addLeaderCompleteState,
       LeaderCompleteState leaderCompleteState,
       long originTimeStampMs) {
+    return sendHeartbeat(
+        topicPartition,
+        callback,
+        leaderMetadataWrapper,
+        addLeaderCompleteState,
+        leaderCompleteState,
+        originTimeStampMs,
+        null);
+  }
+
+  /**
+   * Heartbeat variant that allows a single extra {@link PubSubMessageHeader} to be attached after the headers
+   * computed by {@link #getHeaders}. Used to carry the leader's active-key-count on the heartbeat — see
+   * {@link PubSubMessageHeaders#VENICE_LEADER_KEY_COUNT_HEADER}. {@code extraHeader} may be {@code null}, in which
+   * case behaviour is identical to the no-extra-header overload (no allocation on the existing call sites).
+   */
+  public CompletableFuture<PubSubProduceResult> sendHeartbeat(
+      PubSubTopicPartition topicPartition,
+      PubSubProducerCallback callback,
+      LeaderMetadataWrapper leaderMetadataWrapper,
+      boolean addLeaderCompleteState,
+      LeaderCompleteState leaderCompleteState,
+      long originTimeStampMs,
+      PubSubMessageHeader extraHeader) {
     if (isClosed) {
       logger.warn("VeniceWriter already closed for topic-partition: {}", topicPartition);
       return CompletableFuture.completedFuture(null);
     }
     KafkaMessageEnvelope kafkaMessageEnvelope =
         getHeartbeatKME(originTimeStampMs, leaderMetadataWrapper, heartBeatMessage, writerId);
+    PubSubMessageHeaders headers = getHeaders(
+        kafkaMessageEnvelope.getProducerMetadata(),
+        addLeaderCompleteState,
+        leaderCompleteState,
+        EmptyPubSubMessageHeaders.SINGLETON);
+    if (extraHeader != null) {
+      /*
+       * getHeaders may return the immutable EmptyPubSubMessageHeaders singleton when nothing was added — promote
+       * to a fresh mutable instance before appending so we don't trip the singleton's UnsupportedOperationException.
+       */
+      if (headers instanceof EmptyPubSubMessageHeaders) {
+        headers = new PubSubMessageHeaders();
+      }
+      headers.add(extraHeader);
+    }
     return producerAdapter.sendMessage(
         topicPartition.getPubSubTopic().getName(),
         topicPartition.getPartitionNumber(),
         KafkaKey.HEART_BEAT,
         kafkaMessageEnvelope,
-        getHeaders(
-            kafkaMessageEnvelope.getProducerMetadata(),
-            addLeaderCompleteState,
-            leaderCompleteState,
-            EmptyPubSubMessageHeaders.SINGLETON),
+        headers,
         callback);
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -580,6 +580,110 @@ public class VeniceWriterUnitTest {
   }
 
   /**
+   * Verifies the {@code extraHeader} overload of {@link VeniceWriter#sendHeartbeat} attaches the caller's header
+   * to the {@link PubSubMessageHeaders} forwarded to the producer adapter — this is the wire path for the
+   * {@code lkc} leader active key count header consumed by {@code compareLeaderActiveKeyCountOnHeartbeat}.
+   *
+   * <p>Covers two configurations to exercise both branches of the singleton-promotion in the writer:
+   * <ul>
+   *   <li>{@code addLeaderCompleteState=false}: {@code getHeaders} returns the immutable
+   *       {@link EmptyPubSubMessageHeaders} singleton — writer must promote to a mutable instance before
+   *       appending {@code lkc}, else the singleton's {@code add} throws.</li>
+   *   <li>{@code addLeaderCompleteState=true}: {@code getHeaders} already returns a mutable instance with the
+   *       LCS + VTP headers; appending {@code lkc} should work directly without allocation.</li>
+   * </ul>
+   */
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testSendHeartbeatWithExtraHeader(boolean addLeaderCompleteState) {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    CompletableFuture mockedFuture = mock(CompletableFuture.class);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
+    String stringSchema = "\"string\"";
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
+    String testTopic = "test_vt_v1";
+    VeniceWriterOptions opts = new VeniceWriterOptions.Builder(testTopic).setKeyPayloadSerializer(serializer)
+        .setValuePayloadSerializer(serializer)
+        .setWriteComputePayloadSerializer(serializer)
+        .setPartitioner(new DefaultVenicePartitioner())
+        .setTime(SystemTime.INSTANCE)
+        .setPartitionCount(1)
+        .build();
+    VeniceWriter<Object, Object, Object> writer =
+        new VeniceWriter(opts, new VeniceProperties(new Properties()), mockedProducer);
+    PubSubTopic topic = mock(PubSubTopic.class);
+    when(topic.getName()).thenReturn(testTopic);
+    PubSubTopicPartition topicPartition = mock(PubSubTopicPartition.class);
+    when(topicPartition.getPubSubTopic()).thenReturn(topic);
+    when(topicPartition.getPartitionNumber()).thenReturn(0);
+
+    PubSubMessageHeader extra = new PubSubMessageHeader("lkc", new byte[] { 0, 0, 0, 0, 0, 0, 0, 42 });
+    writer.sendHeartbeat(
+        topicPartition,
+        null,
+        DEFAULT_LEADER_METADATA_WRAPPER,
+        addLeaderCompleteState,
+        LEADER_COMPLETED,
+        System.currentTimeMillis(),
+        extra);
+
+    ArgumentCaptor<PubSubMessageHeaders> headersCap = ArgumentCaptor.forClass(PubSubMessageHeaders.class);
+    verify(mockedProducer).sendMessage(eq(testTopic), eq(0), any(), any(), headersCap.capture(), any());
+    PubSubMessageHeader captured = headersCap.getValue().get("lkc");
+    assertNotNull(captured, "lkc header must be forwarded to the producer adapter");
+    assertEquals(captured.value(), extra.value());
+    /*
+     * The HB KME always has segmentNumber=0 + messageSequenceNumber=0, so getHeaders always attaches the
+     * VENICE_TRANSPORT_PROTOCOL_HEADER (vtp). Without LCS we expect vtp + lkc; with LCS, vtp + lcs + lkc.
+     */
+    assertNotNull(headersCap.getValue().get(VENICE_TRANSPORT_PROTOCOL_HEADER));
+    assertEquals(headersCap.getValue().toList().size(), addLeaderCompleteState ? 3 : 2);
+  }
+
+  /**
+   * Sanity test that the new 7-arg overload behaves exactly like the original 6-arg overload when {@code extraHeader}
+   * is {@code null} — guards against future regressions that change header layout on the legacy code paths.
+   */
+  @Test
+  public void testSendHeartbeatWithNullExtraHeaderMatchesLegacy() {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    CompletableFuture mockedFuture = mock(CompletableFuture.class);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
+    String stringSchema = "\"string\"";
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
+    String testTopic = "test_rt";
+    VeniceWriterOptions opts = new VeniceWriterOptions.Builder(testTopic).setKeyPayloadSerializer(serializer)
+        .setValuePayloadSerializer(serializer)
+        .setWriteComputePayloadSerializer(serializer)
+        .setPartitioner(new DefaultVenicePartitioner())
+        .setTime(SystemTime.INSTANCE)
+        .setPartitionCount(1)
+        .build();
+    VeniceWriter<Object, Object, Object> writer =
+        new VeniceWriter(opts, new VeniceProperties(new Properties()), mockedProducer);
+    PubSubTopic topic = mock(PubSubTopic.class);
+    when(topic.getName()).thenReturn(testTopic);
+    PubSubTopicPartition topicPartition = mock(PubSubTopicPartition.class);
+    when(topicPartition.getPubSubTopic()).thenReturn(topic);
+    when(topicPartition.getPartitionNumber()).thenReturn(0);
+
+    writer.sendHeartbeat(
+        topicPartition,
+        null,
+        DEFAULT_LEADER_METADATA_WRAPPER,
+        false,
+        LEADER_NOT_COMPLETED,
+        System.currentTimeMillis(),
+        null);
+
+    ArgumentCaptor<PubSubMessageHeaders> headersCap = ArgumentCaptor.forClass(PubSubMessageHeaders.class);
+    verify(mockedProducer).sendMessage(eq(testTopic), eq(0), any(), any(), headersCap.capture(), any());
+    // Legacy behaviour: only the auto-attached vtp header on the first HB, no lkc.
+    assertNull(headersCap.getValue().get("lkc"));
+    assertNotNull(headersCap.getValue().get(VENICE_TRANSPORT_PROTOCOL_HEADER));
+    assertEquals(headersCap.getValue().toList().size(), 1);
+  }
+
+  /**
    * Regression test for the missing-vtp DoL stamp bug. {@link VeniceWriter#sendDoLStamp} used to
    * call {@link PubSubProducerAdapter#sendMessage} with {@link EmptyPubSubMessageHeaders#SINGLETON}
    * directly, bypassing {@code getHeaders} — so a fresh-leader DoL on a brand-new version topic


### PR DESCRIPTION
## Problem Statement

In an A/A hybrid store, the active key count on a partition is tracked independently on the leader (which produces to the version topic) and on each follower (which consumes from the version topic and re-applies the leader-stamped `kcs` signal). Today there is no operator-visible signal when the two views diverge — a kcs signal lost in flight, mis-stamped on the wire, or mis-applied on the follower would silently corrupt the follower's count and only surface much later via downstream symptoms.

We need a non-intrusive, observation-only consistency check that operators can enable per cluster and that emits a dashboard signal when leader and follower disagree.

## Solution

When the new consistency check is enabled, the A/A leader attaches an `lkc` (leader key count) PubSub header to every VT heartbeat carrying its current `activeKeyCount`. Followers consuming that heartbeat compare lkc against their own count and, on mismatch, record `ingestion.key.active_count_mismatch_across_replicas` (both Tehuti and OTel) plus a rate-limited WARN log. **The follower's count is NOT invalidated** — the check is diagnostic-only during rollout.

Key design points:

- **Gating.** New config `server.active.key.count.replica.consistency.check.enabled` (default `false`). The `VeniceServerConfig` accessor ANDs it with `isActiveKeyCountForHybridStoreEnabled()` so sensor registration and recording sites can't drift.
- **Ordering.** `PartitionConsumptionState.lastVTProduceCallFuture` switched from a `volatile CompletableFuture` to a `final AtomicReference<CompletableFuture<Void>>` with an atomic `swapLastVTProduceCallFuture(next)` that returns the prior head and rejects null. `sendIngestionHeartbeatToVT` chains the HB send behind the previous chain entry so the lkc lands at the broker after preceding view-writer data writes.
- **Capture lkc on SIT.** The lkc value is read synchronously on the SIT thread BEFORE the swap and closed over the chained-callback lambda. Reading from inside the deferred callback would observe later SIT increments for records queued AFTER this HB and produce false-positive mismatches.
- **Chain failure propagation.** The chained callback skips the HB on prior chain failure (the HB would stamp records that never landed) and surfaces synchronous `sendIngestionHeartbeat` failures into the chain head. Async broker rejections are logged separately and don't gate the chain — matches `queueUpVersionTopicWritesWithViewWriters` enqueue-completion semantics.
- **Robust shutdown.** `closeVeniceViewWriters` now short-circuits the chain head unconditionally so hybrid A/A configs without view writers (which can still grow the chain via the HB swap) don't leave a pending head orphaned at close. `checkAndWaitForLastVTProduceFuture` bounds the EOP-time wait with `VIEW_WRITER_CLOSE_TIMEOUT_IN_MS` and surfaces `TimeoutException` with explicit attribution at the caller.
- **Tighter decode.** `decodeLeaderKeyCountHeaderValue` throws `IllegalArgumentException` on wrong-length payloads instead of returning a `Long.MIN_VALUE` sentinel that would collide with a legitimately round-trippable value.
- **Invalidation reason as dimension.** `ActiveKeyCountInvalidationReason` now implements `VeniceDimensionInterface` and is wired as a dimension on the existing `ingestion.key.active_count_invalidation` metric. Three corruption variants were renamed for clarity: `CORRUPT_KCS_SIGNAL_VALUE → CORRUPT_KEY_COUNT_SIGNAL_HEADER_VALUE`, `CORRUPT_KCS_HEADER_LENGTH → CORRUPT_KEY_COUNT_SIGNAL_HEADER_LENGTH`, and a new `CORRUPT_LEADER_KEY_COUNT_HEADER_LENGTH` for malformed lkc. The enum guards `getMessage` vs `getMessage(int)` against mismatched overload usage via a constructor-computed `templateWithExtraData` flag.
- **VeniceWriter API.** `VeniceWriter.sendHeartbeat` gained a 7-arg overload that attaches an optional extra PubSub header. The 6-arg overload still exists and delegates to the 7-arg with `null`. Tests migrated to the 7-arg stub; production calls the 7-arg form unconditionally. `EmptyPubSubMessageHeaders` is promoted to a fresh mutable instance before appending the extra header.
- **Wire constants.** `PubSubMessageHeaders.VENICE_KEY_COUNT_SIGNAL_HEADER` (kcs) and `VENICE_LEADER_KEY_COUNT_HEADER` (lkc).

###  Code changes
- [x] Added new code behind **a config**. Feature flag: `server.active.key.count.replica.consistency.check.enabled` (default `false`). Effective only when `server.active.key.count.for.hybrid.store.enabled=true` is also on.
- [x] Introduced new **log lines**.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging. The new mismatch WARN goes through `REDUNDANT_LOGGING_FILTER`; the new HB-chain-stall ERROR re-uses the existing close/EOP error path.

###  **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. The chain head is an `AtomicReference` with `getAndSet` linearization; the lkc value is captured on SIT before the swap so deferred callbacks don't observe later increments; chain failures propagate to downstream waiters.
- [x] Proper **synchronization mechanisms** used where needed (atomic swap on the chain head; existing sensor synchronization unchanged).
- [x] No **blocking calls** inside critical sections. The new bounded EOP wait caps its `.get(...)` at `VIEW_WRITER_CLOSE_TIMEOUT_IN_MS` so a stuck common-pool callback can't hang ingestion.
- [x] Verified **thread-safe collections** are used (existing `VeniceConcurrentHashMap` for per-partition state; `AtomicReference` for the chain head).
- [x] Validated proper exception handling in multi-threaded code. The `whenCompleteAsync` callback wraps the send in a `try/catch (Throwable)`; the setup is wrapped in `try/finally` with a `callbackScheduled` guard so a registration-time throw still completes the chain head exceptionally.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (default-off; existing kcs path unchanged; 6-arg `VeniceWriter.sendHeartbeat` retained).

Coverage highlights:

- `ActiveKeyCountHeartbeatTest`: encode/decode round-trip including `Long.MIN_VALUE` / `MAX_VALUE`; `buildLeaderActiveKeyCountHeader` gating (check disabled, pre-EOP, untracked, null PCS, happy path); `compareLeaderActiveKeyCountOnHeartbeat` branches (disabled, pre-EOP, follower not tracking, header absent, leader sentinel, match, mismatch, corrupt length); `sendIngestionHeartbeatToVT` ordering, upstream-failure propagation, sync send-failure propagation.
- `ActiveKeyCountInvalidationReasonTest`: dimension fixture for all 7 enum values.
- `ActiveKeyCountScenarioTest`: end-to-end Tehuti+OTel parity for both `recordActiveKeyCountInvalidation` and `recordActiveKeyCountMismatchAcrossReplicas`, plus cross-system isolation.
- `PartitionConsumptionStateTest`: 32-thread chain atomicity test for `swapLastVTProduceCallFuture`; null-arg NPE test.
- `LeaderFollowerStoreIngestionTaskTest`: bounded EOP-wait timeout, empty-view-writers + pending chain head short-circuit, view-writer/CM-write chain-failure-propagation tests.
- `IngestionOtelMetricEntityTest` / `IngestionOtelStatsTest` / `ServerMetricEntityTest` / `VeniceMetricsDimensionsTest`: updated for the new dimension and the new mismatch metric entity.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.

The feature is gated behind a new config that defaults to `false`. With the flag off, behavior is identical to before the PR (the only observable change is the rename of three internal enum constants on the existing invalidation metric's new dimension, and the new dimension itself only appears when `isActiveKeyCountForHybridStoreEnabled` operators consume that metric).
