### PR TITLE
Eldernewborn/region fabric refactor[controller][test] Extract FabricControllerClientProvider and queryAllRegions fan-out helper

### DIFF
--- a/docs/contributing/architecture/controller-cross-region-fanout.md
+++ b/docs/contributing/architecture/controller-cross-region-fanout.md
@@ -1,0 +1,114 @@
+# Controller Cross-Region Fan-Out and Retry Behavior
+
+This page documents how the Venice controller talks to other regions/fabrics, and the (currently non-uniform) retry
+behavior of each cross-region call site. It is a reference for anyone touching the parent/child controllers or the
+cross-region coordination layer.
+
+> Line numbers below are indicative and drift as the files change; the stable anchor is the **method name**. Search for
+> the method in `VeniceParentHelixAdmin` (parent) or `VeniceHelixAdmin` (child).
+
+## Where the controller clients come from
+
+Both controllers reach other regions through `ControllerClient` instances keyed by region/fabric. Ownership of those
+client maps is centralized in `FabricControllerClientProvider`:
+
+- `getControllerClientMap(clusterName)` — the standard per-cluster/per-colo map (built from the child data-center URL
+  and D2 allowlists).
+- `getFabricBuildoutControllerClient(clusterName, fabric)` — a single client for a fabric that may be outside the
+  standard allowlist (build-out / data-recovery destinations), cached separately.
+
+`VeniceHelixAdmin` (the child) constructs one provider and exposes it via `getFabricControllerClientProvider()`;
+`VeniceParentHelixAdmin` (the parent) shares the same instance. The child's `getControllerClientMap(...)` delegates to
+the provider, and ~25 production call sites plus the parent's fan-out methods draw clients from it.
+
+## The fan-out helper
+
+Most "ask every region the same thing" loops follow one best-effort shape, captured by
+`FabricControllerClientProvider.queryAllRegions(...)`:
+
+```java
+<R extends ControllerResponse, V> Map<String, V> queryAllRegions(
+    Map<String, ControllerClient> controllerClients,
+    String clusterName,
+    int maxAttempts,                       // 1 = no retry; >1 wraps in ControllerClient.retryableRequest
+    Function<ControllerClient, R> request, // the RPC to issue per region
+    Function<R, V> onSuccess,              // map a successful response to a per-region value
+    V errorSentinel)                       // value stored for a region whose query errored
+```
+
+For each region it runs `request` (retried when `maxAttempts > 1`), and on a per-region error it **logs and stores
+`errorSentinel`** rather than aborting. The parent's multi-colo version queries (`getCurrentVersionForMultiRegions`,
+`getFutureVersionsForMultiColos`, `getBackupVersionsForMultiColos`) use it. The remaining fan-out sites still hand-roll
+their loops because their error policy is bespoke (fail-fast, throw, region-filtered, error-collecting,
+first-success-wins, fold/max, etc.).
+
+## The two retry engines
+
+There is **no single retry policy**. Cross-region calls that retry use one of two mechanisms, with different semantics:
+
+### 1. `ControllerClient.retryableRequest(client, totalAttempts, request)`
+
+- **Fixed delay** of `Utils.sleep(2000)` (2 s) between attempts — _not_ exponential. Five attempts therefore cost up to
+  ~8 s of sleeping on the unhappy path.
+- Stops early on success, on a "value schema not found" response, or when an optional `abortRetryCondition` returns true
+  (the overload used by `queryAllRegions` passes `r -> false`).
+- After exhausting attempts: **throws** `VeniceException` if the request threw an exception, but **returns the last
+  error response** if it merely returned `isError()`.
+
+### 2. `RetryUtils.executeWithMaxAttemptAndExponentialBackoff(op, attempts, initialDelay, maxDelay, maxTotalDelay, retryFailureTypes)`
+
+- True **exponential backoff**, bounded by `maxDelay` and `maxTotalDelay`.
+- Retries **only** on the listed exception types; other exceptions propagate immediately.
+- Used by sites whose body throws a sentinel exception to signal "not done yet, retry the whole region sweep."
+
+## Retry catalog
+
+### Fan-out sites that retry (all use 5 attempts)
+
+| Method                                        | Class:line  | RPC                          | Engine                                    | Backoff / cost                | Error policy                        |
+| --------------------------------------------- | ----------- | ---------------------------- | ----------------------------------------- | ----------------------------- | ----------------------------------- |
+| `getFutureVersionsForMultiColos`              | Parent:2264 | `getFutureVersions`          | `queryAllRegions(5)` → `retryableRequest` | fixed 2 s between (~8 s)      | sentinel                            |
+| `isActiveActiveReplicationEnabledInAllRegion` | Parent:1702 | `getStore`                   | `retryableRequest(5)`                     | fixed 2 s between (~8 s)      | log+continue; throw on A/A mismatch |
+| `rollForwardToFutureVersion`                  | Parent:2446 | `rollForwardToFutureVersion` | `RetryUtils` exp-backoff (5)              | 100 ms → 500 ms cap, 10 s max | throw; track `failedRegions`        |
+| `pollChildRegionsForRollbackStatus`           | Parent:2603 | `getStore`                   | `RetryUtils` exp-backoff (5)              | 1 s → 10 s cap, 30 s max      | fold + full re-poll                 |
+| `isRTTopicDeletionPermittedByAllControllers`  | Child:4267  | `getStore`                   | `RetryUtils` exp-backoff (5)              | 10 ms → 500 ms cap, 5 s max   | skip-missing; fail-fast → false     |
+
+### Fan-out sites with no retry (single attempt)
+
+| Method                                    | Class:line  | RPC                                         | Error policy             |
+| ----------------------------------------- | ----------- | ------------------------------------------- | ------------------------ |
+| `getCurrentVersionForMultiRegions`        | Parent:2301 | `getStore`                                  | sentinel                 |
+| `getBackupVersionsForMultiColos`          | Parent:2276 | `getBackupVersions`                         | sentinel                 |
+| `getInUseValueSchemaIds`                  | Parent:764  | `getInUseSchemaIds`                         | fail-fast → empty set    |
+| `getOffLineJobStatus`                     | Parent:3451 | `getLeaderControllerUrl` / `queryJobStatus` | log → UNKNOWN, aggregate |
+| `getClusterStaleStores`                   | Parent:4835 | `getClusterStores`                          | throw                    |
+| `getLargestUsedVersionFromStoreGraveyard` | Parent:4906 | `getStoreLargestUsedVersion`                | fold/max                 |
+| `getLargestUsedVersion`                   | Parent:4919 | `getStoreLargestUsedVersion`                | fold/max                 |
+| `listStorePushInfo`                       | Parent:4955 | `getRegionPushDetails`                      | skip null/continue       |
+| `checkResourceCleanupBeforeStoreCreation` | Parent:4982 | `checkResourceCleanupForStoreCreation`      | fail-fast throw          |
+| `removeStoreFromGraveyard`                | Parent:5519 | `removeStoreFromGraveyard`                  | fail-fast throw          |
+| `validateStoreDeleted`                    | Parent:5585 | `validateStoreDeleted`                      | collect errors           |
+| `sendPushJobDetails`                      | Child:1623  | `sendPushJobDetails`                        | first-success-wins       |
+| `getStoreInfoInChildColos`                | Child:1963  | `getStore`                                  | fail-fast throw          |
+| `deleteRTTopicFromAllFabrics`             | Child:4335  | `deleteKafkaTopic`                          | log + continue           |
+
+### Single-region calls (pick one region's client) — all no-retry
+
+`getRepushInfo` (Parent), `getCurrentVersionInRegion` (Parent), `getOffLinePushStatus` single-region path (Parent),
+`getStoreInChildRegion` (Parent), `initiateDataRecovery` / `prepareDataRecovery` / `isStoreVersionReadyForDataRecovery`
+(Parent), `wipeCluster` (Parent), `compareStore` (Parent), `copyOverStoreSchemasAndConfigs` (Parent), `getStoreInfo`
+(Child), and the store-migration source lookup (Child). Each issues a single attempt; the error policy is `throw`,
+except `isStoreVersionReadyForDataRecovery` (collect) and `getCurrentVersionInRegion` (returns `-1`).
+
+## Known inconsistencies and future work
+
+- **The three sibling version queries disagree on retry:** `getFutureVersionsForMultiColos` retries (5× / fixed 2 s),
+  while `getCurrentVersionForMultiRegions` and `getBackupVersionsForMultiColos` do not. The future-version retry was
+  added deliberately (it gates a "don't start a push when a future version exists" decision), so unifying is a semantic
+  choice, not a pure cleanup. Because all three now go through `queryAllRegions`, changing a policy is a one-number
+  (`maxAttempts`) edit per site.
+- **Two engines, four profiles:** any "unify retry" effort must pick both an engine (fixed-delay `retryableRequest` vs
+  exponential `RetryUtils`) and a delay profile; the five retrying sites currently use four different profiles.
+- **Bespoke loops remain hand-rolled:** only the three uniform best-effort version queries were migrated to
+  `queryAllRegions`; the rest keep their own loops because their error policy differs. Consolidating them further would
+  require a more configurable helper and careful behavior preservation.

--- a/docs/contributing/architecture/controller-cross-region-fanout.md
+++ b/docs/contributing/architecture/controller-cross-region-fanout.md
@@ -12,7 +12,7 @@ cross-region coordination layer.
 Both controllers reach other regions through `ControllerClient` instances keyed by region/fabric. Ownership of those
 client maps is centralized in `FabricControllerClientProvider`:
 
-- `getControllerClientMap(clusterName)` — the standard per-cluster/per-colo map (built from the child data-center URL
+- `getControllerClientMap(clusterName)` — the standard per-cluster/per-fabric map (built from the child data-center URL
   and D2 allowlists).
 - `getFabricBuildoutControllerClient(clusterName, fabric)` — a single client for a fabric that may be outside the
   standard allowlist (build-out / data-recovery destinations), cached separately.
@@ -37,7 +37,7 @@ Most "ask every region the same thing" loops follow one best-effort shape, captu
 ```
 
 For each region it runs `request` (retried when `maxAttempts > 1`), and on a per-region error it **logs and stores
-`errorSentinel`** rather than aborting. The parent's multi-colo version queries (`getCurrentVersionForMultiRegions`,
+`errorSentinel`** rather than aborting. The parent's multi-fabric version queries (`getCurrentVersionForMultiRegions`,
 `getFutureVersionsForMultiColos`, `getBackupVersionsForMultiColos`) use it. The remaining fan-out sites still hand-roll
 their loops because their error policy is bespoke (fail-fast, throw, region-filtered, error-collecting,
 first-success-wins, fold/max, etc.).

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/FabricControllerClientProvider.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/FabricControllerClientProvider.java
@@ -1,0 +1,145 @@
+package com.linkedin.venice.controller;
+
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.D2ControllerClient;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.io.Closeable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang.StringUtils;
+
+
+/**
+ * Owns the controller-client maps used for cross-region / cross-fabric coordination and centralizes their lazy
+ * construction and lifecycle. A single instance is created by {@link VeniceHelixAdmin} (child) and shared with
+ * {@link VeniceParentHelixAdmin} (parent), which previously each maintained their own copy of this plumbing.
+ *
+ * Two maps are maintained:
+ * <ul>
+ *   <li>{@link #clusterControllerClientPerColoMap}: cluster -&gt; colo -&gt; client, built from the standard child
+ *       data-center allowlist (URL and D2 maps) in the cluster config.</li>
+ *   <li>{@link #newFabricControllerClientMap}: cluster -&gt; fabric -&gt; client, built on demand for fabrics that are
+ *       not in the standard allowlist (e.g. build-out / data-recovery destinations).</li>
+ * </ul>
+ *
+ * Both maps are {@link VeniceConcurrentHashMap}s populated via {@code computeIfAbsent}; no external locking is needed.
+ */
+public class FabricControllerClientProvider implements Closeable {
+  private final VeniceControllerMultiClusterConfig multiClusterConfigs;
+  private final Optional<SSLFactory> sslFactory;
+  private final Map<String, D2Client> d2Clients;
+
+  /** Controller Client Map per cluster per colo */
+  private final Map<String, Map<String, ControllerClient>> clusterControllerClientPerColoMap =
+      new VeniceConcurrentHashMap<>();
+
+  /** New fabric controller client map per cluster per fabric */
+  private final Map<String, Map<String, ControllerClient>> newFabricControllerClientMap =
+      new VeniceConcurrentHashMap<>();
+
+  public FabricControllerClientProvider(
+      VeniceControllerMultiClusterConfig multiClusterConfigs,
+      Optional<SSLFactory> sslFactory,
+      Map<String, D2Client> d2Clients) {
+    this.multiClusterConfigs = multiClusterConfigs;
+    this.sslFactory = sslFactory;
+    this.d2Clients = d2Clients;
+  }
+
+  /**
+   * Returns the lazily-constructed map of controller clients (colo -&gt; client) for the standard child data-center
+   * allowlist of the given cluster.
+   */
+  public Map<String, ControllerClient> getControllerClientMap(String clusterName) {
+    return clusterControllerClientPerColoMap.computeIfAbsent(clusterName, cn -> {
+      Map<String, ControllerClient> controllerClients = new HashMap<>();
+      VeniceControllerClusterConfig controllerConfig = multiClusterConfigs.getControllerConfig(clusterName);
+      controllerConfig.getChildDataCenterControllerUrlMap()
+          .entrySet()
+          .forEach(
+              entry -> controllerClients.put(
+                  entry.getKey(),
+                  ControllerClient.constructClusterControllerClient(clusterName, entry.getValue(), sslFactory)));
+
+      // Respect d2Clients from controller constructor, if not provided, create d2 clients by zk d2 service urls
+      // (mainly for testing purpose)
+      if (d2Clients != null) {
+        controllerConfig.getChildDataCenterControllerD2Map()
+            .entrySet()
+            .forEach(
+                entry -> controllerClients.put(
+                    entry.getKey(),
+                    new D2ControllerClient(
+                        controllerConfig.getD2ServiceName(),
+                        clusterName,
+                        d2Clients.get(entry.getKey()),
+                        sslFactory)));
+      } else {
+        controllerConfig.getChildDataCenterControllerD2Map()
+            .entrySet()
+            .forEach(
+                entry -> controllerClients.put(
+                    entry.getKey(),
+                    new D2ControllerClient(
+                        controllerConfig.getD2ServiceName(),
+                        clusterName,
+                        entry.getValue(),
+                        sslFactory)));
+      }
+
+      return controllerClients;
+    });
+  }
+
+  /**
+   * Returns a controller client for a specific fabric of the given cluster. Fabrics in the standard allowlist are
+   * served from {@link #getControllerClientMap(String)}; fabrics outside the allowlist (e.g. build-out / data-recovery
+   * destinations) are built on demand from child cluster configs and cached in {@link #newFabricControllerClientMap}.
+   */
+  public ControllerClient getFabricBuildoutControllerClient(String clusterName, String fabric) {
+    Map<String, ControllerClient> controllerClients = getControllerClientMap(clusterName);
+    if (controllerClients.containsKey(fabric)) {
+      return controllerClients.get(fabric);
+    }
+
+    // For fabrics not in allowlist, build controller clients using child cluster configs and cache them in another map
+    ControllerClient value =
+        newFabricControllerClientMap.computeIfAbsent(clusterName, cn -> new VeniceConcurrentHashMap<>())
+            .computeIfAbsent(fabric, f -> {
+              VeniceControllerClusterConfig controllerConfig = multiClusterConfigs.getControllerConfig(clusterName);
+              String d2ZkHost = controllerConfig.getChildControllerD2ZkHost(fabric);
+              String d2ServiceName = controllerConfig.getD2ServiceName();
+              if (StringUtils.isNotBlank(d2ZkHost) && StringUtils.isNotBlank(d2ServiceName)) {
+                if (d2Clients != null) {
+                  return new D2ControllerClient(d2ServiceName, clusterName, d2Clients.get(fabric));
+                }
+                return new D2ControllerClient(d2ServiceName, clusterName, d2ZkHost, sslFactory);
+              }
+              String url = controllerConfig.getChildControllerUrl(fabric);
+              if (StringUtils.isNotBlank(url)) {
+                return ControllerClient.constructClusterControllerClient(clusterName, url, sslFactory);
+              }
+              return null;
+            });
+
+    if (value == null) {
+      throw new VeniceException(
+          "Could not construct child controller client for cluster " + clusterName + " fabric " + fabric
+              + ". child.cluster.d2 or child.cluster.url value is missing in parent controller");
+    }
+    return value;
+  }
+
+  @Override
+  public void close() {
+    clusterControllerClientPerColoMap.values()
+        .forEach(controllerClientMap -> controllerClientMap.values().forEach(Utils::closeQuietlyWithErrorLogged));
+    newFabricControllerClientMap.values()
+        .forEach(controllerClientMap -> controllerClientMap.values().forEach(Utils::closeQuietlyWithErrorLogged));
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/FabricControllerClientProvider.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/FabricControllerClientProvider.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.controller;
 
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.D2ControllerClient;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.security.SSLFactory;
@@ -11,7 +12,10 @@ import java.io.Closeable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
 /**
@@ -30,6 +34,8 @@ import org.apache.commons.lang.StringUtils;
  * Both maps are {@link VeniceConcurrentHashMap}s populated via {@code computeIfAbsent}; no external locking is needed.
  */
 public class FabricControllerClientProvider implements Closeable {
+  private static final Logger LOGGER = LogManager.getLogger(FabricControllerClientProvider.class);
+
   private final VeniceControllerMultiClusterConfig multiClusterConfigs;
   private final Optional<SSLFactory> sslFactory;
   private final Map<String, D2Client> d2Clients;
@@ -133,6 +139,54 @@ public class FabricControllerClientProvider implements Closeable {
               + ". child.cluster.d2 or child.cluster.url value is missing in parent controller");
     }
     return value;
+  }
+
+  /*
+  * TODO:
+  * we have a wide variety of retry behaviors cataloged in docs/contributing/architecture/controller-cross-region-fanout.md
+  * next iterations we need to unify and land on common behavior.
+   */
+
+  /**
+   * Issues the same query to every region's controller client and collects a per-region result. This captures the
+   * best-effort multi-colo fan-out shape used by the parent controller's version queries: on a per-region error the
+   * failure is logged and {@code errorSentinel} is stored for that region (the query is not aborted), while a
+   * successful response is mapped to a value via {@code onSuccess}. When {@code maxAttempts > 1} the request is retried
+   * via {@link ControllerClient#retryableRequest(ControllerClient, int, Function)}.
+   *
+   * @param controllerClients region -&gt; controller client (typically {@link #getControllerClientMap(String)})
+   * @param clusterName the cluster being queried; used only for log context
+   * @param maxAttempts total attempts per region (1 means no retry)
+   * @param request the controller RPC to issue against each region's client
+   * @param onSuccess maps a successful response to the per-region result value
+   * @param errorSentinel the value stored for a region whose query returned an error
+   */
+  public <R extends ControllerResponse, V> Map<String, V> queryAllRegions(
+      Map<String, ControllerClient> controllerClients,
+      String clusterName,
+      int maxAttempts,
+      Function<ControllerClient, R> request,
+      Function<R, V> onSuccess,
+      V errorSentinel) {
+    Map<String, V> result = new HashMap<>();
+    for (Map.Entry<String, ControllerClient> entry: controllerClients.entrySet()) {
+      String region = entry.getKey();
+      ControllerClient controllerClient = entry.getValue();
+      R response = maxAttempts > 1
+          ? ControllerClient.retryableRequest(controllerClient, maxAttempts, request)
+          : request.apply(controllerClient);
+      if (response.isError()) {
+        LOGGER.error(
+            "Could not query store from region: {} for cluster: {}. Error: {}",
+            region,
+            clusterName,
+            response.getError());
+        result.put(region, errorSentinel);
+      } else {
+        result.put(region, onSuccess.apply(response));
+      }
+    }
+    return result;
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/FabricControllerClientProvider.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/FabricControllerClientProvider.java
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.Logger;
  *
  * Two maps are maintained:
  * <ul>
- *   <li>{@link #clusterControllerClientPerColoMap}: cluster -&gt; colo -&gt; client, built from the standard child
+ *   <li>{@link #clusterControllerClientPerFabricMap}: cluster -&gt; fabric -&gt; client, built from the standard child
  *       data-center allowlist (URL and D2 maps) in the cluster config.</li>
  *   <li>{@link #newFabricControllerClientMap}: cluster -&gt; fabric -&gt; client, built on demand for fabrics that are
  *       not in the standard allowlist (e.g. build-out / data-recovery destinations).</li>
@@ -40,8 +40,8 @@ public class FabricControllerClientProvider implements Closeable {
   private final Optional<SSLFactory> sslFactory;
   private final Map<String, D2Client> d2Clients;
 
-  /** Controller Client Map per cluster per colo */
-  private final Map<String, Map<String, ControllerClient>> clusterControllerClientPerColoMap =
+  /** Controller Client Map per cluster per fabric */
+  private final Map<String, Map<String, ControllerClient>> clusterControllerClientPerFabricMap =
       new VeniceConcurrentHashMap<>();
 
   /** New fabric controller client map per cluster per fabric */
@@ -58,11 +58,11 @@ public class FabricControllerClientProvider implements Closeable {
   }
 
   /**
-   * Returns the lazily-constructed map of controller clients (colo -&gt; client) for the standard child data-center
+   * Returns the lazily-constructed map of controller clients (fabric -&gt; client) for the standard child data-center
    * allowlist of the given cluster.
    */
   public Map<String, ControllerClient> getControllerClientMap(String clusterName) {
-    return clusterControllerClientPerColoMap.computeIfAbsent(clusterName, cn -> {
+    return clusterControllerClientPerFabricMap.computeIfAbsent(clusterName, cn -> {
       Map<String, ControllerClient> controllerClients = new HashMap<>();
       VeniceControllerClusterConfig controllerConfig = multiClusterConfigs.getControllerConfig(clusterName);
       controllerConfig.getChildDataCenterControllerUrlMap()
@@ -149,7 +149,7 @@ public class FabricControllerClientProvider implements Closeable {
 
   /**
    * Issues the same query to every region's controller client and collects a per-region result. This captures the
-   * best-effort multi-colo fan-out shape used by the parent controller's version queries: on a per-region error the
+   * best-effort multi-fabric fan-out shape used by the parent controller's version queries: on a per-region error the
    * failure is logged and {@code errorSentinel} is stored for that region (the query is not aborted), while a
    * successful response is mapped to a value via {@code onSuccess}. When {@code maxAttempts > 1} the request is retried
    * via {@link ControllerClient#retryableRequest(ControllerClient, int, Function)}.
@@ -191,7 +191,7 @@ public class FabricControllerClientProvider implements Closeable {
 
   @Override
   public void close() {
-    clusterControllerClientPerColoMap.values()
+    clusterControllerClientPerFabricMap.values()
         .forEach(controllerClientMap -> controllerClientMap.values().forEach(Utils::closeQuietlyWithErrorLogged));
     newFabricControllerClientMap.values()
         .forEach(controllerClientMap -> controllerClientMap.values().forEach(Utils::closeQuietlyWithErrorLogged));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -424,8 +424,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   private final Map<String, Long> topicToCreationTime = new VeniceConcurrentHashMap<>();
 
   /**
-   * Owns the per-cluster/per-colo and per-cluster/per-fabric controller client maps used for cross-region
-   * coordination. Shared with {@link VeniceParentHelixAdmin} via {@link #getFabricControllerClientProvider()}.
+   * Owns the per-cluster/per-fabric controller client maps used for cross-region coordination. Shared with
+   * {@link VeniceParentHelixAdmin} via {@link #getFabricControllerClientProvider()}.
    */
   private final FabricControllerClientProvider fabricControllerClientProvider;
   private final Map<String, ControllerClient> clusterParentControllerClientMap = new VeniceConcurrentHashMap<>();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -87,7 +87,6 @@ import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerClientFactory;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.ControllerRoute;
-import com.linkedin.venice.controllerapi.D2ControllerClient;
 import com.linkedin.venice.controllerapi.NodeReplicasReadinessState;
 import com.linkedin.venice.controllerapi.RepushInfo;
 import com.linkedin.venice.controllerapi.RepushJobResponse;
@@ -425,10 +424,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   private final Map<String, Long> topicToCreationTime = new VeniceConcurrentHashMap<>();
 
   /**
-   * Controller Client Map per cluster per colo
+   * Owns the per-cluster/per-colo and per-cluster/per-fabric controller client maps used for cross-region
+   * coordination. Shared with {@link VeniceParentHelixAdmin} via {@link #getFabricControllerClientProvider()}.
    */
-  private final Map<String, Map<String, ControllerClient>> clusterControllerClientPerColoMap =
-      new VeniceConcurrentHashMap<>();
+  private final FabricControllerClientProvider fabricControllerClientProvider;
   private final Map<String, ControllerClient> clusterParentControllerClientMap = new VeniceConcurrentHashMap<>();
   private final Map<String, HelixLiveInstanceMonitor> liveInstanceMonitorMap = new HashMap<>();
 
@@ -537,6 +536,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     } else {
       sslFactory = Optional.empty();
     }
+
+    this.fabricControllerClientProvider =
+        new FabricControllerClientProvider(multiClusterConfigs, sslFactory, d2Clients);
 
     // TODO: Consider re-using the same zkClient for the ZKHelixAdmin and TopicManager.
     ZkClient zkClientForHelixAdmin = ZkClientFactory.newZkClient(multiClusterConfigs.getZkAddress());
@@ -2015,44 +2017,15 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   public Map<String, ControllerClient> getControllerClientMap(String clusterName) {
-    return clusterControllerClientPerColoMap.computeIfAbsent(clusterName, cn -> {
-      Map<String, ControllerClient> controllerClients = new HashMap<>();
-      VeniceControllerClusterConfig controllerConfig = multiClusterConfigs.getControllerConfig(clusterName);
-      controllerConfig.getChildDataCenterControllerUrlMap()
-          .entrySet()
-          .forEach(
-              entry -> controllerClients.put(
-                  entry.getKey(),
-                  ControllerClient.constructClusterControllerClient(clusterName, entry.getValue(), sslFactory)));
+    return fabricControllerClientProvider.getControllerClientMap(clusterName);
+  }
 
-      // Respect d2Clients from controller constructor, if not provided, create d2 clients by zk d2 service urls
-      // (mainly for testing purpose)
-      if (d2Clients != null) {
-        controllerConfig.getChildDataCenterControllerD2Map()
-            .entrySet()
-            .forEach(
-                entry -> controllerClients.put(
-                    entry.getKey(),
-                    new D2ControllerClient(
-                        controllerConfig.getD2ServiceName(),
-                        clusterName,
-                        d2Clients.get(entry.getKey()),
-                        sslFactory)));
-      } else {
-        controllerConfig.getChildDataCenterControllerD2Map()
-            .entrySet()
-            .forEach(
-                entry -> controllerClients.put(
-                    entry.getKey(),
-                    new D2ControllerClient(
-                        controllerConfig.getD2ServiceName(),
-                        clusterName,
-                        entry.getValue(),
-                        sslFactory)));
-      }
-
-      return controllerClients;
-    });
+  /**
+   * Provider that owns the cross-region controller client maps. Shared with {@link VeniceParentHelixAdmin} so that
+   * both the child and the parent draw clients from a single, centrally-managed source.
+   */
+  public FabricControllerClientProvider getFabricControllerClientProvider() {
+    return fabricControllerClientProvider;
   }
 
   private StoreInfo getStoreInfo(String storeName, String clusterName) {
@@ -8090,8 +8063,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       Utils.closeQuietlyWithErrorLogged(this.dataRecoveryManager);
       Utils.closeQuietlyWithErrorLogged(this.participantStoreClientsManager);
       Utils.closeQuietlyWithErrorLogged(this.topicManagerRepository);
-      this.clusterControllerClientPerColoMap.values()
-          .forEach(ccMap -> ccMap.values().forEach(Utils::closeQuietlyWithErrorLogged));
+      Utils.closeQuietlyWithErrorLogged(this.fabricControllerClientProvider);
       D2ClientUtils.shutdownClient(this.d2Client);
 
       long elapsedTime = System.currentTimeMillis() - closeStartTime;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -86,7 +86,6 @@ import com.linkedin.venice.controller.versionlifecycle.VersionLifecyclePolicy;
 import com.linkedin.venice.controllerapi.AdminCommandExecution;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
-import com.linkedin.venice.controllerapi.D2ControllerClient;
 import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.MultiStoreInfoResponse;
@@ -301,10 +300,6 @@ public class VeniceParentHelixAdmin implements Admin {
 
   private final IdentityParser identityParser;
   private final LogContext logContext;
-
-  // New fabric controller client map per cluster per fabric
-  private final Map<String, Map<String, ControllerClient>> newFabricControllerClientMap =
-      new VeniceConcurrentHashMap<>();
 
   private static final Set<VersionStatus> TERMINAL_VERSION_SWAP_STATUSES =
       Utils.setOf(ONLINE, PARTIALLY_ONLINE, KILLED, ERROR);
@@ -4424,8 +4419,8 @@ public class VeniceParentHelixAdmin implements Admin {
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     }
-    newFabricControllerClientMap.forEach(
-        (clusterName, controllerClientMap) -> controllerClientMap.values().forEach(Utils::closeQuietlyWithErrorLogged));
+    // The fabric controller client maps are owned and closed by the shared FabricControllerClientProvider in
+    // VeniceHelixAdmin, so there is nothing to close here.
   }
 
   /**
@@ -5430,40 +5425,8 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   private ControllerClient getFabricBuildoutControllerClient(String clusterName, String fabric) {
-    Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
-    if (controllerClients.containsKey(fabric)) {
-      return controllerClients.get(fabric);
-    }
-
-    // For fabrics not in allowlist, build controller clients using child cluster configs and cache them in another map
-    ControllerClient value =
-        newFabricControllerClientMap.computeIfAbsent(clusterName, cn -> new VeniceConcurrentHashMap<>())
-            .computeIfAbsent(fabric, f -> {
-              VeniceControllerClusterConfig controllerConfig = multiClusterConfigs.getControllerConfig(clusterName);
-              String d2ZkHost = controllerConfig.getChildControllerD2ZkHost(fabric);
-              String d2ServiceName = controllerConfig.getD2ServiceName();
-              if (StringUtils.isNotBlank(d2ZkHost) && StringUtils.isNotBlank(d2ServiceName)) {
-                if (veniceHelixAdmin.getD2Clients() != null) {
-                  return new D2ControllerClient(
-                      d2ServiceName,
-                      clusterName,
-                      veniceHelixAdmin.getD2Clients().get(fabric));
-                }
-                return new D2ControllerClient(d2ServiceName, clusterName, d2ZkHost, sslFactory);
-              }
-              String url = controllerConfig.getChildControllerUrl(fabric);
-              if (StringUtils.isNotBlank(url)) {
-                return ControllerClient.constructClusterControllerClient(clusterName, url, sslFactory);
-              }
-              return null;
-            });
-
-    if (value == null) {
-      throw new VeniceException(
-          "Could not construct child controller client for cluster " + clusterName + " fabric " + fabric
-              + ". child.cluster.d2 or child.cluster.url value is missing in parent controller");
-    }
-    return value;
+    return getVeniceHelixAdmin().getFabricControllerClientProvider()
+        .getFabricBuildoutControllerClient(clusterName, fabric);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -89,7 +89,6 @@ import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.MultiStoreInfoResponse;
-import com.linkedin.venice.controllerapi.MultiStoreStatusResponse;
 import com.linkedin.venice.controllerapi.NodeReplicasReadinessState;
 import com.linkedin.venice.controllerapi.ReadyForDataRecoveryResponse;
 import com.linkedin.venice.controllerapi.RegionPushDetailsResponse;
@@ -2263,46 +2262,27 @@ public class VeniceParentHelixAdmin implements Admin {
   @Override
   public Map<String, String> getFutureVersionsForMultiColos(String clusterName, String storeName) {
     Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
-    Map<String, String> result = new HashMap<>();
-    for (Map.Entry<String, ControllerClient> entry: controllerClients.entrySet()) {
-      String region = entry.getKey();
-      ControllerClient controllerClient = entry.getValue();
-      MultiStoreStatusResponse response =
-          ControllerClient.retryableRequest(controllerClient, 5, c -> c.getFutureVersions(clusterName, storeName));
-      if (response.isError()) {
-        LOGGER.error(
-            "Could not query store from region: {} for cluster: {}. Error: {}",
-            region,
+    return getVeniceHelixAdmin().getFabricControllerClientProvider()
+        .queryAllRegions(
+            controllerClients,
             clusterName,
-            response.getError());
-        result.put(region, String.valueOf(IGNORED_CURRENT_VERSION));
-      } else {
-        result.put(region, response.getStoreStatusMap().get(storeName));
-      }
-    }
-    return result;
+            5,
+            controllerClient -> controllerClient.getFutureVersions(clusterName, storeName),
+            response -> response.getStoreStatusMap().get(storeName),
+            String.valueOf(IGNORED_CURRENT_VERSION));
   }
 
   @Override
   public Map<String, String> getBackupVersionsForMultiColos(String clusterName, String storeName) {
     Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
-    Map<String, String> result = new HashMap<>();
-    for (Map.Entry<String, ControllerClient> entry: controllerClients.entrySet()) {
-      String region = entry.getKey();
-      ControllerClient controllerClient = entry.getValue();
-      MultiStoreStatusResponse response = controllerClient.getBackupVersions(clusterName, storeName);
-      if (response.isError()) {
-        LOGGER.error(
-            "Could not query store from region: {} for cluster: {}. Error: {}",
-            region,
+    return getVeniceHelixAdmin().getFabricControllerClientProvider()
+        .queryAllRegions(
+            controllerClients,
             clusterName,
-            response.getError());
-        result.put(region, String.valueOf(IGNORED_CURRENT_VERSION));
-      } else {
-        result.put(region, response.getStoreStatusMap().get(storeName));
-      }
-    }
-    return result;
+            1,
+            controllerClient -> controllerClient.getBackupVersions(clusterName, storeName),
+            response -> response.getStoreStatusMap().get(storeName),
+            String.valueOf(IGNORED_CURRENT_VERSION));
   }
 
   /**
@@ -2322,23 +2302,14 @@ public class VeniceParentHelixAdmin implements Admin {
       String clusterName,
       String storeName,
       Map<String, ControllerClient> controllerClients) {
-    Map<String, Integer> result = new HashMap<>();
-    for (Map.Entry<String, ControllerClient> entry: controllerClients.entrySet()) {
-      String region = entry.getKey();
-      ControllerClient controllerClient = entry.getValue();
-      StoreResponse response = controllerClient.getStore(storeName);
-      if (response.isError()) {
-        LOGGER.error(
-            "Could not query store from region: {} for cluster: {}. Error: {}",
-            region,
+    return getVeniceHelixAdmin().getFabricControllerClientProvider()
+        .queryAllRegions(
+            controllerClients,
             clusterName,
-            response.getError());
-        result.put(region, IGNORED_CURRENT_VERSION);
-      } else {
-        result.put(region, response.getStore().getCurrentVersion());
-      }
-    }
-    return result;
+            1,
+            controllerClient -> controllerClient.getStore(storeName),
+            response -> response.getStore().getCurrentVersion(),
+            IGNORED_CURRENT_VERSION);
   }
 
   /**

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
@@ -156,6 +156,10 @@ public class AbstractTestVeniceParentHelixAdmin {
     doReturn(controllerClients).when(fabricControllerClientProvider).getControllerClientMap(any());
     when(fabricControllerClientProvider.getFabricBuildoutControllerClient(any(), any()))
         .thenAnswer(invocation -> controllerClients.get(invocation.getArgument(1)));
+    // queryAllRegions is a pure fan-out over the supplied client map, so let the real implementation run; this keeps
+    // the parent's multi-colo version queries behaving exactly as the old inline loops did against the mocked clients.
+    when(fabricControllerClientProvider.queryAllRegions(any(), any(), anyInt(), any(), any(), any()))
+        .thenCallRealMethod();
     doReturn(fabricControllerClientProvider).when(internalAdmin).getFabricControllerClientProvider();
 
     resources = mockResources(config, clusterName);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
@@ -148,6 +148,15 @@ public class AbstractTestVeniceParentHelixAdmin {
     controllerClients
         .put(regionName, ControllerClient.constructClusterControllerClient(clusterName, "localhost", Optional.empty()));
     doReturn(controllerClients).when(internalAdmin).getControllerClientMap(any());
+    // The parent's cross-fabric buildout path now routes through the child's FabricControllerClientProvider rather
+    // than calling getControllerClientMap() directly. Stub the provider on the mocked child so that any test driving
+    // a buildout-dependent path (data recovery, compareStore, copy-over) resolves clients from the same
+    // controllerClients map instead of NPEing on an un-stubbed provider getter.
+    FabricControllerClientProvider fabricControllerClientProvider = mock(FabricControllerClientProvider.class);
+    doReturn(controllerClients).when(fabricControllerClientProvider).getControllerClientMap(any());
+    when(fabricControllerClientProvider.getFabricBuildoutControllerClient(any(), any()))
+        .thenAnswer(invocation -> controllerClients.get(invocation.getArgument(1)));
+    doReturn(fabricControllerClientProvider).when(internalAdmin).getFabricControllerClientProvider();
 
     resources = mockResources(config, clusterName);
     doReturn(storeRepository).when(resources).getStoreMetadataRepository();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
@@ -157,7 +157,8 @@ public class AbstractTestVeniceParentHelixAdmin {
     when(fabricControllerClientProvider.getFabricBuildoutControllerClient(any(), any()))
         .thenAnswer(invocation -> controllerClients.get(invocation.getArgument(1)));
     // queryAllRegions is a pure fan-out over the supplied client map, so let the real implementation run; this keeps
-    // the parent's multi-colo version queries behaving exactly as the old inline loops did against the mocked clients.
+    // the parent's multi-fabric version queries behaving exactly as the old inline loops did against the mocked
+    // clients.
     when(fabricControllerClientProvider.queryAllRegions(any(), any(), anyInt(), any(), any(), any()))
         .thenCallRealMethod();
     doReturn(fabricControllerClientProvider).when(internalAdmin).getFabricControllerClientProvider();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/FabricControllerClientProviderTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/FabricControllerClientProviderTest.java
@@ -1,0 +1,205 @@
+package com.linkedin.venice.controller;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
+
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.StoreInfo;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.testng.annotations.Test;
+
+
+public class FabricControllerClientProviderTest {
+  private static final String CLUSTER = "test-cluster";
+  private static final String STORE = "test-store";
+  private static final int SENTINEL = -1;
+
+  private static StoreResponse successStore(int currentVersion) {
+    // StoreInfo#getCurrentVersion is final, so use a real StoreInfo/StoreResponse rather than mocks.
+    StoreInfo storeInfo = new StoreInfo();
+    storeInfo.setCurrentVersion(currentVersion);
+    StoreResponse response = new StoreResponse();
+    response.setStore(storeInfo);
+    return response;
+  }
+
+  private static StoreResponse errorStore() {
+    StoreResponse response = new StoreResponse();
+    response.setError("boom");
+    return response;
+  }
+
+  private static FabricControllerClientProvider providerWith(
+      VeniceControllerMultiClusterConfig configs,
+      Map<String, D2Client> d2Clients) {
+    return new FabricControllerClientProvider(configs, Optional.empty(), d2Clients);
+  }
+
+  private static VeniceControllerClusterConfig clusterConfig(VeniceControllerMultiClusterConfig configs) {
+    VeniceControllerClusterConfig clusterConfig = mock(VeniceControllerClusterConfig.class);
+    when(configs.getControllerConfig(CLUSTER)).thenReturn(clusterConfig);
+    return clusterConfig;
+  }
+
+  @Test
+  public void testQueryAllRegionsNoRetryAggregatesPerRegion() {
+    ControllerClient regionA = mock(ControllerClient.class);
+    when(regionA.getStore(STORE)).thenReturn(successStore(3));
+    ControllerClient regionB = mock(ControllerClient.class);
+    when(regionB.getStore(STORE)).thenReturn(successStore(5));
+    Map<String, ControllerClient> clients = new LinkedHashMap<>();
+    clients.put("regionA", regionA);
+    clients.put("regionB", regionB);
+
+    FabricControllerClientProvider provider = providerWith(mock(VeniceControllerMultiClusterConfig.class), null);
+    Map<String, Integer> result = provider
+        .queryAllRegions(clients, CLUSTER, 1, c -> c.getStore(STORE), r -> r.getStore().getCurrentVersion(), SENTINEL);
+
+    assertEquals(result.size(), 2);
+    assertEquals(result.get("regionA").intValue(), 3);
+    assertEquals(result.get("regionB").intValue(), 5);
+  }
+
+  @Test
+  public void testQueryAllRegionsStoresSentinelOnError() {
+    ControllerClient good = mock(ControllerClient.class);
+    when(good.getStore(STORE)).thenReturn(successStore(9));
+    ControllerClient bad = mock(ControllerClient.class);
+    when(bad.getStore(STORE)).thenReturn(errorStore());
+    Map<String, ControllerClient> clients = new LinkedHashMap<>();
+    clients.put("good", good);
+    clients.put("bad", bad);
+
+    FabricControllerClientProvider provider = providerWith(mock(VeniceControllerMultiClusterConfig.class), null);
+    Map<String, Integer> result = provider
+        .queryAllRegions(clients, CLUSTER, 1, c -> c.getStore(STORE), r -> r.getStore().getCurrentVersion(), SENTINEL);
+
+    assertEquals(result.get("good").intValue(), 9);
+    assertEquals(result.get("bad").intValue(), SENTINEL);
+  }
+
+  @Test
+  public void testQueryAllRegionsWithRetryUsesRetryableRequest() {
+    // maxAttempts > 1 exercises the ControllerClient.retryableRequest branch; a successful response returns on the
+    // first attempt, so no retry sleep is incurred.
+    ControllerClient region = mock(ControllerClient.class);
+    when(region.getStore(STORE)).thenReturn(successStore(4));
+    Map<String, ControllerClient> clients = Collections.singletonMap("region", region);
+
+    FabricControllerClientProvider provider = providerWith(mock(VeniceControllerMultiClusterConfig.class), null);
+    Map<String, Integer> result = provider
+        .queryAllRegions(clients, CLUSTER, 3, c -> c.getStore(STORE), r -> r.getStore().getCurrentVersion(), SENTINEL);
+
+    assertEquals(result.get("region").intValue(), 4);
+  }
+
+  @Test
+  public void testGetControllerClientMapBuildsAndCachesClients() {
+    VeniceControllerMultiClusterConfig configs = mock(VeniceControllerMultiClusterConfig.class);
+    VeniceControllerClusterConfig clusterConfig = clusterConfig(configs);
+    when(clusterConfig.getChildDataCenterControllerUrlMap())
+        .thenReturn(Collections.singletonMap("urlRegion", "http://localhost:1234"));
+    when(clusterConfig.getChildDataCenterControllerD2Map())
+        .thenReturn(Collections.singletonMap("d2Region", "d2-zk-host"));
+    when(clusterConfig.getD2ServiceName()).thenReturn("venice-controller");
+
+    Map<String, D2Client> d2Clients = new HashMap<>();
+    d2Clients.put("d2Region", mock(D2Client.class));
+    FabricControllerClientProvider provider = providerWith(configs, d2Clients);
+
+    Map<String, ControllerClient> map = provider.getControllerClientMap(CLUSTER);
+    assertEquals(map.size(), 2);
+    assertNotNull(map.get("urlRegion"));
+    assertNotNull(map.get("d2Region"));
+    // The per-cluster map is cached: the same instance is returned on a second call.
+    assertSame(provider.getControllerClientMap(CLUSTER), map);
+  }
+
+  @Test
+  public void testGetControllerClientMapWithoutInjectedD2Clients() {
+    VeniceControllerMultiClusterConfig configs = mock(VeniceControllerMultiClusterConfig.class);
+    VeniceControllerClusterConfig clusterConfig = clusterConfig(configs);
+    when(clusterConfig.getChildDataCenterControllerUrlMap())
+        .thenReturn(Collections.singletonMap("urlRegion", "http://localhost:1234"));
+    // Empty D2 map so the d2Clients==null branch is exercised without constructing a ZK-backed D2 client.
+    when(clusterConfig.getChildDataCenterControllerD2Map()).thenReturn(Collections.emptyMap());
+
+    FabricControllerClientProvider provider = providerWith(configs, null);
+    Map<String, ControllerClient> map = provider.getControllerClientMap(CLUSTER);
+    assertEquals(map.size(), 1);
+    assertNotNull(map.get("urlRegion"));
+  }
+
+  @Test
+  public void testGetFabricBuildoutReturnsAllowlistedClient() {
+    VeniceControllerMultiClusterConfig configs = mock(VeniceControllerMultiClusterConfig.class);
+    VeniceControllerClusterConfig clusterConfig = clusterConfig(configs);
+    when(clusterConfig.getChildDataCenterControllerUrlMap())
+        .thenReturn(Collections.singletonMap("dc-1", "http://localhost:1234"));
+    when(clusterConfig.getChildDataCenterControllerD2Map()).thenReturn(Collections.emptyMap());
+
+    FabricControllerClientProvider provider = providerWith(configs, null);
+    ControllerClient client = provider.getFabricBuildoutControllerClient(CLUSTER, "dc-1");
+    assertNotNull(client);
+    // An allowlisted fabric is served straight from the standard controller-client map.
+    assertSame(provider.getControllerClientMap(CLUSTER).get("dc-1"), client);
+  }
+
+  @Test
+  public void testGetFabricBuildoutBuildsD2ClientForNonAllowlistedFabric() {
+    VeniceControllerMultiClusterConfig configs = mock(VeniceControllerMultiClusterConfig.class);
+    VeniceControllerClusterConfig clusterConfig = clusterConfig(configs);
+    when(clusterConfig.getChildDataCenterControllerUrlMap()).thenReturn(Collections.emptyMap());
+    when(clusterConfig.getChildDataCenterControllerD2Map()).thenReturn(Collections.emptyMap());
+    when(clusterConfig.getChildControllerD2ZkHost("dc-x")).thenReturn("dc-x-zk");
+    when(clusterConfig.getD2ServiceName()).thenReturn("venice-controller");
+
+    Map<String, D2Client> d2Clients = new HashMap<>();
+    d2Clients.put("dc-x", mock(D2Client.class));
+    FabricControllerClientProvider provider = providerWith(configs, d2Clients);
+
+    ControllerClient client = provider.getFabricBuildoutControllerClient(CLUSTER, "dc-x");
+    assertNotNull(client);
+    // Cached in the non-allowlist fabric map on subsequent lookups.
+    assertSame(provider.getFabricBuildoutControllerClient(CLUSTER, "dc-x"), client);
+  }
+
+  @Test
+  public void testGetFabricBuildoutBuildsUrlClientForNonAllowlistedFabric() {
+    VeniceControllerMultiClusterConfig configs = mock(VeniceControllerMultiClusterConfig.class);
+    VeniceControllerClusterConfig clusterConfig = clusterConfig(configs);
+    when(clusterConfig.getChildDataCenterControllerUrlMap()).thenReturn(Collections.emptyMap());
+    when(clusterConfig.getChildDataCenterControllerD2Map()).thenReturn(Collections.emptyMap());
+    when(clusterConfig.getChildControllerD2ZkHost("dc-y")).thenReturn("");
+    when(clusterConfig.getD2ServiceName()).thenReturn("venice-controller");
+    when(clusterConfig.getChildControllerUrl("dc-y")).thenReturn("http://localhost:5678");
+
+    FabricControllerClientProvider provider = providerWith(configs, null);
+    assertNotNull(provider.getFabricBuildoutControllerClient(CLUSTER, "dc-y"));
+  }
+
+  @Test
+  public void testGetFabricBuildoutThrowsWhenNoConfigForFabric() {
+    VeniceControllerMultiClusterConfig configs = mock(VeniceControllerMultiClusterConfig.class);
+    VeniceControllerClusterConfig clusterConfig = clusterConfig(configs);
+    when(clusterConfig.getChildDataCenterControllerUrlMap()).thenReturn(Collections.emptyMap());
+    when(clusterConfig.getChildDataCenterControllerD2Map()).thenReturn(Collections.emptyMap());
+    when(clusterConfig.getChildControllerD2ZkHost("dc-z")).thenReturn("");
+    when(clusterConfig.getD2ServiceName()).thenReturn("");
+    when(clusterConfig.getChildControllerUrl("dc-z")).thenReturn("");
+
+    FabricControllerClientProvider provider = providerWith(configs, null);
+    assertThrows(VeniceException.class, () -> provider.getFabricBuildoutControllerClient(CLUSTER, "dc-z"));
+  }
+}


### PR DESCRIPTION
  ## Problem Statement                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                       
  The parent and child controllers each hand-rolled the cross-region controller-client maps and repeated the same best-effort per-region fan-out loop for multi-colo version queries. This duplicated the lazy client-construction/lifecycle plumbing and left no single seam for cross-region coordination.                           

 Tehomachy  , ~ -100 LOC
  ## Solution                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                       
  Two behavior-preserving extractions plus a test:                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                       
  - **`FabricControllerClientProvider`** now owns both controller-client maps (per-colo and non-allowlist build-out) along with `getControllerClientMap`, `getFabricBuildoutControllerClient`, and lifecycle. The child constructs one instance and shares it with the parent via `getFabricControllerClientProvider()`; the parent's  
  old `newFabricControllerClientMap` is gone.                                                                                                                                                                                                                                                                                          
  - **`queryAllRegions`** captures the best-effort fan-out shape (per-region request, optional retry, log + sentinel on error). The three multi-colo version queries (`getCurrentVersionForMultiRegions`, `getFutureVersionsForMultiColos`, `getBackupVersionsForMultiColos`) delegate to it, each keeping its exact retry/sentinel/log
  behavior. Bespoke fan-out loops are intentionally left as-is.                                                                                                                                                                                                                                                                        
  - Added a reference doc (`docs/contributing/architecture/controller-cross-region-fanout.md`) cataloging the cross-region call sites and their differing retry behavior, plus a TODO marking retry unification as future work.                                                                                                        
                                                                                                                                                                                                                                                                                                                                       
  ### Code changes                                                                                                                                                                                                                                                                                                                     
  - [ ] Added new code behind **a config**.                                                                                                                                                                                                                                                                                            
  - [ ] Introduced new **log lines**. <!-- One existing per-region error line now logs under the FabricControllerClientProvider logger; same message/level/args. -->                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                       
  ### Concurrency-Specific Checks                                                                                                                                                                                                                                                                                                      
  - [x] No race conditions / thread-safety issues. <!-- Same VeniceConcurrentHashMap-backed maps via computeIfAbsent; queryAllRegions is a stateless fan-out over a supplied map. -->                                                                                                                                                  
  - [x] Proper synchronization where needed.                                                                                                                                                                                                                                                                                           
  - [x] No blocking calls in critical sections.                                                                                                                                                                                                                                                                                        
  - [x] Thread-safe collections used.                                                                                                                                                                                                                                                                                                  
  - [x] Proper exception handling in multi-threaded code.                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                       
  ## How was this PR tested?                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                       
  - [x] New unit tests added. <!-- FabricControllerClientProviderTest covers queryAllRegions (retry/no-retry, success/error), client-map construction, and build-out paths; lifts diff branch coverage to 90%. -->                                                                                                                     
  - [x] Modified or extended existing tests. <!-- AbstractTestVeniceParentHelixAdmin stubs the shared provider so parent tests exercise the new seam unchanged. -->                                                                                                                                                                    
  - [x] Verified backward compatibility. <!-- Pure refactor; no protocol/schema/config change. Full controller UT + diffCoverage pass locally. -->                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                       
  ## Does this PR introduce any user-facing or breaking changes?                                                                                                                                                                                                                                                                       
  - [x] No.                                                         