### PR TITLE
[server] Config-gate collection-merge element replacement for order:ignore fields

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -66,6 +66,7 @@ import static com.linkedin.venice.ConfigKeys.PUBSUB_PRODUCER_TIMESTAMP_FALLBACK_
 import static com.linkedin.venice.ConfigKeys.PUBSUB_TOPIC_MANAGER_METADATA_FETCHER_CONSUMER_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_TOPIC_MANAGER_METADATA_FETCHER_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_PRINCIPAL_NAME;
+import static com.linkedin.venice.ConfigKeys.SERVER_AA_COLLECTION_FIELD_ELEMENT_REPLACEMENT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_AA_WC_INGESTION_STORAGE_LOOKUP_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_AA_WC_WORKLOAD_PARALLEL_PROCESSING_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_AA_WC_WORKLOAD_PARALLEL_PROCESSING_THREAD_POOL_SIZE;
@@ -480,6 +481,12 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final long storeVersionMetadataWaitDuringStateTransitionTimeMs;
 
   private final boolean computeFastAvroEnabled;
+
+  /**
+   * Whether to replace an existing collection-merge array element with the incoming element on a conflict, instead of
+   * only advancing its replication-metadata timestamp. See SERVER_AA_COLLECTION_FIELD_ELEMENT_REPLACEMENT_ENABLED.
+   */
+  private final boolean activeActiveCollectionFieldElementReplacementEnabled;
 
   private final long participantMessageConsumptionDelayMs;
 
@@ -911,6 +918,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     storeVersionMetadataWaitDuringStateTransitionTimeMs =
         serverProperties.getLong(SERVER_STORE_VERSION_METADATA_WAIT_DURING_STATE_TRANSITION_TIME_MS, 300_000);
     computeFastAvroEnabled = serverProperties.getBoolean(SERVER_COMPUTE_FAST_AVRO_ENABLED, true);
+    activeActiveCollectionFieldElementReplacementEnabled =
+        serverProperties.getBoolean(SERVER_AA_COLLECTION_FIELD_ELEMENT_REPLACEMENT_ENABLED, false);
     participantMessageConsumptionDelayMs = serverProperties.getLong(PARTICIPANT_MESSAGE_CONSUMPTION_DELAY_MS, 60000);
     serverPromotionToLeaderReplicaDelayMs =
         TimeUnit.SECONDS.toMillis(serverProperties.getLong(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, 300));
@@ -1563,6 +1572,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isComputeFastAvroEnabled() {
     return computeFastAvroEnabled;
+  }
+
+  public boolean isActiveActiveCollectionFieldElementReplacementEnabled() {
+    return activeActiveCollectionFieldElementReplacementEnabled;
   }
 
   public long getParticipantMessageConsumptionDelayMs() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -175,7 +175,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
             rmdSerDe,
             getStoreName(),
             isWriteComputationEnabled,
-            getServerConfig().isComputeFastAvroEnabled());
+            getServerConfig().isComputeFastAvroEnabled(),
+            getServerConfig().isActiveActiveCollectionFieldElementReplacementEnabled());
     this.remoteIngestionRepairService = builder.getRemoteIngestionRepairService();
     this.reusableObjectsSupplier = Objects.requireNonNull(builder.getReusableObjectsSupplier());
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolverFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolverFactory.java
@@ -23,12 +23,30 @@ public class MergeConflictResolverFactory {
       String storeName,
       boolean rmdUseFieldLevelTs,
       boolean fastAvroEnabled) {
+    return createMergeConflictResolver(
+        annotatedReadOnlySchemaRepository,
+        rmdSerDe,
+        storeName,
+        rmdUseFieldLevelTs,
+        fastAvroEnabled,
+        false);
+  }
+
+  public MergeConflictResolver createMergeConflictResolver(
+      StringAnnotatedStoreSchemaCache annotatedReadOnlySchemaRepository,
+      RmdSerDe rmdSerDe,
+      String storeName,
+      boolean rmdUseFieldLevelTs,
+      boolean fastAvroEnabled,
+      boolean collectionFieldElementReplacementEnabled) {
     MergeRecordHelper mergeRecordHelper = new CollectionTimestampMergeRecordHelper();
     return new MergeConflictResolver(
         annotatedReadOnlySchemaRepository,
         storeName,
         valueSchemaID -> new GenericData.Record(rmdSerDe.getRmdSchema(valueSchemaID)),
-        new MergeGenericRecord(new WriteComputeProcessor(mergeRecordHelper), mergeRecordHelper),
+        new MergeGenericRecord(
+            new WriteComputeProcessor(mergeRecordHelper, collectionFieldElementReplacementEnabled),
+            mergeRecordHelper),
         new MergeByteBuffer(),
         new MergeResultValueSchemaResolverImpl(annotatedReadOnlySchemaRepository, storeName),
         rmdSerDe,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/AvroCollectionElementComparator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/AvroCollectionElementComparator.java
@@ -17,10 +17,22 @@ import org.apache.commons.lang.Validate;
  */
 @ThreadSafe
 public class AvroCollectionElementComparator {
-  public final static AvroCollectionElementComparator INSTANCE = new AvroCollectionElementComparator();
+  public final static AvroCollectionElementComparator INSTANCE = new AvroCollectionElementComparator(false);
 
-  private AvroCollectionElementComparator() {
-    // Singleton class.
+  /**
+   * Unlike {@link #INSTANCE}, this comparator also compares record fields marked with {@code order: ignore}. It yields a
+   * total order over elements that {@link #INSTANCE} would consider equal because they only differ in ignored fields,
+   * which is required to deterministically break ties between two same-timestamp collection elements during
+   * Active/Active conflict resolution.
+   */
+  public final static AvroCollectionElementComparator FULL_COMPARISON_INSTANCE =
+      new AvroCollectionElementComparator(true);
+
+  private final boolean compareOrderIgnoredFields;
+
+  private AvroCollectionElementComparator(boolean compareOrderIgnoredFields) {
+    // Private constructor: instances are exposed only through the shared INSTANCE and FULL_COMPARISON_INSTANCE fields.
+    this.compareOrderIgnoredFields = compareOrderIgnoredFields;
   }
 
   /**
@@ -55,7 +67,7 @@ public class AvroCollectionElementComparator {
 
   private int compareRecords(GenericRecord r1, GenericRecord r2, Schema schema) {
     for (Schema.Field field: schema.getFields()) {
-      if (field.order() == Schema.Field.Order.IGNORE) {
+      if (!compareOrderIgnoredFields && field.order() == Schema.Field.Order.IGNORE) {
         continue;
       }
       int pos = field.pos();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/SortBasedCollectionFieldOpHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/SortBasedCollectionFieldOpHandler.java
@@ -27,8 +27,22 @@ import org.apache.avro.generic.GenericRecord;
 
 @ThreadSafe
 public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationHandler {
+  /**
+   * When true, a collection-merge (SET_UNION) element that wins a conflict against an existing, comparison-equal element
+   * replaces the stored element (so content in {@code order: ignore} fields is propagated) rather than only advancing the
+   * existing element's replication-metadata timestamp. See ConfigKeys#SERVER_AA_COLLECTION_FIELD_ELEMENT_REPLACEMENT_ENABLED.
+   */
+  private final boolean elementReplacementEnabled;
+
   public SortBasedCollectionFieldOpHandler(AvroCollectionElementComparator elementComparator) {
+    this(elementComparator, false);
+  }
+
+  public SortBasedCollectionFieldOpHandler(
+      AvroCollectionElementComparator elementComparator,
+      boolean elementReplacementEnabled) {
     super(elementComparator);
+    this.elementReplacementEnabled = elementReplacementEnabled;
   }
 
   @Override
@@ -589,8 +603,29 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
         activeElementToTsMap.put(toAddElement, modifyTimestamp);
         updated = true;
       } else if (activeTimestamp < modifyTimestamp) {
+        if (elementReplacementEnabled) {
+          // The incoming element wins on a strictly newer timestamp. Drop the stored element first so the incoming one
+          // (which may carry different content in order:ignore fields) replaces it, rather than IndexedHashMap#put
+          // keeping the existing key and only updating its timestamp.
+          activeElementToTsMap.remove(toAddElement);
+        }
         activeElementToTsMap.put(toAddElement, modifyTimestamp);
         updated = true;
+      } else if (elementReplacementEnabled && activeTimestamp == modifyTimestamp) {
+        // Same timestamp: break the tie deterministically using full element content (including order:ignore fields),
+        // so all Active/Active colos converge on the same element. A negative index means the element was removed above
+        // as part of the put-only part, in which case the legacy behavior is preserved.
+        int existingElementIndex = activeElementToTsMap.indexOf(toAddElement);
+        if (existingElementIndex >= 0) {
+          Object existingElement = activeElementToTsMap.getByIndex(existingElementIndex).getKey();
+          Schema elementSchema = getArraySchema(currValueRecordField.schema()).getElementType();
+          if (AvroCollectionElementComparator.FULL_COMPARISON_INSTANCE
+              .compare(toAddElement, existingElement, elementSchema) > 0) {
+            activeElementToTsMap.remove(toAddElement);
+            activeElementToTsMap.put(toAddElement, modifyTimestamp);
+            updated = true;
+          }
+        }
       }
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/writecompute/WriteComputeHandlerV2.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/writecompute/WriteComputeHandlerV2.java
@@ -32,11 +32,15 @@ public class WriteComputeHandlerV2 extends WriteComputeHandlerV1 {
   private final CollectionFieldOperationHandler collectionFieldOperationHandler;
 
   WriteComputeHandlerV2(MergeRecordHelper mergeRecordHelper) {
+    this(mergeRecordHelper, false);
+  }
+
+  WriteComputeHandlerV2(MergeRecordHelper mergeRecordHelper, boolean collectionFieldElementReplacementEnabled) {
     Validate.notNull(mergeRecordHelper);
     this.mergeRecordHelper = mergeRecordHelper;
-    // TODO: get this variable as a argument passed to this constructor.
-    this.collectionFieldOperationHandler =
-        new SortBasedCollectionFieldOpHandler(AvroCollectionElementComparator.INSTANCE);
+    this.collectionFieldOperationHandler = new SortBasedCollectionFieldOpHandler(
+        AvroCollectionElementComparator.INSTANCE,
+        collectionFieldElementReplacementEnabled);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/writecompute/WriteComputeProcessor.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/writecompute/WriteComputeProcessor.java
@@ -41,7 +41,11 @@ public class WriteComputeProcessor {
   private final WriteComputeHandlerV2 writeComputeHandlerV2;
 
   public WriteComputeProcessor(MergeRecordHelper mergeRecordHelper) {
-    this.writeComputeHandlerV2 = new WriteComputeHandlerV2(mergeRecordHelper);
+    this(mergeRecordHelper, false);
+  }
+
+  public WriteComputeProcessor(MergeRecordHelper mergeRecordHelper, boolean collectionFieldElementReplacementEnabled) {
+    this.writeComputeHandlerV2 = new WriteComputeHandlerV2(mergeRecordHelper, collectionFieldElementReplacementEnabled);
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/merge/SortBasedCollectionFieldElementReplacementTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/merge/SortBasedCollectionFieldElementReplacementTest.java
@@ -1,0 +1,195 @@
+package com.linkedin.davinci.schema.merge;
+
+import com.linkedin.davinci.schema.SchemaUtils;
+import com.linkedin.venice.schema.AvroSchemaParseUtils;
+import com.linkedin.venice.schema.rmd.RmdConstants;
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
+import com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Verifies the collection-merge (SET_UNION) element-replacement behavior gated by
+ * {@code server.aa.collection.field.element.replacement.enabled}.
+ *
+ * The list elements are records with a field marked {@code order: ignore}. Two elements that differ only in that ignored
+ * field are equal under Avro comparison (and {@link Object#equals}/{@link Object#hashCode}), so a union-add of such an
+ * element collides with the stored one. The legacy behavior keeps the stored element and only advances its timestamp,
+ * dropping the incoming element's content in the ignored field; the new behavior (flag on) applies the winning element.
+ */
+public class SortBasedCollectionFieldElementReplacementTest {
+  private static final String LIST_FIELD = "RecordListField";
+  private static final String ID_FIELD = "id";
+  private static final String IGNORED_FIELD = "metadata";
+
+  private static final Schema VALUE_SCHEMA = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(
+      "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"TestValueWithIgnoredField\",\n"
+          + "  \"namespace\": \"com.linkedin.davinci.schema.merge\",\n" + "  \"fields\": [\n" + "    {\n"
+          + "      \"name\": \"" + LIST_FIELD + "\",\n" + "      \"type\": {\n" + "        \"type\": \"array\",\n"
+          + "        \"items\": {\n" + "          \"type\": \"record\",\n"
+          + "          \"name\": \"ElementWithIgnoredField\",\n" + "          \"fields\": [\n"
+          + "            {\"name\": \"" + ID_FIELD + "\", \"type\": \"string\"},\n" + "            {\"name\": \""
+          + IGNORED_FIELD + "\", \"type\": \"string\", \"order\": \"ignore\", \"default\": \"\"}\n" + "          ]\n"
+          + "        }\n" + "      },\n" + "      \"default\": []\n" + "    }\n" + "  ]\n" + "}");
+
+  private static final Schema ELEMENT_SCHEMA = VALUE_SCHEMA.getField(LIST_FIELD).schema().getElementType();
+
+  private static final Schema RMD_SCHEMA =
+      SchemaUtils.annotateRmdSchema(RmdSchemaGenerator.generateMetadataSchema(VALUE_SCHEMA));
+  private static final Schema RMD_TIMESTAMP_SCHEMA =
+      RMD_SCHEMA.getField(RmdConstants.TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
+
+  @Test
+  public void testNewerTimestampKeepsStoredElementWhenDisabled() {
+    SortBasedCollectionFieldOpHandler handler =
+        new SortBasedCollectionFieldOpHandler(AvroCollectionElementComparator.INSTANCE);
+    GenericRecord value = valueWithElement(element("a", "old"));
+    CollectionRmdTimestamp<Object> rmd = collectionMetadata(1L, Collections.singletonList(5L));
+
+    UpdateResultStatus status = handler.handleModifyList(
+        10L,
+        rmd,
+        value,
+        value.getSchema().getField(LIST_FIELD),
+        Collections.singletonList(element("a", "new")),
+        Collections.emptyList());
+
+    Assert.assertEquals(status, UpdateResultStatus.PARTIALLY_UPDATED);
+    List<GenericRecord> result = currentList(value);
+    Assert.assertEquals(result.size(), 1);
+    // Legacy behavior: the ignored-field content of the incoming element is dropped, only the timestamp is advanced.
+    Assert.assertEquals(result.get(0).get(IGNORED_FIELD).toString(), "old");
+    Assert.assertEquals(rmd.getActiveElementTimestamps().get(0).longValue(), 10L);
+  }
+
+  @Test
+  public void testNewerTimestampReplacesStoredElementWhenEnabled() {
+    SortBasedCollectionFieldOpHandler handler =
+        new SortBasedCollectionFieldOpHandler(AvroCollectionElementComparator.INSTANCE, true);
+    GenericRecord value = valueWithElement(element("a", "old"));
+    CollectionRmdTimestamp<Object> rmd = collectionMetadata(1L, Collections.singletonList(5L));
+
+    UpdateResultStatus status = handler.handleModifyList(
+        10L,
+        rmd,
+        value,
+        value.getSchema().getField(LIST_FIELD),
+        Collections.singletonList(element("a", "new")),
+        Collections.emptyList());
+
+    Assert.assertEquals(status, UpdateResultStatus.PARTIALLY_UPDATED);
+    List<GenericRecord> result = currentList(value);
+    Assert.assertEquals(result.size(), 1);
+    // New behavior: the incoming element (newer timestamp) replaces the stored one, propagating the ignored field.
+    Assert.assertEquals(result.get(0).get(IGNORED_FIELD).toString(), "new");
+    Assert.assertEquals(rmd.getActiveElementTimestamps().get(0).longValue(), 10L);
+  }
+
+  @Test
+  public void testEqualTimestampReplacesWhenIncomingWinsTieBreak() {
+    SortBasedCollectionFieldOpHandler handler =
+        new SortBasedCollectionFieldOpHandler(AvroCollectionElementComparator.INSTANCE, true);
+    GenericRecord value = valueWithElement(element("a", "aaa"));
+    CollectionRmdTimestamp<Object> rmd = collectionMetadata(1L, Collections.singletonList(5L));
+
+    // Same timestamp as the stored element; "zzz" > "aaa" by full-content comparison, so the incoming element wins.
+    handler.handleModifyList(
+        5L,
+        rmd,
+        value,
+        value.getSchema().getField(LIST_FIELD),
+        Collections.singletonList(element("a", "zzz")),
+        Collections.emptyList());
+
+    List<GenericRecord> result = currentList(value);
+    Assert.assertEquals(result.size(), 1);
+    Assert.assertEquals(result.get(0).get(IGNORED_FIELD).toString(), "zzz");
+    Assert.assertEquals(rmd.getActiveElementTimestamps().get(0).longValue(), 5L);
+  }
+
+  @Test
+  public void testEqualTimestampKeepsExistingWhenIncomingLosesTieBreak() {
+    SortBasedCollectionFieldOpHandler handler =
+        new SortBasedCollectionFieldOpHandler(AvroCollectionElementComparator.INSTANCE, true);
+    GenericRecord value = valueWithElement(element("a", "zzz"));
+    CollectionRmdTimestamp<Object> rmd = collectionMetadata(1L, Collections.singletonList(5L));
+
+    // Same timestamp; "aaa" < "zzz" by full-content comparison, so the stored element is kept (deterministic
+    // tie-break).
+    handler.handleModifyList(
+        5L,
+        rmd,
+        value,
+        value.getSchema().getField(LIST_FIELD),
+        Collections.singletonList(element("a", "aaa")),
+        Collections.emptyList());
+
+    List<GenericRecord> result = currentList(value);
+    Assert.assertEquals(result.size(), 1);
+    Assert.assertEquals(result.get(0).get(IGNORED_FIELD).toString(), "zzz");
+    Assert.assertEquals(rmd.getActiveElementTimestamps().get(0).longValue(), 5L);
+  }
+
+  @Test
+  public void testEqualTimestampNoOpWhenContentIsIdentical() {
+    SortBasedCollectionFieldOpHandler handler =
+        new SortBasedCollectionFieldOpHandler(AvroCollectionElementComparator.INSTANCE, true);
+    GenericRecord value = valueWithElement(element("a", "same"));
+    CollectionRmdTimestamp<Object> rmd = collectionMetadata(1L, Collections.singletonList(5L));
+
+    // Same timestamp and identical content (full-content comparison == 0): the deterministic tie-break replaces
+    // nothing, so the element is untouched and no update is reported (no Active/Active churn on a redundant re-add).
+    UpdateResultStatus status = handler.handleModifyList(
+        5L,
+        rmd,
+        value,
+        value.getSchema().getField(LIST_FIELD),
+        Collections.singletonList(element("a", "same")),
+        Collections.emptyList());
+
+    Assert.assertEquals(status, UpdateResultStatus.NOT_UPDATED_AT_ALL);
+    List<GenericRecord> result = currentList(value);
+    Assert.assertEquals(result.size(), 1);
+    Assert.assertEquals(result.get(0).get(IGNORED_FIELD).toString(), "same");
+    Assert.assertEquals(rmd.getActiveElementTimestamps().get(0).longValue(), 5L);
+  }
+
+  private GenericRecord element(String id, String ignoredFieldValue) {
+    GenericRecord record = new GenericData.Record(ELEMENT_SCHEMA);
+    record.put(ID_FIELD, id);
+    record.put(IGNORED_FIELD, ignoredFieldValue);
+    return record;
+  }
+
+  private GenericRecord valueWithElement(GenericRecord element) {
+    GenericRecord value = new GenericData.Record(VALUE_SCHEMA);
+    value.put(LIST_FIELD, new ArrayList<>(Collections.singletonList(element)));
+    return value;
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<GenericRecord> currentList(GenericRecord value) {
+    return (List<GenericRecord>) value.get(LIST_FIELD);
+  }
+
+  private CollectionRmdTimestamp<Object> collectionMetadata(
+      long topLevelTimestamp,
+      List<Long> activeElementTimestamps) {
+    CollectionTimestampBuilder builder = new CollectionTimestampBuilder(ELEMENT_SCHEMA);
+    builder.setTopLevelTimestamps(topLevelTimestamp);
+    builder.setTopLevelColoID(0);
+    builder.setPutOnlyPartLength(0);
+    builder.setActiveElementsTimestamps(activeElementTimestamps);
+    builder.setDeletedElementTimestamps(Collections.<Long>emptyList());
+    builder.setDeletedElements(ELEMENT_SCHEMA, Collections.emptyList());
+    builder.setCollectionTimestampSchema(RMD_TIMESTAMP_SCHEMA.getField(LIST_FIELD).schema());
+    return new CollectionRmdTimestamp<>(builder.build());
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1069,6 +1069,17 @@ public class ConfigKeys {
   public static final String SERVER_COMPUTE_FAST_AVRO_ENABLED = "server.compute.fast.avro.enabled";
 
   /**
+   * Whether to replace an existing collection-merge (SET_UNION) array element with the incoming element on a conflict,
+   * instead of only advancing its replication-metadata timestamp. When two elements are considered equal by Avro's
+   * comparison (which excludes {@code order: ignore} fields), the legacy behavior keeps the stored element and drops the
+   * incoming element's content in the ignored fields. Enabling this flag applies the incoming element when it wins the
+   * conflict (newer timestamp, or equal timestamp with a deterministic full-content tie-break). Active/Active only.
+   * Defaults to false to preserve the legacy behavior for controlled rollout.
+   */
+  public static final String SERVER_AA_COLLECTION_FIELD_ELEMENT_REPLACEMENT_ENABLED =
+      "server.aa.collection.field.element.replacement.enabled";
+
+  /**
    * Whether to enable parallel lookup for batch-get.
    */
   public static final String SERVER_ENABLE_PARALLEL_BATCH_GET = "server.enable.parallel.batch.get";

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPartialUpdateWithActiveActiveReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPartialUpdateWithActiveActiveReplication.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.endToEnd;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC;
 import static com.linkedin.venice.ConfigKeys.PARENT_KAFKA_CLUSTER_FABRIC_LIST;
+import static com.linkedin.venice.ConfigKeys.SERVER_AA_COLLECTION_FIELD_ELEMENT_REPLACEMENT_ENABLED;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_PARENT_DATA_CENTER_REGION_NAME;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingRecord;
 import static com.linkedin.venice.utils.TestUtils.assertCommand;
@@ -62,6 +63,9 @@ public class TestPartialUpdateWithActiveActiveReplication extends AbstractMultiR
   public static final String NULLABLE_LIST_FIELD = "nullableListField";
   public static final String MAP_FIELD = "mapField";
   public static final String NULLABLE_MAP_FIELD = "nullableMapField";
+  public static final String RECORD_LIST_FIELD = "recordListField";
+  public static final String ELEMENT_ID_FIELD = "id";
+  public static final String ELEMENT_IGNORED_FIELD = "metadata";
 
   private static final Map<String, Integer> MAP_FIELD_DEFAULT_VALUE = Collections.emptyMap();
   private static final List<Integer> LIST_FIELD_DEFAULT_VALUE = Collections.emptyList();
@@ -92,6 +96,16 @@ public class TestPartialUpdateWithActiveActiveReplication extends AbstractMultiR
     controllerProps.put(NATIVE_REPLICATION_SOURCE_FABRIC, "dc-0");
     controllerProps.put(PARENT_KAFKA_CLUSTER_FABRIC_LIST, DEFAULT_PARENT_DATA_CENTER_REGION_NAME);
     return controllerProps;
+  }
+
+  @Override
+  protected Properties getExtraServerProperties() {
+    Properties serverProps = new Properties();
+    // Enable the fix that replaces (rather than only re-timestamps) a collection-merge element on conflict, so content
+    // in order:ignore fields is propagated. Exercised by
+    // testAAReplicationForCollectionElementReplacementWithIgnoredField.
+    serverProps.setProperty(SERVER_AA_COLLECTION_FIELD_ELEMENT_REPLACEMENT_ENABLED, "true");
+    return serverProps;
   }
 
   @Override
@@ -418,6 +432,102 @@ public class TestPartialUpdateWithActiveActiveReplication extends AbstractMultiR
         routerUrl,
         k -> ClientFactory
             .getAndStartGenericAvroClient(ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(routerUrl)));
+  }
+
+  /**
+   * Verifies the collection-merge element-replacement fix end-to-end in an A/A + write-compute store. The array element
+   * record has a field marked {@code order: ignore}, so two elements that share the same {@code id} but differ in the
+   * ignored {@code metadata} field are considered equal by Avro comparison. A SET_UNION that adds such an element must
+   * replace the stored element (propagating the new ignored-field content), not merely re-timestamp it. The behavior is
+   * gated by {@code server.aa.collection.field.element.replacement.enabled}, enabled in
+   * {@link #getExtraServerProperties()} for this test class.
+   *
+   * <p>Both timestamp-ordering paths are exercised against the same stored element: first a strictly-newer timestamp
+   * ({@code activeTimestamp < modifyTimestamp}), where the incoming element wins on timestamp and replaces the stored
+   * one; then an equal timestamp ({@code activeTimestamp == modifyTimestamp}), where the equal-timestamp tie-break
+   * deterministically keeps whichever element wins a full-content comparison (including the ignored field), so all A/A
+   * regions converge regardless of arrival order.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testAAReplicationForCollectionElementReplacementWithIgnoredField() throws IOException {
+    Schema valueSchema =
+        AvroCompatibilityHelper.parse(loadFileAsString("PartialUpdateRecordListWithIgnoredField.avsc"));
+    Schema updateSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(valueSchema);
+    Schema elementSchema = valueSchema.getField(RECORD_LIST_FIELD).schema().getElementType();
+
+    assertCommand(parentControllerClient.createNewStore(storeName, "owner", KEY_SCHEMA_STR, valueSchema.toString()));
+    UpdateStoreQueryParams params = new UpdateStoreQueryParams().setNativeReplicationEnabled(true)
+        .setActiveActiveReplicationEnabled(true)
+        .setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+        .setChunkingEnabled(false)
+        .setHybridRewindSeconds(25L)
+        .setHybridOffsetLagThreshold(1L)
+        .setWriteComputationEnabled(true);
+    assertCommand(parentControllerClient.updateStore(storeName, params));
+
+    runEmptyPushAndVerifyStoreVersion(storeName, 1);
+    startVeniceSystemProducers();
+
+    String key = "key1";
+
+    // First SET_UNION: add element {id: "e1", metadata: "v1"} at timestamp 1000.
+    GenericRecord firstElement = new GenericData.Record(elementSchema);
+    firstElement.put(ELEMENT_ID_FIELD, "e1");
+    firstElement.put(ELEMENT_IGNORED_FIELD, "v1");
+    UpdateBuilder firstUpdate = new UpdateBuilderImpl(updateSchema);
+    firstUpdate.setElementsToAddToListField(RECORD_LIST_FIELD, Collections.singletonList(firstElement));
+    sendStreamingRecord(systemProducerMap.get(childDatacenters.get(0)), storeName, key, firstUpdate.build(), 1000L);
+    verifyCollectionElementIgnoredField(storeName, dc0RouterUrl, key, "e1", "v1");
+
+    // Second SET_UNION: add element {id: "e1", metadata: "v2"} at a newer timestamp 2000. The element is equal to the
+    // stored one (only the order:ignore field differs), so this exercises the conflict path.
+    GenericRecord secondElement = new GenericData.Record(elementSchema);
+    secondElement.put(ELEMENT_ID_FIELD, "e1");
+    secondElement.put(ELEMENT_IGNORED_FIELD, "v2");
+    UpdateBuilder secondUpdate = new UpdateBuilderImpl(updateSchema);
+    secondUpdate.setElementsToAddToListField(RECORD_LIST_FIELD, Collections.singletonList(secondElement));
+    sendStreamingRecord(systemProducerMap.get(childDatacenters.get(0)), storeName, key, secondUpdate.build(), 2000L);
+
+    // The newer element replaces the stored one; both regions converge to the updated ignored-field content.
+    verifyCollectionElementIgnoredField(storeName, dc0RouterUrl, key, "e1", "v2");
+    verifyCollectionElementIgnoredField(storeName, dc1RouterUrl, key, "e1", "v2");
+
+    // Third SET_UNION: add element {id: "e1", metadata: "v3"} at the SAME timestamp 2000 as the now-stored element.
+    // The timestamps tie, so this exercises the equal-timestamp tie-break: "v3" wins a full-content comparison over
+    // the stored "v2" and replaces it, instead of the equal-timestamp write being dropped.
+    GenericRecord thirdElement = new GenericData.Record(elementSchema);
+    thirdElement.put(ELEMENT_ID_FIELD, "e1");
+    thirdElement.put(ELEMENT_IGNORED_FIELD, "v3");
+    UpdateBuilder thirdUpdate = new UpdateBuilderImpl(updateSchema);
+    thirdUpdate.setElementsToAddToListField(RECORD_LIST_FIELD, Collections.singletonList(thirdElement));
+    sendStreamingRecord(systemProducerMap.get(childDatacenters.get(0)), storeName, key, thirdUpdate.build(), 2000L);
+
+    // The equal-timestamp tie-break winner replaces the stored element; both regions converge to the new content.
+    verifyCollectionElementIgnoredField(storeName, dc0RouterUrl, key, "e1", "v3");
+    verifyCollectionElementIgnoredField(storeName, dc1RouterUrl, key, "e1", "v3");
+  }
+
+  private void verifyCollectionElementIgnoredField(
+      String storeName,
+      String routerUrl,
+      String key,
+      String expectedId,
+      String expectedIgnoredFieldValue) {
+    AvroGenericStoreClient<String, GenericRecord> client = getStoreClient(storeName, routerUrl);
+    // retryOnThrowable=true so a transient ExecutionException/InterruptedException from client.get(key).get() is
+    // retried
+    // rather than failing the test immediately.
+    TestUtils.waitForNonDeterministicAssertion(120, TimeUnit.SECONDS, false, true, () -> {
+      GenericRecord retrievedValue = client.get(key).get();
+      assertNotNull(retrievedValue);
+      @SuppressWarnings("unchecked")
+      List<GenericRecord> recordList = (List<GenericRecord>) retrievedValue.get(RECORD_LIST_FIELD);
+      assertNotNull(recordList);
+      assertEquals(recordList.size(), 1);
+      GenericRecord element = recordList.get(0);
+      assertEquals(element.get(ELEMENT_ID_FIELD).toString(), expectedId);
+      assertEquals(element.get(ELEMENT_IGNORED_FIELD).toString(), expectedIgnoredFieldValue);
+    });
   }
 
   /**

--- a/internal/venice-test-common/src/integrationTest/resources/PartialUpdateRecordListWithIgnoredField.avsc
+++ b/internal/venice-test-common/src/integrationTest/resources/PartialUpdateRecordListWithIgnoredField.avsc
@@ -1,0 +1,36 @@
+{
+  "type": "record",
+  "name": "TestValueWithIgnoredField",
+  "namespace": "com.linkedin.venice.endToEnd",
+  "fields": [
+    {
+      "name": "regularField",
+      "type": "string",
+      "default": "default_venice"
+    },
+    {
+      "name": "recordListField",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "ElementWithIgnoredField",
+          "fields": [
+            {
+              "name": "id",
+              "type": "string",
+              "default": ""
+            },
+            {
+              "name": "metadata",
+              "type": "string",
+              "order": "ignore",
+              "default": ""
+            }
+          ]
+        }
+      },
+      "default": []
+    }
+  ]
+}


### PR DESCRIPTION
## Problem Statement

During Active/Active (A/A) write-compute collection merge, a `SET_UNION` (add-to-set) on an array field that re-adds an element which is *comparison-equal* to an already-stored element only advances that element's per-element replication-metadata (RMD) timestamp — it keeps the stored object. Element identity is `GenericRecord` `equals`/`hashCode`, which (like Avro's `GenericData` comparison) **excludes fields marked `order: ignore`**.

As a result, when the array-element record has an `order: ignore` field, an incoming element with the same identity but different content in the ignored field is treated as "already present", and the incoming content is **silently dropped** — the write appears applied (RMD timestamp moves, status is `PARTIALLY_UPDATED`) but the visible value never changes.

The actual entry point for this path is `WriteComputeHandlerV2.handleModifyList` → `SortBasedCollectionFieldOpHandler.handleModifyCollectionMergeList`, where the per-element map (`IndexedHashMap`) keeps the existing key on a colliding `put` and only overwrites the timestamp value.

## Solution

Add element replacement in `SortBasedCollectionFieldOpHandler`, gated by a new server config (default `false`):

- **Newer timestamp** (`existingTs < modifyTs`): remove-then-put so the incoming element replaces the stored one, propagating `order:ignore`-field content.
- **Equal timestamp** (`existingTs == modifyTs`): deterministically break the tie by a **full element comparison that includes `order:ignore` fields** (`AvroCollectionElementComparator.FULL_COMPARISON_INSTANCE`), so all A/A colos converge on the same element. The default comparator excludes ignored fields and would return 0 for exactly this case, so a dedicated comparison instance is required.

When the flag is `false`, behavior is byte-for-byte the legacy behavior. The flag is threaded `VeniceServerConfig` → `ActiveActiveStoreIngestionTask` → `MergeConflictResolverFactory` → `WriteComputeProcessor` → `WriteComputeHandlerV2` → `SortBasedCollectionFieldOpHandler` via backward-compatible constructor/factory overloads (no existing caller changed). Scope is the A/A merge path only; the non-A/A leader write-compute path is unchanged (single-writer, no conflict).

### Code changes
- [x] Added new code behind **a config**: `server.aa.collection.field.element.replacement.enabled`, default **`false`**.
- [ ] Introduced new **log lines**.

### Concurrency-Specific Checks
- [x] Code has **no race conditions** or **thread safety issues**. The new field is an immutable `final boolean` set at construction; the handler and comparators are already `@ThreadSafe` and stateless per request.

## How was this PR tested?

- [x] New unit tests added: `SortBasedCollectionFieldElementReplacementTest` — array-of-record schema with an `order:ignore` field; covers flag-off (legacy: content dropped, timestamp advanced), flag-on newer-timestamp (replaced), and flag-on equal-timestamp tie-break in both directions.
- [x] New integration tests added: `TestPartialUpdateWithActiveActiveReplication#testAAReplicationForCollectionElementReplacementWithIgnoredField` — A/A + write-compute store, two `SET_UNION` updates that differ only in the `order:ignore` field; verifies both regions converge to the newer content with the config enabled. **Passed (35.9s).**
- [x] Modified or extended existing tests: enabled the config in the test class's server properties.
- [x] Verified backward compatibility: existing `schema.merge`, `schema.writecompute`, and `replication.merge` suites pass unchanged (default flag-off path).

## Does this PR introduce any user-facing or breaking changes?
- [x] No. The new behavior is off by default; enabling the config is an opt-in change to A/A collection-merge conflict resolution for stores whose array-element records use `order: ignore`.
