### PR TITLE
[server][fc] Fix gRPC read stats recording successful reads as failures

### DIFF
--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/grpc/handlers/GrpcOutboundStatsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/grpc/handlers/GrpcOutboundStatsHandler.java
@@ -38,10 +38,15 @@ public class GrpcOutboundStatsHandler extends VeniceServerGrpcHandler {
 
     double elapsedTime = LatencyUtils.getElapsedTimeFromNSToMS(statsContext.getRequestStartTimeInNS());
 
-    if (!ctx.hasError() && !responseStatus.equals(HttpResponseStatus.OK)
-        || responseStatus.equals(HttpResponseStatus.NOT_FOUND)) {
+    /*
+     * Record a success only when no handler flagged an error and the response is OK (value found) or NOT_FOUND
+     * (key absent); otherwise record an error. TOO_MANY_REQUESTS is recorded as neither, since a throttled
+     * request is not a server-side failure. Mirrors the Netty StatsHandler categorization.
+     */
+    if (!ctx.hasError()
+        && (responseStatus.equals(HttpResponseStatus.OK) || responseStatus.equals(HttpResponseStatus.NOT_FOUND))) {
       statsContext.successRequest(serverHttpRequestStats, elapsedTime);
-    } else {
+    } else if (!responseStatus.equals(HttpResponseStatus.TOO_MANY_REQUESTS)) {
       statsContext.errorRequest(serverHttpRequestStats, elapsedTime);
     }
   }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/grpc/handlers/GrpcOutboundStatsHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/grpc/handlers/GrpcOutboundStatsHandlerTest.java
@@ -1,0 +1,77 @@
+package com.linkedin.venice.listener.grpc.handlers;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpResponseStatus.TOO_MANY_REQUESTS;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.venice.listener.ServerStatsContext;
+import com.linkedin.venice.listener.grpc.GrpcRequestContext;
+import com.linkedin.venice.protocols.VeniceServerResponse;
+import com.linkedin.venice.stats.AggServerHttpRequestStats;
+import com.linkedin.venice.stats.ServerHttpRequestStats;
+import io.grpc.stub.StreamObserver;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class GrpcOutboundStatsHandlerTest {
+  private static final String STORE_NAME = "test_store";
+
+  /*
+   * Each row is: the response status, whether a prior handler flagged an error, and the expected outcome -
+   * TRUE = recorded as success, FALSE = recorded as error, null = recorded as neither (throttled).
+   */
+  @DataProvider(name = "responseStatusCases", parallel = true)
+  public Object[][] responseStatusCases() {
+    return new Object[][] { { OK, false, Boolean.TRUE }, // value found -> success (regression guard for 200-as-fail)
+        { NOT_FOUND, false, Boolean.TRUE }, // key absent -> success
+        { OK, true, Boolean.FALSE }, // error flagged despite OK status -> error
+        { BAD_REQUEST, false, Boolean.FALSE }, // malformed request -> error
+        { INTERNAL_SERVER_ERROR, false, Boolean.FALSE }, // server failure -> error
+        { TOO_MANY_REQUESTS, false, null } }; // throttled -> neither success nor error
+  }
+
+  @Test(dataProvider = "responseStatusCases")
+  public void testRequestCategorization(HttpResponseStatus responseStatus, boolean hasError, Boolean expectSuccess) {
+    ServerHttpRequestStats storeStats = mock(ServerHttpRequestStats.class);
+    AggServerHttpRequestStats aggStats = mock(AggServerHttpRequestStats.class);
+    when(aggStats.getStoreStats(STORE_NAME)).thenReturn(storeStats);
+
+    ServerStatsContext statsContext = mock(ServerStatsContext.class);
+    when(statsContext.getResponseStatus()).thenReturn(responseStatus);
+    when(statsContext.getStoreName()).thenReturn(STORE_NAME);
+    when(statsContext.getCurrentStats()).thenReturn(aggStats);
+    when(statsContext.getRequestStartTimeInNS()).thenReturn(0L);
+
+    @SuppressWarnings("unchecked")
+    StreamObserver<VeniceServerResponse> responseObserver = mock(StreamObserver.class);
+    GrpcRequestContext ctx = new GrpcRequestContext(null, VeniceServerResponse.newBuilder(), responseObserver);
+    ctx.setGrpcStatsContext(statsContext);
+    if (hasError) {
+      ctx.setError();
+    }
+
+    new GrpcOutboundStatsHandler().processRequest(ctx);
+
+    if (expectSuccess == null) {
+      verify(statsContext, never()).successRequest(eq(storeStats), anyDouble());
+      verify(statsContext, never()).errorRequest(eq(storeStats), anyDouble());
+    } else if (expectSuccess) {
+      verify(statsContext, times(1)).successRequest(eq(storeStats), anyDouble());
+      verify(statsContext, never()).errorRequest(eq(storeStats), anyDouble());
+    } else {
+      verify(statsContext, times(1)).errorRequest(eq(storeStats), anyDouble());
+      verify(statsContext, never()).successRequest(eq(storeStats), anyDouble());
+    }
+  }
+}


### PR DESCRIPTION
## Problem Statement

`GrpcOutboundStatsHandler` decides whether a read is recorded as a success or an error with:

```java
!ctx.hasError() && !responseStatus.equals(OK) || responseStatus.equals(NOT_FOUND)
```

Because Java binds `&&` tighter than `||`, this parses as
`(!hasError && !status.equals(OK)) || status.equals(NOT_FOUND)`. For a successful
value-found read (`hasError == false`, status `OK`) it evaluates to `false`, so the read
is recorded via `errorRequest()`. Every successful gRPC read therefore emits
`Venice.Server.Read.CallCount{Http.Response.StatusCode=200, Venice.Response.StatusCodeCategory=fail}`
and increments the `error_request` sensor. The same condition also records genuine `400`/`500`
responses and `429` throttles as successes.

This silently inflates the gRPC read error rate (and deflates real errors), which can falsely
trip `error_request`-based alerts on any store served over gRPC fast-client. The Netty path
(`StatsHandler`) already categorizes correctly; only the gRPC handler is affected.

## Solution

Parenthesize the condition to mirror `StatsHandler`:

- record a success only when no handler flagged an error **and** the status is `OK` or `NOT_FOUND`;
- record `TOO_MANY_REQUESTS` as neither (a throttled request is not a server-side failure);
- record everything else as an error.

### Code changes
- [ ] Added new code behind **a config**. — No.
- [ ] Introduced new **log lines**. — No.

### **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. The change is a pure boolean-condition correction; no shared state, locking, or threading is touched.

## How was this PR tested?

- [x] New unit tests added.

Added `GrpcOutboundStatsHandlerTest` (parameterized) covering:
- value-found (`200`, no error) → success — regression guard for the reported `(200, fail)` series;
- key-absent (`404`) → success;
- error flagged with `OK` status → error;
- `400` / `500` → error;
- `429` → neither.

Verified the test **fails** against the pre-fix condition (the value-found, `400`, `500`, and `429`
cases) and **passes** with the fix. SpotBugs on `:services:venice-server` is clean.

## Does this PR introduce any user-facing or breaking changes?

- [x] No.

Metric-only correctness change — corrects success/error attribution for gRPC reads. No API or
runtime behavior change otherwise.
