### PR TITLE
[fast-client][thin-client] Route single-key batchGet through single-GET path'

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
@@ -297,6 +297,11 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
       BatchGetRequestContext<K, V> requestContext,
       Set<K> keys,
       StreamingCallback<K, V> callback) {
+    if (keys.size() == 1) {
+      streamingBatchGetForSingleKey(keys.iterator().next(), callback);
+      return;
+    }
+
     multiKeyStreamingRequest(
         requestContext,
         RequestType.MULTI_GET_STREAMING,

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/InternalAvroStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/InternalAvroStoreClient.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.client.store.streaming.VeniceResponseCompletableFutur
 import com.linkedin.venice.client.store.streaming.VeniceResponseMap;
 import com.linkedin.venice.client.store.streaming.VeniceResponseMapImpl;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
+import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -52,6 +53,7 @@ public abstract class InternalAvroStoreClient<K, V> implements AvroGenericReadCo
    * long-tail retry on 1-key batch gets.
    */
   protected final void streamingBatchGetForSingleKey(K key, StreamingCallback<K, V> callback) {
+    getClientConfig().getStats(RequestType.MULTI_GET_STREAMING).recordBatchGetRoutedToSingleGetRequest();
     get(key).whenComplete((value, throwable) -> {
       if (throwable != null) {
         callback.onCompletion(Optional.of(toException(throwable)));

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/InternalAvroStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/InternalAvroStoreClient.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -38,6 +39,25 @@ public abstract class InternalAvroStoreClient<K, V> implements AvroGenericReadCo
   }
 
   protected abstract CompletableFuture<V> get(GetRequestContext<K> requestContext, K key) throws VeniceClientException;
+
+  protected final void streamingBatchGetForSingleKey(K key, StreamingCallback<K, V> callback) {
+    get(key).whenComplete((value, throwable) -> {
+      if (throwable != null) {
+        callback.onCompletion(Optional.of(toException(throwable)));
+        return;
+      }
+      callback.onRecordReceived(key, value);
+      callback.onCompletion(Optional.empty());
+    });
+  }
+
+  private static Exception toException(Throwable throwable) {
+    Throwable unwrappedThrowable =
+        throwable instanceof CompletionException && throwable.getCause() != null ? throwable.getCause() : throwable;
+    return unwrappedThrowable instanceof Exception
+        ? (Exception) unwrappedThrowable
+        : new VeniceClientException(unwrappedThrowable);
+  }
 
   @Override
   public final CompletableFuture<Map<K, V>> batchGet(Set<K> keys) throws VeniceClientException {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/InternalAvroStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/InternalAvroStoreClient.java
@@ -40,6 +40,17 @@ public abstract class InternalAvroStoreClient<K, V> implements AvroGenericReadCo
 
   protected abstract CompletableFuture<V> get(GetRequestContext<K> requestContext, K key) throws VeniceClientException;
 
+  /**
+   * Serves a single-key batchGet/streamingBatchGet by issuing a single-GET request instead of a multi-get
+   * streaming request.
+   *
+   * NOTE: this changes the request type seen by the server from a (streaming) multi-get to a single-get. That
+   * shifts server-side routing, read-quota accounting (single-get and batch-get quotas are tracked/throttled
+   * separately) and per-request-type server metrics for these 1-key requests. It also means the request follows
+   * the single-get long-tail retry configuration rather than the batch-get one (see
+   * {@link RetriableAvroGenericStoreClient#get}); a store that enabled only batch-get long-tail retry will get no
+   * long-tail retry on 1-key batch gets.
+   */
   protected final void streamingBatchGetForSingleKey(K key, StreamingCallback<K, V> callback) {
     get(key).whenComplete((value, throwable) -> {
       if (throwable != null) {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
@@ -260,6 +260,9 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
       Set<K> keys,
       StreamingCallback<K, V> callback) throws VeniceClientException {
     if (keys.size() == 1) {
+      // Single-key batchGet is served via single-GET, so it follows the single-get long-tail retry config (this
+      // class's #get) rather than the batch-get retry threshold below. A store with only batch-get long-tail retry
+      // enabled gets no long-tail retry on 1-key batch gets. See #streamingBatchGetForSingleKey for details.
       streamingBatchGetForSingleKey(keys.iterator().next(), callback);
       return;
     }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
@@ -259,6 +259,11 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
       BatchGetRequestContext<K, V> requestContext,
       Set<K> keys,
       StreamingCallback<K, V> callback) throws VeniceClientException {
+    if (keys.size() == 1) {
+      streamingBatchGetForSingleKey(keys.iterator().next(), callback);
+      return;
+    }
+
     int longTailRetryThresholdForBatchGetInMicroSeconds =
         getLongTailRetryThresholdForBatchGetInMicroSeconds(keys.size());
     retryStreamingMultiKeyRequest(

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/FastClientMetricEntity.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/FastClientMetricEntity.java
@@ -25,6 +25,16 @@ public enum FastClientMetricEntity implements ModuleMetricEntityInterface {
   ),
 
   /**
+   * Count of batch-get/streaming-batch-get requests that contained a single key and were therefore
+   * served via a single-GET lookup.
+   */
+  BATCH_GET_SINGLE_KEY_REROUTE_COUNT(
+      "request.batch_get_routed_to_single_get_count", MetricType.COUNTER, MetricUnit.NUMBER,
+      "Count of single-key batch-get requests served via a single-GET lookup",
+      setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_REQUEST_METHOD)
+  ),
+
+  /**
    * Metadata staleness watermark reported asynchronously in milliseconds.
    */
   METADATA_STALENESS_DURATION(

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/FastClientStats.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/FastClientStats.java
@@ -51,6 +51,8 @@ public class FastClientStats extends ClientStats {
 
   private final Sensor leakedRequestCountSensor;
   private volatile MetricEntityStateOneEnum<RejectionReason> rejectionRatio;
+  /** Counts batch-get requests that contained a single key and were therefore served via a single-GET lookup. */
+  private volatile MetricEntityStateBase batchGetRoutedToSingleGetRequestCount;
 
   // OTel metrics
   private volatile MetricEntityStateOneEnum<RequestRetryType> longTailRetry;
@@ -156,6 +158,15 @@ public class FastClientStats extends ClientStats {
         otelRepository,
         this::registerSensor,
         FastClientTehutiMetricName.RETRY_REQUEST_WIN,
+        Collections.singletonList(new OccurrenceRate()),
+        baseDimensionsMap,
+        getBaseAttributes());
+
+    this.batchGetRoutedToSingleGetRequestCount = MetricEntityStateBase.create(
+        FastClientMetricEntity.BATCH_GET_SINGLE_KEY_REROUTE_COUNT.getMetricEntity(),
+        otelRepository,
+        this::registerSensor,
+        FastClientTehutiMetricName.BATCH_GET_ROUTED_TO_SINGLE_GET_REQUEST_COUNT,
         Collections.singletonList(new OccurrenceRate()),
         baseDimensionsMap,
         getBaseAttributes());
@@ -271,6 +282,14 @@ public class FastClientStats extends ClientStats {
   }
 
   /**
+   * Records a batch-get/streaming-batch-get request that contained a single key and was therefore short-circuited
+   * to a single-GET lookup (see {@code InternalAvroStoreClient#streamingBatchGetForSingleKey}).
+   */
+  public void recordBatchGetRoutedToSingleGetRequest() {
+    batchGetRoutedToSingleGetRequestCount.record(1);
+  }
+
+  /**
    * This method is a utility method to build concise summaries useful in tests
    * and for logging. It generates a single string for all metrics for a sensor
    * @return
@@ -308,6 +327,7 @@ public class FastClientStats extends ClientStats {
    */
   public enum FastClientTehutiMetricName implements TehutiMetricNameEnum {
     LONG_TAIL_RETRY_REQUEST, ERROR_RETRY_REQUEST, RETRY_REQUEST_WIN, METADATA_STALENESS_HIGH_WATERMARK_MS, FANOUT_SIZE,
-    RETRY_FANOUT_SIZE, NO_AVAILABLE_REPLICA_REQUEST_COUNT, REJECTED_REQUEST_COUNT_BY_LOAD_CONTROLLER, REJECTION_RATIO
+    RETRY_FANOUT_SIZE, NO_AVAILABLE_REPLICA_REQUEST_COUNT, REJECTED_REQUEST_COUNT_BY_LOAD_CONTROLLER, REJECTION_RATIO,
+    BATCH_GET_ROUTED_TO_SINGLE_GET_REQUEST_COUNT
   }
 }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientUnitTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientUnitTest.java
@@ -89,6 +89,15 @@ public class BatchGetAvroStoreClientUnitTest {
         client.getSimulatorCompleteFuture());
 
     validateMetrics(client, 1, 1, 0, 0);
+
+    // The single-key batch-get should be counted as routed to a single-GET lookup.
+    Map<String, ? extends Metric> metrics = getStats(client.getClientConfig());
+    assertTrue(
+        metrics
+            .get(
+                "." + client.UNIT_TEST_STORE_NAME
+                    + "--multiget_streaming_batch_get_routed_to_single_get_request_count.OccurrenceRate")
+            .value() > 0);
   }
 
   /**

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientUnitTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientUnitTest.java
@@ -108,8 +108,10 @@ public class BatchGetAvroStoreClientUnitTest {
       throws InterruptedException, ExecutionException, TimeoutException {
 
     TestClientSimulator client = new TestClientSimulator();
-    client.generateKeyValues(0, 2)
-        .partitionKeys(2)
+    // Use >=5 keys on a single partition so this stays a multi-get request (a 1-key batch-get is served via
+    // single-GET) while still exercising the batch-get timeout path on a single route.
+    client.generateKeyValues(0, 5)
+        .partitionKeys(1)
         .assignRouteToPartitions("https://host1.linkedin.com", 0)
         .expectRequestWithKeysForPartitionOnRoute(1, 1, "https://host1.linkedin.com", 0)
         .respondToRequestWithKeyValues((int) CLIENT_TIME_OUT_IN_SECONDS * 2 * 1000, 1)

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientUnitTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientUnitTest.java
@@ -71,6 +71,26 @@ public class BatchGetAvroStoreClientUnitTest {
     validateMetrics(client, 1000, 1000, 0, 0);
   }
 
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testSingleKeyStreamingBatchGetUsesSingleGet()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    TestClientSimulator client = new TestClientSimulator();
+    client.generateKeyValues(0, 1)
+        .setLongTailRangeBasedRetryThresholdForBatchGetInMilliSeconds("1-:10000")
+        .partitionKeys(1)
+        .assignRouteToPartitions("https://host1.linkedin.com", 0)
+        .expectSingleGetRequestWithKeyForPartitionOnRoute(1, 1, "https://host1.linkedin.com", 0)
+        .respondToRequestWithKeyValues(5, 1)
+        .simulate();
+
+    callStreamingBatchGetAndVerifyResults(
+        client.getFastClient(),
+        client.getRequestedKeyValues(),
+        client.getSimulatorCompleteFuture());
+
+    validateMetrics(client, 1, 1, 0, 0);
+  }
+
   /**
    * Error case: Timeout due to response taking a longer time than the simulator's allowed timeout.
    */

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
@@ -43,6 +43,7 @@ import com.linkedin.venice.fastclient.meta.StoreMetadata;
 import com.linkedin.venice.fastclient.transport.TransportClientResponseForRoute;
 import com.linkedin.venice.fastclient.utils.ClientTestUtils;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
 import com.linkedin.venice.router.exception.VeniceKeyCountLimitException;
@@ -90,6 +91,14 @@ public class DispatchingAvroGenericStoreClientTest {
   private static final Set<String> BATCH_GET_KEYS = new HashSet<>();
   private static final Set<String> BATCH_GET_PARTIAL_KEYS_1 = new HashSet<>();
   private static final Set<String> BATCH_GET_PARTIAL_KEYS_2 = new HashSet<>();
+  /**
+   * Multi-key (>=5 keys) batch-get requests whose keys all route to the same single replica as
+   * {@code test_key_1} / {@code test_key_2} respectively. Used by the route-blocking tests so that a single-route
+   * batch-get stays on the multi-get path (a 1-key batch-get is now served via single-GET) while still blocking
+   * exactly one replica.
+   */
+  private static final Set<String> BATCH_GET_BLOCK_KEYS_REPLICA1 = new HashSet<>();
+  private static final Set<String> BATCH_GET_BLOCK_KEYS_REPLICA2 = new HashSet<>();
   private static final Map<String, GenericRecord> BATCH_GET_VALUE_RESPONSE = new HashMap<>();
   private static final RecordSerializer VALUE_SERIALIZER =
       FastSerializerDeserializerFactory.getFastAvroGenericSerializer(STORE_VALUE_SCHEMA);
@@ -119,6 +128,8 @@ public class DispatchingAvroGenericStoreClientTest {
     BATCH_GET_KEYS.add("test_key_2");
     BATCH_GET_PARTIAL_KEYS_1.add("test_key_1");
     BATCH_GET_PARTIAL_KEYS_2.add("test_key_2");
+    BATCH_GET_BLOCK_KEYS_REPLICA1.addAll(generateKeysForSamePartition("test_key_1", 5));
+    BATCH_GET_BLOCK_KEYS_REPLICA2.addAll(generateKeysForSamePartition("test_key_2", 5));
     GenericRecord value1 = (GenericRecord) rrg.randomGeneric(STORE_VALUE_SCHEMA);
     GenericRecord value2 = (GenericRecord) rrg.randomGeneric(STORE_VALUE_SCHEMA);
     BATCH_GET_VALUE_RESPONSE.put("test_key_1", value1);
@@ -137,6 +148,28 @@ public class DispatchingAvroGenericStoreClientTest {
     projectionResultForKey2.put("name", "TEST_NAME_2");
     projectionResultForKey2.put(VENICE_COMPUTATION_ERROR_MAP_FIELD_NAME, Collections.emptyMap());
     COMPUTE_REQUEST_VALUE_RESPONSE.put("test_key_2", projectionResultForKey2);
+  }
+
+  /**
+   * Generates {@code count} keys that all route to the same partition (hence the same single replica, since the
+   * test metadata has one replica per partition) as {@code anchorKey}. This lets the route-blocking tests issue a
+   * multi-key batch-get that fans out to exactly one replica, since a 1-key batch-get is now served via single-GET.
+   * Mirrors the client's partitioning: FastAvro key serialization + {@link DefaultVenicePartitioner} over 2 partitions.
+   */
+  private static Set<String> generateKeysForSamePartition(String anchorKey, int count) {
+    RecordSerializer<Object> keySerializer =
+        FastSerializerDeserializerFactory.getFastAvroGenericSerializer(AvroCompatibilityHelper.parse(KEY_SCHEMA));
+    DefaultVenicePartitioner partitioner = new DefaultVenicePartitioner();
+    int numPartitions = 2;
+    int targetPartition = partitioner.getPartitionId(keySerializer.serialize(anchorKey), numPartitions);
+    Set<String> keys = new HashSet<>();
+    for (int candidate = 0; keys.size() < count; candidate++) {
+      String key = anchorKey + "_block_" + candidate;
+      if (partitioner.getPartitionId(keySerializer.serialize(key), numPartitions) == targetPartition) {
+        keys.add(key);
+      }
+    }
+    return keys;
   }
 
   private void setUpClient() throws InterruptedException {
@@ -394,6 +427,27 @@ public class DispatchingAvroGenericStoreClientTest {
         numBlockedReplicas);
   }
 
+  private void validateMultiGetMetrics(
+      BatchGetRequestContext batchGetRequestContext,
+      boolean healthyRequest,
+      boolean partialHealthyRequest,
+      RequestType requestType,
+      boolean noAvailableReplicas,
+      int numKeys,
+      double numBlockedReplicas,
+      double expectedRequestKeyCountMax) {
+    validateMetrics(
+        null,
+        batchGetRequestContext,
+        healthyRequest,
+        partialHealthyRequest,
+        requestType,
+        noAvailableReplicas,
+        numKeys,
+        numBlockedReplicas,
+        expectedRequestKeyCountMax);
+  }
+
   private void validateComputeRequestMetrics(
       boolean healthyRequest,
       boolean partialHealthyRequest,
@@ -453,13 +507,41 @@ public class DispatchingAvroGenericStoreClientTest {
       boolean noAvailableReplicas,
       int numKeys,
       double numBlockedReplicas) {
+    // By default the largest request seen by this request type is the current request's key count.
+    validateMetrics(
+        getRequestContext,
+        batchGetRequestContext,
+        healthyRequest,
+        partialHealthyRequest,
+        requestType,
+        noAvailableReplicas,
+        numKeys,
+        numBlockedReplicas,
+        numKeys);
+  }
+
+  /**
+   * @param expectedRequestKeyCountMax the expected {@code request_key_count.Max} value. This is a cumulative max
+   *        across all requests of this type in the test, so it can differ from {@code numKeys} when an earlier
+   *        request (e.g. a route-blocking batch-get) had more keys than the request currently being validated.
+   */
+  private void validateMetrics(
+      GetRequestContext getRequestContext,
+      BatchGetRequestContext batchGetRequestContext,
+      boolean healthyRequest,
+      boolean partialHealthyRequest,
+      RequestType requestType,
+      boolean noAvailableReplicas,
+      int numKeys,
+      double numBlockedReplicas,
+      double expectedRequestKeyCountMax) {
     String metricPrefix = ClientTestUtils.getMetricPrefix(STORE_NAME, requestType);
     boolean batchGet = requestType == RequestType.MULTI_GET || requestType == RequestType.MULTI_GET_STREAMING;
     boolean computeRequest = requestType == RequestType.COMPUTE || requestType == RequestType.COMPUTE_STREAMING;
 
     String routeMetricsPrefix = "." + STORE_NAME;
     double successKeyCount;
-    double requestKeyCount = numKeys;
+    double requestKeyCount = expectedRequestKeyCountMax;
     if (partialHealthyRequest) {
       // batchGet and partialHealthyRequest: 1 request is unsuccessful
       successKeyCount = numKeys - 1;
@@ -966,8 +1048,8 @@ public class DispatchingAvroGenericStoreClientTest {
     try {
       setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       BatchGetRequestContext batchGetRequestContext =
-          new BatchGetRequestContext<>(BATCH_GET_PARTIAL_KEYS_2.size(), false);
-      statsAvroGenericStoreClient.batchGet(batchGetRequestContext, BATCH_GET_PARTIAL_KEYS_2).get();
+          new BatchGetRequestContext<>(BATCH_GET_BLOCK_KEYS_REPLICA2.size(), false);
+      statsAvroGenericStoreClient.batchGet(batchGetRequestContext, BATCH_GET_BLOCK_KEYS_REPLICA2).get();
       fail();
     } catch (Exception e) {
       assertTrue(e.getMessage().endsWith("At least one route did not complete"), e.getMessage());
@@ -988,7 +1070,8 @@ public class DispatchingAvroGenericStoreClientTest {
             () -> {
               assertTrue(metrics.get("." + STORE_NAME + "--multiget_streaming_request.OccurrenceRate").value() > 0);
             });
-        validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET, true, 2, 1);
+        // The blocking (first) batch-get used 5 keys, so request_key_count.Max is 5 even though this request has 2.
+        validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET, true, 2, 1, 5);
       }
     } finally {
       tearDown();
@@ -1194,16 +1277,16 @@ public class DispatchingAvroGenericStoreClientTest {
     try {
       setUpClient(false, false, false, false, TimeUnit.SECONDS.toMillis(1));
       BatchGetRequestContext batchGetRequestContext =
-          new BatchGetRequestContext<>(BATCH_GET_PARTIAL_KEYS_1.size(), true);
+          new BatchGetRequestContext<>(BATCH_GET_BLOCK_KEYS_REPLICA1.size(), true);
       VeniceResponseMap<String, GenericRecord> response =
           (VeniceResponseMap<String, GenericRecord>) statsAvroGenericStoreClient
-              .streamingBatchGet(batchGetRequestContext, BATCH_GET_PARTIAL_KEYS_1)
+              .streamingBatchGet(batchGetRequestContext, BATCH_GET_BLOCK_KEYS_REPLICA1)
               .get();
       assertFalse(response.isFullResponse());
       assertEquals(response.getTotalEntryCount(), 0);
       // First batchGet fails with unreachable host after timeout and this adds the hosts
       // as blocked due to setRoutingPendingRequestCounterInstanceBlockThreshold(1)
-      validateMultiGetMetrics(batchGetRequestContext, false, false, RequestType.MULTI_GET_STREAMING, false, 1);
+      validateMultiGetMetrics(batchGetRequestContext, false, false, RequestType.MULTI_GET_STREAMING, false, 5);
 
       BatchGetRequestContext batchGetRequestContext2 = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), true);
       VeniceResponseMap<String, GenericRecord> response2 =
@@ -1212,7 +1295,8 @@ public class DispatchingAvroGenericStoreClientTest {
               .get();
       assertFalse(response2.isFullResponse());
       assertEquals(response2.getTotalEntryCount(), 0);
-      validateMultiGetMetrics(batchGetRequestContext2, false, false, RequestType.MULTI_GET_STREAMING, true, 2);
+      // The blocking (first) batch-get used 5 keys, so request_key_count.Max is 5 even though this request has 2.
+      validateMultiGetMetrics(batchGetRequestContext2, false, false, RequestType.MULTI_GET_STREAMING, true, 2, 2, 5);
     } finally {
       tearDown();
     }
@@ -1230,16 +1314,16 @@ public class DispatchingAvroGenericStoreClientTest {
     try {
       setUpClient(false, false, true, true, TimeUnit.SECONDS.toMillis(1));
       BatchGetRequestContext batchGetRequestContext =
-          new BatchGetRequestContext<>(BATCH_GET_PARTIAL_KEYS_2.size(), true);
+          new BatchGetRequestContext<>(BATCH_GET_BLOCK_KEYS_REPLICA2.size(), true);
       VeniceResponseMap<String, GenericRecord> response =
           (VeniceResponseMap<String, GenericRecord>) statsAvroGenericStoreClient
-              .streamingBatchGet(batchGetRequestContext, BATCH_GET_PARTIAL_KEYS_2)
+              .streamingBatchGet(batchGetRequestContext, BATCH_GET_BLOCK_KEYS_REPLICA2)
               .get();
       assertFalse(response.isFullResponse());
       assertEquals(response.getTotalEntryCount(), 0);
       // First batchGet fails with unreachable host after timeout and this adds the hosts
       // as blocked due to setRoutingPendingRequestCounterInstanceBlockThreshold(1)
-      validateMultiGetMetrics(batchGetRequestContext, false, false, RequestType.MULTI_GET_STREAMING, false, 1);
+      validateMultiGetMetrics(batchGetRequestContext, false, false, RequestType.MULTI_GET_STREAMING, false, 5);
       BatchGetRequestContext batchGetRequestContext2 = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), true);
       CompletableFuture<VeniceResponseMap<String, GenericRecord>> future =
           statsAvroGenericStoreClient.streamingBatchGet(batchGetRequestContext2, BATCH_GET_KEYS);

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
@@ -415,25 +415,6 @@ public class DispatchingAvroGenericStoreClientTest {
       RequestType requestType,
       boolean noAvailableReplicas,
       int numKeys,
-      double numBlockedReplicas) {
-    validateMetrics(
-        null,
-        batchGetRequestContext,
-        healthyRequest,
-        partialHealthyRequest,
-        requestType,
-        noAvailableReplicas,
-        numKeys,
-        numBlockedReplicas);
-  }
-
-  private void validateMultiGetMetrics(
-      BatchGetRequestContext batchGetRequestContext,
-      boolean healthyRequest,
-      boolean partialHealthyRequest,
-      RequestType requestType,
-      boolean noAvailableReplicas,
-      int numKeys,
       double numBlockedReplicas,
       double expectedRequestKeyCountMax) {
     validateMetrics(

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/SingleKeyBatchGetAsSingleGetTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/SingleKeyBatchGetAsSingleGetTest.java
@@ -1,0 +1,151 @@
+package com.linkedin.venice.fastclient;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import com.linkedin.venice.client.store.streaming.StreamingCallback;
+import com.linkedin.venice.fastclient.utils.TestClientSimulator;
+import com.linkedin.venice.read.RequestType;
+import com.linkedin.venice.utils.Time;
+import io.tehuti.Metric;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.avro.util.Utf8;
+import org.testng.annotations.Test;
+
+
+/**
+ * Focused tests for the fast-client optimization where a {@code streamingBatchGet} containing a single key is served
+ * via a single-GET request instead of a multi-get request (see
+ * {@link DispatchingAvroGenericStoreClient#streamingBatchGet} and
+ * {@link RetriableAvroGenericStoreClient#streamingBatchGet}).
+ *
+ * <p>{@link TestClientSimulator} asserts the request shape on the wire: a single-key request must produce a single-GET
+ * request ({@link TestClientSimulator#expectSingleGetRequestWithKeyForPartitionOnRoute}) and increment the
+ * {@code batch_get_routed_to_single_get_request_count} metric, while a multi-key request must produce a multi-get
+ * request and leave that metric at zero.
+ */
+public class SingleKeyBatchGetAsSingleGetTest {
+  private static final int TEST_TIMEOUT = 30 * Time.MS_PER_SECOND;
+  private static final long CLIENT_TIME_OUT_IN_SECONDS = 10;
+
+  /**
+   * A single-key batch-get is served via a single-GET request and is counted by the reroute metric.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testSingleKeyBatchGetRoutedToSingleGet()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    TestClientSimulator client = new TestClientSimulator();
+    client.generateKeyValues(0, 1)
+        .setLongTailRangeBasedRetryThresholdForBatchGetInMilliSeconds("1-:10000")
+        .partitionKeys(1)
+        .assignRouteToPartitions("https://host1.linkedin.com", 0)
+        .expectSingleGetRequestWithKeyForPartitionOnRoute(1, 1, "https://host1.linkedin.com", 0)
+        .respondToRequestWithKeyValues(5, 1)
+        .simulate();
+
+    Map<String, String> results = streamingBatchGetAndCollect(client, false);
+    assertEquals(results, client.getRequestedKeyValues());
+
+    assertTrue(rerouteMetricValue(client) > 0, "Single-key batch-get should be counted as routed to single-GET");
+  }
+
+  /**
+   * A single-key batch-get propagates a single-GET failure to the streaming callback's {@code onCompletion}. A 429 is
+   * used so the single-GET path does not trigger an error retry (which would require a second simulated request).
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testSingleKeyBatchGetErrorPropagated() throws InterruptedException, ExecutionException, TimeoutException {
+    TestClientSimulator client = new TestClientSimulator();
+    client.generateKeyValues(0, 1)
+        .setLongTailRangeBasedRetryThresholdForBatchGetInMilliSeconds("1-:10000")
+        .partitionKeys(1)
+        .assignRouteToPartitions("https://host1.linkedin.com", 0)
+        .expectSingleGetRequestWithKeyForPartitionOnRoute(1, 1, "https://host1.linkedin.com", 0)
+        .respondToRequestWithError(5, 1, 429)
+        .simulate();
+
+    // Expecting the streaming callback to complete exceptionally.
+    streamingBatchGetAndCollect(client, true);
+  }
+
+  /**
+   * Contrast: a multi-key batch-get is NOT rerouted; it is served via a multi-get request and the reroute metric
+   * stays at zero.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testMultiKeyBatchGetNotRoutedToSingleGet()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    TestClientSimulator client = new TestClientSimulator();
+    client.generateKeyValues(0, 2)
+        .setLongTailRangeBasedRetryThresholdForBatchGetInMilliSeconds("1-:10000")
+        .partitionKeys(1)
+        .assignRouteToPartitions("https://host1.linkedin.com", 0)
+        .expectRequestWithKeysForPartitionOnRoute(1, 1, "https://host1.linkedin.com", 0)
+        .respondToRequestWithKeyValues(5, 1)
+        .simulate();
+
+    Map<String, String> results = streamingBatchGetAndCollect(client, false);
+    assertEquals(results, client.getRequestedKeyValues());
+
+    assertFalse(rerouteMetricValue(client) > 0, "Multi-key batch-get must not be counted as routed to single-GET");
+  }
+
+  /**
+   * Issues a {@code streamingBatchGet} for all of the simulator's keys, collecting the received values. Blocks until
+   * both the record stream and the simulation complete (or fail).
+   */
+  private Map<String, String> streamingBatchGetAndCollect(TestClientSimulator client, boolean expectError)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    Map<String, String> results = new ConcurrentHashMap<>();
+    CompletableFuture<Void> recordCompletion = new CompletableFuture<>();
+    client.getFastClient()
+        .streamingBatchGet(client.getRequestedKeyValues().keySet(), new StreamingCallback<String, Utf8>() {
+          @Override
+          public void onRecordReceived(String key, Utf8 value) {
+            if (value != null) {
+              results.put(key, value.toString());
+            }
+          }
+
+          @Override
+          public void onCompletion(Optional<Exception> exception) {
+            if (exception.isPresent()) {
+              recordCompletion.completeExceptionally(exception.get());
+            } else {
+              recordCompletion.complete(null);
+            }
+          }
+        });
+
+    try {
+      CompletableFuture.allOf(recordCompletion, client.getSimulatorCompleteFuture())
+          .get(CLIENT_TIME_OUT_IN_SECONDS, TimeUnit.SECONDS);
+      if (expectError) {
+        fail("Expected the single-key batch-get to fail");
+      }
+    } catch (ExecutionException e) {
+      if (!expectError) {
+        throw e;
+      }
+    }
+    return results;
+  }
+
+  private double rerouteMetricValue(TestClientSimulator client) {
+    Map<String, ? extends Metric> metrics =
+        client.getClientConfig().getStats(RequestType.MULTI_GET_STREAMING).getMetricsRepository().metrics();
+    return metrics
+        .get(
+            "." + client.UNIT_TEST_STORE_NAME
+                + "--multiget_streaming_batch_get_routed_to_single_get_request_count.OccurrenceRate")
+        .value();
+  }
+}

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTest.java
@@ -424,15 +424,26 @@ public class RequestBasedMetadataTest {
     try (RequestBasedMetadata requestBasedMetadata = new RequestBasedMetadata(clientConfig, d2TransportClient)) {
       RequestBasedMetadata spy = spy(requestBasedMetadata);
       spy.setD2ServiceDiscovery(d2ServiceDiscovery);
-      // let child thread handling the start logic otherwise the main thread cannot verify the invocation times.
-      CompletableFuture.runAsync(spy::start);
+      // Run start() on a dedicated thread (not the shared ForkJoinPool.commonPool() that runAsync uses): start()
+      // blocks indefinitely on isReadyLatch.await() in this all-failures scenario, and dispatching it onto the common
+      // pool makes the test flaky under load (the task can sit queued past the verification timeout). A dedicated
+      // daemon thread guarantees start() begins promptly so the main thread can verify the invocation counts.
+      Thread starter = new Thread(spy::start, "on-demand-refresh-start");
+      starter.setDaemon(true);
+      starter.start();
 
-      // refresh would happen multiple times
-      // the first one w/o onDemond refresh and would fail due to d2 client exception
-      verify(spy, timeout(3000).atLeast(1)).updateCache(false);
+      try {
+        // refresh would happen multiple times
+        // the first one w/o onDemond refresh and would fail due to d2 client exception
+        verify(spy, timeout(3000).atLeast(1)).updateCache(false);
 
-      // the first failed refresh triggers a onDemand refresh
-      verify(spy, timeout(3000).atLeast(1)).updateCache(true);
+        // the first failed refresh triggers a onDemand refresh
+        verify(spy, timeout(3000).atLeast(1)).updateCache(true);
+      } finally {
+        starter.interrupt();
+        starter.join(TimeUnit.SECONDS.toMillis(5));
+        assertFalse(starter.isAlive(), "starter thread should exit after interruption");
+      }
     }
   }
 

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/stats/FastClientMetricEntityTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/stats/FastClientMetricEntityTest.java
@@ -33,6 +33,14 @@ public class FastClientMetricEntityTest {
             "Count of retry requests which won",
             setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_REQUEST_METHOD)));
     map.put(
+        FastClientMetricEntity.BATCH_GET_SINGLE_KEY_REROUTE_COUNT,
+        new MetricEntityExpectation(
+            "request.batch_get_routed_to_single_get_count",
+            MetricType.COUNTER,
+            MetricUnit.NUMBER,
+            "Count of single-key batch-get requests served via a single-GET lookup",
+            setOf(VENICE_STORE_NAME, VENICE_CLUSTER_NAME, VENICE_REQUEST_METHOD)));
+    map.put(
         FastClientMetricEntity.METADATA_STALENESS_DURATION,
         new MetricEntityExpectation(
             "metadata.staleness_duration",

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/stats/FastClientStatsFastClientTehutiMetricNameTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/stats/FastClientStatsFastClientTehutiMetricNameTest.java
@@ -26,6 +26,9 @@ public class FastClientStatsFastClientTehutiMetricNameTest {
         FastClientTehutiMetricName.REJECTED_REQUEST_COUNT_BY_LOAD_CONTROLLER,
         "rejected_request_count_by_load_controller");
     map.put(FastClientTehutiMetricName.REJECTION_RATIO, "rejection_ratio");
+    map.put(
+        FastClientTehutiMetricName.BATCH_GET_ROUTED_TO_SINGLE_GET_REQUEST_COUNT,
+        "batch_get_routed_to_single_get_request_count");
     return map;
   }
 }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/stats/FastClientStatsTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/stats/FastClientStatsTest.java
@@ -67,6 +67,27 @@ public class FastClientStatsTest {
   }
 
   @Test
+  public void testBatchGetRoutedToSingleGetRequest() {
+    InMemoryMetricReader inMemoryMetricReader = InMemoryMetricReader.create();
+    FastClientStats stats = createStats(inMemoryMetricReader);
+
+    stats.recordBatchGetRoutedToSingleGetRequest();
+
+    // Check Tehuti metric
+    Map<String, ? extends Metric> metrics = stats.getMetricsRepository().metrics();
+    assertTrue(metrics.get(".test_store--batch_get_routed_to_single_get_request_count.OccurrenceRate").value() > 0.0);
+
+    // Check OTel metric
+    Attributes expectedAttr = getBaseAttributes("test_store");
+    validateLongPointDataFromCounter(
+        inMemoryMetricReader,
+        1,
+        expectedAttr,
+        BATCH_GET_SINGLE_KEY_REROUTE_COUNT.getMetricEntity().getMetricName(),
+        FAST_CLIENT.getMetricsPrefix());
+  }
+
+  @Test
   public void testMetadataStalenessHighWatermark() throws Exception {
     InMemoryMetricReader inMemoryMetricReader = InMemoryMetricReader.create();
     FastClientStats stats = createStats(inMemoryMetricReader);

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
@@ -13,6 +13,7 @@ import com.linkedin.r2.message.rest.RestRequest;
 import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.r2.message.rest.RestResponseBuilder;
 import com.linkedin.r2.transport.common.Client;
+import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.CompressorFactory;
@@ -30,6 +31,7 @@ import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.utils.EncodingUtils;
 import com.linkedin.venice.utils.TestUtils;
 import io.tehuti.metrics.MetricsRepository;
 import java.net.URI;
@@ -162,10 +164,28 @@ public class TestClientSimulator implements Client {
       int requestId,
       String route,
       int... partitions) {
+    return expectRequestWithKeysForPartitionOnRouteInternal(false, timeTick, requestId, route, partitions);
+  }
+
+  public TestClientSimulator expectSingleGetRequestWithKeyForPartitionOnRoute(
+      int timeTick,
+      int requestId,
+      String route,
+      int partition) {
+    return expectRequestWithKeysForPartitionOnRouteInternal(true, timeTick, requestId, route, partition);
+  }
+
+  private TestClientSimulator expectRequestWithKeysForPartitionOnRouteInternal(
+      boolean singleGetRequest,
+      int timeTick,
+      int requestId,
+      String route,
+      int... partitions) {
     RequestInfo requestInfo = new RequestInfo();
     requestInfo.requestId = requestId;
     requestInfo.route = route;
     requestInfo.timeTick = timeTick;
+    requestInfo.singleGetRequest = singleGetRequest;
 
     Set<Integer> partitionSet = Sets.newHashSet(Ints.asList(partitions));
     requestInfo.keyValues = keysToPartitions.entrySet()
@@ -174,6 +194,9 @@ public class TestClientSimulator implements Client {
         .collect(Collectors.toMap(e -> e.getKey(), e -> keyValues.get(e.getKey())));
 
     requestedKeyValues.putAll(requestInfo.keyValues);
+    if (singleGetRequest) {
+      Assert.assertEquals(requestInfo.keyValues.size(), 1, "Single-get expectation must resolve to exactly one key");
+    }
 
     requestIdToRequestInfos.put(requestInfo.requestId, requestInfo);
     ExpectedRequestEvent expectedRequestEvent = new ExpectedRequestEvent(requestInfo, timeTick);
@@ -255,16 +278,33 @@ public class TestClientSimulator implements Client {
           expectedRequestEvent.info.requestId);
 
       ByteString entity = request.getEntity();
-      Iterable<MultiGetRouterRequestKeyV1> multiGetRouterRequestKeyV1s =
-          multiGetRequestDeserializer.deserializeObjects(new ByteBufferOptimizedBinaryDecoder(entity.copyBytes()));
-      for (MultiGetRouterRequestKeyV1 keyRecord: multiGetRouterRequestKeyV1s) {
-        Utf8 key = keyDeserializer.deserialize(keyRecord.keyBytes);
-        LOGGER.info("t:{} Received key {} on route {} ", currentTimeTick.get(), key, route);
+      boolean singleGetRequest = entity.length() == 0;
+      Assert.assertEquals(
+          singleGetRequest,
+          expectedRequestEvent.info.singleGetRequest,
+          "Unexpected request type for route " + route);
+      if (singleGetRequest) {
+        String path = uri.getPath();
+        String encodedKey = path.substring(path.lastIndexOf('/') + 1);
+        Utf8 key = keyDeserializer.deserialize(EncodingUtils.base64DecodeFromString(encodedKey));
+        LOGGER.info("t:{} Received single-get key {} on route {} ", currentTimeTick.get(), key, route);
         Assert.assertTrue(
             expectedKeys.contains(key.toString()),
             "Unexpected key received: " + key + " Expected keys: " + expectedKeys);
         expectedKeys.remove(key.toString());
         expectedRequestEvent.info.orderedKeys.add(key.toString());
+      } else {
+        Iterable<MultiGetRouterRequestKeyV1> multiGetRouterRequestKeyV1s =
+            multiGetRequestDeserializer.deserializeObjects(new ByteBufferOptimizedBinaryDecoder(entity.copyBytes()));
+        for (MultiGetRouterRequestKeyV1 keyRecord: multiGetRouterRequestKeyV1s) {
+          Utf8 key = keyDeserializer.deserialize(keyRecord.keyBytes);
+          LOGGER.info("t:{} Received key {} on route {} ", currentTimeTick.get(), key, route);
+          Assert.assertTrue(
+              expectedKeys.contains(key.toString()),
+              "Unexpected key received: " + key + " Expected keys: " + expectedKeys);
+          expectedKeys.remove(key.toString());
+          expectedRequestEvent.info.orderedKeys.add(key.toString());
+        }
       }
       Assert.assertTrue(expectedKeys.isEmpty());
       expectedRequestEvent.info.callback = callback;
@@ -322,6 +362,7 @@ public class TestClientSimulator implements Client {
     Map<String, String> keyValues;
     Callback<RestResponse> callback;
     List<String> orderedKeys;
+    boolean singleGetRequest;
 
     @Override
     public String toString() {
@@ -390,18 +431,25 @@ public class TestClientSimulator implements Client {
             info.keyValues.size(),
             info.route,
             info.requestId);
-        List<MultiGetResponseRecordV1> multiGetResponse = new ArrayList<>();
-        for (int i = 0; i < info.orderedKeys.size(); i++) {
-          MultiGetResponseRecordV1 rec = new MultiGetResponseRecordV1();
-          rec.value = ByteBuffer.wrap(keySerializer.serialize(info.keyValues.get(info.orderedKeys.get(i))));
-          rec.keyIndex = i;
-          rec.schemaId = expectedValueSchemaId;
-          multiGetResponse.add(rec);
-        }
         RestResponseBuilder restResponseBuilder = new RestResponseBuilder();
-        restResponseBuilder.setEntity(multiGetResponseSerializer.serializeObjects(multiGetResponse))
-            .setStatus(200)
-            .build();
+        if (info.singleGetRequest) {
+          restResponseBuilder.setEntity(keySerializer.serialize(info.keyValues.get(info.orderedKeys.get(0))))
+              .setHeader(HttpConstants.VENICE_SCHEMA_ID, Integer.toString(expectedValueSchemaId))
+              .setStatus(200)
+              .build();
+        } else {
+          List<MultiGetResponseRecordV1> multiGetResponse = new ArrayList<>();
+          for (int i = 0; i < info.orderedKeys.size(); i++) {
+            MultiGetResponseRecordV1 rec = new MultiGetResponseRecordV1();
+            rec.value = ByteBuffer.wrap(keySerializer.serialize(info.keyValues.get(info.orderedKeys.get(i))));
+            rec.keyIndex = i;
+            rec.schemaId = expectedValueSchemaId;
+            multiGetResponse.add(rec);
+          }
+          restResponseBuilder.setEntity(multiGetResponseSerializer.serializeObjects(multiGetResponse))
+              .setStatus(200)
+              .build();
+        }
         info.callback.onSuccess(restResponseBuilder.build());
       }
       future.complete(timeTick);

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -441,7 +442,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
    *
    * @param stats The {@link ClientStats} object to record into. Should be the one passed by the {@link StatTrackingStoreClient}.
    * @param preRequestTimeInNS The request start time. Should be the one passed by the {@link StatTrackingStoreClient}.
-   * @param handleResponseOnDeserializationExecutor if true, will execute the {@param responseHandler} on the {@link deserializationExecutor}
+   * @param handleResponseOnDeserializationExecutor if true, will execute the {@param responseHandler} on the {@link #deserializationExecutor}
    *                                                if false, will execute the {@param responseHandler} on the same thread.
    * @param requestSubmitter A closure which ONLY submits the request to the backend. Should not include any pre-submission work (i.e.: serialization).
    * @param responseHandler A closure which interprets the response from the backend (i.e.: deserialization).
@@ -745,10 +746,14 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
       // empty key set
       return;
     }
+    TrackingStreamingCallback<K, V> decoderCallback = DelegatingTrackingCallback.wrap(callback);
+    if (keys.size() == 1) {
+      streamingBatchGetForSingleKey(keys.iterator().next(), decoderCallback);
+      return;
+    }
     tryStart(1);
 
     List<K> keyList = new ArrayList<>(keys);
-    TrackingStreamingCallback<K, V> decoderCallback = DelegatingTrackingCallback.wrap(callback);
     RecordStreamDecoder decoder = new MultiGetRecordStreamDecoder<>(
         keyList,
         decoderCallback,
@@ -757,6 +762,32 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
         this::getDataRecordDeserializerFromCache,
         this::decompressRecord);
     streamingBatchGet(keyList, decoder, decoderCallback.getStats());
+  }
+
+  private void streamingBatchGetForSingleKey(K key, TrackingStreamingCallback<K, V> callback) {
+    get(key, callback.getStats(), System.nanoTime()).whenComplete((value, throwable) -> {
+      Optional<Exception> completedException = Optional.empty();
+      int successKeyCount = 0;
+      if (throwable != null) {
+        completedException = Optional.of(toException(throwable));
+      } else {
+        callback.onRecordReceived(key, value);
+        callback.onRecordDeserialized();
+        if (value != null) {
+          successKeyCount = 1;
+        }
+      }
+      callback.onCompletion(completedException);
+      callback.onDeserializationCompletion(completedException, successKeyCount, 0);
+    });
+  }
+
+  private static Exception toException(Throwable throwable) {
+    Throwable unwrappedThrowable =
+        throwable instanceof CompletionException && throwable.getCause() != null ? throwable.getCause() : throwable;
+    return unwrappedThrowable instanceof Exception
+        ? (Exception) unwrappedThrowable
+        : new VeniceClientException(unwrappedThrowable);
   }
 
   private void streamingBatchGet(

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -764,6 +764,14 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
     streamingBatchGet(keyList, decoder, decoderCallback.getStats());
   }
 
+  /**
+   * Serves a single-key batchGet/streamingBatchGet by issuing a single-GET request instead of a multi-get request.
+   *
+   * NOTE: this changes the request type seen by the server from a multi-get to a single-get, which shifts
+   * server-side routing, read-quota accounting (single-get and batch-get quotas are tracked/throttled separately)
+   * and per-request-type server metrics for these 1-key requests. Single-get timing is recorded into the
+   * multi-get-streaming {@link com.linkedin.venice.client.stats.ClientStats} carried by {@code callback}.
+   */
   private void streamingBatchGetForSingleKey(K key, TrackingStreamingCallback<K, V> callback) {
     get(key, callback.getStats(), System.nanoTime()).whenComplete((value, throwable) -> {
       Optional<Exception> completedException = Optional.empty();

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -442,12 +442,12 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
    *
    * @param stats The {@link ClientStats} object to record into. Should be the one passed by the {@link StatTrackingStoreClient}.
    * @param preRequestTimeInNS The request start time. Should be the one passed by the {@link StatTrackingStoreClient}.
-   * @param handleResponseOnDeserializationExecutor if true, will execute the {@param responseHandler} on the {@link #deserializationExecutor}
-   *                                                if false, will execute the {@param responseHandler} on the same thread.
+   * @param handleResponseOnDeserializationExecutor if true, will execute the {@code responseHandler} on the {@link #deserializationExecutor}
+   *                                                if false, will execute the {@code responseHandler} on the same thread.
    * @param requestSubmitter A closure which ONLY submits the request to the backend. Should not include any pre-submission work (i.e.: serialization).
    * @param responseHandler A closure which interprets the response from the backend (i.e.: deserialization).
-   * @param <R> The return type of the {@param responseHandler}.
-   * @return a {@link CompletableFuture<R>} wrapping the return of the {@param responseHandler}.
+   * @param <R> The return type of the {@code responseHandler}.
+   * @return a {@link CompletableFuture<R>} wrapping the return of the {@code responseHandler}.
    * @throws VeniceClientException
    */
   private <R> CompletableFuture<R> requestSubmissionWithStatsHandling(

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AbstractAvroStoreClientTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AbstractAvroStoreClientTest.java
@@ -55,6 +55,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -452,6 +453,68 @@ public class AbstractAvroStoreClientTest {
     Assert.assertEquals(result.size(), 2);
     Assert.assertEquals(result.get("key1"), result1);
     Assert.assertEquals(result.get("key2"), result2);
+  }
+
+  @Test
+  public void testSingleKeyBatchGetUsesSingleGet() throws Exception {
+    GenericRecord recordFieldValue = new GenericData.Record(VALUE_SCHEMA.getField("record_field").schema());
+    recordFieldValue.put("nested_field1", 5.1d);
+
+    GenericRecord expectedValue = new GenericData.Record(VALUE_SCHEMA);
+    expectedValue.put("int_field", 1);
+    expectedValue.put("float_field", 1.1f);
+    expectedValue.put("record_field", recordFieldValue);
+    expectedValue.put("float_array_field1", Collections.emptyList());
+    expectedValue.put("float_array_field2", Collections.emptyList());
+    expectedValue.put("int_array_field2", Collections.emptyList());
+
+    AtomicInteger getCount = new AtomicInteger();
+    AtomicInteger streamPostCount = new AtomicInteger();
+    TransportClient mockTransportClient = new TransportClient() {
+      @Override
+      public CompletableFuture<TransportClientResponse> get(String requestPath, Map<String, String> headers) {
+        getCount.incrementAndGet();
+        return CompletableFuture.completedFuture(
+            new TransportClientResponse(1, CompressionStrategy.NO_OP, valueSerializer.serialize(expectedValue)));
+      }
+
+      @Override
+      public CompletableFuture<TransportClientResponse> post(
+          String requestPath,
+          Map<String, String> headers,
+          byte[] requestBody) {
+        CompletableFuture<TransportClientResponse> result = new CompletableFuture<>();
+        result.completeExceptionally(new AssertionError("One-key batch-get should not use post"));
+        return result;
+      }
+
+      @Override
+      public void streamPost(
+          String requestPath,
+          Map<String, String> headers,
+          byte[] requestBody,
+          TransportClientStreamingCallback callback,
+          int keyCount) {
+        streamPostCount.incrementAndGet();
+        Assert.fail("One-key batch-get should not use streamPost");
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+
+    SimpleStoreClient<String, GenericRecord> storeClient = new SimpleStoreClient<>(
+        mockTransportClient,
+        "test_store",
+        true,
+        AbstractAvroStoreClient.getDefaultDeserializationExecutor());
+
+    Map<String, GenericRecord> result = storeClient.batchGet(Collections.singleton("key1")).get();
+    Assert.assertEquals(result.size(), 1);
+    Assert.assertEquals(result.get("key1"), expectedValue);
+    Assert.assertEquals(getCount.get(), 1);
+    Assert.assertEquals(streamPostCount.get(), 0);
   }
 
   @Test

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AbstractAvroStoreClientTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AbstractAvroStoreClientTest.java
@@ -64,7 +64,7 @@ import org.testng.annotations.Test;
 
 
 public class AbstractAvroStoreClientTest {
-  private static class SimpleStoreClient<K, V> extends AbstractAvroStoreClient<K, V> {
+  static class SimpleStoreClient<K, V> extends AbstractAvroStoreClient<K, V> {
     private final TransportClient transportClient;
     private final String storeName;
     private final boolean overrideGetSchemaReader;
@@ -132,7 +132,7 @@ public class AbstractAvroStoreClientTest {
     }
   }
 
-  private static final Schema VALUE_SCHEMA = Schema.parse(
+  static final Schema VALUE_SCHEMA = Schema.parse(
       "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"record_schema\",\n" + "  \"fields\": [\n" + "    {\n"
           + "      \"name\": \"int_field\",\n" + "      \"type\": \"int\",\n" + "      \"default\": 0,\n"
           + "      \"doc\": \"doc for int_field\"\n" + "    },\n"
@@ -148,7 +148,7 @@ public class AbstractAvroStoreClientTest {
           + "    { \"name\": \"int_array_field2\", \"type\": { \"type\": \"array\", \"items\": \"int\" } }\n" + "  ]\n"
           + "}\n");
 
-  private static final RecordSerializer<GenericRecord> valueSerializer =
+  static final RecordSerializer<GenericRecord> valueSerializer =
       FastSerializerDeserializerFactory.getFastAvroGenericSerializer(VALUE_SCHEMA);
 
   private static final Set<String> keys = new HashSet<>();

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/SingleKeyBatchGetAsSingleGetTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/SingleKeyBatchGetAsSingleGetTest.java
@@ -1,0 +1,210 @@
+package com.linkedin.venice.client.store;
+
+import com.linkedin.venice.client.exceptions.VeniceClientException;
+import com.linkedin.venice.client.store.transport.TransportClient;
+import com.linkedin.venice.client.store.transport.TransportClientResponse;
+import com.linkedin.venice.client.store.transport.TransportClientStreamingCallback;
+import com.linkedin.venice.compression.CompressionStrategy;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Focused tests for the optimization where a {@code batchGet}/{@code streamingBatchGet} containing a single key is
+ * served via a single-GET request instead of a multi-get request (see
+ * {@link AbstractAvroStoreClient#streamingBatchGet(java.util.Set, com.linkedin.venice.client.store.streaming.StreamingCallback)}).
+ *
+ * <p>The {@link TransportClient} is mocked so the routing decision is directly observable: a single-key request must
+ * invoke {@link TransportClient#get} (single-GET) and never {@link TransportClient#streamPost} (multi-get), while a
+ * multi-key request must do the opposite. The shared {@code SimpleStoreClient} test fixture and value schema are
+ * reused from {@link AbstractAvroStoreClientTest}.
+ */
+public class SingleKeyBatchGetAsSingleGetTest {
+  private static GenericRecord buildValue() {
+    GenericRecord recordFieldValue =
+        new GenericData.Record(AbstractAvroStoreClientTest.VALUE_SCHEMA.getField("record_field").schema());
+    recordFieldValue.put("nested_field1", 5.1d);
+
+    GenericRecord value = new GenericData.Record(AbstractAvroStoreClientTest.VALUE_SCHEMA);
+    value.put("int_field", 1);
+    value.put("float_field", 1.1f);
+    value.put("record_field", recordFieldValue);
+    value.put("float_array_field1", Collections.emptyList());
+    value.put("float_array_field2", Collections.emptyList());
+    value.put("int_array_field2", Collections.emptyList());
+    return value;
+  }
+
+  private static AbstractAvroStoreClientTest.SimpleStoreClient<String, GenericRecord> newStoreClient(
+      TransportClient transportClient) {
+    return new AbstractAvroStoreClientTest.SimpleStoreClient<>(
+        transportClient,
+        "test_store",
+        true,
+        AbstractAvroStoreClient.getDefaultDeserializationExecutor());
+  }
+
+  /**
+   * Base mock that fails the test if {@code streamPost} (multi-get) is invoked, so single-key routing is asserted.
+   */
+  private abstract static class SingleGetOnlyTransportClient extends TransportClient {
+    final AtomicInteger getCount = new AtomicInteger();
+    final AtomicInteger streamPostCount = new AtomicInteger();
+
+    @Override
+    public CompletableFuture<TransportClientResponse> post(
+        String requestPath,
+        Map<String, String> headers,
+        byte[] requestBody) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void streamPost(
+        String requestPath,
+        Map<String, String> headers,
+        byte[] requestBody,
+        TransportClientStreamingCallback callback,
+        int keyCount) {
+      streamPostCount.incrementAndGet();
+      Assert.fail("Single-key batch-get must not use streamPost (multi-get)");
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+
+  /**
+   * A single-key {@code batchGet} for an existing key is served via single-GET and returns the value.
+   */
+  @Test
+  public void testSingleKeyBatchGetRoutedToSingleGet() throws Exception {
+    GenericRecord expectedValue = buildValue();
+    SingleGetOnlyTransportClient transportClient = new SingleGetOnlyTransportClient() {
+      @Override
+      public CompletableFuture<TransportClientResponse> get(String requestPath, Map<String, String> headers) {
+        getCount.incrementAndGet();
+        return CompletableFuture.completedFuture(
+            new TransportClientResponse(
+                1,
+                CompressionStrategy.NO_OP,
+                AbstractAvroStoreClientTest.valueSerializer.serialize(expectedValue)));
+      }
+    };
+
+    Map<String, GenericRecord> result = newStoreClient(transportClient).batchGet(Collections.singleton("key1")).get();
+
+    Assert.assertEquals(result.size(), 1);
+    Assert.assertEquals(result.get("key1"), expectedValue);
+    Assert.assertEquals(transportClient.getCount.get(), 1);
+    Assert.assertEquals(transportClient.streamPostCount.get(), 0);
+  }
+
+  /**
+   * A single-key {@code batchGet} for a non-existing key (single-GET returns a {@code null} response) yields an empty
+   * map. Exercises the non-existing-key branch of {@code streamingBatchGetForSingleKey}.
+   */
+  @Test
+  public void testSingleKeyBatchGetMissingKey() throws Exception {
+    SingleGetOnlyTransportClient transportClient = new SingleGetOnlyTransportClient() {
+      @Override
+      public CompletableFuture<TransportClientResponse> get(String requestPath, Map<String, String> headers) {
+        getCount.incrementAndGet();
+        // A null response indicates the key does not exist.
+        return CompletableFuture.completedFuture(null);
+      }
+    };
+
+    Map<String, GenericRecord> result =
+        newStoreClient(transportClient).batchGet(Collections.singleton("missingKey")).get();
+
+    Assert.assertTrue(result.isEmpty());
+    Assert.assertEquals(transportClient.getCount.get(), 1);
+    Assert.assertEquals(transportClient.streamPostCount.get(), 0);
+  }
+
+  /**
+   * A single-key {@code batchGet} propagates a single-GET failure to the caller. Exercises the error branch of
+   * {@code streamingBatchGetForSingleKey} and its {@code toException} unwrapping.
+   */
+  @Test
+  public void testSingleKeyBatchGetErrorPropagated() {
+    SingleGetOnlyTransportClient transportClient = new SingleGetOnlyTransportClient() {
+      @Override
+      public CompletableFuture<TransportClientResponse> get(String requestPath, Map<String, String> headers) {
+        getCount.incrementAndGet();
+        CompletableFuture<TransportClientResponse> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new VeniceClientException("Simulated single-GET failure"));
+        return failed;
+      }
+    };
+
+    ExecutionException thrown = Assert.expectThrows(
+        ExecutionException.class,
+        () -> newStoreClient(transportClient).batchGet(Collections.singleton("key1")).get());
+    Assert.assertTrue(thrown.getCause() instanceof VeniceClientException, "Unexpected cause: " + thrown.getCause());
+    Assert.assertEquals(transportClient.getCount.get(), 1);
+    Assert.assertEquals(transportClient.streamPostCount.get(), 0);
+  }
+
+  /**
+   * Contrast: a multi-key {@code batchGet} must NOT be routed through single-GET; it uses {@code streamPost}
+   * (multi-get). The stream is completed with an error purely to unblock the future.
+   */
+  @Test
+  public void testMultiKeyBatchGetDoesNotRouteToSingleGet() {
+    AtomicInteger getCount = new AtomicInteger();
+    AtomicInteger streamPostCount = new AtomicInteger();
+    TransportClient transportClient = new TransportClient() {
+      @Override
+      public CompletableFuture<TransportClientResponse> get(String requestPath, Map<String, String> headers) {
+        getCount.incrementAndGet();
+        Assert.fail("Multi-key batch-get must not use single-GET");
+        return null;
+      }
+
+      @Override
+      public CompletableFuture<TransportClientResponse> post(
+          String requestPath,
+          Map<String, String> headers,
+          byte[] requestBody) {
+        return CompletableFuture.completedFuture(null);
+      }
+
+      @Override
+      public void streamPost(
+          String requestPath,
+          Map<String, String> headers,
+          byte[] requestBody,
+          TransportClientStreamingCallback callback,
+          int keyCount) {
+        streamPostCount.incrementAndGet();
+        // Unblock the caller by completing the multi-get stream with an error.
+        callback.onCompletion(Optional.of(new VeniceClientException("contrast: stop multi-get")));
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+
+    Set<String> twoKeys = new HashSet<>();
+    twoKeys.add("key1");
+    twoKeys.add("key2");
+
+    Assert.expectThrows(ExecutionException.class, () -> newStoreClient(transportClient).batchGet(twoKeys).get());
+    Assert.assertEquals(getCount.get(), 0);
+    Assert.assertEquals(streamPostCount.get(), 1);
+  }
+}


### PR DESCRIPTION
## Problem Statement

`batchGet` / `streamingBatchGet` requests always go through the multi-get streaming path, even when the caller passes exactly one key. For a 1-key request this is wasteful and inconsistent: it incurs the full multi-get machinery (scatter/gather, streaming response assembly, batch-get routing) to fetch a single value that the single-GET path already serves more directly. There was no way to distinguish or measure these degenerate single-key batch requests, which are common in practice when callers build key sets dynamically.

## Solution

For `batchGet` / `streamingBatchGet` requests containing exactly one key, short-circuit to a single-GET lookup instead of issuing a multi-get streaming request. This is implemented in both the fast client and the thin client:

- Add `streamingBatchGetForSingleKey` helpers in `InternalAvroStoreClient` (fast client) and `AbstractAvroStoreClient` (thin client). Each issues a `get(key)`, adapts the result back onto the `StreamingCallback` (`onRecordReceived` + `onCompletion`), and unwraps `CompletionException` so callers see the original cause.
- Short-circuit at the entry points: `DispatchingAvroGenericStoreClient` and `RetriableAvroGenericStoreClient` (fast client) detect `keys.size() == 1` and route through the single-key helper, so the optimization applies regardless of which layer triggers it.
- Add a new fast-client metric, `batch_get_routed_to_single_get_request_count` (Tehuti) / `request.batch_get_routed_to_single_get_count` (OTel COUNTER, dimensions store/cluster/request-method), recorded at the single-key short-circuit choke point so every 1-key request served via single-GET is counted exactly once. It is wired through the dual-backend `MetricEntityStateBase` pattern (built in `buildFastClientOtelStats` so it survives cluster-name rebuilds), consistent with `retry_request_win`.
- Document the behavior change at the short-circuit sites: a 1-key batch get now follows the single-get long-tail retry configuration rather than the batch-get one, and the server sees a single-get request type instead of a multi-get — which shifts server-side routing, read-quota accounting (single-get and batch-get quotas are throttled separately), and per-request-type server metrics for these requests.

Trade-off worth calling out: a store that enabled **only** batch-get long-tail retry will get no long-tail retry on 1-key batch gets, since those now follow the single-get retry config.

Testing: added dedicated `SingleKeyBatchGetAsSingleGetTest` in both clients (single-GET routing, non-existing key, error propagation, multi-key contrast), extended `TestClientSimulator` with single-get expectation support, and fixed pre-existing batch-get tests that issued 1-key requests by switching them to 5-key requests so they remain genuine multi-get tests. Confirmed `diffCoverage` branch coverage (venice-client 58.33%, venice-thin-client 66.67%, min 0.45); SpotBugs and spotless clean.

###  Code changes
- [ ] Added new code behind **a config**. (No new config; behavior is unconditional for 1-key requests.)
- [ ] Introduced new **log lines**. (No new log lines — only a new metric.)
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**. (Single-key helper composes on the existing `get` future via `whenComplete`; introduces no shared mutable state.)
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed. (None needed.)
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`). (N/A — no new collections.)
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination. (`whenComplete` callback unwraps and forwards exceptions through the callback; `CompletionException` is unwrapped to the original cause.)

## How was this PR tested?

- [x] New unit tests added. (`SingleKeyBatchGetAsSingleGetTest` in both fast and thin clients; new `FastClientStats` / `FastClientMetricEntity` metric tests.)
- [ ] New integration tests added.
- [x] Modified or extended existing tests. (Updated `BatchGetAvroStoreClientUnitTest`, `DispatchingAvroGenericStoreClientTest`, `RequestBasedMetadataTest`, `FastClientStatsFastClientTehutiMetricNameTest`, and `TestClientSimulator` to account for single-GET routing.)
- [x] Verified backward compatibility (if applicable). (Result semantics of 1-key `batchGet`/`streamingBatchGet` are unchanged; only the underlying request path differs.)

## Does this PR introduce any user-facing or breaking changes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.

For `batchGet` / `streamingBatchGet` with exactly one key, the client now issues a **single-GET** request instead of a multi-get streaming request. The returned values/map are unchanged, but observable behavior shifts:

- **Retry config**: these requests follow the **single-get** long-tail retry configuration rather than the batch-get one. A store that enabled *only* batch-get long-tail retry will get no long-tail retry on 1-key batch gets.
- **Server-side**: the server sees a single-get request type, changing routing, read-quota accounting (single-get and batch-get quotas are throttled separately), and per-request-type server metrics for these 1-key requests.
- **Client metrics**: a new metric `batch_get_routed_to_single_get_request_count` / `request.batch_get_routed_to_single_get_count` is emitted for each such routed request.
