### PR TITLE
[vpj] Snapshot-at-T: new VPJ mode (rewind knobs + offline RT merge)

### DIFF
--- a/.github/workflows/VeniceCI-E2ETests.yml
+++ b/.github/workflows/VeniceCI-E2ETests.yml
@@ -1629,6 +1629,25 @@ jobs:
         with:
           shard: 85
 
+  IntegrationTests_86:
+    name: IntegrationTests_86
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    permissions:
+     contents: read
+    timeout-minutes: 15
+    concurrency:
+     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-jdk17-IntegrationTests_86
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/integration-test-run
+        with:
+          shard: 86
+
   IntegrationTests_99:
     name: IntegrationTests_99
     strategy:
@@ -1656,7 +1675,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [IntegrationTests_1, IntegrationTests_2, IntegrationTests_3, IntegrationTests_4, IntegrationTests_5, IntegrationTests_6, IntegrationTests_7, IntegrationTests_8, IntegrationTests_9, IntegrationTests_10, IntegrationTests_11, IntegrationTests_12, IntegrationTests_13, IntegrationTests_14, IntegrationTests_15, IntegrationTests_16, IntegrationTests_17, IntegrationTests_18, IntegrationTests_19, IntegrationTests_20, IntegrationTests_21, IntegrationTests_22, IntegrationTests_23, IntegrationTests_24, IntegrationTests_25, IntegrationTests_26, IntegrationTests_27, IntegrationTests_28, IntegrationTests_29, IntegrationTests_30, IntegrationTests_31, IntegrationTests_32, IntegrationTests_33, IntegrationTests_34, IntegrationTests_35, IntegrationTests_36, IntegrationTests_37, IntegrationTests_38, IntegrationTests_39, IntegrationTests_40, IntegrationTests_41, IntegrationTests_42, IntegrationTests_43, IntegrationTests_44, IntegrationTests_45, IntegrationTests_46, IntegrationTests_47, IntegrationTests_48, IntegrationTests_49, IntegrationTests_50, IntegrationTests_51, IntegrationTests_52, IntegrationTests_53, IntegrationTests_54, IntegrationTests_55, IntegrationTests_56, IntegrationTests_57, IntegrationTests_58, IntegrationTests_59, IntegrationTests_60, IntegrationTests_61, IntegrationTests_62, IntegrationTests_63, IntegrationTests_64, IntegrationTests_65, IntegrationTests_66, IntegrationTests_67, IntegrationTests_68, IntegrationTests_69, IntegrationTests_70, IntegrationTests_71, IntegrationTests_72, IntegrationTests_73, IntegrationTests_74, IntegrationTests_75, IntegrationTests_76, IntegrationTests_77, IntegrationTests_78, IntegrationTests_79, IntegrationTests_80, IntegrationTests_81, IntegrationTests_82, IntegrationTests_83, IntegrationTests_84, IntegrationTests_85, IntegrationTests_99]
+    needs: [IntegrationTests_1, IntegrationTests_2, IntegrationTests_3, IntegrationTests_4, IntegrationTests_5, IntegrationTests_6, IntegrationTests_7, IntegrationTests_8, IntegrationTests_9, IntegrationTests_10, IntegrationTests_11, IntegrationTests_12, IntegrationTests_13, IntegrationTests_14, IntegrationTests_15, IntegrationTests_16, IntegrationTests_17, IntegrationTests_18, IntegrationTests_19, IntegrationTests_20, IntegrationTests_21, IntegrationTests_22, IntegrationTests_23, IntegrationTests_24, IntegrationTests_25, IntegrationTests_26, IntegrationTests_27, IntegrationTests_28, IntegrationTests_29, IntegrationTests_30, IntegrationTests_31, IntegrationTests_32, IntegrationTests_33, IntegrationTests_34, IntegrationTests_35, IntegrationTests_36, IntegrationTests_37, IntegrationTests_38, IntegrationTests_39, IntegrationTests_40, IntegrationTests_41, IntegrationTests_42, IntegrationTests_43, IntegrationTests_44, IntegrationTests_45, IntegrationTests_46, IntegrationTests_47, IntegrationTests_48, IntegrationTests_49, IntegrationTests_50, IntegrationTests_51, IntegrationTests_52, IntegrationTests_53, IntegrationTests_54, IntegrationTests_55, IntegrationTests_56, IntegrationTests_57, IntegrationTests_58, IntegrationTests_59, IntegrationTests_60, IntegrationTests_61, IntegrationTests_62, IntegrationTests_63, IntegrationTests_64, IntegrationTests_65, IntegrationTests_66, IntegrationTests_67, IntegrationTests_68, IntegrationTests_69, IntegrationTests_70, IntegrationTests_71, IntegrationTests_72, IntegrationTests_73, IntegrationTests_74, IntegrationTests_75, IntegrationTests_76, IntegrationTests_77, IntegrationTests_78, IntegrationTests_79, IntegrationTests_80, IntegrationTests_81, IntegrationTests_82, IntegrationTests_83, IntegrationTests_84, IntegrationTests_85, IntegrationTests_86, IntegrationTests_99]
     timeout-minutes: 20
     if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     steps:

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -79,6 +79,8 @@ public class PushJobSetting implements Serializable {
   public long snapshotAtTRewindBufferSeconds;
   // Set to true when the snapshot-at-T rewind override is actually applied (after the threshold gate passes).
   public boolean snapshotAtTRewindApplied;
+  // Per-region RT source brokers (colo id -> broker address) for the snapshot-at-T merge.
+  public Map<Integer, String> snapshotAtTRtRegionBrokers;
   public boolean pushToSeparateRealtimeTopicEnabled;
   public boolean versionSeparateRealTimeTopicEnabled;
   public boolean kafkaInputCombinerEnabled;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -72,6 +72,13 @@ public class PushJobSetting implements Serializable {
   public String kafkaInputTopic;
   public int repushSourceVersion;
   public long rewindTimeInSecondsOverride;
+  // Snapshot-at-T rewind-shortening knobs (per-VPJ). See VenicePushJobConstants#SNAPSHOT_AT_T_REWIND_ENABLED.
+  public boolean snapshotAtTRewindEnabled;
+  public long snapshotAtTMinRewindThresholdSeconds;
+  public long snapshotAtTCutoffEpochSeconds;
+  public long snapshotAtTRewindBufferSeconds;
+  // Set to true when the snapshot-at-T rewind override is actually applied (after the threshold gate passes).
+  public boolean snapshotAtTRewindApplied;
   public boolean pushToSeparateRealtimeTopicEnabled;
   public boolean versionSeparateRealTimeTopicEnabled;
   public boolean kafkaInputCombinerEnabled;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -81,6 +81,10 @@ public class PushJobSetting implements Serializable {
   public boolean snapshotAtTRewindApplied;
   // Per-region RT source brokers (colo id -> broker address) for the snapshot-at-T merge.
   public Map<Integer, String> snapshotAtTRtRegionBrokers;
+  // When true, the snapshot-at-T batch+RT merge runs as a distributed Spark job instead of single-process.
+  public boolean snapshotAtTDistributedMergeEnabled;
+  // The store's schemas, fetched on the driver and broadcast to executors by the distributed merge job.
+  public transient com.linkedin.venice.hadoop.snapshot.SnapshotAtTSchemaBundle snapshotAtTSchemaBundle;
   public boolean pushToSeparateRealtimeTopicEnabled;
   public boolean versionSeparateRealTimeTopicEnabled;
   public boolean kafkaInputCombinerEnabled;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -77,6 +77,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.REWIND_TIME_IN_SECO
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SEND_CONTROL_MESSAGES_DIRECTLY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_CUTOFF_EPOCH_SECONDS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_DISTRIBUTED_MERGE_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_MIN_REWIND_THRESHOLD_SECONDS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_REWIND_ENABLED;
@@ -134,10 +135,12 @@ import com.linkedin.venice.hadoop.input.recordreader.avro.VeniceAvroRecordReader
 import com.linkedin.venice.hadoop.mapreduce.datawriter.jobs.DataWriterMRJob;
 import com.linkedin.venice.hadoop.mapreduce.engine.DefaultJobClientWrapper;
 import com.linkedin.venice.hadoop.schema.HDFSSchemaSource;
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTDataWriterSparkJob;
 import com.linkedin.venice.hadoop.snapshot.SnapshotAtTPushExecutor;
 import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRecordMerger;
 import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRtReader;
 import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRtRecord;
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTSchemaBundle;
 import com.linkedin.venice.hadoop.snapshot.SnapshotAtTSchemaRepository;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
 import com.linkedin.venice.hadoop.utils.HadoopUtils;
@@ -597,6 +600,8 @@ public class VenicePushJob implements AutoCloseable {
         props.getLong(SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS, DEFAULT_SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS);
     pushJobSettingToReturn.snapshotAtTRtRegionBrokers =
         parseSnapshotAtTRegionBrokers(props.getString(SNAPSHOT_AT_T_RT_REGION_BROKERS, ""));
+    pushJobSettingToReturn.snapshotAtTDistributedMergeEnabled =
+        props.getBoolean(SNAPSHOT_AT_T_DISTRIBUTED_MERGE_ENABLED, false);
 
     pushJobSettingToReturn.extendedSchemaValidityCheckEnabled =
         props.getBoolean(EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED, DEFAULT_EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED);
@@ -885,6 +890,7 @@ public class VenicePushJob implements AutoCloseable {
         }
       }
       maybeApplySnapshotAtTRewindOverride(pushJobSetting);
+      maybeSetupSnapshotAtTDistributedMerge(pushJobSetting, controllerClient);
       checkRegularPushWithTTLRepush(controllerClient, pushJobSetting);
       // Create new store version, topic and fetch Kafka url from backend
       createNewStoreVersion(
@@ -934,9 +940,10 @@ public class VenicePushJob implements AutoCloseable {
         if (pushJobSetting.repushTTLEnabled || pushJobSetting.materializedViewConfigFlatMap != null) {
           buildHDFSSchemaDir();
         }
-        if (pushJobSetting.snapshotAtTRewindApplied) {
-          // Snapshot-at-T mode owns Start/End-Of-Push and the data via a single writer (one producer), so DIV
-          // stays consistent. The controller does not send SOP for this mode (see createNewStoreVersion).
+        if (pushJobSetting.snapshotAtTRewindApplied && !pushJobSetting.snapshotAtTDistributedMergeEnabled) {
+          // Single-process snapshot-at-T: one writer owns Start/End-Of-Push and the data (one producer, so DIV
+          // stays consistent), and the controller does not send SOP for this mode (see createNewStoreVersion). The
+          // distributed-merge variant instead runs as a normal data-writer job below (controller sends SOP).
           runSnapshotAtTMergePush(controllerClient);
         } else {
           if (pushJobSetting.sendControlMessagesDirectly) {
@@ -2702,6 +2709,21 @@ public class VenicePushJob implements AutoCloseable {
     return setting.jobStartTimeMs;
   }
 
+  /**
+   * When the distributed-merge flag is on for an active snapshot-at-T push, fetch the store's schemas on the driver
+   * (to broadcast to executors) and route the merge through {@link SnapshotAtTDataWriterSparkJob} -- a normal
+   * data-writer job whose input is the distributed batch+RT cogroup -- instead of the single-process merge. A no-op
+   * when the flag is off or the rewind override was not applied, so the default path is unchanged.
+   */
+  void maybeSetupSnapshotAtTDistributedMerge(PushJobSetting setting, ControllerClient controllerClient) {
+    if (!setting.snapshotAtTRewindApplied || !setting.snapshotAtTDistributedMergeEnabled) {
+      return;
+    }
+    setting.snapshotAtTSchemaBundle = SnapshotAtTSchemaBundle.fromController(controllerClient, setting.storeName);
+    setting.dataWriterComputeJobClass = SnapshotAtTDataWriterSparkJob.class;
+    LOGGER.info("Snapshot-at-T: routing the merge through the distributed Spark job for store {}.", setting.storeName);
+  }
+
   static Map<Integer, String> parseSnapshotAtTRegionBrokers(String config) {
     Map<Integer, String> regionBrokers = new HashMap<>();
     if (config == null || config.trim().isEmpty()) {
@@ -2740,7 +2762,7 @@ public class VenicePushJob implements AutoCloseable {
    * landed on the separate RT (incremental-push data). Both topics live on the same per-region broker, so each is
    * read from every configured region.
    */
-  static List<String> snapshotAtTRtTopicNames(StoreInfo storeInfo) {
+  public static List<String> snapshotAtTRtTopicNames(StoreInfo storeInfo) {
     String realTimeTopicName = Utils.getRealTimeTopicName(storeInfo);
     if (storeInfo.isSeparateRealTimeTopicEnabled()) {
       return Arrays.asList(realTimeTopicName, Utils.getSeparateRealTimeTopicName(storeInfo));
@@ -2905,9 +2927,10 @@ public class VenicePushJob implements AutoCloseable {
       VeniceProperties props,
       Optional<ByteBuffer> optionalCompressionDictionary) {
     Version.PushType pushType = getPushType(setting);
-    // Snapshot-at-T sends its own Start-Of-Push from the same writer as the data, so the controller must not.
-    boolean askControllerToSendControlMessage =
-        !setting.sendControlMessagesDirectly && !setting.snapshotAtTRewindApplied;
+    // Single-process snapshot-at-T sends its own Start-Of-Push from the same writer as the data, so the controller
+    // must not. The distributed-merge variant is a normal multi-writer data-writer job, so the controller sends SOP.
+    boolean askControllerToSendControlMessage = !setting.sendControlMessagesDirectly
+        && !(setting.snapshotAtTRewindApplied && !setting.snapshotAtTDistributedMergeEnabled);
     final String partitioners = props.getString(VENICE_PARTITIONERS, DefaultVenicePartitioner.class.getName());
 
     Optional<String> dictionary;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -29,6 +29,8 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_EXTENDED_SC
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_JOB_STATUS_IN_UNKNOWN_STATE_TIMEOUT_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_POLL_STATUS_INTERVAL_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_RE_PUSH_REWIND_IN_SECONDS_OVERRIDE;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_SNAPSHOT_AT_T_MIN_REWIND_THRESHOLD_SECONDS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_SSL_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFER_VERSION_SWAP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ENABLE_SSL;
@@ -73,6 +75,10 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.REWIND_EPOCH_TIME_I
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REWIND_TIME_IN_SECONDS_OVERRIDE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SEND_CONTROL_MESSAGES_DIRECTLY;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_CUTOFF_EPOCH_SECONDS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_MIN_REWIND_THRESHOLD_SECONDS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_REWIND_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_ETL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_GRID_FABRIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_KAFKA;
@@ -567,6 +573,15 @@ public class VenicePushJob implements AutoCloseable {
       }
     }
 
+    // Snapshot-at-T rewind-shortening knobs (per-VPJ). The store's hybrid config is not known yet at
+    // config-parse time, so the threshold gate is applied later in maybeApplySnapshotAtTRewindOverride().
+    pushJobSettingToReturn.snapshotAtTRewindEnabled = props.getBoolean(SNAPSHOT_AT_T_REWIND_ENABLED, false);
+    pushJobSettingToReturn.snapshotAtTMinRewindThresholdSeconds =
+        props.getLong(SNAPSHOT_AT_T_MIN_REWIND_THRESHOLD_SECONDS, DEFAULT_SNAPSHOT_AT_T_MIN_REWIND_THRESHOLD_SECONDS);
+    pushJobSettingToReturn.snapshotAtTCutoffEpochSeconds = props.getLong(SNAPSHOT_AT_T_CUTOFF_EPOCH_SECONDS, NOT_SET);
+    pushJobSettingToReturn.snapshotAtTRewindBufferSeconds =
+        props.getLong(SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS, DEFAULT_SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS);
+
     pushJobSettingToReturn.extendedSchemaValidityCheckEnabled =
         props.getBoolean(EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED, DEFAULT_EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED);
 
@@ -853,6 +868,7 @@ public class VenicePushJob implements AutoCloseable {
           LOGGER.info("Overriding re-push rewind time in seconds to: {}", pushJobSetting.rewindTimeInSecondsOverride);
         }
       }
+      maybeApplySnapshotAtTRewindOverride(pushJobSetting);
       checkRegularPushWithTTLRepush(controllerClient, pushJobSetting);
       // Create new store version, topic and fetch Kafka url from backend
       createNewStoreVersion(
@@ -2561,6 +2577,91 @@ public class VenicePushJob implements AutoCloseable {
 
   private Version.PushType getPushType(PushJobSetting pushJobSetting) {
     return pushJobSetting.isIncrementalPush ? Version.PushType.INCREMENTAL : Version.PushType.BATCH;
+  }
+
+  /**
+   * Applies the snapshot-at-T rewind override when its per-VPJ knobs opt in and the store's effective
+   * rewind warrants it. See {@link VenicePushJobConstants#SNAPSHOT_AT_T_REWIND_ENABLED}.
+   *
+   * <p>The optimization is skipped (returns {@code false}, leaving the rewind unchanged) when:
+   * <ul>
+   *   <li>the master switch is off (default),</li>
+   *   <li>the push is incremental or a KIF repush (repush sets its own rewind override),</li>
+   *   <li>the store is not hybrid,</li>
+   *   <li>an explicit rewind override is already set (we never clobber it), or</li>
+   *   <li>the store's effective rewind is below the configured threshold (not worth the merge cost).</li>
+   * </ul>
+   *
+   * <p><b>Control plane only:</b> shortening the rewind is correct ONLY when the batch dataset already
+   * incorporates real-time data up to {@code T} (the offline merge data plane). The master flag defaults to
+   * off and must remain off in production until that data plane is in place; otherwise the shortened rewind
+   * would skip nearline writes between the offline cutoff and {@code T} (a data gap).
+   *
+   * @return {@code true} iff the rewind override was applied.
+   */
+  static boolean maybeApplySnapshotAtTRewindOverride(PushJobSetting setting) {
+    if (!setting.snapshotAtTRewindEnabled) {
+      return false;
+    }
+    // Snapshot-at-T is a full-push (BATCH) optimization. Incremental pushes and KIF repush are out of scope;
+    // repush already manages its own rewind override (DEFAULT_RE_PUSH_REWIND_IN_SECONDS_OVERRIDE).
+    if (setting.isIncrementalPush || setting.isSourceKafka) {
+      LOGGER.info(
+          "Snapshot-at-T: not applicable to incremental/repush jobs for store {}; skipping rewind override.",
+          setting.storeName);
+      return false;
+    }
+    if (setting.hybridStoreConfig == null) {
+      LOGGER.info("Snapshot-at-T: store {} is not hybrid; skipping rewind override.", setting.storeName);
+      return false;
+    }
+    // Never clobber an explicitly-provided rewind override.
+    if (setting.rewindTimeInSecondsOverride != NOT_SET) {
+      LOGGER.info(
+          "Snapshot-at-T: an explicit rewind override ({}s) is already set for store {}; skipping.",
+          setting.rewindTimeInSecondsOverride,
+          setting.storeName);
+      return false;
+    }
+    // Threshold gate: only worthwhile when the rewind that would otherwise be the final rewind for this push
+    // is large enough to justify the offline-merge cost.
+    long effectiveRewindSeconds = setting.hybridStoreConfig.getRewindTimeInSeconds();
+    if (effectiveRewindSeconds < setting.snapshotAtTMinRewindThresholdSeconds) {
+      LOGGER.info(
+          "Snapshot-at-T: store {} effective rewind {}s is below threshold {}s; "
+              + "proceeding with a normal full push (no rewind override).",
+          setting.storeName,
+          effectiveRewindSeconds,
+          setting.snapshotAtTMinRewindThresholdSeconds);
+      return false;
+    }
+    long nowSeconds = setting.jobStartTimeMs / 1000;
+    long cutoffEpochSeconds =
+        setting.snapshotAtTCutoffEpochSeconds == NOT_SET ? nowSeconds : setting.snapshotAtTCutoffEpochSeconds;
+    if (cutoffEpochSeconds > nowSeconds) {
+      throw new VeniceException(
+          String.format(
+              "Provided '%d' for %s; the snapshot-at-T cutoff cannot be a timestamp in the future (now=%ds).",
+              cutoffEpochSeconds,
+              SNAPSHOT_AT_T_CUTOFF_EPOCH_SECONDS,
+              nowSeconds));
+    }
+    long finalRewindSeconds = (nowSeconds - cutoffEpochSeconds) + setting.snapshotAtTRewindBufferSeconds;
+    setting.rewindTimeInSecondsOverride = finalRewindSeconds;
+    // Snapshot-at-T relies on REWIND_FROM_SOP semantics, same as the epoch-based rewind override.
+    setting.validateRemoteReplayPolicy = BufferReplayPolicy.REWIND_FROM_SOP;
+    setting.snapshotAtTRewindApplied = true;
+    LOGGER.info(
+        "Snapshot-at-T: store {} effective rewind {}s >= threshold {}s; overriding rewind to {}s "
+            + "(cutoff epoch {}s, buffer {}s). NOTE: requires the batch dataset to already incorporate "
+            + "real-time data up to the cutoff.",
+        setting.storeName,
+        effectiveRewindSeconds,
+        setting.snapshotAtTMinRewindThresholdSeconds,
+        finalRewindSeconds,
+        cutoffEpochSeconds,
+        setting.snapshotAtTRewindBufferSeconds);
+    return true;
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -96,12 +96,16 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_DISCOVER_URL_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_STORE_NAME_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.ZSTD_COMPRESSION_LEVEL;
 
+import com.github.luben.zstd.Zstd;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.venice.PushJobCheckpoints;
 import com.linkedin.venice.annotation.VisibleForTesting;
 import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.compression.CompressorFactory;
+import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.compression.ZstdWithDictCompressor;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerClientFactory;
@@ -2682,7 +2686,7 @@ public class VenicePushJob implements AutoCloseable {
     return true;
   }
 
-  private static Map<Integer, String> parseSnapshotAtTRegionBrokers(String config) {
+  static Map<Integer, String> parseSnapshotAtTRegionBrokers(String config) {
     Map<Integer, String> regionBrokers = new HashMap<>();
     if (config == null || config.trim().isEmpty()) {
       return regionBrokers;
@@ -2714,9 +2718,17 @@ public class VenicePushJob implements AutoCloseable {
       throw new VeniceException(
           "Snapshot-at-T mode requires " + SNAPSHOT_AT_T_RT_REGION_BROKERS + " to list the per-region RT brokers.");
     }
-    Map<ByteBuffer, ByteBuffer> batchValues = readBatchInputForSnapshot();
-
     StoreInfo storeInfo = setting.storeResponse.getStore();
+    if (storeInfo.getHybridStoreConfig() == null) {
+      throw new VeniceException(
+          "Snapshot-at-T mode requires a hybrid store, but " + setting.storeName + " is not hybrid.");
+    }
+    if (!storeInfo.isActiveActiveReplicationEnabled()) {
+      throw new VeniceException(
+          "Snapshot-at-T mode requires Active-Active replication, which is not enabled on " + setting.storeName + ".");
+    }
+
+    Map<ByteBuffer, ByteBuffer> batchValues = readBatchInputForSnapshot();
     String realTimeTopicName = Utils.getRealTimeTopicName(storeInfo);
     long cutoffMs = setting.snapshotAtTCutoffEpochSeconds > 0 ? setting.snapshotAtTCutoffEpochSeconds * 1000 : 0L;
     SnapshotAtTRtReader rtReader = new SnapshotAtTRtReader();
@@ -2743,16 +2755,32 @@ public class VenicePushJob implements AutoCloseable {
         rmdVersionId,
         setting.isStoreWriteComputeEnabled);
 
+    CompressorFactory compressorFactory = new CompressorFactory();
+    Optional<ByteBuffer> compressionDictionary = Optional.empty();
+    VeniceCompressor compressor;
+    if (setting.topicCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT) {
+      if (setting.topicDictionary == null) {
+        throw new VeniceException(
+            "Snapshot-at-T mode for a ZSTD_WITH_DICT store requires a compression dictionary, but none was built.");
+      }
+      compressor = compressorFactory.createCompressorWithDictionary(
+          setting.topicDictionary,
+          props.getInt(ZSTD_COMPRESSION_LEVEL, Zstd.maxCompressionLevel()));
+      compressionDictionary = Optional.of(ByteBuffer.wrap(setting.topicDictionary));
+    } else {
+      compressor = compressorFactory.getCompressor(setting.topicCompressionStrategy);
+    }
+
     VeniceWriter<byte[], byte[], byte[]> dataWriter = createSnapshotAtTDataWriter();
     try {
       dataWriter.broadcastStartOfPush(
           false,
           setting.isChunkingEnabled,
           setting.topicCompressionStrategy,
-          Optional.empty(),
+          compressionDictionary,
           Collections.emptyMap());
-      SnapshotAtTPushExecutor.Stats stats =
-          new SnapshotAtTPushExecutor().execute(dataWriter, batchValues, setting.valueSchemaId, rtRecords, merger);
+      SnapshotAtTPushExecutor.Stats stats = new SnapshotAtTPushExecutor()
+          .execute(dataWriter, batchValues, setting.valueSchemaId, rtRecords, merger, compressor);
       dataWriter.broadcastEndOfPush(Collections.emptyMap());
       LOGGER.info(
           "Snapshot-at-T merge push produced {} records ({} batch keys, {} RT records across {} regions).",
@@ -2762,6 +2790,7 @@ public class VenicePushJob implements AutoCloseable {
           setting.snapshotAtTRtRegionBrokers.size());
     } finally {
       Utils.closeQuietlyWithErrorLogged(dataWriter);
+      Utils.closeQuietlyWithErrorLogged(compressorFactory);
     }
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2614,10 +2614,12 @@ public class VenicePushJob implements AutoCloseable {
    *   <li>the store's effective rewind is below the configured threshold (not worth the merge cost).</li>
    * </ul>
    *
-   * <p><b>Control plane only:</b> shortening the rewind is correct ONLY when the batch dataset already
-   * incorporates real-time data up to {@code T} (the offline merge data plane). The master flag defaults to
-   * off and must remain off in production until that data plane is in place; otherwise the shortened rewind
-   * would skip nearline writes between the offline cutoff and {@code T} (a data gap).
+   * <p><b>Correctness:</b> shortening the rewind is correct ONLY when the batch dataset already incorporates
+   * real-time data up to {@code T} (the offline merge data plane in {@link #runSnapshotAtTMergePush}). To keep the
+   * server's REWIND_FROM_SOP rewind starting at or before the snapshot's coverage regardless of how long the merge
+   * takes, that path stamps the Start-Of-Push with the job start time (see
+   * {@link #snapshotAtTStartOfPushTimestampMs}) rather than the real (late) broadcast time. The master flag
+   * defaults to off and must remain off in production until the full data plane is wired end to end.
    *
    * @return {@code true} iff the rewind override was applied.
    */
@@ -2686,6 +2688,20 @@ public class VenicePushJob implements AutoCloseable {
     return true;
   }
 
+  /**
+   * The Start-Of-Push producer timestamp to stamp for the snapshot-at-T merge push. The server computes an A/A
+   * hybrid store's REWIND_FROM_SOP rewind start as {@code SOP messageTimestamp - rewindTimeInSecondsOverride}, and
+   * the override is {@code (jobStart - cutoff) + buffer}. Stamping the SOP with the job start time therefore pins
+   * the server's rewind start to {@code cutoff - buffer} (or {@code jobStart - buffer} when no cutoff is set) — at
+   * or before the snapshot's coverage, with the buffer as safety overlap — deterministically and independent of
+   * how long the offline merge took to produce the SOP. Using the real (late) broadcast time instead would let the
+   * rewind start drift past the snapshot's coverage on a long merge and silently drop the real-time writes in the
+   * gap.
+   */
+  static long snapshotAtTStartOfPushTimestampMs(PushJobSetting setting) {
+    return setting.jobStartTimeMs;
+  }
+
   static Map<Integer, String> parseSnapshotAtTRegionBrokers(String config) {
     Map<Integer, String> regionBrokers = new HashMap<>();
     if (config == null || config.trim().isEmpty()) {
@@ -2701,10 +2717,35 @@ public class VenicePushJob implements AutoCloseable {
         throw new VeniceException(
             "Invalid " + SNAPSHOT_AT_T_RT_REGION_BROKERS + " entry '" + trimmed + "'; expected 'coloId=broker'.");
       }
-      regionBrokers
-          .put(Integer.parseInt(trimmed.substring(0, separator).trim()), trimmed.substring(separator + 1).trim());
+      int coloId = Integer.parseInt(trimmed.substring(0, separator).trim());
+      String brokerAddress = trimmed.substring(separator + 1).trim();
+      if (brokerAddress.isEmpty()) {
+        throw new VeniceException(
+            "Invalid " + SNAPSHOT_AT_T_RT_REGION_BROKERS + " entry '" + trimmed + "'; the broker address is empty.");
+      }
+      if (regionBrokers.containsKey(coloId)) {
+        throw new VeniceException(
+            "Duplicate coloId " + coloId + " in " + SNAPSHOT_AT_T_RT_REGION_BROKERS
+                + "; each region must be listed exactly once.");
+      }
+      regionBrokers.put(coloId, brokerAddress);
     }
     return regionBrokers;
+  }
+
+  /**
+   * The real-time topic names the snapshot-at-T merge reads for {@code storeInfo}: the regular RT, plus the
+   * separate RT topic when the store has separate-real-time-topic enabled. This mirrors the server, which during a
+   * hybrid rewind subscribes to both topics per region; reading only the regular RT would drop every write that
+   * landed on the separate RT (incremental-push data). Both topics live on the same per-region broker, so each is
+   * read from every configured region.
+   */
+  static List<String> snapshotAtTRtTopicNames(StoreInfo storeInfo) {
+    String realTimeTopicName = Utils.getRealTimeTopicName(storeInfo);
+    if (storeInfo.isSeparateRealTimeTopicEnabled()) {
+      return Arrays.asList(realTimeTopicName, Utils.getSeparateRealTimeTopicName(storeInfo));
+    }
+    return Collections.singletonList(realTimeTopicName);
   }
 
   /**
@@ -2729,19 +2770,22 @@ public class VenicePushJob implements AutoCloseable {
     }
 
     Map<ByteBuffer, ByteBuffer> batchValues = readBatchInputForSnapshot();
-    String realTimeTopicName = Utils.getRealTimeTopicName(storeInfo);
+    List<String> realTimeTopicNames = snapshotAtTRtTopicNames(storeInfo);
     long cutoffMs = setting.snapshotAtTCutoffEpochSeconds > 0 ? setting.snapshotAtTCutoffEpochSeconds * 1000 : 0L;
     SnapshotAtTRtReader rtReader = new SnapshotAtTRtReader();
     List<SnapshotAtTRtRecord> rtRecords = new ArrayList<>();
     for (Map.Entry<Integer, String> region: setting.snapshotAtTRtRegionBrokers.entrySet()) {
-      rtRecords.addAll(
-          rtReader.readRegion(
-              snapshotConsumerProps(region.getValue()),
-              region.getValue(),
-              realTimeTopicName,
-              setting.partitionCount,
-              cutoffMs,
-              region.getKey()));
+      VeniceProperties consumerProps = snapshotConsumerProps(region.getValue());
+      for (String realTimeTopicName: realTimeTopicNames) {
+        rtRecords.addAll(
+            rtReader.readRegion(
+                consumerProps,
+                region.getValue(),
+                realTimeTopicName,
+                setting.partitionCount,
+                cutoffMs,
+                region.getKey()));
+      }
     }
 
     SnapshotAtTSchemaRepository schemaRepository =
@@ -2778,7 +2822,8 @@ public class VenicePushJob implements AutoCloseable {
           setting.isChunkingEnabled,
           setting.topicCompressionStrategy,
           compressionDictionary,
-          Collections.emptyMap());
+          Collections.emptyMap(),
+          snapshotAtTStartOfPushTimestampMs(setting));
       SnapshotAtTPushExecutor.Stats stats = new SnapshotAtTPushExecutor()
           .execute(dataWriter, batchValues, setting.valueSchemaId, rtRecords, merger, compressor);
       dataWriter.broadcastEndOfPush(Collections.emptyMap());
@@ -2809,7 +2854,14 @@ public class VenicePushJob implements AutoCloseable {
       for (FileStatus status: fs.listStatus(inputPath, PATH_FILTER)) {
         try (VeniceAvroFileIterator iterator = new VeniceAvroFileIterator(fs, status.getPath(), recordReader)) {
           while (iterator.next()) {
-            batchValues.put(ByteBuffer.wrap(iterator.getCurrentKey()), ByteBuffer.wrap(iterator.getCurrentValue()));
+            byte[] value = iterator.getCurrentValue();
+            if (value == null) {
+              // ETL/Avro inputs encode a delete as a null value. In a fresh version an absent key already means
+              // deleted, and any real RT write for the key wins over batch data regardless, so there is nothing
+              // to seed for it.
+              continue;
+            }
+            batchValues.put(ByteBuffer.wrap(iterator.getCurrentKey()), ByteBuffer.wrap(value));
           }
         }
       }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_DELIVERY_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_REQUEST_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_RETRIES_CONFIG;
 import static com.linkedin.venice.ConfigKeys.MULTI_REGION;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.VENICE_PARTITIONERS;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENABLED_CONFIG;
@@ -79,6 +80,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_CUTOF
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_MIN_REWIND_THRESHOLD_SECONDS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_REWIND_ENABLED;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_RT_REGION_BROKERS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_ETL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_GRID_FABRIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_KAFKA;
@@ -123,9 +125,16 @@ import com.linkedin.venice.hadoop.exceptions.VeniceInvalidInputException;
 import com.linkedin.venice.hadoop.exceptions.VeniceSchemaFieldNotFoundException;
 import com.linkedin.venice.hadoop.exceptions.VeniceSchemaMismatchException;
 import com.linkedin.venice.hadoop.input.kafka.KafkaInputDictTrainer;
+import com.linkedin.venice.hadoop.input.recordreader.avro.VeniceAvroFileIterator;
+import com.linkedin.venice.hadoop.input.recordreader.avro.VeniceAvroRecordReader;
 import com.linkedin.venice.hadoop.mapreduce.datawriter.jobs.DataWriterMRJob;
 import com.linkedin.venice.hadoop.mapreduce.engine.DefaultJobClientWrapper;
 import com.linkedin.venice.hadoop.schema.HDFSSchemaSource;
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTPushExecutor;
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRecordMerger;
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRtReader;
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRtRecord;
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTSchemaRepository;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
 import com.linkedin.venice.hadoop.utils.HadoopUtils;
 import com.linkedin.venice.hadoop.utils.VPJSSLUtils;
@@ -151,6 +160,7 @@ import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.schema.writecompute.WriteComputeOperation;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -581,6 +591,8 @@ public class VenicePushJob implements AutoCloseable {
     pushJobSettingToReturn.snapshotAtTCutoffEpochSeconds = props.getLong(SNAPSHOT_AT_T_CUTOFF_EPOCH_SECONDS, NOT_SET);
     pushJobSettingToReturn.snapshotAtTRewindBufferSeconds =
         props.getLong(SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS, DEFAULT_SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS);
+    pushJobSettingToReturn.snapshotAtTRtRegionBrokers =
+        parseSnapshotAtTRegionBrokers(props.getString(SNAPSHOT_AT_T_RT_REGION_BROKERS, ""));
 
     pushJobSettingToReturn.extendedSchemaValidityCheckEnabled =
         props.getBoolean(EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED, DEFAULT_EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED);
@@ -918,33 +930,39 @@ public class VenicePushJob implements AutoCloseable {
         if (pushJobSetting.repushTTLEnabled || pushJobSetting.materializedViewConfigFlatMap != null) {
           buildHDFSSchemaDir();
         }
-        if (pushJobSetting.sendControlMessagesDirectly) {
-          getVeniceWriter(pushJobSetting).broadcastStartOfPush(
-              pushJobSetting.isSortedIngestionEnabled,
-              pushJobSetting.isChunkingEnabled,
-              pushJobSetting.topicCompressionStrategy,
-              optionalCompressionDictionary,
-              Collections.emptyMap());
+        if (pushJobSetting.snapshotAtTRewindApplied) {
+          // Snapshot-at-T mode owns Start/End-Of-Push and the data via a single writer (one producer), so DIV
+          // stays consistent. The controller does not send SOP for this mode (see createNewStoreVersion).
+          runSnapshotAtTMergePush(controllerClient);
         } else {
-          /**
-           * No-op, as it was already sent as part of the call to
-           * {@link createNewStoreVersion(PushJobSetting, long, ControllerClient, String, VeniceProperties)}
-           */
-        }
-        runJobWithKillDetection();
-
-        if (!pushJobSetting.suppressEndOfPushMessage) {
-          Map<Integer, Long> partitionRecordCounts = getPerPartitionRecordCounts();
           if (pushJobSetting.sendControlMessagesDirectly) {
-            getVeniceWriter(pushJobSetting).broadcastEndOfPush(Collections.emptyMap(), partitionRecordCounts);
+            getVeniceWriter(pushJobSetting).broadcastStartOfPush(
+                pushJobSetting.isSortedIngestionEnabled,
+                pushJobSetting.isChunkingEnabled,
+                pushJobSetting.topicCompressionStrategy,
+                optionalCompressionDictionary,
+                Collections.emptyMap());
           } else {
-            ControllerResponse eopResponse = controllerClient
-                .writeEndOfPush(pushJobSetting.storeName, pushJobSetting.version, partitionRecordCounts);
-            if (eopResponse.isError()) {
-              throw new VeniceException(
-                  "Failed to write End-of-Push for topic: "
-                      + Version.composeKafkaTopic(pushJobSetting.storeName, pushJobSetting.version) + ": "
-                      + eopResponse.getError());
+            /**
+             * No-op, as it was already sent as part of the call to
+             * {@link createNewStoreVersion(PushJobSetting, long, ControllerClient, String, VeniceProperties)}
+             */
+          }
+          runJobWithKillDetection();
+
+          if (!pushJobSetting.suppressEndOfPushMessage) {
+            Map<Integer, Long> partitionRecordCounts = getPerPartitionRecordCounts();
+            if (pushJobSetting.sendControlMessagesDirectly) {
+              getVeniceWriter(pushJobSetting).broadcastEndOfPush(Collections.emptyMap(), partitionRecordCounts);
+            } else {
+              ControllerResponse eopResponse = controllerClient
+                  .writeEndOfPush(pushJobSetting.storeName, pushJobSetting.version, partitionRecordCounts);
+              if (eopResponse.isError()) {
+                throw new VeniceException(
+                    "Failed to write End-of-Push for topic: "
+                        + Version.composeKafkaTopic(pushJobSetting.storeName, pushJobSetting.version) + ": "
+                        + eopResponse.getError());
+              }
             }
           }
         }
@@ -2664,6 +2682,137 @@ public class VenicePushJob implements AutoCloseable {
     return true;
   }
 
+  private static Map<Integer, String> parseSnapshotAtTRegionBrokers(String config) {
+    Map<Integer, String> regionBrokers = new HashMap<>();
+    if (config == null || config.trim().isEmpty()) {
+      return regionBrokers;
+    }
+    for (String entry: config.split(";")) {
+      String trimmed = entry.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      int separator = trimmed.indexOf('=');
+      if (separator <= 0) {
+        throw new VeniceException(
+            "Invalid " + SNAPSHOT_AT_T_RT_REGION_BROKERS + " entry '" + trimmed + "'; expected 'coloId=broker'.");
+      }
+      regionBrokers
+          .put(Integer.parseInt(trimmed.substring(0, separator).trim()), trimmed.substring(separator + 1).trim());
+    }
+    return regionBrokers;
+  }
+
+  /**
+   * Runs the snapshot-at-T data plane in place of the normal data-writer job: read the offline batch input and
+   * each region's real-time topic up to the cutoff, merge per key (value + RMD) via {@link SnapshotAtTRecordMerger},
+   * and produce the merged records to the new version topic. Start-Of-Push / End-Of-Push are sent by the caller.
+   */
+  void runSnapshotAtTMergePush(ControllerClient controllerClient) {
+    PushJobSetting setting = pushJobSetting;
+    if (setting.snapshotAtTRtRegionBrokers == null || setting.snapshotAtTRtRegionBrokers.isEmpty()) {
+      throw new VeniceException(
+          "Snapshot-at-T mode requires " + SNAPSHOT_AT_T_RT_REGION_BROKERS + " to list the per-region RT brokers.");
+    }
+    Map<ByteBuffer, ByteBuffer> batchValues = readBatchInputForSnapshot();
+
+    StoreInfo storeInfo = setting.storeResponse.getStore();
+    String realTimeTopicName = Utils.getRealTimeTopicName(storeInfo);
+    long cutoffMs = setting.snapshotAtTCutoffEpochSeconds > 0 ? setting.snapshotAtTCutoffEpochSeconds * 1000 : 0L;
+    SnapshotAtTRtReader rtReader = new SnapshotAtTRtReader();
+    List<SnapshotAtTRtRecord> rtRecords = new ArrayList<>();
+    for (Map.Entry<Integer, String> region: setting.snapshotAtTRtRegionBrokers.entrySet()) {
+      rtRecords.addAll(
+          rtReader.readRegion(
+              snapshotConsumerProps(region.getValue()),
+              region.getValue(),
+              realTimeTopicName,
+              setting.partitionCount,
+              cutoffMs,
+              region.getKey()));
+    }
+
+    SnapshotAtTSchemaRepository schemaRepository =
+        SnapshotAtTSchemaRepository.fromController(controllerClient, setting.storeName);
+    int rmdVersionId = schemaRepository.getRmdVersionId() > 0
+        ? schemaRepository.getRmdVersionId()
+        : RmdSchemaGenerator.getLatestVersion();
+    SnapshotAtTRecordMerger merger = new SnapshotAtTRecordMerger(
+        schemaRepository,
+        setting.storeName,
+        rmdVersionId,
+        setting.isStoreWriteComputeEnabled);
+
+    VeniceWriter<byte[], byte[], byte[]> dataWriter = createSnapshotAtTDataWriter();
+    try {
+      dataWriter.broadcastStartOfPush(
+          false,
+          setting.isChunkingEnabled,
+          setting.topicCompressionStrategy,
+          Optional.empty(),
+          Collections.emptyMap());
+      SnapshotAtTPushExecutor.Stats stats =
+          new SnapshotAtTPushExecutor().execute(dataWriter, batchValues, setting.valueSchemaId, rtRecords, merger);
+      dataWriter.broadcastEndOfPush(Collections.emptyMap());
+      LOGGER.info(
+          "Snapshot-at-T merge push produced {} records ({} batch keys, {} RT records across {} regions).",
+          stats.getTotalProduced(),
+          batchValues.size(),
+          rtRecords.size(),
+          setting.snapshotAtTRtRegionBrokers.size());
+    } finally {
+      Utils.closeQuietlyWithErrorLogged(dataWriter);
+    }
+  }
+
+  private Map<ByteBuffer, ByteBuffer> readBatchInputForSnapshot() {
+    Map<ByteBuffer, ByteBuffer> batchValues = new HashMap<>();
+    Path inputPath = new Path(pushJobSetting.inputURI);
+    VeniceAvroRecordReader recordReader = new VeniceAvroRecordReader(
+        pushJobSetting.inputDataSchema,
+        pushJobSetting.keyField,
+        pushJobSetting.valueField,
+        pushJobSetting.rmdField == null ? "" : pushJobSetting.rmdField,
+        pushJobSetting.etlValueSchemaTransformation,
+        null);
+    try {
+      FileSystem fs = inputPath.getFileSystem(new Configuration());
+      for (FileStatus status: fs.listStatus(inputPath, PATH_FILTER)) {
+        try (VeniceAvroFileIterator iterator = new VeniceAvroFileIterator(fs, status.getPath(), recordReader)) {
+          while (iterator.next()) {
+            batchValues.put(ByteBuffer.wrap(iterator.getCurrentKey()), ByteBuffer.wrap(iterator.getCurrentValue()));
+          }
+        }
+      }
+    } catch (IOException e) {
+      throw new VeniceException("Failed to read batch input for snapshot-at-T merge from " + inputPath, e);
+    }
+    return batchValues;
+  }
+
+  private VeniceWriter<byte[], byte[], byte[]> createSnapshotAtTDataWriter() {
+    VeniceWriterFactory veniceWriterFactory = new VeniceWriterFactory(getVeniceWriterProperties(pushJobSetting));
+    Properties partitionerProperties = new Properties();
+    partitionerProperties.putAll(pushJobSetting.partitionerParams);
+    VenicePartitioner partitioner = PartitionUtils
+        .getVenicePartitioner(pushJobSetting.partitionerClass, new VeniceProperties(partitionerProperties));
+    VeniceWriterOptions options = new VeniceWriterOptions.Builder(pushJobSetting.topic).setPartitioner(partitioner)
+        .setPartitionCount(pushJobSetting.partitionCount)
+        .setChunkingEnabled(pushJobSetting.chunkingEnabled)
+        .setRmdChunkingEnabled(pushJobSetting.rmdChunkingEnabled)
+        .setMaxRecordSizeBytes(pushJobSetting.maxRecordSizeBytes)
+        .build();
+    return veniceWriterFactory.createVeniceWriter(options);
+  }
+
+  /** Consumer config for reading one region's RT topic: the job's pubsub config with the region's broker. */
+  private VeniceProperties snapshotConsumerProps(String brokerAddress) {
+    Properties consumerProps = props.toProperties();
+    consumerProps.setProperty(PUBSUB_BROKER_ADDRESS, brokerAddress);
+    consumerProps.setProperty(KAFKA_BOOTSTRAP_SERVERS, brokerAddress);
+    return new VeniceProperties(consumerProps);
+  }
+
   /**
    * This method will talk to parent controller to create new store version, which will create new topic for the version as well.
    */
@@ -2675,7 +2824,9 @@ public class VenicePushJob implements AutoCloseable {
       VeniceProperties props,
       Optional<ByteBuffer> optionalCompressionDictionary) {
     Version.PushType pushType = getPushType(setting);
-    boolean askControllerToSendControlMessage = !setting.sendControlMessagesDirectly;
+    // Snapshot-at-T sends its own Start-Of-Push from the same writer as the data, so the controller must not.
+    boolean askControllerToSendControlMessage =
+        !setting.sendControlMessagesDirectly && !setting.snapshotAtTRewindApplied;
     final String partitioners = props.getString(VENICE_PARTITIONERS, DefaultVenicePartitioner.class.getName());
 
     Optional<String> dictionary;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTDataWriterSparkJob.java
@@ -1,0 +1,64 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import com.linkedin.venice.spark.datawriter.jobs.DataWriterSparkJob;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.List;
+import java.util.Map;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+
+/**
+ * A {@link DataWriterSparkJob} variant for the snapshot-at-T merge: its input DataFrame is the distributed cogroup
+ * of the batch Avro input and every upstream region's real-time topics (read up to the cutoff), merged per key via
+ * {@link SnapshotAtTSparkMerge}. Everything downstream of the input frame — partitioning, chunking, RMD, producing
+ * to the version topic — is the unchanged data-writer pipeline, so the merge is memory-bounded per key-group
+ * instead of loading the whole batch + all RT into one process.
+ *
+ * <p>The snapshot context (schemas, region brokers, cutoff, ...) is supplied via {@link #setSnapshotAtTContext}
+ * before {@code runJob()} by the driver, which holds the controller client used to build the schema bundle.
+ */
+public class SnapshotAtTDataWriterSparkJob extends DataWriterSparkJob {
+  private SnapshotAtTSchemaBundle schemaBundle;
+  private Map<Integer, String> regionBrokers;
+  private List<String> rtTopicNames;
+  private long cutoffTimestampMs;
+  private int batchValueSchemaId;
+  private int rmdProtocolVersion;
+  private boolean rmdUseFieldLevelTimestamp;
+
+  public void setSnapshotAtTContext(
+      SnapshotAtTSchemaBundle schemaBundle,
+      Map<Integer, String> regionBrokers,
+      List<String> rtTopicNames,
+      long cutoffTimestampMs,
+      int batchValueSchemaId,
+      int rmdProtocolVersion,
+      boolean rmdUseFieldLevelTimestamp) {
+    this.schemaBundle = schemaBundle;
+    this.regionBrokers = regionBrokers;
+    this.rtTopicNames = rtTopicNames;
+    this.cutoffTimestampMs = cutoffTimestampMs;
+    this.batchValueSchemaId = batchValueSchemaId;
+    this.rmdProtocolVersion = rmdProtocolVersion;
+    this.rmdUseFieldLevelTimestamp = rmdUseFieldLevelTimestamp;
+  }
+
+  @Override
+  protected Dataset<Row> getUserInputDataFrame() {
+    // The batch (key, value, rmd) frame from the Avro input, exactly as a normal Spark push reads it.
+    Dataset<Row> batch = super.getUserInputDataFrame();
+    SparkSession spark = getSparkSession();
+    VeniceProperties props = getJobProperties();
+    // Plan RT splits on the driver (queries brokers for partition ranges), then read them distributed.
+    List<SnapshotAtTRtSplit> splits = new SnapshotAtTRtSplitPlanner().plan(regionBrokers, rtTopicNames, props);
+    Dataset<Row> rt = SnapshotAtTSparkMerge.readRtDataFrame(spark, splits, props, cutoffTimestampMs);
+    Broadcast<SnapshotAtTSchemaBundle> broadcastBundle =
+        JavaSparkContext.fromSparkContext(spark.sparkContext()).broadcast(schemaBundle);
+    return SnapshotAtTSparkMerge
+        .merge(batch, rt, batchValueSchemaId, broadcastBundle, rmdProtocolVersion, rmdUseFieldLevelTimestamp);
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTDataWriterSparkJob.java
@@ -1,9 +1,12 @@
 package com.linkedin.venice.hadoop.snapshot;
 
+import com.linkedin.venice.hadoop.PushJobSetting;
+import com.linkedin.venice.hadoop.VenicePushJob;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.spark.datawriter.jobs.DataWriterSparkJob;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.List;
-import java.util.Map;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.Dataset;
@@ -14,51 +17,40 @@ import org.apache.spark.sql.SparkSession;
 /**
  * A {@link DataWriterSparkJob} variant for the snapshot-at-T merge: its input DataFrame is the distributed cogroup
  * of the batch Avro input and every upstream region's real-time topics (read up to the cutoff), merged per key via
- * {@link SnapshotAtTSparkMerge}. Everything downstream of the input frame — partitioning, chunking, RMD, producing
- * to the version topic — is the unchanged data-writer pipeline, so the merge is memory-bounded per key-group
- * instead of loading the whole batch + all RT into one process.
+ * {@link SnapshotAtTSparkMerge}. Everything downstream of the input frame -- partitioning, chunking, RMD, producing
+ * to the version topic, Start/End-Of-Push -- is the unchanged data-writer pipeline, so the merge is memory-bounded
+ * per key-group instead of loading the whole batch + all RT into one process.
  *
- * <p>The snapshot context (schemas, region brokers, cutoff, ...) is supplied via {@link #setSnapshotAtTContext}
- * before {@code runJob()} by the driver, which holds the controller client used to build the schema bundle.
+ * <p>It is constructed reflectively by the normal data-writer launch path, so it reads all of its context (the
+ * broadcast schema bundle, region brokers, cutoff, ...) from {@link PushJobSetting}, populated on the driver by
+ * {@code VenicePushJob.maybeSetupSnapshotAtTDistributedMerge}.
  */
 public class SnapshotAtTDataWriterSparkJob extends DataWriterSparkJob {
-  private SnapshotAtTSchemaBundle schemaBundle;
-  private Map<Integer, String> regionBrokers;
-  private List<String> rtTopicNames;
-  private long cutoffTimestampMs;
-  private int batchValueSchemaId;
-  private int rmdProtocolVersion;
-  private boolean rmdUseFieldLevelTimestamp;
-
-  public void setSnapshotAtTContext(
-      SnapshotAtTSchemaBundle schemaBundle,
-      Map<Integer, String> regionBrokers,
-      List<String> rtTopicNames,
-      long cutoffTimestampMs,
-      int batchValueSchemaId,
-      int rmdProtocolVersion,
-      boolean rmdUseFieldLevelTimestamp) {
-    this.schemaBundle = schemaBundle;
-    this.regionBrokers = regionBrokers;
-    this.rtTopicNames = rtTopicNames;
-    this.cutoffTimestampMs = cutoffTimestampMs;
-    this.batchValueSchemaId = batchValueSchemaId;
-    this.rmdProtocolVersion = rmdProtocolVersion;
-    this.rmdUseFieldLevelTimestamp = rmdUseFieldLevelTimestamp;
-  }
-
   @Override
   protected Dataset<Row> getUserInputDataFrame() {
+    PushJobSetting setting = getPushJobSetting();
+    StoreInfo storeInfo = setting.storeResponse.getStore();
+    SnapshotAtTSchemaBundle bundle = setting.snapshotAtTSchemaBundle;
+    int rmdProtocolVersion =
+        bundle.getRmdVersionId() > 0 ? bundle.getRmdVersionId() : RmdSchemaGenerator.getLatestVersion();
+    long cutoffMs = setting.snapshotAtTCutoffEpochSeconds > 0 ? setting.snapshotAtTCutoffEpochSeconds * 1000 : 0L;
+
     // The batch (key, value, rmd) frame from the Avro input, exactly as a normal Spark push reads it.
     Dataset<Row> batch = super.getUserInputDataFrame();
     SparkSession spark = getSparkSession();
     VeniceProperties props = getJobProperties();
     // Plan RT splits on the driver (queries brokers for partition ranges), then read them distributed.
-    List<SnapshotAtTRtSplit> splits = new SnapshotAtTRtSplitPlanner().plan(regionBrokers, rtTopicNames, props);
-    Dataset<Row> rt = SnapshotAtTSparkMerge.readRtDataFrame(spark, splits, props, cutoffTimestampMs);
+    List<SnapshotAtTRtSplit> splits = new SnapshotAtTRtSplitPlanner()
+        .plan(setting.snapshotAtTRtRegionBrokers, VenicePushJob.snapshotAtTRtTopicNames(storeInfo), props);
+    Dataset<Row> rt = SnapshotAtTSparkMerge.readRtDataFrame(spark, splits, props, cutoffMs);
     Broadcast<SnapshotAtTSchemaBundle> broadcastBundle =
-        JavaSparkContext.fromSparkContext(spark.sparkContext()).broadcast(schemaBundle);
-    return SnapshotAtTSparkMerge
-        .merge(batch, rt, batchValueSchemaId, broadcastBundle, rmdProtocolVersion, rmdUseFieldLevelTimestamp);
+        JavaSparkContext.fromSparkContext(spark.sparkContext()).broadcast(bundle);
+    return SnapshotAtTSparkMerge.merge(
+        batch,
+        rt,
+        setting.valueSchemaId,
+        broadcastBundle,
+        rmdProtocolVersion,
+        setting.isStoreWriteComputeEnabled);
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTPushExecutor.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTPushExecutor.java
@@ -80,11 +80,6 @@ public class SnapshotAtTPushExecutor {
     for (SnapshotAtTRtRecord rt: rtRecords) {
       rtByKey.computeIfAbsent(rt.getKey(), k -> new ArrayList<>()).add(rt);
     }
-    // Folding order does not change the converged DCR result, but a deterministic timestamp order keeps runs
-    // reproducible and mirrors how a server applies writes.
-    for (List<SnapshotAtTRtRecord> perKey: rtByKey.values()) {
-      perKey.sort(Comparator.comparingLong(SnapshotAtTRtRecord::getWriteTimestamp));
-    }
 
     Set<ByteBuffer> allKeys = new LinkedHashSet<>(batchValuesByKey.keySet());
     allKeys.addAll(rtByKey.keySet());
@@ -93,44 +88,14 @@ public class SnapshotAtTPushExecutor {
     for (ByteBuffer key: allKeys) {
       ByteBuffer batchValue = batchValuesByKey.get(key);
       List<SnapshotAtTRtRecord> perKeyRt = rtByKey.get(key);
-
-      KeyMergeState state = batchValue != null
-          ? merger.seedFromBatch(batchValue.duplicate(), batchValueSchemaId)
-          : merger.newState(batchValueSchemaId);
       if (batchValue != null && perKeyRt == null) {
         stats.batchOnlyKeys++;
       }
       if (perKeyRt != null) {
         stats.rtTouchedKeys++;
-        for (SnapshotAtTRtRecord rt: perKeyRt) {
-          switch (rt.getOp()) {
-            case PUT:
-              merger.applyPut(
-                  state,
-                  rt.getPayload().duplicate(),
-                  rt.getValueSchemaId(),
-                  rt.getWriteTimestamp(),
-                  rt.getColoId());
-              break;
-            case UPDATE:
-              merger.applyUpdate(
-                  state,
-                  rt.getPayload().duplicate(),
-                  rt.getValueSchemaId(),
-                  rt.getUpdateProtocolVersion(),
-                  rt.getWriteTimestamp(),
-                  rt.getColoId());
-              break;
-            case DELETE:
-              merger.applyDelete(state, rt.getWriteTimestamp(), rt.getColoId());
-              break;
-            default:
-              throw new IllegalStateException("Unexpected RT op: " + rt.getOp());
-          }
-        }
       }
 
-      MergedRecord merged = merger.finalizeRecord(state);
+      MergedRecord merged = mergeKey(batchValue, batchValueSchemaId, perKeyRt, merger);
       byte[] keyBytes = toByteArray(key);
       if (merged.isDelete()) {
         writer.delete(
@@ -157,6 +122,58 @@ public class SnapshotAtTPushExecutor {
         batchValuesByKey.size(),
         stats.rtTouchedKeys);
     return stats;
+  }
+
+  /**
+   * Merge one key: seed from its batch value (if any), fold its RT records in write-timestamp order, and finalize
+   * to a {@link MergedRecord}. This is the per-key reducer body shared by this single-process executor and the
+   * distributed (Spark) cogroup, so both produce identical merged records. Conflict resolution is
+   * timestamp-commutative, so the sort only makes runs reproducible; it does not change the converged result.
+   *
+   * @param batchValue the key's batch value (no schema-id prefix), or {@code null} if the key has no batch value
+   * @param batchValueSchemaId the value schema id the batch value is serialized with
+   * @param perKeyRtRecords the key's RT records across all regions (may be {@code null}/empty)
+   * @param merger the merge engine (its rmdUseFieldLevelTimestamp must match the store config)
+   */
+  public static MergedRecord mergeKey(
+      ByteBuffer batchValue,
+      int batchValueSchemaId,
+      List<SnapshotAtTRtRecord> perKeyRtRecords,
+      SnapshotAtTRecordMerger merger) {
+    KeyMergeState state = batchValue != null
+        ? merger.seedFromBatch(batchValue.duplicate(), batchValueSchemaId)
+        : merger.newState(batchValueSchemaId);
+    if (perKeyRtRecords != null && !perKeyRtRecords.isEmpty()) {
+      List<SnapshotAtTRtRecord> sorted = new ArrayList<>(perKeyRtRecords);
+      sorted.sort(Comparator.comparingLong(SnapshotAtTRtRecord::getWriteTimestamp));
+      for (SnapshotAtTRtRecord rt: sorted) {
+        switch (rt.getOp()) {
+          case PUT:
+            merger.applyPut(
+                state,
+                rt.getPayload().duplicate(),
+                rt.getValueSchemaId(),
+                rt.getWriteTimestamp(),
+                rt.getColoId());
+            break;
+          case UPDATE:
+            merger.applyUpdate(
+                state,
+                rt.getPayload().duplicate(),
+                rt.getValueSchemaId(),
+                rt.getUpdateProtocolVersion(),
+                rt.getWriteTimestamp(),
+                rt.getColoId());
+            break;
+          case DELETE:
+            merger.applyDelete(state, rt.getWriteTimestamp(), rt.getColoId());
+            break;
+          default:
+            throw new IllegalStateException("Unexpected RT op: " + rt.getOp());
+        }
+      }
+    }
+    return merger.finalizeRecord(state);
   }
 
   private static byte[] compress(VeniceCompressor compressor, byte[] value) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTPushExecutor.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTPushExecutor.java
@@ -1,10 +1,13 @@
 package com.linkedin.venice.hadoop.snapshot;
 
+import com.linkedin.venice.compression.VeniceCompressor;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRecordMerger.KeyMergeState;
 import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRecordMerger.MergedRecord;
 import com.linkedin.venice.writer.AbstractVeniceWriter;
 import com.linkedin.venice.writer.DeleteMetadata;
 import com.linkedin.venice.writer.PutMetadata;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -64,13 +67,15 @@ public class SnapshotAtTPushExecutor {
    * @param batchValueSchemaId the value schema id the batch values are serialized with
    * @param rtRecords RT records from all regions, already read up to {@code T} and tagged with their colo id
    * @param merger the merge engine (its rmdUseFieldLevelTimestamp must match the store config)
+   * @param compressor compresses each merged value to the version's compression strategy before it is written
    */
   public Stats execute(
       AbstractVeniceWriter<byte[], byte[], byte[]> writer,
       Map<ByteBuffer, ByteBuffer> batchValuesByKey,
       int batchValueSchemaId,
       List<SnapshotAtTRtRecord> rtRecords,
-      SnapshotAtTRecordMerger merger) {
+      SnapshotAtTRecordMerger merger,
+      VeniceCompressor compressor) {
     Map<ByteBuffer, List<SnapshotAtTRtRecord>> rtByKey = new HashMap<>();
     for (SnapshotAtTRtRecord rt: rtRecords) {
       rtByKey.computeIfAbsent(rt.getKey(), k -> new ArrayList<>()).add(rt);
@@ -136,7 +141,7 @@ public class SnapshotAtTPushExecutor {
       } else {
         writer.put(
             keyBytes,
-            toByteArray(merged.getValue()),
+            compress(compressor, toByteArray(merged.getValue())),
             merged.getValueSchemaId(),
             null,
             new PutMetadata(merged.getRmdProtocolVersion(), merged.getRmd()));
@@ -152,6 +157,14 @@ public class SnapshotAtTPushExecutor {
         batchValuesByKey.size(),
         stats.rtTouchedKeys);
     return stats;
+  }
+
+  private static byte[] compress(VeniceCompressor compressor, byte[] value) {
+    try {
+      return compressor.compress(value);
+    } catch (IOException e) {
+      throw new VeniceException("Failed to compress merged value for snapshot-at-T push", e);
+    }
   }
 
   private static byte[] toByteArray(ByteBuffer buffer) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTPushExecutor.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTPushExecutor.java
@@ -1,0 +1,164 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRecordMerger.KeyMergeState;
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRecordMerger.MergedRecord;
+import com.linkedin.venice.writer.AbstractVeniceWriter;
+import com.linkedin.venice.writer.DeleteMetadata;
+import com.linkedin.venice.writer.PutMetadata;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Produces the snapshot-at-T merged version: for every key, it seeds {@link SnapshotAtTRecordMerger} from the
+ * offline batch value (if any), folds in that key's real-time (RT) records collected from all regions up to the
+ * cutoff {@code T}, and writes the merged value + RMD (or an RMD-carrying delete tombstone) to the new version
+ * topic via a {@link AbstractVeniceWriter}. The writer partitions each key itself, so no manual partitioning is
+ * needed.
+ *
+ * <p>Start-Of-Push / End-Of-Push are sent by the caller around {@link #execute}; this class only produces the
+ * data records. The shortened rewind is applied separately at version-creation time (the control plane).
+ */
+public class SnapshotAtTPushExecutor {
+  private static final Logger LOGGER = LogManager.getLogger(SnapshotAtTPushExecutor.class);
+
+  /** Counters describing what a run produced. */
+  public static final class Stats {
+    private long puts;
+    private long deletes;
+    private long batchOnlyKeys;
+    private long rtTouchedKeys;
+
+    public long getPuts() {
+      return puts;
+    }
+
+    public long getDeletes() {
+      return deletes;
+    }
+
+    public long getBatchOnlyKeys() {
+      return batchOnlyKeys;
+    }
+
+    public long getRtTouchedKeys() {
+      return rtTouchedKeys;
+    }
+
+    public long getTotalProduced() {
+      return puts + deletes;
+    }
+  }
+
+  /**
+   * @param writer destination writer for the new version topic (caller owns its lifecycle and SOP/EOP)
+   * @param batchValuesByKey offline batch values keyed by serialized key (no schema-id prefix); may be empty
+   * @param batchValueSchemaId the value schema id the batch values are serialized with
+   * @param rtRecords RT records from all regions, already read up to {@code T} and tagged with their colo id
+   * @param merger the merge engine (its rmdUseFieldLevelTimestamp must match the store config)
+   */
+  public Stats execute(
+      AbstractVeniceWriter<byte[], byte[], byte[]> writer,
+      Map<ByteBuffer, ByteBuffer> batchValuesByKey,
+      int batchValueSchemaId,
+      List<SnapshotAtTRtRecord> rtRecords,
+      SnapshotAtTRecordMerger merger) {
+    Map<ByteBuffer, List<SnapshotAtTRtRecord>> rtByKey = new HashMap<>();
+    for (SnapshotAtTRtRecord rt: rtRecords) {
+      rtByKey.computeIfAbsent(rt.getKey(), k -> new ArrayList<>()).add(rt);
+    }
+    // Folding order does not change the converged DCR result, but a deterministic timestamp order keeps runs
+    // reproducible and mirrors how a server applies writes.
+    for (List<SnapshotAtTRtRecord> perKey: rtByKey.values()) {
+      perKey.sort(Comparator.comparingLong(SnapshotAtTRtRecord::getWriteTimestamp));
+    }
+
+    Set<ByteBuffer> allKeys = new LinkedHashSet<>(batchValuesByKey.keySet());
+    allKeys.addAll(rtByKey.keySet());
+
+    Stats stats = new Stats();
+    for (ByteBuffer key: allKeys) {
+      ByteBuffer batchValue = batchValuesByKey.get(key);
+      List<SnapshotAtTRtRecord> perKeyRt = rtByKey.get(key);
+
+      KeyMergeState state = batchValue != null
+          ? merger.seedFromBatch(batchValue.duplicate(), batchValueSchemaId)
+          : merger.newState(batchValueSchemaId);
+      if (batchValue != null && perKeyRt == null) {
+        stats.batchOnlyKeys++;
+      }
+      if (perKeyRt != null) {
+        stats.rtTouchedKeys++;
+        for (SnapshotAtTRtRecord rt: perKeyRt) {
+          switch (rt.getOp()) {
+            case PUT:
+              merger.applyPut(
+                  state,
+                  rt.getPayload().duplicate(),
+                  rt.getValueSchemaId(),
+                  rt.getWriteTimestamp(),
+                  rt.getColoId());
+              break;
+            case UPDATE:
+              merger.applyUpdate(
+                  state,
+                  rt.getPayload().duplicate(),
+                  rt.getValueSchemaId(),
+                  rt.getUpdateProtocolVersion(),
+                  rt.getWriteTimestamp(),
+                  rt.getColoId());
+              break;
+            case DELETE:
+              merger.applyDelete(state, rt.getWriteTimestamp(), rt.getColoId());
+              break;
+            default:
+              throw new IllegalStateException("Unexpected RT op: " + rt.getOp());
+          }
+        }
+      }
+
+      MergedRecord merged = merger.finalizeRecord(state);
+      byte[] keyBytes = toByteArray(key);
+      if (merged.isDelete()) {
+        writer.delete(
+            keyBytes,
+            null,
+            new DeleteMetadata(merged.getValueSchemaId(), merged.getRmdProtocolVersion(), merged.getRmd()));
+        stats.deletes++;
+      } else {
+        writer.put(
+            keyBytes,
+            toByteArray(merged.getValue()),
+            merged.getValueSchemaId(),
+            null,
+            new PutMetadata(merged.getRmdProtocolVersion(), merged.getRmd()));
+        stats.puts++;
+      }
+    }
+
+    LOGGER.info(
+        "Snapshot-at-T merge produced {} records ({} puts, {} deletes) from {} batch keys and {} RT-touched keys.",
+        stats.getTotalProduced(),
+        stats.puts,
+        stats.deletes,
+        batchValuesByKey.size(),
+        stats.rtTouchedKeys);
+    return stats;
+  }
+
+  private static byte[] toByteArray(ByteBuffer buffer) {
+    ByteBuffer duplicate = buffer.duplicate();
+    duplicate.rewind();
+    byte[] bytes = new byte[duplicate.remaining()];
+    duplicate.get(bytes);
+    return bytes;
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRecordMerger.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRecordMerger.java
@@ -1,0 +1,217 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import com.linkedin.davinci.replication.RmdWithValueSchemaId;
+import com.linkedin.davinci.replication.merge.MergeConflictResolver;
+import com.linkedin.davinci.replication.merge.MergeConflictResolverFactory;
+import com.linkedin.davinci.replication.merge.MergeConflictResult;
+import com.linkedin.davinci.replication.merge.RmdSerDe;
+import com.linkedin.davinci.replication.merge.StringAnnotatedStoreSchemaCache;
+import com.linkedin.venice.meta.ReadOnlySchemaRepository;
+import com.linkedin.venice.schema.rmd.RmdConstants;
+import com.linkedin.venice.utils.lazy.Lazy;
+import java.nio.ByteBuffer;
+
+
+/**
+ * Offline merge of real-time (RT) writes onto a batch base value, producing the merged value <b>and its
+ * Replication Metadata (RMD)</b>, by reusing Venice's own {@link MergeConflictResolver}. The result is
+ * identical to what a server would produce by replaying the same RT records on top of the batch data
+ * during a hybrid rewind.
+ *
+ * <p>This is the correctness core of the "snapshot-at-T" data plane. Instead of every server replica
+ * replaying RT after a batch push (the long hybrid rewind), the push job folds RT up to a cutoff {@code T}
+ * into the batch dataset once, offline. Because the merged record carries real per-record / per-field RMD,
+ * the short {@code [T, now]} rewind that follows resolves correctly against it. Reusing
+ * {@link MergeConflictResolver} (rather than re-implementing conflict resolution) is what makes the offline
+ * result equal to the online one — including Active-Active field-level timestamps and write-compute partial
+ * updates.
+ *
+ * <p>Per key: {@link #seedFromBatch} with the offline batch value (which establishes the batch-sentinel RMD,
+ * timestamp {@link RmdConstants#BATCH_RMD_SENTINEL_TIMESTAMP}, exactly as a server does for batch data, so any
+ * real RT write applied next wins), or {@link #newState} for an RT-only key; then
+ * {@link #applyPut}/{@link #applyUpdate}/{@link #applyDelete} for each RT record; then {@link #finalizeRecord}.
+ * Conflict resolution is timestamp-commutative, so the converged result does not depend on the order RT
+ * records are folded in.
+ *
+ * <p>Not thread-safe. Use one instance and one {@link KeyMergeState} per key within a task.
+ */
+public class SnapshotAtTRecordMerger {
+  private final MergeConflictResolver resolver;
+  private final RmdSerDe rmdSerDe;
+  private final int rmdProtocolVersion;
+
+  /**
+   * @param schemaRepository resolves value, RMD, and write-compute (derived) schemas for the store
+   * @param storeName the Venice store name
+   * @param rmdProtocolVersion the store's RMD protocol version (the version the merged RMD is written with)
+   * @param rmdUseFieldLevelTimestamp {@code true} for stores that track per-field timestamps (write-compute /
+   *        partial-update stores); {@code false} for value-level timestamps. Must match the store's config so
+   *        the offline merge matches the server.
+   */
+  public SnapshotAtTRecordMerger(
+      ReadOnlySchemaRepository schemaRepository,
+      String storeName,
+      int rmdProtocolVersion,
+      boolean rmdUseFieldLevelTimestamp) {
+    StringAnnotatedStoreSchemaCache schemaCache = new StringAnnotatedStoreSchemaCache(storeName, schemaRepository);
+    this.rmdSerDe = new RmdSerDe(schemaCache, rmdProtocolVersion);
+    this.resolver = MergeConflictResolverFactory.getInstance()
+        .createMergeConflictResolver(schemaCache, rmdSerDe, storeName, rmdUseFieldLevelTimestamp, true);
+    this.rmdProtocolVersion = rmdProtocolVersion;
+  }
+
+  /** Mutable merge state for a single key. */
+  public static final class KeyMergeState {
+    // Current value (no value-schema-id prefix), or null once the key resolves to a delete / before any value
+    // has been established. Stored as a byte[] so it is independent of any ByteBuffer position the resolver may
+    // have advanced while reading the inputs.
+    private byte[] valueBytes;
+    private int valueSchemaId;
+    // Current RMD; null until the first value is established (batch seed or first RT write), after which the
+    // resolver always supplies one.
+    private RmdWithValueSchemaId rmd;
+
+    private KeyMergeState(int valueSchemaId) {
+      this.valueSchemaId = valueSchemaId;
+    }
+
+    /** The merged value bytes (no schema-id prefix), or {@code null} if the key resolves to a delete. */
+    public ByteBuffer getValueBytes() {
+      return valueBytes == null ? null : ByteBuffer.wrap(valueBytes);
+    }
+
+    public int getValueSchemaId() {
+      return valueSchemaId;
+    }
+
+    public boolean isDeleted() {
+      return valueBytes == null;
+    }
+  }
+
+  /** A finished merged record, ready to be written to the new version topic. */
+  public static final class MergedRecord {
+    private final ByteBuffer value;
+    private final ByteBuffer rmd;
+    private final int valueSchemaId;
+    private final int rmdProtocolVersion;
+    private final boolean delete;
+
+    MergedRecord(ByteBuffer value, ByteBuffer rmd, int valueSchemaId, int rmdProtocolVersion, boolean delete) {
+      this.value = value;
+      this.rmd = rmd;
+      this.valueSchemaId = valueSchemaId;
+      this.rmdProtocolVersion = rmdProtocolVersion;
+      this.delete = delete;
+    }
+
+    /** Merged value bytes (no schema-id prefix), or {@code null} for a delete. */
+    public ByteBuffer getValue() {
+      return value;
+    }
+
+    /** Serialized merged RMD. Always present (a delete still carries an RMD tombstone). */
+    public ByteBuffer getRmd() {
+      return rmd;
+    }
+
+    public int getValueSchemaId() {
+      return valueSchemaId;
+    }
+
+    public int getRmdProtocolVersion() {
+      return rmdProtocolVersion;
+    }
+
+    public boolean isDelete() {
+      return delete;
+    }
+  }
+
+  /** A fresh state for a key that has no batch value (RT-only); the first applied RT write establishes it. */
+  public KeyMergeState newState(int valueSchemaId) {
+    return new KeyMergeState(valueSchemaId);
+  }
+
+  /**
+   * Seed the merge for a key from its offline batch value. Applying it with no prior RMD yields the
+   * batch-sentinel RMD (timestamp {@link RmdConstants#BATCH_RMD_SENTINEL_TIMESTAMP}), matching how a server
+   * stores batch data, so any real RT write folded in afterwards wins.
+   */
+  public KeyMergeState seedFromBatch(ByteBuffer batchValueBytes, int valueSchemaId) {
+    KeyMergeState state = new KeyMergeState(valueSchemaId);
+    applyPut(state, batchValueBytes, valueSchemaId, RmdConstants.BATCH_RMD_SENTINEL_TIMESTAMP, 0);
+    return state;
+  }
+
+  /** Fold a full-value PUT from RT. */
+  public void applyPut(KeyMergeState state, ByteBuffer value, int valueSchemaId, long writeTimestamp, int coloId) {
+    MergeConflictResult result =
+        resolver.put(oldValueProvider(state), state.rmd, value, writeTimestamp, valueSchemaId, coloId);
+    applyResult(state, result);
+  }
+
+  /** Fold a write-compute (partial-update) UPDATE from RT. */
+  public void applyUpdate(
+      KeyMergeState state,
+      ByteBuffer updateBytes,
+      int valueSchemaId,
+      int updateProtocolVersion,
+      long writeTimestamp,
+      int coloId) {
+    MergeConflictResult result = resolver.update(
+        oldValueProvider(state),
+        state.rmd,
+        updateBytes,
+        valueSchemaId,
+        updateProtocolVersion,
+        writeTimestamp,
+        coloId,
+        null);
+    applyResult(state, result);
+  }
+
+  /** Fold a DELETE from RT. */
+  public void applyDelete(KeyMergeState state, long writeTimestamp, int coloId) {
+    MergeConflictResult result = resolver.delete(oldValueProvider(state), state.rmd, writeTimestamp, coloId);
+    applyResult(state, result);
+  }
+
+  /** Produce the writer-ready merged record (value + serialized RMD) for the current state. */
+  public MergedRecord finalizeRecord(KeyMergeState state) {
+    ByteBuffer rmdBytes = rmdSerDe.serializeRmdRecord(state.valueSchemaId, state.rmd.getRmdRecord());
+    return new MergedRecord(
+        state.getValueBytes(),
+        rmdBytes,
+        state.valueSchemaId,
+        rmdProtocolVersion,
+        state.isDeleted());
+  }
+
+  private static Lazy<ByteBuffer> oldValueProvider(KeyMergeState state) {
+    // A fresh ByteBuffer per call so a previously-advanced position can never leak into a later operation.
+    return Lazy.of(() -> state.valueBytes == null ? null : ByteBuffer.wrap(state.valueBytes));
+  }
+
+  private void applyResult(KeyMergeState state, MergeConflictResult result) {
+    // A stale write (older than what is already merged) is ignored, leaving the state untouched.
+    if (result.isUpdateIgnored()) {
+      return;
+    }
+    state.valueBytes = toByteArray(result.getNewValue());
+    state.valueSchemaId = result.getValueSchemaId();
+    state.rmd = new RmdWithValueSchemaId(result.getValueSchemaId(), rmdProtocolVersion, result.getRmdRecord());
+  }
+
+  /** Read a ByteBuffer's full content into a byte[] without depending on (or mutating) its position. */
+  private static byte[] toByteArray(ByteBuffer buffer) {
+    if (buffer == null) {
+      return null;
+    }
+    ByteBuffer duplicate = buffer.duplicate();
+    duplicate.rewind();
+    byte[] bytes = new byte[duplicate.remaining()];
+    duplicate.get(bytes);
+    return bytes;
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtReader.java
@@ -2,12 +2,6 @@ package com.linkedin.venice.hadoop.snapshot;
 
 import com.linkedin.venice.acl.VeniceComponent;
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.kafka.protocol.Delete;
-import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
-import com.linkedin.venice.kafka.protocol.Put;
-import com.linkedin.venice.kafka.protocol.Update;
-import com.linkedin.venice.kafka.protocol.enums.MessageType;
-import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
 import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
@@ -23,7 +17,6 @@ import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pubsub.manager.TopicManagerContext;
 import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
 import com.linkedin.venice.utils.VeniceProperties;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -128,7 +121,7 @@ public class SnapshotAtTRtReader {
           emptyPolls = 0;
           for (DefaultPubSubMessage message: messages) {
             consumed++;
-            SnapshotAtTRtRecord record = toRtRecord(message, coloId, cutoffTimestampMs);
+            SnapshotAtTRtRecord record = SnapshotAtTRtRecordDecoder.decode(message, coloId, cutoffTimestampMs);
             if (record != null) {
               records.add(record);
             }
@@ -152,69 +145,5 @@ public class SnapshotAtTRtReader {
     }
     LOGGER.info("Read {} RT records from {} (colo {}).", records.size(), rtTopicName, coloId);
     return records;
-  }
-
-  private static SnapshotAtTRtRecord toRtRecord(DefaultPubSubMessage message, int coloId, long cutoffTimestampMs) {
-    KafkaKey key = message.getKey();
-    if (key.isControlMessage() || key.isGlobalRtDiv()) {
-      return null;
-    }
-    KafkaMessageEnvelope envelope = message.getValue();
-    long writeTimestamp = envelope.producerMetadata.logicalTimestamp >= 0
-        ? envelope.producerMetadata.logicalTimestamp
-        : envelope.producerMetadata.messageTimestamp;
-    if (cutoffTimestampMs > 0 && writeTimestamp > cutoffTimestampMs) {
-      return null;
-    }
-    // Copy the key/value bytes out of the consumed message immediately: the message envelope's buffers may be
-    // pooled/reused by the consumer on the next poll, and these records are processed only after the whole read
-    // completes.
-    ByteBuffer keyBytes = copy(ByteBuffer.wrap(key.getKey(), 0, key.getKeyLength()));
-    MessageType messageType = MessageType.valueOf(envelope);
-    switch (messageType) {
-      case PUT:
-        Put put = (Put) envelope.payloadUnion;
-        return new SnapshotAtTRtRecord(
-            SnapshotAtTRtRecord.Op.PUT,
-            keyBytes,
-            copy(put.putValue),
-            put.schemaId,
-            -1,
-            writeTimestamp,
-            coloId);
-      case UPDATE:
-        Update update = (Update) envelope.payloadUnion;
-        return new SnapshotAtTRtRecord(
-            SnapshotAtTRtRecord.Op.UPDATE,
-            keyBytes,
-            copy(update.updateValue),
-            update.schemaId,
-            update.updateSchemaId,
-            writeTimestamp,
-            coloId);
-      case DELETE:
-        Delete delete = (Delete) envelope.payloadUnion;
-        return new SnapshotAtTRtRecord(
-            SnapshotAtTRtRecord.Op.DELETE,
-            keyBytes,
-            null,
-            delete.schemaId,
-            -1,
-            writeTimestamp,
-            coloId);
-      default:
-        return null;
-    }
-  }
-
-  /** Copy a buffer's remaining content into a fresh, independently-owned ByteBuffer. */
-  private static ByteBuffer copy(ByteBuffer source) {
-    if (source == null) {
-      return null;
-    }
-    ByteBuffer duplicate = source.duplicate();
-    byte[] bytes = new byte[duplicate.remaining()];
-    duplicate.get(bytes);
-    return ByteBuffer.wrap(bytes);
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtReader.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.hadoop.snapshot;
 
 import com.linkedin.venice.acl.VeniceComponent;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.Delete;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.Put;
@@ -89,6 +90,16 @@ public class SnapshotAtTRtReader {
         TopicManager topicManager =
             new TopicManagerRepository(topicManagerContext, brokerAddress).getLocalTopicManager();
         PubSubConsumerAdapter consumer = clientsFactory.getConsumerAdapterFactory().create(consumerContext)) {
+      // The separate RT topic may not exist yet for a store that has it enabled but has taken no incremental
+      // push; an absent topic genuinely has no records to merge, so return empty rather than failing the read.
+      if (!topicManager.containsTopic(rtTopic)) {
+        LOGGER.info(
+            "RT topic {} does not exist on broker {} (colo {}); nothing to read.",
+            rtTopicName,
+            brokerAddress,
+            coloId);
+        return records;
+      }
       Map<PubSubTopicPartition, PubSubPosition> startPositions =
           topicManager.getStartPositionsForTopicWithRetries(rtTopic);
       Map<PubSubTopicPartition, PubSubPosition> endPositions = topicManager.getEndPositionsForTopicWithRetries(rtTopic);
@@ -128,12 +139,14 @@ public class SnapshotAtTRtReader {
         }
         consumer.unSubscribe(topicPartition);
         if (consumed < target) {
-          LOGGER.warn(
-              "RT read of {} partition {} stopped early: consumed {} of {} expected records.",
-              rtTopicName,
-              partition,
-              consumed,
-              target);
+          throw new VeniceException(
+              String.format(
+                  "Snapshot-at-T RT read of %s partition %d is incomplete: consumed %d of %d expected records. "
+                      + "Aborting to avoid producing a partial merged dataset (potential data loss).",
+                  rtTopicName,
+                  partition,
+                  consumed,
+                  target));
         }
       }
     }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtReader.java
@@ -1,0 +1,207 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import com.linkedin.venice.acl.VeniceComponent;
+import com.linkedin.venice.kafka.protocol.Delete;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.Put;
+import com.linkedin.venice.kafka.protocol.Update;
+import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.pubsub.PubSubClientsFactory;
+import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
+import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.pubsub.manager.TopicManager;
+import com.linkedin.venice.pubsub.manager.TopicManagerContext;
+import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Reads a single region's real-time (RT) topic and normalizes its records for the snapshot-at-T merge. Each
+ * record is tagged with the caller-supplied {@code coloId} (the region the topic belongs to), so the merger can
+ * do Active-Active conflict resolution across regions. Call once per region and concatenate the results.
+ *
+ * <p>It reads exactly the start-to-end record count of each partition (so the read is deterministic, not a flaky
+ * poll-until-idle drain), which corresponds to "up to the current tail" (T = read time). Records whose write
+ * timestamp exceeds {@code cutoffTimestampMs} are filtered out, giving event-time bounding when a {@code T}
+ * earlier than now is requested.
+ */
+public class SnapshotAtTRtReader {
+  private static final Logger LOGGER = LogManager.getLogger(SnapshotAtTRtReader.class);
+  private static final long POLL_TIMEOUT_MS = 5_000;
+  private static final int MAX_EMPTY_POLLS = 10;
+
+  /**
+   * @param consumerProps pubsub client config (selects the consumer/admin adapter implementation)
+   * @param brokerAddress the region's pubsub broker address
+   * @param rtTopicName the store's RT topic name
+   * @param partitionCount number of partitions of the RT topic
+   * @param cutoffTimestampMs include only records with write timestamp &le; this; {@code <= 0} means no bound
+   * @param coloId the colo id to tag this region's records with (for cross-region conflict resolution)
+   */
+  public List<SnapshotAtTRtRecord> readRegion(
+      VeniceProperties consumerProps,
+      String brokerAddress,
+      String rtTopicName,
+      int partitionCount,
+      long cutoffTimestampMs,
+      int coloId) {
+    PubSubClientsFactory clientsFactory = new PubSubClientsFactory(consumerProps);
+    PubSubTopicRepository topicRepository = new PubSubTopicRepository();
+    PubSubTopic rtTopic = topicRepository.getTopic(rtTopicName);
+    List<SnapshotAtTRtRecord> records = new ArrayList<>();
+
+    TopicManagerContext topicManagerContext =
+        new TopicManagerContext.Builder().setPubSubPropertiesSupplier(k -> consumerProps)
+            .setPubSubTopicRepository(topicRepository)
+            .setPubSubPositionTypeRegistry(PubSubPositionTypeRegistry.fromPropertiesOrDefault(consumerProps))
+            .setPubSubAdminAdapterFactory(clientsFactory.getAdminAdapterFactory())
+            .setPubSubConsumerAdapterFactory(clientsFactory.getConsumerAdapterFactory())
+            .setTopicMetadataFetcherThreadPoolSize(1)
+            .setTopicMetadataFetcherConsumerPoolSize(1)
+            .setVeniceComponent(VeniceComponent.PUSH_JOB)
+            .build();
+
+    PubSubConsumerAdapterContext consumerContext =
+        new PubSubConsumerAdapterContext.Builder().setConsumerName("snapshot-at-t-rt-reader-colo-" + coloId)
+            .setPubSubBrokerAddress(brokerAddress)
+            .setVeniceProperties(consumerProps)
+            .setPubSubTopicRepository(topicRepository)
+            .setPubSubMessageDeserializer(PubSubMessageDeserializer.createDefaultDeserializer())
+            .setPubSubPositionTypeRegistry(PubSubPositionTypeRegistry.fromPropertiesOrDefault(consumerProps))
+            .build();
+
+    try (
+        TopicManager topicManager =
+            new TopicManagerRepository(topicManagerContext, brokerAddress).getLocalTopicManager();
+        PubSubConsumerAdapter consumer = clientsFactory.getConsumerAdapterFactory().create(consumerContext)) {
+      Map<PubSubTopicPartition, PubSubPosition> startPositions =
+          topicManager.getStartPositionsForTopicWithRetries(rtTopic);
+      Map<PubSubTopicPartition, PubSubPosition> endPositions = topicManager.getEndPositionsForTopicWithRetries(rtTopic);
+
+      for (int partition = 0; partition < partitionCount; partition++) {
+        PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(rtTopic, partition);
+        PubSubPosition start = startPositions.get(topicPartition);
+        PubSubPosition end = endPositions.get(topicPartition);
+        if (start == null || end == null) {
+          continue;
+        }
+        long target = topicManager.diffPosition(topicPartition, end, start);
+        if (target <= 0) {
+          continue;
+        }
+        consumer.subscribe(topicPartition, start, true);
+        long consumed = 0;
+        int emptyPolls = 0;
+        while (consumed < target && emptyPolls < MAX_EMPTY_POLLS) {
+          Map<PubSubTopicPartition, List<DefaultPubSubMessage>> polled = consumer.poll(POLL_TIMEOUT_MS);
+          List<DefaultPubSubMessage> messages = polled.get(topicPartition);
+          if (messages == null || messages.isEmpty()) {
+            emptyPolls++;
+            continue;
+          }
+          emptyPolls = 0;
+          for (DefaultPubSubMessage message: messages) {
+            consumed++;
+            SnapshotAtTRtRecord record = toRtRecord(message, coloId, cutoffTimestampMs);
+            if (record != null) {
+              records.add(record);
+            }
+            if (consumed >= target) {
+              break;
+            }
+          }
+        }
+        consumer.unSubscribe(topicPartition);
+        if (consumed < target) {
+          LOGGER.warn(
+              "RT read of {} partition {} stopped early: consumed {} of {} expected records.",
+              rtTopicName,
+              partition,
+              consumed,
+              target);
+        }
+      }
+    }
+    LOGGER.info("Read {} RT records from {} (colo {}).", records.size(), rtTopicName, coloId);
+    return records;
+  }
+
+  private static SnapshotAtTRtRecord toRtRecord(DefaultPubSubMessage message, int coloId, long cutoffTimestampMs) {
+    KafkaKey key = message.getKey();
+    if (key.isControlMessage() || key.isGlobalRtDiv()) {
+      return null;
+    }
+    KafkaMessageEnvelope envelope = message.getValue();
+    long writeTimestamp = envelope.producerMetadata.logicalTimestamp >= 0
+        ? envelope.producerMetadata.logicalTimestamp
+        : envelope.producerMetadata.messageTimestamp;
+    if (cutoffTimestampMs > 0 && writeTimestamp > cutoffTimestampMs) {
+      return null;
+    }
+    // Copy the key/value bytes out of the consumed message immediately: the message envelope's buffers may be
+    // pooled/reused by the consumer on the next poll, and these records are processed only after the whole read
+    // completes.
+    ByteBuffer keyBytes = copy(ByteBuffer.wrap(key.getKey(), 0, key.getKeyLength()));
+    MessageType messageType = MessageType.valueOf(envelope);
+    switch (messageType) {
+      case PUT:
+        Put put = (Put) envelope.payloadUnion;
+        return new SnapshotAtTRtRecord(
+            SnapshotAtTRtRecord.Op.PUT,
+            keyBytes,
+            copy(put.putValue),
+            put.schemaId,
+            -1,
+            writeTimestamp,
+            coloId);
+      case UPDATE:
+        Update update = (Update) envelope.payloadUnion;
+        return new SnapshotAtTRtRecord(
+            SnapshotAtTRtRecord.Op.UPDATE,
+            keyBytes,
+            copy(update.updateValue),
+            update.schemaId,
+            update.updateSchemaId,
+            writeTimestamp,
+            coloId);
+      case DELETE:
+        Delete delete = (Delete) envelope.payloadUnion;
+        return new SnapshotAtTRtRecord(
+            SnapshotAtTRtRecord.Op.DELETE,
+            keyBytes,
+            null,
+            delete.schemaId,
+            -1,
+            writeTimestamp,
+            coloId);
+      default:
+        return null;
+    }
+  }
+
+  /** Copy a buffer's remaining content into a fresh, independently-owned ByteBuffer. */
+  private static ByteBuffer copy(ByteBuffer source) {
+    if (source == null) {
+      return null;
+    }
+    ByteBuffer duplicate = source.duplicate();
+    byte[] bytes = new byte[duplicate.remaining()];
+    duplicate.get(bytes);
+    return ByteBuffer.wrap(bytes);
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtRecord.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtRecord.java
@@ -1,0 +1,71 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import java.nio.ByteBuffer;
+
+
+/**
+ * One real-time (RT) record read from a region's RT topic, normalized for the offline snapshot-at-T merge.
+ * Carries everything {@link SnapshotAtTRecordMerger} needs to fold it onto a batch base: the operation, the
+ * key, the payload (full value for PUT, write-compute bytes for UPDATE), the value/update schema ids, the
+ * write timestamp used for conflict resolution, and the source region's colo id.
+ */
+public class SnapshotAtTRtRecord {
+  public enum Op {
+    PUT, UPDATE, DELETE
+  }
+
+  private final Op op;
+  private final ByteBuffer key;
+  // Full value bytes for PUT, write-compute (partial-update) bytes for UPDATE, null for DELETE.
+  private final ByteBuffer payload;
+  private final int valueSchemaId;
+  // Only meaningful for UPDATE (the write-compute / derived schema protocol version).
+  private final int updateProtocolVersion;
+  private final long writeTimestamp;
+  private final int coloId;
+
+  public SnapshotAtTRtRecord(
+      Op op,
+      ByteBuffer key,
+      ByteBuffer payload,
+      int valueSchemaId,
+      int updateProtocolVersion,
+      long writeTimestamp,
+      int coloId) {
+    this.op = op;
+    this.key = key;
+    this.payload = payload;
+    this.valueSchemaId = valueSchemaId;
+    this.updateProtocolVersion = updateProtocolVersion;
+    this.writeTimestamp = writeTimestamp;
+    this.coloId = coloId;
+  }
+
+  public Op getOp() {
+    return op;
+  }
+
+  public ByteBuffer getKey() {
+    return key;
+  }
+
+  public ByteBuffer getPayload() {
+    return payload;
+  }
+
+  public int getValueSchemaId() {
+    return valueSchemaId;
+  }
+
+  public int getUpdateProtocolVersion() {
+    return updateProtocolVersion;
+  }
+
+  public long getWriteTimestamp() {
+    return writeTimestamp;
+  }
+
+  public int getColoId() {
+    return coloId;
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtRecordDecoder.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtRecordDecoder.java
@@ -1,0 +1,95 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import com.linkedin.venice.kafka.protocol.Delete;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.Put;
+import com.linkedin.venice.kafka.protocol.Update;
+import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import java.nio.ByteBuffer;
+
+
+/**
+ * Decodes a consumed real-time (RT) {@link DefaultPubSubMessage} into a normalized {@link SnapshotAtTRtRecord} for
+ * the snapshot-at-T merge, tagging it with the source region's {@code coloId}. Control / Global-RT-DIV messages and
+ * records whose write timestamp exceeds the cutoff are dropped (returns {@code null}).
+ *
+ * <p>This is shared by the single-process {@link SnapshotAtTRtReader} and the distributed reader
+ * ({@link SnapshotAtTRtSplitReader}) so both produce byte-for-byte identical records from the same RT message.
+ */
+public final class SnapshotAtTRtRecordDecoder {
+  private SnapshotAtTRtRecordDecoder() {
+  }
+
+  /**
+   * @param message a consumed RT message
+   * @param coloId the colo id of the region this message came from (for cross-region conflict resolution)
+   * @param cutoffTimestampMs include only records with write timestamp &le; this; {@code <= 0} means no bound
+   * @return the normalized record, or {@code null} if the message is a control / Global-RT-DIV message, is past the
+   *         cutoff, or is not a PUT/UPDATE/DELETE
+   */
+  public static SnapshotAtTRtRecord decode(DefaultPubSubMessage message, int coloId, long cutoffTimestampMs) {
+    KafkaKey key = message.getKey();
+    if (key.isControlMessage() || key.isGlobalRtDiv()) {
+      return null;
+    }
+    KafkaMessageEnvelope envelope = message.getValue();
+    long writeTimestamp = envelope.producerMetadata.logicalTimestamp >= 0
+        ? envelope.producerMetadata.logicalTimestamp
+        : envelope.producerMetadata.messageTimestamp;
+    if (cutoffTimestampMs > 0 && writeTimestamp > cutoffTimestampMs) {
+      return null;
+    }
+    // Copy the key/value bytes out of the consumed message immediately: the message envelope's buffers may be
+    // pooled/reused by the consumer on the next poll, and these records are processed only after the whole read
+    // completes.
+    ByteBuffer keyBytes = copy(ByteBuffer.wrap(key.getKey(), 0, key.getKeyLength()));
+    MessageType messageType = MessageType.valueOf(envelope);
+    switch (messageType) {
+      case PUT:
+        Put put = (Put) envelope.payloadUnion;
+        return new SnapshotAtTRtRecord(
+            SnapshotAtTRtRecord.Op.PUT,
+            keyBytes,
+            copy(put.putValue),
+            put.schemaId,
+            -1,
+            writeTimestamp,
+            coloId);
+      case UPDATE:
+        Update update = (Update) envelope.payloadUnion;
+        return new SnapshotAtTRtRecord(
+            SnapshotAtTRtRecord.Op.UPDATE,
+            keyBytes,
+            copy(update.updateValue),
+            update.schemaId,
+            update.updateSchemaId,
+            writeTimestamp,
+            coloId);
+      case DELETE:
+        Delete delete = (Delete) envelope.payloadUnion;
+        return new SnapshotAtTRtRecord(
+            SnapshotAtTRtRecord.Op.DELETE,
+            keyBytes,
+            null,
+            delete.schemaId,
+            -1,
+            writeTimestamp,
+            coloId);
+      default:
+        return null;
+    }
+  }
+
+  /** Copy a buffer's remaining content into a fresh, independently-owned ByteBuffer. */
+  static ByteBuffer copy(ByteBuffer source) {
+    if (source == null) {
+      return null;
+    }
+    ByteBuffer duplicate = source.duplicate();
+    byte[] bytes = new byte[duplicate.remaining()];
+    duplicate.get(bytes);
+    return ByteBuffer.wrap(bytes);
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtSplit.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtSplit.java
@@ -1,0 +1,43 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import com.linkedin.venice.vpj.pubsub.input.PubSubPartitionSplit;
+import java.io.Serializable;
+import java.util.Objects;
+
+
+/**
+ * A unit of distributed RT-reading work for the snapshot-at-T merge: one {@link PubSubPartitionSplit} (a bounded
+ * range of one RT topic-partition) plus the two things the shared split lacks for multi-region reads — the
+ * {@code broker} the partition lives on and the {@code coloId} of that region (for cross-region Active-Active
+ * conflict resolution). One split is processed by one distributed task.
+ */
+public class SnapshotAtTRtSplit implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final PubSubPartitionSplit split;
+  private final String broker;
+  private final int coloId;
+
+  public SnapshotAtTRtSplit(PubSubPartitionSplit split, String broker, int coloId) {
+    this.split = Objects.requireNonNull(split, "split");
+    this.broker = Objects.requireNonNull(broker, "broker");
+    this.coloId = coloId;
+  }
+
+  public PubSubPartitionSplit getSplit() {
+    return split;
+  }
+
+  public String getBroker() {
+    return broker;
+  }
+
+  public int getColoId() {
+    return coloId;
+  }
+
+  @Override
+  public String toString() {
+    return "SnapshotAtTRtSplit{colo=" + coloId + ", broker=" + broker + ", split=" + split + "}";
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtSplitPlanner.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtSplitPlanner.java
@@ -1,0 +1,66 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
+
+import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.vpj.pubsub.input.PubSubPartitionSplit;
+import com.linkedin.venice.vpj.pubsub.input.PubSubSplitPlanner;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+
+/**
+ * Plans the distributed RT-reading work for a snapshot-at-T merge across all upstream regions. For each region
+ * (coloId &rarr; broker) and each RT topic to read (the regular RT, plus the separate RT for sepRT-enabled stores),
+ * it reuses {@link PubSubSplitPlanner} to cut that topic into per-partition {@link PubSubPartitionSplit}s, then tags
+ * each with its broker and coloId as a {@link SnapshotAtTRtSplit}. The union of all regions' splits is what the
+ * distributed merge fans out over — so total RT-reading parallelism is {@code regions x topics x partitions x
+ * splits-per-partition}, never a single-process drain.
+ */
+public class SnapshotAtTRtSplitPlanner {
+  private final PubSubSplitPlanner splitPlanner;
+
+  public SnapshotAtTRtSplitPlanner() {
+    this(new PubSubSplitPlanner());
+  }
+
+  // Visible for testing: inject a stub planner so the multi-region fan-out can be verified without a live broker.
+  SnapshotAtTRtSplitPlanner(PubSubSplitPlanner splitPlanner) {
+    this.splitPlanner = splitPlanner;
+  }
+
+  /**
+   * @param regionBrokers coloId &rarr; broker address for every upstream region to read
+   * @param rtTopicNames the RT topic name(s) to read per region (regular RT, plus separate RT when enabled)
+   * @param baseProps the job's pubsub client config (the per-region broker + topic are overlaid onto a copy of it)
+   * @return one {@link SnapshotAtTRtSplit} per (region, topic, partition-split), tagged with broker + coloId
+   */
+  public List<SnapshotAtTRtSplit> plan(
+      Map<Integer, String> regionBrokers,
+      List<String> rtTopicNames,
+      VeniceProperties baseProps) {
+    List<SnapshotAtTRtSplit> splits = new ArrayList<>();
+    for (Map.Entry<Integer, String> region: regionBrokers.entrySet()) {
+      int coloId = region.getKey();
+      String broker = region.getValue();
+      for (String rtTopicName: rtTopicNames) {
+        VeniceProperties regionProps = withSource(baseProps, broker, rtTopicName);
+        for (PubSubPartitionSplit split: splitPlanner.plan(regionProps)) {
+          splits.add(new SnapshotAtTRtSplit(split, broker, coloId));
+        }
+      }
+    }
+    return splits;
+  }
+
+  /** A copy of {@code baseProps} with the repush source broker + input topic pointed at one region's RT topic. */
+  private static VeniceProperties withSource(VeniceProperties baseProps, String broker, String rtTopicName) {
+    Properties properties = baseProps.toProperties();
+    properties.setProperty(VENICE_REPUSH_SOURCE_PUBSUB_BROKER, broker);
+    properties.setProperty(KAFKA_INPUT_TOPIC, rtTopicName);
+    return new VeniceProperties(properties);
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtSplitReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtSplitReader.java
@@ -1,0 +1,73 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.pubsub.PubSubClientsFactory;
+import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
+import com.linkedin.venice.pubsub.PubSubPositionTypeRegistry;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.vpj.pubsub.input.PubSubSplitIterator;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+
+/**
+ * Reads one {@link SnapshotAtTRtSplit} (a bounded range of one RT topic-partition in one region) into normalized
+ * {@link SnapshotAtTRtRecord}s. Each distributed task runs this for its own split, so no task ever holds more than a
+ * single partition-range — this is what makes the distributed merge memory-bounded instead of draining all RT into a
+ * single process. Reuses {@link PubSubSplitIterator} for the bounded, control-message-skipping read and the shared
+ * {@link SnapshotAtTRtRecordDecoder} for decoding, so a split's records match the single-process reader exactly.
+ */
+public class SnapshotAtTRtSplitReader {
+  /**
+   * @param rtSplit the split to read (carries the broker, coloId, and the partition's start/end positions)
+   * @param baseProps the job's pubsub client config; the split's broker is overlaid onto a copy of it
+   * @param cutoffTimestampMs include only records with write timestamp &le; this; {@code <= 0} means no bound
+   */
+  public List<SnapshotAtTRtRecord> read(
+      SnapshotAtTRtSplit rtSplit,
+      VeniceProperties baseProps,
+      long cutoffTimestampMs) {
+    VeniceProperties consumerProps = withBroker(baseProps, rtSplit.getBroker());
+    PubSubClientsFactory clientsFactory = new PubSubClientsFactory(consumerProps);
+    PubSubConsumerAdapterContext consumerContext = new PubSubConsumerAdapterContext.Builder()
+        .setConsumerName("snapshot-at-t-rt-split-reader-colo-" + rtSplit.getColoId())
+        .setPubSubBrokerAddress(rtSplit.getBroker())
+        .setVeniceProperties(consumerProps)
+        .setPubSubTopicRepository(new PubSubTopicRepository())
+        .setPubSubMessageDeserializer(PubSubMessageDeserializer.createDefaultDeserializer())
+        .setPubSubPositionTypeRegistry(PubSubPositionTypeRegistry.fromPropertiesOrDefault(consumerProps))
+        .build();
+
+    List<SnapshotAtTRtRecord> records = new ArrayList<>();
+    try (PubSubConsumerAdapter consumer = clientsFactory.getConsumerAdapterFactory().create(consumerContext);
+        PubSubSplitIterator splitIterator = new PubSubSplitIterator(consumer, rtSplit.getSplit(), false)) {
+      PubSubSplitIterator.PubSubInputRecord record;
+      while ((record = splitIterator.next()) != null) {
+        SnapshotAtTRtRecord rtRecord =
+            SnapshotAtTRtRecordDecoder.decode(record.getPubSubMessage(), rtSplit.getColoId(), cutoffTimestampMs);
+        if (rtRecord != null) {
+          records.add(rtRecord);
+        }
+      }
+    } catch (IOException e) {
+      throw new VeniceException("Failed to read snapshot-at-T RT split " + rtSplit, e);
+    }
+    return records;
+  }
+
+  /** A copy of {@code baseProps} pointed at the split's region broker. */
+  private static VeniceProperties withBroker(VeniceProperties baseProps, String broker) {
+    Properties properties = baseProps.toProperties();
+    properties.setProperty(PUBSUB_BROKER_ADDRESS, broker);
+    properties.setProperty(KAFKA_BOOTSTRAP_SERVERS, broker);
+    return new VeniceProperties(properties);
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSchemaBundle.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSchemaBundle.java
@@ -1,0 +1,160 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.MultiSchemaResponse;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
+import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * A serializable snapshot of a store's value / replication-metadata / derived schemas (as strings), fetched once
+ * from the controller on the driver. Because it holds only strings and ids it can be Spark-broadcast to executors,
+ * where {@link #buildMerger} reconstructs a {@link SnapshotAtTRecordMerger} per task — the merger itself wraps a
+ * non-serializable {@code MergeConflictResolver}, so it cannot be shipped directly.
+ *
+ * <p>This is also the single place the controller schema fetch + validation lives;
+ * {@link SnapshotAtTSchemaRepository#fromController} builds a repository from a bundle.
+ */
+public class SnapshotAtTSchemaBundle implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final String storeName;
+  private final Map<Integer, String> valueSchemas;
+  private final int latestValueSchemaId;
+  // Keyed by SnapshotAtTSchemaRepository.key(rmdValueSchemaId, protocolId) -> rmd schema string.
+  private final Map<Long, String> rmdSchemas;
+  // Keyed by SnapshotAtTSchemaRepository.key(valueSchemaId, derivedSchemaId) -> derived schema string.
+  private final Map<Long, String> derivedSchemas;
+  private final int rmdVersionId;
+
+  SnapshotAtTSchemaBundle(
+      String storeName,
+      Map<Integer, String> valueSchemas,
+      int latestValueSchemaId,
+      Map<Long, String> rmdSchemas,
+      Map<Long, String> derivedSchemas,
+      int rmdVersionId) {
+    this.storeName = storeName;
+    this.valueSchemas = valueSchemas;
+    this.latestValueSchemaId = latestValueSchemaId;
+    this.rmdSchemas = rmdSchemas;
+    this.derivedSchemas = derivedSchemas;
+    this.rmdVersionId = rmdVersionId;
+  }
+
+  /** The replication-metadata protocol version the store's RMD schemas are registered with ({@code -1} if none). */
+  public int getRmdVersionId() {
+    return rmdVersionId;
+  }
+
+  public static SnapshotAtTSchemaBundle fromController(ControllerClient controllerClient, String storeName) {
+    Map<Integer, String> valueSchemas = new HashMap<>();
+    int latestValueSchemaId = -1;
+    MultiSchemaResponse valueResponse = controllerClient.getAllValueSchema(storeName);
+    if (valueResponse.isError()) {
+      throw new VeniceException(
+          "Failed to fetch value schemas for store " + storeName + ": " + valueResponse.getError());
+    }
+    for (MultiSchemaResponse.Schema schema: valueResponse.getSchemas()) {
+      valueSchemas.put(schema.getId(), schema.getSchemaStr());
+      latestValueSchemaId = Math.max(latestValueSchemaId, schema.getId());
+    }
+    if (valueSchemas.isEmpty()) {
+      throw new VeniceException(
+          "No value schemas returned for store " + storeName + "; cannot run the snapshot-at-T merge.");
+    }
+
+    // RMD and derived schemas are required for correct conflict resolution / write-compute merges, so a fetch
+    // error must abort the push rather than silently proceed with an empty schema set.
+    Map<Long, String> rmdSchemas = new HashMap<>();
+    int rmdVersionId = -1;
+    MultiSchemaResponse rmdResponse = controllerClient.getAllReplicationMetadataSchemas(storeName);
+    if (rmdResponse.isError()) {
+      throw new VeniceException(
+          "Failed to fetch replication-metadata schemas for store " + storeName + ": " + rmdResponse.getError());
+    }
+    for (MultiSchemaResponse.Schema schema: rmdResponse.getSchemas()) {
+      rmdSchemas
+          .put(SnapshotAtTSchemaRepository.key(schema.getRmdValueSchemaId(), schema.getId()), schema.getSchemaStr());
+      rmdVersionId = Math.max(rmdVersionId, schema.getId());
+    }
+
+    Map<Long, String> derivedSchemas = new HashMap<>();
+    MultiSchemaResponse derivedResponse = controllerClient.getAllValueAndDerivedSchema(storeName);
+    if (derivedResponse.isError()) {
+      throw new VeniceException(
+          "Failed to fetch derived schemas for store " + storeName + ": " + derivedResponse.getError());
+    }
+    for (MultiSchemaResponse.Schema schema: derivedResponse.getSchemas()) {
+      if (schema.getDerivedSchemaId() > 0) {
+        derivedSchemas
+            .put(SnapshotAtTSchemaRepository.key(schema.getId(), schema.getDerivedSchemaId()), schema.getSchemaStr());
+      }
+    }
+
+    return new SnapshotAtTSchemaBundle(
+        storeName,
+        valueSchemas,
+        latestValueSchemaId,
+        rmdSchemas,
+        derivedSchemas,
+        rmdVersionId);
+  }
+
+  /** Parse the bundled schema strings into a read-only repository (called on the driver and on each executor). */
+  public SnapshotAtTSchemaRepository buildRepository() {
+    Map<Integer, SchemaEntry> valueEntries = new HashMap<>();
+    for (Map.Entry<Integer, String> e: valueSchemas.entrySet()) {
+      valueEntries.put(e.getKey(), new SchemaEntry(e.getKey(), e.getValue()));
+    }
+    Map<Long, RmdSchemaEntry> rmdEntries = new HashMap<>();
+    for (Map.Entry<Long, String> e: rmdSchemas.entrySet()) {
+      int rmdValueSchemaId = SnapshotAtTSchemaRepository.keyHighBits(e.getKey());
+      int protocolId = SnapshotAtTSchemaRepository.keyLowBits(e.getKey());
+      rmdEntries.put(e.getKey(), new RmdSchemaEntry(rmdValueSchemaId, protocolId, e.getValue()));
+    }
+    Map<Long, DerivedSchemaEntry> derivedEntries = new HashMap<>();
+    for (Map.Entry<Long, String> e: derivedSchemas.entrySet()) {
+      int valueSchemaId = SnapshotAtTSchemaRepository.keyHighBits(e.getKey());
+      int derivedSchemaId = SnapshotAtTSchemaRepository.keyLowBits(e.getKey());
+      derivedEntries.put(e.getKey(), new DerivedSchemaEntry(valueSchemaId, derivedSchemaId, e.getValue()));
+    }
+    return new SnapshotAtTSchemaRepository(valueEntries, latestValueSchemaId, rmdEntries, derivedEntries, rmdVersionId);
+  }
+
+  /**
+   * Build a {@link SnapshotAtTRecordMerger} from this bundle. Safe to call on an executor (parses the bundled
+   * schema strings; no controller access).
+   */
+  public SnapshotAtTRecordMerger buildMerger(int rmdProtocolVersion, boolean rmdUseFieldLevelTimestamp) {
+    return new SnapshotAtTRecordMerger(buildRepository(), storeName, rmdProtocolVersion, rmdUseFieldLevelTimestamp);
+  }
+
+  /** Visible for testing: build a bundle directly from schema strings without a controller. */
+  static SnapshotAtTSchemaBundle of(
+      String storeName,
+      Map<Integer, String> valueSchemas,
+      Map<Long, String> rmdSchemas,
+      Map<Long, String> derivedSchemas,
+      int rmdVersionId) {
+    int latestValueSchemaId = -1;
+    List<Integer> ids = new ArrayList<>(valueSchemas.keySet());
+    for (int id: ids) {
+      latestValueSchemaId = Math.max(latestValueSchemaId, id);
+    }
+    return new SnapshotAtTSchemaBundle(
+        storeName,
+        valueSchemas,
+        latestValueSchemaId,
+        rmdSchemas,
+        derivedSchemas,
+        rmdVersionId);
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSchemaRepository.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSchemaRepository.java
@@ -1,0 +1,176 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.MultiSchemaResponse;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.ReadOnlySchemaRepository;
+import com.linkedin.venice.schema.GeneratedSchemaID;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
+import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * A minimal, read-only {@link ReadOnlySchemaRepository} for the snapshot-at-T merge, populated once from the
+ * controller's value / replication-metadata / derived schemas for a single store. Only the methods that
+ * {@link SnapshotAtTRecordMerger} (via {@code MergeConflictResolver}) calls are implemented; the rest throw.
+ */
+public class SnapshotAtTSchemaRepository implements ReadOnlySchemaRepository {
+  private final String storeName;
+  private final Map<Integer, SchemaEntry> valueSchemas;
+  private final int latestValueSchemaId;
+  private final Map<Long, RmdSchemaEntry> rmdSchemas;
+  private final Map<Long, DerivedSchemaEntry> derivedSchemas;
+  private final int rmdVersionId;
+
+  private SnapshotAtTSchemaRepository(
+      String storeName,
+      Map<Integer, SchemaEntry> valueSchemas,
+      int latestValueSchemaId,
+      Map<Long, RmdSchemaEntry> rmdSchemas,
+      Map<Long, DerivedSchemaEntry> derivedSchemas,
+      int rmdVersionId) {
+    this.storeName = storeName;
+    this.valueSchemas = valueSchemas;
+    this.latestValueSchemaId = latestValueSchemaId;
+    this.rmdSchemas = rmdSchemas;
+    this.derivedSchemas = derivedSchemas;
+    this.rmdVersionId = rmdVersionId;
+  }
+
+  /** The replication-metadata protocol version the store's RMD schemas are registered with. */
+  public int getRmdVersionId() {
+    return rmdVersionId;
+  }
+
+  public static SnapshotAtTSchemaRepository fromController(ControllerClient controllerClient, String storeName) {
+    Map<Integer, SchemaEntry> valueSchemas = new HashMap<>();
+    int latestValueSchemaId = -1;
+    MultiSchemaResponse valueResponse = controllerClient.getAllValueSchema(storeName);
+    if (valueResponse.isError()) {
+      throw new VeniceException(
+          "Failed to fetch value schemas for store " + storeName + ": " + valueResponse.getError());
+    }
+    for (MultiSchemaResponse.Schema schema: valueResponse.getSchemas()) {
+      valueSchemas.put(schema.getId(), new SchemaEntry(schema.getId(), schema.getSchemaStr()));
+      latestValueSchemaId = Math.max(latestValueSchemaId, schema.getId());
+    }
+
+    Map<Long, RmdSchemaEntry> rmdSchemas = new HashMap<>();
+    int rmdVersionId = -1;
+    MultiSchemaResponse rmdResponse = controllerClient.getAllReplicationMetadataSchemas(storeName);
+    if (!rmdResponse.isError()) {
+      for (MultiSchemaResponse.Schema schema: rmdResponse.getSchemas()) {
+        rmdSchemas.put(
+            key(schema.getRmdValueSchemaId(), schema.getId()),
+            new RmdSchemaEntry(schema.getRmdValueSchemaId(), schema.getId(), schema.getSchemaStr()));
+        rmdVersionId = Math.max(rmdVersionId, schema.getId());
+      }
+    }
+
+    Map<Long, DerivedSchemaEntry> derivedSchemas = new HashMap<>();
+    MultiSchemaResponse derivedResponse = controllerClient.getAllValueAndDerivedSchema(storeName);
+    if (!derivedResponse.isError()) {
+      for (MultiSchemaResponse.Schema schema: derivedResponse.getSchemas()) {
+        if (schema.getDerivedSchemaId() > 0) {
+          derivedSchemas.put(
+              key(schema.getId(), schema.getDerivedSchemaId()),
+              new DerivedSchemaEntry(schema.getId(), schema.getDerivedSchemaId(), schema.getSchemaStr()));
+        }
+      }
+    }
+
+    return new SnapshotAtTSchemaRepository(
+        storeName,
+        valueSchemas,
+        latestValueSchemaId,
+        rmdSchemas,
+        derivedSchemas,
+        rmdVersionId);
+  }
+
+  private static long key(int valueSchemaId, int subId) {
+    return (((long) valueSchemaId) << 32) | (subId & 0xffffffffL);
+  }
+
+  @Override
+  public SchemaEntry getValueSchema(String storeName, int id) {
+    return valueSchemas.get(id);
+  }
+
+  @Override
+  public SchemaEntry getSupersetOrLatestValueSchema(String storeName) {
+    return valueSchemas.get(latestValueSchemaId);
+  }
+
+  @Override
+  public SchemaEntry getSupersetSchema(String storeName) {
+    return valueSchemas.get(latestValueSchemaId);
+  }
+
+  @Override
+  public Collection<SchemaEntry> getValueSchemas(String storeName) {
+    return valueSchemas.values();
+  }
+
+  @Override
+  public DerivedSchemaEntry getDerivedSchema(String storeName, int valueSchemaId, int writeComputeSchemaId) {
+    return derivedSchemas.get(key(valueSchemaId, writeComputeSchemaId));
+  }
+
+  @Override
+  public RmdSchemaEntry getReplicationMetadataSchema(
+      String storeName,
+      int valueSchemaId,
+      int replicationMetadataVersionId) {
+    return rmdSchemas.get(key(valueSchemaId, replicationMetadataVersionId));
+  }
+
+  @Override
+  public boolean hasValueSchema(String storeName, int id) {
+    return valueSchemas.containsKey(id);
+  }
+
+  @Override
+  public SchemaEntry getKeySchema(String storeName) {
+    throw new UnsupportedOperationException("getKeySchema is not supported by SnapshotAtTSchemaRepository");
+  }
+
+  @Override
+  public int getValueSchemaId(String storeName, String valueSchemaStr) {
+    throw new UnsupportedOperationException("getValueSchemaId is not supported by SnapshotAtTSchemaRepository");
+  }
+
+  @Override
+  public GeneratedSchemaID getDerivedSchemaId(String storeName, String derivedSchemaStr) {
+    throw new UnsupportedOperationException("getDerivedSchemaId is not supported by SnapshotAtTSchemaRepository");
+  }
+
+  @Override
+  public Collection<DerivedSchemaEntry> getDerivedSchemas(String storeName) {
+    return derivedSchemas.values();
+  }
+
+  @Override
+  public DerivedSchemaEntry getLatestDerivedSchema(String storeName, int valueSchemaId) {
+    throw new UnsupportedOperationException("getLatestDerivedSchema is not supported by SnapshotAtTSchemaRepository");
+  }
+
+  @Override
+  public Collection<RmdSchemaEntry> getReplicationMetadataSchemas(String storeName) {
+    return rmdSchemas.values();
+  }
+
+  @Override
+  public void refresh() {
+    // Schemas are fetched once at construction; nothing to refresh.
+  }
+
+  @Override
+  public void clear() {
+    // No-op.
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSchemaRepository.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSchemaRepository.java
@@ -55,28 +55,38 @@ public class SnapshotAtTSchemaRepository implements ReadOnlySchemaRepository {
       valueSchemas.put(schema.getId(), new SchemaEntry(schema.getId(), schema.getSchemaStr()));
       latestValueSchemaId = Math.max(latestValueSchemaId, schema.getId());
     }
+    if (valueSchemas.isEmpty()) {
+      throw new VeniceException(
+          "No value schemas returned for store " + storeName + "; cannot run the snapshot-at-T merge.");
+    }
 
+    // RMD and derived schemas are required for correct conflict resolution / write-compute merges, so a fetch
+    // error must abort the push rather than silently proceed with an empty schema set.
     Map<Long, RmdSchemaEntry> rmdSchemas = new HashMap<>();
     int rmdVersionId = -1;
     MultiSchemaResponse rmdResponse = controllerClient.getAllReplicationMetadataSchemas(storeName);
-    if (!rmdResponse.isError()) {
-      for (MultiSchemaResponse.Schema schema: rmdResponse.getSchemas()) {
-        rmdSchemas.put(
-            key(schema.getRmdValueSchemaId(), schema.getId()),
-            new RmdSchemaEntry(schema.getRmdValueSchemaId(), schema.getId(), schema.getSchemaStr()));
-        rmdVersionId = Math.max(rmdVersionId, schema.getId());
-      }
+    if (rmdResponse.isError()) {
+      throw new VeniceException(
+          "Failed to fetch replication-metadata schemas for store " + storeName + ": " + rmdResponse.getError());
+    }
+    for (MultiSchemaResponse.Schema schema: rmdResponse.getSchemas()) {
+      rmdSchemas.put(
+          key(schema.getRmdValueSchemaId(), schema.getId()),
+          new RmdSchemaEntry(schema.getRmdValueSchemaId(), schema.getId(), schema.getSchemaStr()));
+      rmdVersionId = Math.max(rmdVersionId, schema.getId());
     }
 
     Map<Long, DerivedSchemaEntry> derivedSchemas = new HashMap<>();
     MultiSchemaResponse derivedResponse = controllerClient.getAllValueAndDerivedSchema(storeName);
-    if (!derivedResponse.isError()) {
-      for (MultiSchemaResponse.Schema schema: derivedResponse.getSchemas()) {
-        if (schema.getDerivedSchemaId() > 0) {
-          derivedSchemas.put(
-              key(schema.getId(), schema.getDerivedSchemaId()),
-              new DerivedSchemaEntry(schema.getId(), schema.getDerivedSchemaId(), schema.getSchemaStr()));
-        }
+    if (derivedResponse.isError()) {
+      throw new VeniceException(
+          "Failed to fetch derived schemas for store " + storeName + ": " + derivedResponse.getError());
+    }
+    for (MultiSchemaResponse.Schema schema: derivedResponse.getSchemas()) {
+      if (schema.getDerivedSchemaId() > 0) {
+        derivedSchemas.put(
+            key(schema.getId(), schema.getDerivedSchemaId()),
+            new DerivedSchemaEntry(schema.getId(), schema.getDerivedSchemaId(), schema.getSchemaStr()));
       }
     }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSchemaRepository.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSchemaRepository.java
@@ -1,15 +1,12 @@
 package com.linkedin.venice.hadoop.snapshot;
 
 import com.linkedin.venice.controllerapi.ControllerClient;
-import com.linkedin.venice.controllerapi.MultiSchemaResponse;
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.schema.GeneratedSchemaID;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 
 
@@ -25,7 +22,7 @@ public class SnapshotAtTSchemaRepository implements ReadOnlySchemaRepository {
   private final Map<Long, DerivedSchemaEntry> derivedSchemas;
   private final int rmdVersionId;
 
-  private SnapshotAtTSchemaRepository(
+  SnapshotAtTSchemaRepository(
       Map<Integer, SchemaEntry> valueSchemas,
       int latestValueSchemaId,
       Map<Long, RmdSchemaEntry> rmdSchemas,
@@ -44,57 +41,21 @@ public class SnapshotAtTSchemaRepository implements ReadOnlySchemaRepository {
   }
 
   public static SnapshotAtTSchemaRepository fromController(ControllerClient controllerClient, String storeName) {
-    Map<Integer, SchemaEntry> valueSchemas = new HashMap<>();
-    int latestValueSchemaId = -1;
-    MultiSchemaResponse valueResponse = controllerClient.getAllValueSchema(storeName);
-    if (valueResponse.isError()) {
-      throw new VeniceException(
-          "Failed to fetch value schemas for store " + storeName + ": " + valueResponse.getError());
-    }
-    for (MultiSchemaResponse.Schema schema: valueResponse.getSchemas()) {
-      valueSchemas.put(schema.getId(), new SchemaEntry(schema.getId(), schema.getSchemaStr()));
-      latestValueSchemaId = Math.max(latestValueSchemaId, schema.getId());
-    }
-    if (valueSchemas.isEmpty()) {
-      throw new VeniceException(
-          "No value schemas returned for store " + storeName + "; cannot run the snapshot-at-T merge.");
-    }
-
-    // RMD and derived schemas are required for correct conflict resolution / write-compute merges, so a fetch
-    // error must abort the push rather than silently proceed with an empty schema set.
-    Map<Long, RmdSchemaEntry> rmdSchemas = new HashMap<>();
-    int rmdVersionId = -1;
-    MultiSchemaResponse rmdResponse = controllerClient.getAllReplicationMetadataSchemas(storeName);
-    if (rmdResponse.isError()) {
-      throw new VeniceException(
-          "Failed to fetch replication-metadata schemas for store " + storeName + ": " + rmdResponse.getError());
-    }
-    for (MultiSchemaResponse.Schema schema: rmdResponse.getSchemas()) {
-      rmdSchemas.put(
-          key(schema.getRmdValueSchemaId(), schema.getId()),
-          new RmdSchemaEntry(schema.getRmdValueSchemaId(), schema.getId(), schema.getSchemaStr()));
-      rmdVersionId = Math.max(rmdVersionId, schema.getId());
-    }
-
-    Map<Long, DerivedSchemaEntry> derivedSchemas = new HashMap<>();
-    MultiSchemaResponse derivedResponse = controllerClient.getAllValueAndDerivedSchema(storeName);
-    if (derivedResponse.isError()) {
-      throw new VeniceException(
-          "Failed to fetch derived schemas for store " + storeName + ": " + derivedResponse.getError());
-    }
-    for (MultiSchemaResponse.Schema schema: derivedResponse.getSchemas()) {
-      if (schema.getDerivedSchemaId() > 0) {
-        derivedSchemas.put(
-            key(schema.getId(), schema.getDerivedSchemaId()),
-            new DerivedSchemaEntry(schema.getId(), schema.getDerivedSchemaId(), schema.getSchemaStr()));
-      }
-    }
-
-    return new SnapshotAtTSchemaRepository(valueSchemas, latestValueSchemaId, rmdSchemas, derivedSchemas, rmdVersionId);
+    return SnapshotAtTSchemaBundle.fromController(controllerClient, storeName).buildRepository();
   }
 
-  private static long key(int valueSchemaId, int subId) {
+  static long key(int valueSchemaId, int subId) {
     return (((long) valueSchemaId) << 32) | (subId & 0xffffffffL);
+  }
+
+  /** The high 32 bits of a {@link #key} (the value / rmd-value schema id). */
+  static int keyHighBits(long key) {
+    return (int) (key >> 32);
+  }
+
+  /** The low 32 bits of a {@link #key} (the protocol / derived schema id). */
+  static int keyLowBits(long key) {
+    return (int) key;
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSchemaRepository.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSchemaRepository.java
@@ -19,7 +19,6 @@ import java.util.Map;
  * {@link SnapshotAtTRecordMerger} (via {@code MergeConflictResolver}) calls are implemented; the rest throw.
  */
 public class SnapshotAtTSchemaRepository implements ReadOnlySchemaRepository {
-  private final String storeName;
   private final Map<Integer, SchemaEntry> valueSchemas;
   private final int latestValueSchemaId;
   private final Map<Long, RmdSchemaEntry> rmdSchemas;
@@ -27,13 +26,11 @@ public class SnapshotAtTSchemaRepository implements ReadOnlySchemaRepository {
   private final int rmdVersionId;
 
   private SnapshotAtTSchemaRepository(
-      String storeName,
       Map<Integer, SchemaEntry> valueSchemas,
       int latestValueSchemaId,
       Map<Long, RmdSchemaEntry> rmdSchemas,
       Map<Long, DerivedSchemaEntry> derivedSchemas,
       int rmdVersionId) {
-    this.storeName = storeName;
     this.valueSchemas = valueSchemas;
     this.latestValueSchemaId = latestValueSchemaId;
     this.rmdSchemas = rmdSchemas;
@@ -83,13 +80,7 @@ public class SnapshotAtTSchemaRepository implements ReadOnlySchemaRepository {
       }
     }
 
-    return new SnapshotAtTSchemaRepository(
-        storeName,
-        valueSchemas,
-        latestValueSchemaId,
-        rmdSchemas,
-        derivedSchemas,
-        rmdVersionId);
+    return new SnapshotAtTSchemaRepository(valueSchemas, latestValueSchemaId, rmdSchemas, derivedSchemas, rmdVersionId);
   }
 
   private static long key(int valueSchemaId, int subId) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSparkMerge.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSparkMerge.java
@@ -1,0 +1,164 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import static com.linkedin.venice.spark.SparkConstants.DEFAULT_SCHEMA;
+import static com.linkedin.venice.spark.SparkConstants.KEY_COLUMN_NAME;
+import static com.linkedin.venice.spark.SparkConstants.VALUE_COLUMN_NAME;
+
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRecordMerger.MergedRecord;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.spark.api.java.function.CoGroupFunction;
+import org.apache.spark.api.java.function.MapFunction;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.KeyValueGroupedDataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.encoders.RowEncoder;
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+
+/**
+ * The distributed snapshot-at-T merge: co-groups the batch {@code (key, value, rmd)} DataFrame with the real-time
+ * (RT) DataFrame by key and reduces each key through {@link SnapshotAtTPushExecutor#mergeKey} (the same per-key
+ * merge the single-process executor uses), emitting the merged {@code (key, value, rmd)} DataFrame. Because Spark
+ * co-locates every value for a key on one task, memory is bounded per key-group — never the whole dataset.
+ *
+ * <p>The {@link SnapshotAtTRecordMerger} wraps a non-serializable conflict resolver, so it is rebuilt on each task
+ * from a broadcast {@link SnapshotAtTSchemaBundle} rather than shipped.
+ */
+public final class SnapshotAtTSparkMerge {
+  // RT record columns. The key column shares KEY_COLUMN_NAME so both sides of the cogroup group on the same field.
+  static final int RT_KEY = 0;
+  static final int RT_OP = 1;
+  static final int RT_PAYLOAD = 2;
+  static final int RT_VALUE_SCHEMA_ID = 3;
+  static final int RT_UPDATE_PROTOCOL_VERSION = 4;
+  static final int RT_WRITE_TIMESTAMP = 5;
+  static final int RT_COLO_ID = 6;
+
+  public static final StructType RT_SCHEMA = new StructType(
+      new StructField[] { new StructField(KEY_COLUMN_NAME, DataTypes.BinaryType, false, Metadata.empty()),
+          new StructField("op", DataTypes.IntegerType, false, Metadata.empty()),
+          new StructField("payload", DataTypes.BinaryType, true, Metadata.empty()),
+          new StructField("valueSchemaId", DataTypes.IntegerType, false, Metadata.empty()),
+          new StructField("updateProtocolVersion", DataTypes.IntegerType, false, Metadata.empty()),
+          new StructField("writeTimestamp", DataTypes.LongType, false, Metadata.empty()),
+          new StructField("coloId", DataTypes.IntegerType, false, Metadata.empty()) });
+
+  private SnapshotAtTSparkMerge() {
+  }
+
+  /**
+   * Co-group {@code batch} (key,value,rmd) with {@code rt} ({@link #RT_SCHEMA}) by key and merge each key, returning
+   * the merged {@code (key,value,rmd)} DataFrame ({@link DEFAULT_SCHEMA}). A merged delete is emitted with a null
+   * value and the RMD tombstone.
+   *
+   * @param batchValueSchemaId the value schema id the batch values are serialized with
+   * @param bundle broadcast schemas used to rebuild the merger per task
+   * @param rmdProtocolVersion the store's RMD protocol version
+   * @param rmdUseFieldLevelTimestamp whether the store uses per-field RMD timestamps (write-compute)
+   */
+  public static Dataset<Row> merge(
+      Dataset<Row> batch,
+      Dataset<Row> rt,
+      int batchValueSchemaId,
+      Broadcast<SnapshotAtTSchemaBundle> bundle,
+      int rmdProtocolVersion,
+      boolean rmdUseFieldLevelTimestamp) {
+    KeyValueGroupedDataset<byte[], Row> batchByKey =
+        batch.groupByKey((MapFunction<Row, byte[]>) row -> row.getAs(KEY_COLUMN_NAME), Encoders.BINARY());
+    KeyValueGroupedDataset<byte[], Row> rtByKey =
+        rt.groupByKey((MapFunction<Row, byte[]>) row -> row.getAs(KEY_COLUMN_NAME), Encoders.BINARY());
+    return batchByKey.cogroup(
+        rtByKey,
+        new MergeCoGroupFunction(bundle, batchValueSchemaId, rmdProtocolVersion, rmdUseFieldLevelTimestamp),
+        RowEncoder.apply(DEFAULT_SCHEMA));
+  }
+
+  /** Convert one normalized RT record to an {@link #RT_SCHEMA} row (driver side, when building the RT DataFrame). */
+  public static Row rtRecordToRow(SnapshotAtTRtRecord record) {
+    return new GenericRowWithSchema(
+        new Object[] { toByteArray(record.getKey()), record.getOp().ordinal(),
+            record.getPayload() == null ? null : toByteArray(record.getPayload()), record.getValueSchemaId(),
+            record.getUpdateProtocolVersion(), record.getWriteTimestamp(), record.getColoId() },
+        RT_SCHEMA);
+  }
+
+  static SnapshotAtTRtRecord rowToRtRecord(Row row) {
+    byte[] payload = row.isNullAt(RT_PAYLOAD) ? null : row.getAs(RT_PAYLOAD);
+    return new SnapshotAtTRtRecord(
+        SnapshotAtTRtRecord.Op.values()[row.getInt(RT_OP)],
+        ByteBuffer.wrap(row.getAs(RT_KEY)),
+        payload == null ? null : ByteBuffer.wrap(payload),
+        row.getInt(RT_VALUE_SCHEMA_ID),
+        row.getInt(RT_UPDATE_PROTOCOL_VERSION),
+        row.getLong(RT_WRITE_TIMESTAMP),
+        row.getInt(RT_COLO_ID));
+  }
+
+  private static byte[] toByteArray(ByteBuffer buffer) {
+    ByteBuffer duplicate = buffer.duplicate();
+    duplicate.rewind();
+    byte[] bytes = new byte[duplicate.remaining()];
+    duplicate.get(bytes);
+    return bytes;
+  }
+
+  /** Per-key reducer: rebuilds the merger from the broadcast bundle once per task, then folds via mergeKey. */
+  private static final class MergeCoGroupFunction implements CoGroupFunction<byte[], Row, Row, Row> {
+    private static final long serialVersionUID = 1L;
+
+    private final Broadcast<SnapshotAtTSchemaBundle> bundle;
+    private final int batchValueSchemaId;
+    private final int rmdProtocolVersion;
+    private final boolean rmdUseFieldLevelTimestamp;
+    private transient SnapshotAtTRecordMerger merger;
+
+    MergeCoGroupFunction(
+        Broadcast<SnapshotAtTSchemaBundle> bundle,
+        int batchValueSchemaId,
+        int rmdProtocolVersion,
+        boolean rmdUseFieldLevelTimestamp) {
+      this.bundle = bundle;
+      this.batchValueSchemaId = batchValueSchemaId;
+      this.rmdProtocolVersion = rmdProtocolVersion;
+      this.rmdUseFieldLevelTimestamp = rmdUseFieldLevelTimestamp;
+    }
+
+    @Override
+    public Iterator<Row> call(byte[] key, Iterator<Row> batchRows, Iterator<Row> rtRows) {
+      ByteBuffer batchValue = null;
+      if (batchRows.hasNext()) {
+        byte[] value = batchRows.next().getAs(VALUE_COLUMN_NAME);
+        batchValue = value == null ? null : ByteBuffer.wrap(value);
+      }
+      List<SnapshotAtTRtRecord> rtRecords = new ArrayList<>();
+      while (rtRows.hasNext()) {
+        rtRecords.add(rowToRtRecord(rtRows.next()));
+      }
+      if (batchValue == null && rtRecords.isEmpty()) {
+        return Collections.emptyIterator();
+      }
+      MergedRecord merged = SnapshotAtTPushExecutor.mergeKey(batchValue, batchValueSchemaId, rtRecords, merger());
+      byte[] valueBytes = merged.isDelete() ? null : toByteArray(merged.getValue());
+      byte[] rmdBytes = toByteArray(merged.getRmd());
+      Row out = new GenericRowWithSchema(new Object[] { key, valueBytes, rmdBytes }, DEFAULT_SCHEMA);
+      return Collections.singletonList(out).iterator();
+    }
+
+    private SnapshotAtTRecordMerger merger() {
+      if (merger == null) {
+        merger = bundle.value().buildMerger(rmdProtocolVersion, rmdUseFieldLevelTimestamp);
+      }
+      return merger;
+    }
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSparkMerge.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSparkMerge.java
@@ -5,18 +5,24 @@ import static com.linkedin.venice.spark.SparkConstants.KEY_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.VALUE_COLUMN_NAME;
 
 import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRecordMerger.MergedRecord;
+import com.linkedin.venice.utils.VeniceProperties;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Properties;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.CoGroupFunction;
+import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.KeyValueGroupedDataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.encoders.RowEncoder;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.apache.spark.sql.types.DataTypes;
@@ -81,6 +87,36 @@ public final class SnapshotAtTSparkMerge {
         rtByKey,
         new MergeCoGroupFunction(bundle, batchValueSchemaId, rmdProtocolVersion, rmdUseFieldLevelTimestamp),
         RowEncoder.apply(DEFAULT_SCHEMA));
+  }
+
+  /**
+   * Build the RT {@link #RT_SCHEMA} DataFrame by reading every {@link SnapshotAtTRtSplit} in parallel: one Spark
+   * task per split reads only that split's bounded partition-range via {@link SnapshotAtTRtSplitReader}, so RT is
+   * never drained into a single process. The split planning (which queries brokers) happens on the driver; this
+   * distributes the reads.
+   *
+   * @param splits the region/topic/partition splits to read (from {@link SnapshotAtTRtSplitPlanner})
+   * @param baseProps the job's pubsub client config (each split overlays its own broker)
+   * @param cutoffTimestampMs include only RT records with write timestamp &le; this; {@code <= 0} means no bound
+   */
+  public static Dataset<Row> readRtDataFrame(
+      SparkSession spark,
+      List<SnapshotAtTRtSplit> splits,
+      VeniceProperties baseProps,
+      long cutoffTimestampMs) {
+    JavaSparkContext sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+    // Capture only serializable state (Properties, primitives, serializable splits) in the executor closure.
+    Properties props = baseProps.toProperties();
+    JavaRDD<Row> rtRows = sparkContext.parallelize(splits).flatMap((FlatMapFunction<SnapshotAtTRtSplit, Row>) split -> {
+      List<SnapshotAtTRtRecord> records =
+          new SnapshotAtTRtSplitReader().read(split, new VeniceProperties(props), cutoffTimestampMs);
+      List<Row> rows = new ArrayList<>(records.size());
+      for (SnapshotAtTRtRecord record: records) {
+        rows.add(rtRecordToRow(record));
+      }
+      return rows.iterator();
+    });
+    return spark.createDataFrame(rtRows, RT_SCHEMA);
   }
 
   /** Convert one normalized RT record to an {@link #RT_SCHEMA} row (driver side, when building the RT DataFrame). */

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -287,6 +287,51 @@ public final class VenicePushJobConstants {
       "rewind.epoch.time.buffer.in.seconds.override";
 
   /**
+   * Snapshot-at-T: per-VPJ knobs that let a hybrid full push ship a <em>shortened</em> rewind window
+   * (only {@code [T, now]}) instead of the store's full configured rewind, on the premise that the batch
+   * dataset already incorporates real-time data up to the cutoff timestamp {@code T}.
+   *
+   * <p><b>Control plane only.</b> Shortening the rewind is correct ONLY when the batch dataset actually
+   * incorporates the real-time data up to {@code T} (the offline merge "data plane" that produces that
+   * combined dataset is tracked separately). The master switch defaults to {@code false} and must remain
+   * off in production until that data plane is in place, otherwise the shortened rewind would skip
+   * nearline writes between the offline cutoff and {@code T} (a data gap).
+   *
+   * <p>Master switch. When {@code false} (default) the push behaves exactly as before.
+   */
+  public static final String SNAPSHOT_AT_T_REWIND_ENABLED = "snapshot.at.t.rewind.enabled";
+
+  /**
+   * Threshold (in seconds) guarding the snapshot-at-T optimization: it is only triggered when the store's
+   * effective rewind time — i.e. the rewind that would otherwise be the final rewind for this push — is at
+   * least this value. For stores whose rewind window is already short, the optimization's offline-merge
+   * cost is not justified, so the push proceeds as a normal full push with the store's configured rewind.
+   * Defaults to {@link #DEFAULT_SNAPSHOT_AT_T_MIN_REWIND_THRESHOLD_SECONDS}.
+   */
+  public static final String SNAPSHOT_AT_T_MIN_REWIND_THRESHOLD_SECONDS = "snapshot.at.t.min.rewind.threshold.seconds";
+
+  /**
+   * The real-time cutoff timestamp {@code T} (epoch seconds) baked into the batch dataset. The resulting
+   * (final) rewind window is {@code (now - T) + buffer}. Defaults to the job start time (i.e. {@code T} =
+   * start of push, the maximal shortening). A value in the future is rejected.
+   */
+  public static final String SNAPSHOT_AT_T_CUTOFF_EPOCH_SECONDS = "snapshot.at.t.cutoff.epoch.seconds";
+
+  /**
+   * Safety buffer (in seconds) added to the resulting rewind window so the post-snapshot {@code [T, now]}
+   * rewind overlaps — rather than gaps — the data baked into the batch dataset (overlap is harmless because
+   * conflict resolution is idempotent; a gap is data loss). Defaults to
+   * {@link #DEFAULT_SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS}.
+   */
+  public static final String SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS = "snapshot.at.t.rewind.buffer.seconds";
+
+  /** Default {@link #SNAPSHOT_AT_T_MIN_REWIND_THRESHOLD_SECONDS}: one day. */
+  public static final long DEFAULT_SNAPSHOT_AT_T_MIN_REWIND_THRESHOLD_SECONDS = Time.SECONDS_PER_DAY;
+
+  /** Default {@link #SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS}: 60 seconds. */
+  public static final long DEFAULT_SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS = 60;
+
+  /**
    * This config is a boolean which suppresses submitting the end of push message after data has been sent and does
    * not poll for the status of the job to complete. Using this flag means that a user must manually mark the job success
    * or failed.

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -340,6 +340,13 @@ public final class VenicePushJobConstants {
   public static final String SNAPSHOT_AT_T_RT_REGION_BROKERS = "snapshot.at.t.rt.region.brokers";
 
   /**
+   * When {@code true} (and snapshot-at-T mode is active), the batch+RT merge runs as a distributed Spark job
+   * ({@code SnapshotAtTDataWriterSparkJob}) instead of the single-process in-memory merge, so it is memory-bounded
+   * per task and scales to production datasets. Defaults to {@code false}.
+   */
+  public static final String SNAPSHOT_AT_T_DISTRIBUTED_MERGE_ENABLED = "snapshot.at.t.distributed.merge.enabled";
+
+  /**
    * This config is a boolean which suppresses submitting the end of push message after data has been sent and does
    * not poll for the status of the job to complete. Using this flag means that a user must manually mark the job success
    * or failed.

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -332,6 +332,14 @@ public final class VenicePushJobConstants {
   public static final long DEFAULT_SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS = 60;
 
   /**
+   * Real-time source brokers for the snapshot-at-T merge, as {@code coloId=brokerAddress} pairs separated by
+   * {@code ;} (e.g. {@code 0=dc0-broker:9092;1=dc1-broker:9092}). The merge reads each region's RT topic up to
+   * the cutoff and resolves conflicts across regions by colo id. Required when the snapshot-at-T mode runs;
+   * auto-discovering these from the controller's Active-Active source-fabric config is a follow-up.
+   */
+  public static final String SNAPSHOT_AT_T_RT_REGION_BROKERS = "snapshot.at.t.rt.region.brokers";
+
+  /**
    * This config is a boolean which suppresses submitting the end of push message after data has been sent and does
    * not poll for the status of the job to complete. Using this flag means that a user must manually mark the job success
    * or failed.

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -111,6 +111,7 @@ import com.linkedin.venice.status.protocol.PushJobDetailsStatusTuple;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.views.MaterializedView;
 import com.linkedin.venice.views.ViewUtils;
@@ -119,6 +120,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -539,6 +541,28 @@ public class VenicePushJobTest {
   }
 
   /**
+   * Snapshot-at-T stamps the SOP with the job start time, so the server's REWIND_FROM_SOP rewind start
+   * (SOP messageTimestamp - rewindTimeInSecondsOverride) is pinned to (cutoff - buffer) regardless of how long the
+   * merge takes. It must never drift past the snapshot's cutoff, which would silently drop real-time writes.
+   */
+  @Test
+  public void testSnapshotAtTStartOfPushTimestampPinsServerRewindToCutoff() {
+    PushJobSetting setting = newSnapshotAtTSetting();
+    long nowSeconds = setting.jobStartTimeMs / 1000;
+    long twoHours = 2 * 60 * 60;
+    long cutoffSeconds = nowSeconds - twoHours;
+    setting.snapshotAtTCutoffEpochSeconds = cutoffSeconds;
+    assertTrue(VenicePushJob.maybeApplySnapshotAtTRewindOverride(setting));
+
+    // The server computes rewindStart = SOP messageTimestamp - rewindTimeInSecondsOverride.
+    long sopTimestampMs = VenicePushJob.snapshotAtTStartOfPushTimestampMs(setting);
+    long serverRewindStartMs = sopTimestampMs - setting.rewindTimeInSecondsOverride * 1000;
+    // Pinned to (cutoff - buffer): at or before the snapshot's coverage, with the buffer as safety overlap.
+    assertEquals(serverRewindStartMs, cutoffSeconds * 1000 - setting.snapshotAtTRewindBufferSeconds * 1000);
+    assertTrue(serverRewindStartMs <= cutoffSeconds * 1000, "rewind start must not drift past the snapshot cutoff");
+  }
+
+  /**
    * Integration: the per-VPJ knobs, parsed by getPushJobSetting and gated by
    * maybeApplySnapshotAtTRewindOverride, must carry the shortened rewind into the controller's
    * version-creation request (requestTopicForWrites).
@@ -608,6 +632,36 @@ public class VenicePushJobTest {
     assertEquals(VenicePushJob.parseSnapshotAtTRegionBrokers("0=brokerA; ").size(), 1);
     // A malformed entry (missing '=') is rejected.
     assertThrows(VeniceException.class, () -> VenicePushJob.parseSnapshotAtTRegionBrokers("no-equals"));
+    // An empty broker address is rejected: it would later fail to connect, or be mistaken for a valid region.
+    assertThrows(VeniceException.class, () -> VenicePushJob.parseSnapshotAtTRegionBrokers("0="));
+    // A duplicate coloId is rejected: silently overwriting it would drop one region's real-time data.
+    assertThrows(VeniceException.class, () -> VenicePushJob.parseSnapshotAtTRegionBrokers("0=brokerA;0=brokerB"));
+  }
+
+  /**
+   * For a store with separate-real-time-topic enabled, the snapshot-at-T merge must read BOTH the regular RT and
+   * the separate RT topic (mirroring the server, which subscribes to both), otherwise every write that landed on
+   * the separate RT (incremental-push data) would be lost from the offline merge.
+   */
+  @Test
+  public void testSnapshotAtTRtTopicNamesIncludesSeparateRtWhenEnabled() {
+    StoreInfo storeInfo = new StoreInfo();
+    storeInfo.setName(TEST_STORE);
+    storeInfo.setVersions(Collections.emptyList());
+    storeInfo.setHybridStoreConfig(new HybridStoreConfigImpl(3600, 1000, -1, BufferReplayPolicy.REWIND_FROM_SOP));
+    String realTimeTopicName = Utils.getRealTimeTopicName(storeInfo);
+
+    storeInfo.setSeparateRealTimeTopicEnabled(false);
+    assertEquals(
+        VenicePushJob.snapshotAtTRtTopicNames(storeInfo),
+        Collections.singletonList(realTimeTopicName),
+        "Only the regular RT should be read when separate-RT is disabled");
+
+    storeInfo.setSeparateRealTimeTopicEnabled(true);
+    List<String> withSeparate = VenicePushJob.snapshotAtTRtTopicNames(storeInfo);
+    assertEquals(withSeparate.size(), 2, "Both the regular RT and the separate RT should be read");
+    assertEquals(withSeparate.get(0), realTimeTopicName);
+    assertEquals(withSeparate.get(1), realTimeTopicName + Utils.SEPARATE_TOPIC_SUFFIX);
   }
 
   /**

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -596,6 +596,20 @@ public class VenicePushJobTest {
     }
   }
 
+  @Test
+  public void testParseSnapshotAtTRegionBrokers() {
+    Map<Integer, String> parsed = VenicePushJob.parseSnapshotAtTRegionBrokers("0=broker0:9092;1=broker1:9092");
+    assertEquals(parsed.size(), 2);
+    assertEquals(parsed.get(0), "broker0:9092");
+    assertEquals(parsed.get(1), "broker1:9092");
+    assertTrue(VenicePushJob.parseSnapshotAtTRegionBrokers("").isEmpty());
+    assertTrue(VenicePushJob.parseSnapshotAtTRegionBrokers("   ").isEmpty());
+    // A trailing/empty entry is skipped.
+    assertEquals(VenicePushJob.parseSnapshotAtTRegionBrokers("0=brokerA; ").size(), 1);
+    // A malformed entry (missing '=') is rejected.
+    assertThrows(VeniceException.class, () -> VenicePushJob.parseSnapshotAtTRegionBrokers("no-equals"));
+  }
+
   /**
    * When repush.use.fallback.value.schema.id is enabled, the latest value schema ID should be
    * retrieved from the controller as a global fallback for records missing per-record schema IDs.

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -13,6 +13,8 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.D2_ZK_HOSTS_PREFIX;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DATA_WRITER_COMPUTE_JOB_CLASS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_RMD_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_SNAPSHOT_AT_T_MIN_REWIND_THRESHOLD_SECONDS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFER_VERSION_SWAP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
@@ -22,12 +24,16 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.LEGACY_AVRO_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.LEGACY_AVRO_VALUE_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.NOT_SET;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PARENT_CONTROLLER_REGION_NAME;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_TIMEOUT_OVERRIDE_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_SECONDS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_START_TIMESTAMP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_USE_FALLBACK_VALUE_SCHEMA_ID;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_MIN_REWIND_THRESHOLD_SECONDS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SNAPSHOT_AT_T_REWIND_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_ETL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_KAFKA;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_ENABLED;
@@ -85,6 +91,7 @@ import com.linkedin.venice.hadoop.mapreduce.datawriter.jobs.DataWriterMRJob;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
 import com.linkedin.venice.jobs.DataWriterComputeJob;
 import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.meta.BufferReplayPolicy;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.MaterializedViewParameters;
 import com.linkedin.venice.meta.StoreInfo;
@@ -120,6 +127,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.avro.Schema;
+import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -425,6 +433,166 @@ public class VenicePushJobTest {
       Assert.assertFalse(pushJobSetting.repushTTLEnabled);
       Assert.assertEquals(pushJobSetting.repushTTLStartTimeMs, -1);
       Assert.assertTrue(Version.isPushIdRePush(pushJob.getPushJobDetails().getPushId().toString()));
+    }
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Snapshot-at-T rewind-shortening knobs (per-VPJ). See VenicePushJobConstants#SNAPSHOT_AT_T_REWIND_ENABLED.
+  // -------------------------------------------------------------------------------------------
+
+  /** Base setting: feature on, 3-day hybrid rewind, default 1-day threshold, default (now) cutoff, 60s buffer. */
+  private PushJobSetting newSnapshotAtTSetting() {
+    PushJobSetting setting = new PushJobSetting();
+    setting.storeName = TEST_STORE;
+    // Fixed job start so "now" is deterministic: 10_000_000_000 ms => 10_000_000 s.
+    setting.jobStartTimeMs = 10_000_000_000L;
+    setting.rewindTimeInSecondsOverride = NOT_SET;
+    setting.snapshotAtTRewindEnabled = true;
+    setting.snapshotAtTMinRewindThresholdSeconds = DEFAULT_SNAPSHOT_AT_T_MIN_REWIND_THRESHOLD_SECONDS;
+    setting.snapshotAtTCutoffEpochSeconds = NOT_SET;
+    setting.snapshotAtTRewindBufferSeconds = DEFAULT_SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS;
+    setting.hybridStoreConfig =
+        new HybridStoreConfigImpl(3 * Time.SECONDS_PER_DAY, 1000, -1, BufferReplayPolicy.REWIND_FROM_SOP);
+    return setting;
+  }
+
+  @Test
+  public void testSnapshotAtTRewindOverrideAppliedWithDefaultCutoff() {
+    PushJobSetting setting = newSnapshotAtTSetting();
+    assertTrue(VenicePushJob.maybeApplySnapshotAtTRewindOverride(setting));
+    // Default cutoff == now, so the resulting (final) rewind is just the buffer.
+    assertEquals(setting.rewindTimeInSecondsOverride, DEFAULT_SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS);
+    assertEquals(setting.validateRemoteReplayPolicy, BufferReplayPolicy.REWIND_FROM_SOP);
+    assertTrue(setting.snapshotAtTRewindApplied);
+  }
+
+  @Test
+  public void testSnapshotAtTRewindOverrideWithExplicitPastCutoff() {
+    PushJobSetting setting = newSnapshotAtTSetting();
+    long nowSeconds = setting.jobStartTimeMs / 1000;
+    long twoHours = 2 * 60 * 60;
+    setting.snapshotAtTCutoffEpochSeconds = nowSeconds - twoHours;
+    setting.snapshotAtTRewindBufferSeconds = 120;
+    assertTrue(VenicePushJob.maybeApplySnapshotAtTRewindOverride(setting));
+    // Final rewind = (now - cutoff) + buffer.
+    assertEquals(setting.rewindTimeInSecondsOverride, twoHours + 120);
+  }
+
+  @Test
+  public void testSnapshotAtTRewindOverrideThresholdBoundaryApplied() {
+    PushJobSetting setting = newSnapshotAtTSetting();
+    // Effective rewind exactly equals the threshold -> still applied (the gate is >=).
+    setting.snapshotAtTMinRewindThresholdSeconds = 3 * Time.SECONDS_PER_DAY;
+    assertTrue(VenicePushJob.maybeApplySnapshotAtTRewindOverride(setting));
+    assertTrue(setting.snapshotAtTRewindApplied);
+  }
+
+  @Test
+  public void testSnapshotAtTRewindOverrideSkippedBelowThreshold() {
+    PushJobSetting setting = newSnapshotAtTSetting();
+    // Store rewind (1h) below the default 1-day threshold -> skipped, rewind untouched.
+    setting.hybridStoreConfig = new HybridStoreConfigImpl(60 * 60, 1000, -1, BufferReplayPolicy.REWIND_FROM_SOP);
+    assertFalse(VenicePushJob.maybeApplySnapshotAtTRewindOverride(setting));
+    assertEquals(setting.rewindTimeInSecondsOverride, NOT_SET);
+    assertFalse(setting.snapshotAtTRewindApplied);
+  }
+
+  @Test
+  public void testSnapshotAtTRewindOverrideSkippedForIneligibleJobs() {
+    // Disabled (master switch off).
+    PushJobSetting disabled = newSnapshotAtTSetting();
+    disabled.snapshotAtTRewindEnabled = false;
+    assertFalse(VenicePushJob.maybeApplySnapshotAtTRewindOverride(disabled));
+    assertEquals(disabled.rewindTimeInSecondsOverride, NOT_SET);
+
+    // Non-hybrid store.
+    PushJobSetting nonHybrid = newSnapshotAtTSetting();
+    nonHybrid.hybridStoreConfig = null;
+    assertFalse(VenicePushJob.maybeApplySnapshotAtTRewindOverride(nonHybrid));
+    assertEquals(nonHybrid.rewindTimeInSecondsOverride, NOT_SET);
+
+    // Incremental push.
+    PushJobSetting incremental = newSnapshotAtTSetting();
+    incremental.isIncrementalPush = true;
+    assertFalse(VenicePushJob.maybeApplySnapshotAtTRewindOverride(incremental));
+    assertEquals(incremental.rewindTimeInSecondsOverride, NOT_SET);
+
+    // KIF repush (manages its own rewind override).
+    PushJobSetting repush = newSnapshotAtTSetting();
+    repush.isSourceKafka = true;
+    assertFalse(VenicePushJob.maybeApplySnapshotAtTRewindOverride(repush));
+    assertEquals(repush.rewindTimeInSecondsOverride, NOT_SET);
+
+    // Explicit rewind override already set -> not clobbered.
+    PushJobSetting explicit = newSnapshotAtTSetting();
+    explicit.rewindTimeInSecondsOverride = 4242;
+    assertFalse(VenicePushJob.maybeApplySnapshotAtTRewindOverride(explicit));
+    assertEquals(explicit.rewindTimeInSecondsOverride, 4242);
+  }
+
+  @Test
+  public void testSnapshotAtTRewindOverrideRejectsFutureCutoff() {
+    PushJobSetting setting = newSnapshotAtTSetting();
+    long nowSeconds = setting.jobStartTimeMs / 1000;
+    setting.snapshotAtTCutoffEpochSeconds = nowSeconds + 100;
+    assertThrows(VeniceException.class, () -> VenicePushJob.maybeApplySnapshotAtTRewindOverride(setting));
+  }
+
+  /**
+   * Integration: the per-VPJ knobs, parsed by getPushJobSetting and gated by
+   * maybeApplySnapshotAtTRewindOverride, must carry the shortened rewind into the controller's
+   * version-creation request (requestTopicForWrites).
+   */
+  @Test
+  public void testSnapshotAtTRewindOverrideReachesControllerRequest() {
+    HybridStoreConfigImpl hybridConfig =
+        new HybridStoreConfigImpl(3 * Time.SECONDS_PER_DAY, 1000, -1, BufferReplayPolicy.REWIND_FROM_SOP);
+    ControllerClient client = getClient(storeInfo -> storeInfo.setHybridStoreConfig(hybridConfig));
+    long buffer = 120;
+    Properties props = new Properties();
+    props.setProperty(SNAPSHOT_AT_T_REWIND_ENABLED, "true");
+    props.setProperty(SNAPSHOT_AT_T_MIN_REWIND_THRESHOLD_SECONDS, String.valueOf(Time.SECONDS_PER_DAY));
+    props.setProperty(SNAPSHOT_AT_T_REWIND_BUFFER_SECONDS, String.valueOf(buffer));
+    try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
+      PushJobSetting setting = pushJob.getPushJobSetting();
+      // Knobs are parsed from the VPJ props.
+      assertTrue(setting.snapshotAtTRewindEnabled);
+      assertEquals(setting.snapshotAtTRewindBufferSeconds, buffer);
+      // Simulate the store-info fetch that run() performs before the override is applied.
+      setting.hybridStoreConfig = hybridConfig;
+
+      // Gate triggers (3-day rewind >= 1-day threshold); default cutoff == now => final rewind == buffer.
+      assertTrue(VenicePushJob.maybeApplySnapshotAtTRewindOverride(setting));
+      assertEquals(setting.rewindTimeInSecondsOverride, buffer);
+
+      // The shortened rewind must reach the controller's version-creation request.
+      pushJob.createNewStoreVersion(
+          setting,
+          100L,
+          client,
+          "snapshot-at-t-push",
+          new VeniceProperties(props),
+          Optional.empty());
+      ArgumentCaptor<Long> rewindCaptor = ArgumentCaptor.forClass(Long.class);
+      verify(client).requestTopicForWrites(
+          anyString(),
+          anyLong(),
+          any(),
+          anyString(),
+          anyBoolean(),
+          anyBoolean(),
+          anyBoolean(),
+          any(),
+          any(),
+          any(),
+          anyBoolean(),
+          rewindCaptor.capture(),
+          anyBoolean(),
+          any(),
+          anyInt(),
+          anyBoolean(),
+          anyInt());
+      assertEquals(rewindCaptor.getValue().longValue(), buffer);
     }
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTPushExecutorTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTPushExecutorTest.java
@@ -1,0 +1,137 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.compression.CompressorFactory;
+import com.linkedin.venice.compression.VeniceCompressor;
+import com.linkedin.venice.meta.ReadOnlySchemaRepository;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
+import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
+import com.linkedin.venice.writer.AbstractVeniceWriter;
+import com.linkedin.venice.writer.DeleteMetadata;
+import com.linkedin.venice.writer.PutMetadata;
+import com.linkedin.venice.writer.VeniceWriter;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link SnapshotAtTPushExecutor}: per key, it seeds from the batch value, folds RT records via the
+ * merger, and writes the merged value+RMD (or an RMD-carrying delete) to the writer.
+ */
+public class SnapshotAtTPushExecutorTest {
+  private static final String STORE = "snapshot_exec_test";
+  private static final String STRING_SCHEMA = "\"string\"";
+  private static final int VALUE_SCHEMA_ID = 1;
+
+  private VeniceAvroKafkaSerializer serializer;
+  private SnapshotAtTRecordMerger merger;
+  private VeniceCompressor noOpCompressor;
+
+  @BeforeMethod
+  public void setUp() {
+    Schema valueSchema = new Schema.Parser().parse(STRING_SCHEMA);
+    int rmdVersion = RmdSchemaGenerator.getLatestVersion();
+    Schema rmdSchema = RmdSchemaGenerator.generateMetadataSchema(valueSchema, rmdVersion);
+    ReadOnlySchemaRepository repository = mock(ReadOnlySchemaRepository.class);
+    when(repository.getValueSchema(anyString(), anyInt())).thenReturn(new SchemaEntry(VALUE_SCHEMA_ID, valueSchema));
+    when(repository.getSupersetOrLatestValueSchema(anyString()))
+        .thenReturn(new SchemaEntry(VALUE_SCHEMA_ID, valueSchema));
+    when(repository.getSupersetSchema(anyString())).thenReturn(new SchemaEntry(VALUE_SCHEMA_ID, valueSchema));
+    when(repository.getReplicationMetadataSchema(anyString(), anyInt(), anyInt()))
+        .thenReturn(new RmdSchemaEntry(VALUE_SCHEMA_ID, rmdVersion, rmdSchema));
+    merger = new SnapshotAtTRecordMerger(repository, STORE, rmdVersion, false);
+    serializer = new VeniceAvroKafkaSerializer(STRING_SCHEMA);
+    noOpCompressor = new CompressorFactory().getCompressor(CompressionStrategy.NO_OP);
+  }
+
+  @Test
+  public void testExecuteMergesBatchAndRtAndProduces() {
+    Map<ByteBuffer, ByteBuffer> batch = new HashMap<>();
+    batch.put(key("1"), value("batch_1"));
+    batch.put(key("2"), value("batch_2"));
+    List<SnapshotAtTRtRecord> rtRecords = new ArrayList<>();
+    rtRecords.add(put("2", "rt_2", 1000L, 0));
+    rtRecords.add(put("3", "rt_3", 1000L, 1));
+
+    Map<String, byte[]> produced = new HashMap<>();
+    SnapshotAtTPushExecutor.Stats stats = new SnapshotAtTPushExecutor()
+        .execute(recordingWriter(produced), batch, VALUE_SCHEMA_ID, rtRecords, merger, noOpCompressor);
+
+    assertEquals(stats.getPuts(), 3);
+    assertEquals(stats.getDeletes(), 0);
+    assertEquals(deserialize(produced.get("1")), "batch_1"); // batch only
+    assertEquals(deserialize(produced.get("2")), "rt_2"); // RT wins over the batch base
+    assertEquals(deserialize(produced.get("3")), "rt_3"); // RT only
+  }
+
+  @Test
+  public void testExecuteProducesDeleteTombstone() {
+    Map<ByteBuffer, ByteBuffer> batch = new HashMap<>();
+    batch.put(key("1"), value("batch_1"));
+    List<SnapshotAtTRtRecord> rtRecords = new ArrayList<>();
+    rtRecords
+        .add(new SnapshotAtTRtRecord(SnapshotAtTRtRecord.Op.DELETE, key("1"), null, VALUE_SCHEMA_ID, -1, 2000L, 0));
+
+    Map<String, byte[]> produced = new HashMap<>();
+    SnapshotAtTPushExecutor.Stats stats = new SnapshotAtTPushExecutor()
+        .execute(recordingWriter(produced), batch, VALUE_SCHEMA_ID, rtRecords, merger, noOpCompressor);
+
+    assertEquals(stats.getDeletes(), 1);
+    assertEquals(stats.getPuts(), 0);
+    assertNull(produced.get("1")); // delete tombstone -> null value
+  }
+
+  private ByteBuffer key(String value) {
+    return ByteBuffer.wrap(serializer.serialize(null, value));
+  }
+
+  private ByteBuffer value(String value) {
+    return ByteBuffer.wrap(serializer.serialize(null, value));
+  }
+
+  private SnapshotAtTRtRecord put(String key, String value, long timestamp, int coloId) {
+    return new SnapshotAtTRtRecord(
+        SnapshotAtTRtRecord.Op.PUT,
+        key(key),
+        value(value),
+        VALUE_SCHEMA_ID,
+        -1,
+        timestamp,
+        coloId);
+  }
+
+  private String deserialize(byte[] bytes) {
+    return serializer.deserialize(bytes).toString();
+  }
+
+  @SuppressWarnings("unchecked")
+  private AbstractVeniceWriter<byte[], byte[], byte[]> recordingWriter(Map<String, byte[]> produced) {
+    VeniceWriter<byte[], byte[], byte[]> writer = mock(VeniceWriter.class);
+    doAnswer(invocation -> {
+      produced.put(deserialize((byte[]) invocation.getArgument(0)), (byte[]) invocation.getArgument(1));
+      return null;
+    }).when(writer).put(any(byte[].class), any(byte[].class), anyInt(), any(), any(PutMetadata.class));
+    doAnswer(invocation -> {
+      produced.put(deserialize((byte[]) invocation.getArgument(0)), null);
+      return null;
+    }).when(writer).delete(any(byte[].class), any(), any(DeleteMetadata.class));
+    return writer;
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRecordMergerTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRecordMergerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -23,6 +24,9 @@ import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.writer.update.UpdateBuilderImpl;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiConsumer;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -132,7 +136,99 @@ public class SnapshotAtTRecordMergerTest {
     assertEquals(((Number) timestampRecord.get("field2")).longValue(), 0L);
   }
 
+  /**
+   * The fold must converge to the same result no matter the order RT records are applied in. The executor sorts a
+   * key's records by timestamp before folding, but the fold itself must be commutative (this is what makes an
+   * out-of-order / distributed merge safe). One key, batch base + cross-colo out-of-order PUT(100,colo0),
+   * DELETE(200,colo1), PUT(300,colo0) [latest -> wins], PUT(50,colo1): value-level DCR must converge to the ts=300
+   * PUT in any order, dropping every superseded write.
+   */
+  @Test
+  public void testFoldIsOrderIndependentAcrossColosForPutAndDelete() {
+    List<BiConsumer<SnapshotAtTRecordMerger, KeyMergeState>> ops = Arrays.asList(
+        (m, s) -> m.applyPut(s, serializeValue("ts100", "b"), VALUE_SCHEMA_ID, 100L, 0),
+        (m, s) -> m.applyDelete(s, 200L, 1),
+        (m, s) -> m.applyPut(s, serializeValue("winner", "b"), VALUE_SCHEMA_ID, 300L, 0),
+        (m, s) -> m.applyPut(s, serializeValue("ts50", "b"), VALUE_SCHEMA_ID, 50L, 1));
+
+    MergedRecord ascending = foldInOrder(ops, new int[] { 3, 0, 1, 2 }, false);
+    MergedRecord scrambled = foldInOrder(ops, new int[] { 2, 0, 3, 1 }, false);
+
+    for (MergedRecord record: Arrays.asList(ascending, scrambled)) {
+      assertFalse(record.isDelete());
+      assertEquals(valueField(record, "field1"), "winner");
+      assertEquals(valueLevelRmdTimestamp(record), 300L);
+    }
+  }
+
+  /**
+   * Field-level (write-compute) DCR resolves each field by its own per-field timestamp, so folding UPDATEs in any
+   * order must converge to the same per-field winner: UPDATE field1@100, field2@300, field1@200 (latest for
+   * field1) -> field1="f1-200", field2="f2-300".
+   */
+  @Test
+  public void testFoldIsOrderIndependentForFieldLevelUpdates() {
+    List<BiConsumer<SnapshotAtTRecordMerger, KeyMergeState>> ops = Arrays.asList(
+        (m, s) -> m.applyUpdate(
+            s,
+            serializeUpdate(setField("field1", "f1-100")),
+            VALUE_SCHEMA_ID,
+            UPDATE_PROTOCOL_VERSION,
+            100L,
+            0),
+        (m, s) -> m.applyUpdate(
+            s,
+            serializeUpdate(setField("field2", "f2-300")),
+            VALUE_SCHEMA_ID,
+            UPDATE_PROTOCOL_VERSION,
+            300L,
+            1),
+        (m, s) -> m.applyUpdate(
+            s,
+            serializeUpdate(setField("field1", "f1-200")),
+            VALUE_SCHEMA_ID,
+            UPDATE_PROTOCOL_VERSION,
+            200L,
+            0));
+
+    MergedRecord ascending = foldInOrder(ops, new int[] { 0, 2, 1 }, true);
+    MergedRecord scrambled = foldInOrder(ops, new int[] { 1, 2, 0 }, true);
+
+    for (MergedRecord record: Arrays.asList(ascending, scrambled)) {
+      assertFalse(record.isDelete());
+      assertEquals(valueField(record, "field1"), "f1-200");
+      assertEquals(valueField(record, "field2"), "f2-300");
+      GenericRecord timestampRecord = fieldLevelRmdTimestampRecord(record);
+      assertEquals(((Number) timestampRecord.get("field1")).longValue(), 200L);
+      assertEquals(((Number) timestampRecord.get("field2")).longValue(), 300L);
+    }
+  }
+
   // ---- helpers ----
+
+  /** Fold the given ops onto a fresh batch-seeded state in the given order, returning the finished record. */
+  private MergedRecord foldInOrder(
+      List<BiConsumer<SnapshotAtTRecordMerger, KeyMergeState>> ops,
+      int[] order,
+      boolean fieldLevelTimestamp) {
+    SnapshotAtTRecordMerger merger =
+        new SnapshotAtTRecordMerger(schemaRepository, STORE, rmdVersion, fieldLevelTimestamp);
+    KeyMergeState state = merger.seedFromBatch(serializeValue("batch", "b"), VALUE_SCHEMA_ID);
+    for (int index: order) {
+      ops.get(index).accept(merger, state);
+    }
+    return merger.finalizeRecord(state);
+  }
+
+  private GenericRecord setField(String fieldName, String value) {
+    return new UpdateBuilderImpl(updateSchema).setNewFieldValue(fieldName, value).build();
+  }
+
+  private String valueField(MergedRecord record, String fieldName) {
+    GenericRecord value = (GenericRecord) MapOrderPreservingSerDeFactory.getDeserializer(valueSchema, valueSchema)
+        .deserialize(record.getValue());
+    return value.get(fieldName).toString();
+  }
 
   private ByteBuffer serializeValue(String field1, String field2) {
     GenericRecord record = new GenericData.Record(valueSchema);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRecordMergerTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRecordMergerTest.java
@@ -1,0 +1,164 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.davinci.replication.merge.RmdSerDe;
+import com.linkedin.davinci.replication.merge.StringAnnotatedStoreSchemaCache;
+import com.linkedin.davinci.serializer.avro.MapOrderPreservingSerDeFactory;
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRecordMerger.KeyMergeState;
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRecordMerger.MergedRecord;
+import com.linkedin.venice.meta.ReadOnlySchemaRepository;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.rmd.RmdConstants;
+import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
+import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
+import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
+import com.linkedin.venice.writer.update.UpdateBuilderImpl;
+import java.nio.ByteBuffer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link SnapshotAtTRecordMerger}: folding RT PUT/UPDATE/DELETE onto a batch base via the real
+ * {@link com.linkedin.davinci.replication.merge.MergeConflictResolver} must produce the merged value AND the
+ * correct RMD, for both value-level and (write-compute) field-level stores.
+ */
+public class SnapshotAtTRecordMergerTest {
+  private static final String STORE = "snapshot_test_store";
+  private static final int VALUE_SCHEMA_ID = 1;
+  private static final int UPDATE_PROTOCOL_VERSION = 1;
+  private static final String VALUE_SCHEMA_STR = "{\n" + "  \"type\": \"record\",\n"
+      + "  \"name\": \"SnapshotTestValue\",\n" + "  \"namespace\": \"com.linkedin.venice.hadoop.snapshot\",\n"
+      + "  \"fields\": [\n" + "    {\"name\": \"field1\", \"type\": \"string\", \"default\": \"\"},\n"
+      + "    {\"name\": \"field2\", \"type\": \"string\", \"default\": \"\"}\n" + "  ]\n" + "}";
+
+  private Schema valueSchema;
+  private Schema rmdSchema;
+  private Schema updateSchema;
+  private int rmdVersion;
+  private ReadOnlySchemaRepository schemaRepository;
+  private RmdSerDe rmdSerDe;
+
+  @BeforeMethod
+  public void setUp() {
+    valueSchema = new Schema.Parser().parse(VALUE_SCHEMA_STR);
+    rmdVersion = RmdSchemaGenerator.getLatestVersion();
+    rmdSchema = RmdSchemaGenerator.generateMetadataSchema(valueSchema, rmdVersion);
+    updateSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(valueSchema);
+
+    schemaRepository = mock(ReadOnlySchemaRepository.class);
+    when(schemaRepository.getValueSchema(eq(STORE), anyInt()))
+        .thenReturn(new SchemaEntry(VALUE_SCHEMA_ID, valueSchema));
+    when(schemaRepository.getSupersetOrLatestValueSchema(STORE))
+        .thenReturn(new SchemaEntry(VALUE_SCHEMA_ID, valueSchema));
+    when(schemaRepository.getSupersetSchema(STORE)).thenReturn(new SchemaEntry(VALUE_SCHEMA_ID, valueSchema));
+    when(schemaRepository.getReplicationMetadataSchema(eq(STORE), anyInt(), anyInt()))
+        .thenReturn(new RmdSchemaEntry(VALUE_SCHEMA_ID, rmdVersion, rmdSchema));
+    when(schemaRepository.getDerivedSchema(eq(STORE), anyInt(), anyInt()))
+        .thenReturn(new DerivedSchemaEntry(VALUE_SCHEMA_ID, UPDATE_PROTOCOL_VERSION, updateSchema));
+
+    // A separate RmdSerDe (same schemas) to read back the merged RMD bytes for assertions.
+    rmdSerDe = new RmdSerDe(new StringAnnotatedStoreSchemaCache(STORE, schemaRepository), rmdVersion);
+  }
+
+  @Test
+  public void testFoldRtPutOntoBatchBaseProducesValueAndRmd() {
+    SnapshotAtTRecordMerger merger = new SnapshotAtTRecordMerger(schemaRepository, STORE, rmdVersion, false);
+    KeyMergeState state = merger.seedFromBatch(serializeValue("batch", "b"), VALUE_SCHEMA_ID);
+
+    // The batch base carries the sentinel RMD (timestamp 0).
+    assertEquals(field(merger, state, "field1"), "batch");
+    assertEquals(valueLevelRmdTimestamp(merger.finalizeRecord(state)), 0L);
+
+    // An RT PUT at ts=1000 wins over the sentinel, and the merged record carries RMD timestamp 1000.
+    merger.applyPut(state, serializeValue("rt", "b"), VALUE_SCHEMA_ID, 1000L, 0);
+    assertEquals(field(merger, state, "field1"), "rt");
+    assertEquals(valueLevelRmdTimestamp(merger.finalizeRecord(state)), 1000L);
+
+    // A stale RT PUT at ts=500 is ignored (only possible because the RMD tracks the winning timestamp 1000).
+    merger.applyPut(state, serializeValue("stale", "b"), VALUE_SCHEMA_ID, 500L, 0);
+    assertEquals(field(merger, state, "field1"), "rt");
+    assertEquals(valueLevelRmdTimestamp(merger.finalizeRecord(state)), 1000L);
+  }
+
+  @Test
+  public void testFoldRtDeleteProducesTombstoneWithRmd() {
+    SnapshotAtTRecordMerger merger = new SnapshotAtTRecordMerger(schemaRepository, STORE, rmdVersion, false);
+    KeyMergeState state = merger.seedFromBatch(serializeValue("batch", "b"), VALUE_SCHEMA_ID);
+    merger.applyPut(state, serializeValue("rt", "b"), VALUE_SCHEMA_ID, 1000L, 0);
+
+    merger.applyDelete(state, 2000L, 0);
+    assertTrue(state.isDeleted());
+
+    MergedRecord record = merger.finalizeRecord(state);
+    assertTrue(record.isDelete());
+    assertNull(record.getValue());
+    // A delete still carries an RMD tombstone (timestamp 2000) so later writes resolve against it.
+    assertNotNull(record.getRmd());
+    assertEquals(valueLevelRmdTimestamp(record), 2000L);
+
+    // A PUT older than the delete is ignored.
+    merger.applyPut(state, serializeValue("resurrect-but-stale", "b"), VALUE_SCHEMA_ID, 1500L, 0);
+    assertTrue(state.isDeleted());
+  }
+
+  @Test
+  public void testFoldRtPartialUpdateProducesFieldLevelRmd() {
+    SnapshotAtTRecordMerger merger = new SnapshotAtTRecordMerger(schemaRepository, STORE, rmdVersion, true);
+    KeyMergeState state = merger.seedFromBatch(serializeValue("a", "b"), VALUE_SCHEMA_ID);
+
+    // Partial update sets only field1.
+    GenericRecord update = new UpdateBuilderImpl(updateSchema).setNewFieldValue("field1", "updated").build();
+    merger.applyUpdate(state, serializeUpdate(update), VALUE_SCHEMA_ID, UPDATE_PROTOCOL_VERSION, 1500L, 0);
+
+    assertEquals(field(merger, state, "field1"), "updated"); // updated field
+    assertEquals(field(merger, state, "field2"), "b"); // untouched field preserved from the batch base
+
+    // RMD is field-level: field1's per-field timestamp is the update timestamp; field2 stays at the batch sentinel.
+    GenericRecord timestampRecord = fieldLevelRmdTimestampRecord(merger.finalizeRecord(state));
+    assertEquals(((Number) timestampRecord.get("field1")).longValue(), 1500L);
+    assertEquals(((Number) timestampRecord.get("field2")).longValue(), 0L);
+  }
+
+  // ---- helpers ----
+
+  private ByteBuffer serializeValue(String field1, String field2) {
+    GenericRecord record = new GenericData.Record(valueSchema);
+    record.put("field1", field1);
+    record.put("field2", field2);
+    return ByteBuffer.wrap(MapOrderPreservingSerDeFactory.<GenericRecord>getSerializer(valueSchema).serialize(record));
+  }
+
+  private ByteBuffer serializeUpdate(GenericRecord updateRecord) {
+    return ByteBuffer
+        .wrap(MapOrderPreservingSerDeFactory.<GenericRecord>getSerializer(updateSchema).serialize(updateRecord));
+  }
+
+  private String field(SnapshotAtTRecordMerger merger, KeyMergeState state, String fieldName) {
+    GenericRecord value = (GenericRecord) MapOrderPreservingSerDeFactory.getDeserializer(valueSchema, valueSchema)
+        .deserialize(state.getValueBytes());
+    return value.get(fieldName).toString();
+  }
+
+  private long valueLevelRmdTimestamp(MergedRecord record) {
+    GenericRecord rmd = rmdSerDe.deserializeRmdBytes(VALUE_SCHEMA_ID, VALUE_SCHEMA_ID, record.getRmd());
+    return ((Number) rmd.get(RmdConstants.TIMESTAMP_FIELD_NAME)).longValue();
+  }
+
+  private GenericRecord fieldLevelRmdTimestampRecord(MergedRecord record) {
+    GenericRecord rmd = rmdSerDe.deserializeRmdBytes(VALUE_SCHEMA_ID, VALUE_SCHEMA_ID, record.getRmd());
+    return (GenericRecord) rmd.get(RmdConstants.TIMESTAMP_FIELD_NAME);
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtSplitPlannerTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTRtSplitPlannerTest.java
@@ -1,0 +1,60 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.vpj.pubsub.input.PubSubPartitionSplit;
+import com.linkedin.venice.vpj.pubsub.input.PubSubSplitPlanner;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link SnapshotAtTRtSplitPlanner}: it must fan {@link PubSubSplitPlanner} out across every region
+ * and every RT topic, tagging each resulting split with the right broker + coloId.
+ */
+public class SnapshotAtTRtSplitPlannerTest {
+  @Test
+  public void testPlanFansOutAcrossRegionsAndTopics() {
+    // The injected planner returns one split per call, tagged with the topic it was asked to plan, so the fan-out
+    // (region, topic) -> tagged splits can be asserted without a live broker.
+    PubSubSplitPlanner planner = mock(PubSubSplitPlanner.class);
+    when(planner.plan(any())).thenAnswer(invocation -> {
+      VeniceProperties regionProps = invocation.getArgument(0);
+      PubSubPartitionSplit split = mock(PubSubPartitionSplit.class);
+      when(split.getTopicName()).thenReturn(regionProps.getString(KAFKA_INPUT_TOPIC));
+      return Collections.singletonList(split);
+    });
+
+    Map<Integer, String> regionBrokers = new LinkedHashMap<>();
+    regionBrokers.put(0, "broker0:9092");
+    regionBrokers.put(1, "broker1:9092");
+    List<String> rtTopicNames = Arrays.asList("store_rt", "store_rt_sep");
+
+    List<SnapshotAtTRtSplit> splits =
+        new SnapshotAtTRtSplitPlanner(planner).plan(regionBrokers, rtTopicNames, VeniceProperties.empty());
+
+    // 2 regions x 2 topics x 1 split each, each tagged with its own broker + coloId + topic.
+    assertEquals(splits.size(), 4);
+    assertTrue(hasSplit(splits, 0, "broker0:9092", "store_rt"));
+    assertTrue(hasSplit(splits, 0, "broker0:9092", "store_rt_sep"));
+    assertTrue(hasSplit(splits, 1, "broker1:9092", "store_rt"));
+    assertTrue(hasSplit(splits, 1, "broker1:9092", "store_rt_sep"));
+  }
+
+  private static boolean hasSplit(List<SnapshotAtTRtSplit> splits, int coloId, String broker, String topicName) {
+    return splits.stream()
+        .anyMatch(
+            s -> s.getColoId() == coloId && s.getBroker().equals(broker)
+                && s.getSplit().getTopicName().equals(topicName));
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSchemaRepositoryTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSchemaRepositoryTest.java
@@ -1,0 +1,97 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.MultiSchemaResponse;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
+import org.apache.avro.Schema;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link SnapshotAtTSchemaRepository}: it is populated once from the controller's value / RMD /
+ * derived schemas, and only the merge-path lookups are supported.
+ */
+public class SnapshotAtTSchemaRepositoryTest {
+  private static final String STORE = "snapshot_repo_test";
+  private static final String STRING_SCHEMA = "\"string\"";
+
+  @Test
+  public void testFromControllerPopulatesSchemas() {
+    Schema valueSchema = new Schema.Parser().parse(STRING_SCHEMA);
+    int rmdVersion = RmdSchemaGenerator.getLatestVersion();
+    String rmdSchemaStr = RmdSchemaGenerator.generateMetadataSchema(valueSchema, rmdVersion).toString();
+
+    ControllerClient client = mock(ControllerClient.class);
+    when(client.getAllValueSchema(STORE)).thenReturn(valueSchemaResponse());
+    when(client.getAllReplicationMetadataSchemas(STORE)).thenReturn(rmdSchemaResponse(rmdVersion, rmdSchemaStr));
+    when(client.getAllValueAndDerivedSchema(STORE)).thenReturn(emptyResponse());
+
+    SnapshotAtTSchemaRepository repository = SnapshotAtTSchemaRepository.fromController(client, STORE);
+    assertNotNull(repository.getValueSchema(STORE, 1));
+    assertNotNull(repository.getSupersetOrLatestValueSchema(STORE));
+    assertNotNull(repository.getSupersetSchema(STORE));
+    assertTrue(repository.hasValueSchema(STORE, 1));
+    assertNotNull(repository.getReplicationMetadataSchema(STORE, 1, rmdVersion));
+    assertEquals(repository.getRmdVersionId(), rmdVersion);
+    assertNull(repository.getValueSchema(STORE, 99));
+    assertEquals(repository.getValueSchemas(STORE).size(), 1);
+    assertEquals(repository.getReplicationMetadataSchemas(STORE).size(), 1);
+  }
+
+  @Test
+  public void testFromControllerThrowsOnValueSchemaError() {
+    ControllerClient client = mock(ControllerClient.class);
+    MultiSchemaResponse error = new MultiSchemaResponse();
+    error.setError("boom");
+    when(client.getAllValueSchema(STORE)).thenReturn(error);
+    assertThrows(VeniceException.class, () -> SnapshotAtTSchemaRepository.fromController(client, STORE));
+  }
+
+  @Test
+  public void testUnsupportedMethodsThrow() {
+    ControllerClient client = mock(ControllerClient.class);
+    when(client.getAllValueSchema(STORE)).thenReturn(valueSchemaResponse());
+    when(client.getAllReplicationMetadataSchemas(STORE)).thenReturn(emptyResponse());
+    when(client.getAllValueAndDerivedSchema(STORE)).thenReturn(emptyResponse());
+    SnapshotAtTSchemaRepository repository = SnapshotAtTSchemaRepository.fromController(client, STORE);
+    assertThrows(UnsupportedOperationException.class, () -> repository.getKeySchema(STORE));
+    assertThrows(UnsupportedOperationException.class, () -> repository.getValueSchemaId(STORE, STRING_SCHEMA));
+    assertThrows(UnsupportedOperationException.class, () -> repository.getLatestDerivedSchema(STORE, 1));
+    repository.refresh(); // no-op
+    repository.clear(); // no-op
+  }
+
+  private MultiSchemaResponse valueSchemaResponse() {
+    MultiSchemaResponse response = new MultiSchemaResponse();
+    MultiSchemaResponse.Schema schema = new MultiSchemaResponse.Schema();
+    schema.setId(1);
+    schema.setSchemaStr(STRING_SCHEMA);
+    response.setSchemas(new MultiSchemaResponse.Schema[] { schema });
+    return response;
+  }
+
+  private MultiSchemaResponse rmdSchemaResponse(int rmdVersion, String rmdSchemaStr) {
+    MultiSchemaResponse response = new MultiSchemaResponse();
+    MultiSchemaResponse.Schema schema = new MultiSchemaResponse.Schema();
+    schema.setId(rmdVersion);
+    schema.setRmdValueSchemaId(1);
+    schema.setSchemaStr(rmdSchemaStr);
+    response.setSchemas(new MultiSchemaResponse.Schema[] { schema });
+    return response;
+  }
+
+  private MultiSchemaResponse emptyResponse() {
+    MultiSchemaResponse response = new MultiSchemaResponse();
+    response.setSchemas(new MultiSchemaResponse.Schema[0]);
+    return response;
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSchemaRepositoryTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSchemaRepositoryTest.java
@@ -57,6 +57,41 @@ public class SnapshotAtTSchemaRepositoryTest {
   }
 
   @Test
+  public void testFromControllerThrowsOnEmptyValueSchemas() {
+    // A successful-but-empty value-schema response leaves no latest value schema id; the merge would later get a
+    // null superset schema, so fail fast at construction instead.
+    ControllerClient client = mock(ControllerClient.class);
+    when(client.getAllValueSchema(STORE)).thenReturn(emptyResponse());
+    when(client.getAllReplicationMetadataSchemas(STORE)).thenReturn(emptyResponse());
+    when(client.getAllValueAndDerivedSchema(STORE)).thenReturn(emptyResponse());
+    assertThrows(VeniceException.class, () -> SnapshotAtTSchemaRepository.fromController(client, STORE));
+  }
+
+  @Test
+  public void testFromControllerThrowsOnRmdSchemaError() {
+    // Conflict resolution depends on RMD schemas; an RMD fetch error must abort, not proceed with empty RMD.
+    ControllerClient client = mock(ControllerClient.class);
+    when(client.getAllValueSchema(STORE)).thenReturn(valueSchemaResponse());
+    MultiSchemaResponse rmdError = new MultiSchemaResponse();
+    rmdError.setError("rmd boom");
+    when(client.getAllReplicationMetadataSchemas(STORE)).thenReturn(rmdError);
+    when(client.getAllValueAndDerivedSchema(STORE)).thenReturn(emptyResponse());
+    assertThrows(VeniceException.class, () -> SnapshotAtTSchemaRepository.fromController(client, STORE));
+  }
+
+  @Test
+  public void testFromControllerThrowsOnDerivedSchemaError() {
+    // Write-compute (partial-update) merges depend on derived schemas; a derived fetch error must abort.
+    ControllerClient client = mock(ControllerClient.class);
+    when(client.getAllValueSchema(STORE)).thenReturn(valueSchemaResponse());
+    when(client.getAllReplicationMetadataSchemas(STORE)).thenReturn(emptyResponse());
+    MultiSchemaResponse derivedError = new MultiSchemaResponse();
+    derivedError.setError("derived boom");
+    when(client.getAllValueAndDerivedSchema(STORE)).thenReturn(derivedError);
+    assertThrows(VeniceException.class, () -> SnapshotAtTSchemaRepository.fromController(client, STORE));
+  }
+
+  @Test
   public void testUnsupportedMethodsThrow() {
     ControllerClient client = mock(ControllerClient.class);
     when(client.getAllValueSchema(STORE)).thenReturn(valueSchemaResponse());

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSparkMergeTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/snapshot/SnapshotAtTSparkMergeTest.java
@@ -1,0 +1,113 @@
+package com.linkedin.venice.hadoop.snapshot;
+
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
+import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
+import com.linkedin.venice.spark.SparkConstants;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SparkSession;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for {@link SnapshotAtTSparkMerge} on a local SparkSession: co-grouping a batch (key,value,rmd) frame
+ * with an RT frame and reducing per key must produce the same converged result as the single-process executor --
+ * RT wins over the batch base where it exists, batch-only keys keep their batch value -- proving the distributed
+ * merge is correct end to end through Spark.
+ */
+public class SnapshotAtTSparkMergeTest {
+  private static final String STRING_SCHEMA = "\"string\"";
+  private static final String STORE = "snapshot_spark_merge_test";
+
+  private SparkSession spark;
+  private VeniceAvroKafkaSerializer serializer;
+  private int rmdVersion;
+  private SnapshotAtTSchemaBundle bundle;
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    spark = SparkSession.builder().appName("snapshot-at-t-merge-test").master("local[2]").getOrCreate();
+    serializer = new VeniceAvroKafkaSerializer(STRING_SCHEMA);
+    Schema valueSchema = new Schema.Parser().parse(STRING_SCHEMA);
+    rmdVersion = RmdSchemaGenerator.getLatestVersion();
+    String rmdSchemaStr = RmdSchemaGenerator.generateMetadataSchema(valueSchema, rmdVersion).toString();
+
+    Map<Integer, String> valueSchemas = new HashMap<>();
+    valueSchemas.put(1, STRING_SCHEMA);
+    Map<Long, String> rmdSchemas = new HashMap<>();
+    rmdSchemas.put(SnapshotAtTSchemaRepository.key(1, rmdVersion), rmdSchemaStr);
+    bundle = SnapshotAtTSchemaBundle.of(STORE, valueSchemas, rmdSchemas, Collections.emptyMap(), rmdVersion);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void tearDown() {
+    if (spark != null) {
+      spark.stop();
+    }
+  }
+
+  @Test
+  public void testCogroupMergeRtWinsOverBatch() {
+    // Batch keys 1, 2, 3.
+    List<Row> batchRows = Arrays.asList(
+        RowFactory.create(serialize("1"), serialize("batch_1"), null),
+        RowFactory.create(serialize("2"), serialize("batch_2"), null),
+        RowFactory.create(serialize("3"), serialize("batch_3"), null));
+    Dataset<Row> batchDf = spark.createDataFrame(batchRows, SparkConstants.DEFAULT_SCHEMA);
+
+    // RT: key 1 PUT rt_1 @1000 colo 0, key 3 PUT rt_3 @2000 colo 1 (key 2 has no RT).
+    List<Row> rtRows = Arrays.asList(
+        SnapshotAtTSparkMerge.rtRecordToRow(put("1", "rt_1", 1000L, 0)),
+        SnapshotAtTSparkMerge.rtRecordToRow(put("3", "rt_3", 2000L, 1)));
+    Dataset<Row> rtDf = spark.createDataFrame(rtRows, SnapshotAtTSparkMerge.RT_SCHEMA);
+
+    Broadcast<SnapshotAtTSchemaBundle> broadcastBundle =
+        JavaSparkContext.fromSparkContext(spark.sparkContext()).broadcast(bundle);
+    Dataset<Row> merged = SnapshotAtTSparkMerge.merge(batchDf, rtDf, 1, broadcastBundle, rmdVersion, false);
+
+    Map<String, String> result = new HashMap<>();
+    for (Row row: merged.collectAsList()) {
+      String key = deserialize(row.getAs("key"));
+      byte[] value = row.getAs("value");
+      result.put(key, value == null ? null : deserialize(value));
+    }
+
+    assertEquals(result.size(), 3);
+    assertEquals(result.get("1"), "rt_1"); // RT wins over the batch base
+    assertEquals(result.get("2"), "batch_2"); // batch-only key keeps its batch value
+    assertEquals(result.get("3"), "rt_3"); // RT wins
+  }
+
+  private byte[] serialize(String value) {
+    return serializer.serialize(null, value);
+  }
+
+  private String deserialize(byte[] bytes) {
+    return serializer.deserialize(null, bytes).toString();
+  }
+
+  private SnapshotAtTRtRecord put(String key, String value, long writeTimestamp, int coloId) {
+    return new SnapshotAtTRtRecord(
+        SnapshotAtTRtRecord.Op.PUT,
+        ByteBuffer.wrap(serialize(key)),
+        ByteBuffer.wrap(serialize(value)),
+        1,
+        -1,
+        writeTimestamp,
+        coloId);
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -2757,24 +2757,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       boolean incrementSequenceNumber,
       LeaderMetadataWrapper leaderMetadataWrapper,
       long logicalTs) {
-    return getKafkaMessageEnvelope(
-        messageType,
-        isEndOfSegment,
-        partition,
-        incrementSequenceNumber,
-        leaderMetadataWrapper,
-        logicalTs,
-        USE_WRITER_CLOCK_FOR_MESSAGE_TIMESTAMP);
-  }
-
-  KafkaMessageEnvelope getKafkaMessageEnvelope(
-      MessageType messageType,
-      boolean isEndOfSegment,
-      int partition,
-      boolean incrementSequenceNumber,
-      LeaderMetadataWrapper leaderMetadataWrapper,
-      long logicalTs,
-      long messageTimestamp) {
     // If single-threaded, the kafkaValue could be re-used (and clobbered). TODO: explore GC tuning later.
     KafkaMessageEnvelope kafkaValue = new KafkaMessageEnvelope();
     kafkaValue.messageType = messageType.getValue();
@@ -2789,8 +2771,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     } else {
       producerMetadata.messageSequenceNumber = currentSegment.getSequenceNumber();
     }
-    producerMetadata.messageTimestamp =
-        messageTimestamp == USE_WRITER_CLOCK_FOR_MESSAGE_TIMESTAMP ? time.getMilliseconds() : messageTimestamp;
+    producerMetadata.messageTimestamp = time.getMilliseconds();
     producerMetadata.logicalTimestamp = logicalTs;
     kafkaValue.producerMetadata = producerMetadata;
 
@@ -2807,6 +2788,33 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       kafkaValue.leaderMetadataFooter.upstreamMessageTimestamp = leaderMetadataWrapper.getUpstreamMessageTimestamp();
     }
 
+    return kafkaValue;
+  }
+
+  /**
+   * Builds the envelope via the overridable 6-arg {@link #getKafkaMessageEnvelope(MessageType, boolean, int,
+   * boolean, LeaderMetadataWrapper, long)} — so {@link VeniceWriter} subclasses that override it still participate
+   * on every send path — then pins the producer {@code messageTimestamp} when the caller supplied a non-sentinel
+   * value (snapshot-at-T's Start-Of-Push). Otherwise the writer-clock timestamp set by the 6-arg method stands.
+   */
+  KafkaMessageEnvelope getKafkaMessageEnvelope(
+      MessageType messageType,
+      boolean isEndOfSegment,
+      int partition,
+      boolean incrementSequenceNumber,
+      LeaderMetadataWrapper leaderMetadataWrapper,
+      long logicalTs,
+      long messageTimestamp) {
+    KafkaMessageEnvelope kafkaValue = getKafkaMessageEnvelope(
+        messageType,
+        isEndOfSegment,
+        partition,
+        incrementSequenceNumber,
+        leaderMetadataWrapper,
+        logicalTs);
+    if (messageTimestamp != USE_WRITER_CLOCK_FOR_MESSAGE_TIMESTAMP) {
+      kafkaValue.producerMetadata.messageTimestamp = messageTimestamp;
+    }
     return kafkaValue;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -229,6 +229,15 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   public static final long VENICE_DEFAULT_LOGICAL_TS = -1;
 
   /**
+   * Sentinel for the optional control-message {@code messageTimestamp} argument: when passed, the
+   * {@link ProducerMetadata#messageTimestamp} is stamped from the writer's own clock ({@link #time}) as usual.
+   * A real (non-sentinel) value lets a caller pin the timestamp — e.g. snapshot-at-T stamps the Start-Of-Push so
+   * the server's REWIND_FROM_SOP rewind is computed from a deterministic point, independent of how long the
+   * offline merge took.
+   */
+  private static final long USE_WRITER_CLOCK_FOR_MESSAGE_TIMESTAMP = -1;
+
+  /**
    * This sentinel value indicates that the venice samza apps have not provided the logical timestamp.
    */
   public static final long APP_DEFAULT_LOGICAL_TS = -2;
@@ -1496,6 +1505,29 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       CompressionStrategy compressionStrategy,
       Optional<ByteBuffer> optionalCompressionDictionary,
       Map<String, String> debugInfo) {
+    broadcastStartOfPush(
+        sorted,
+        chunked,
+        compressionStrategy,
+        optionalCompressionDictionary,
+        debugInfo,
+        USE_WRITER_CLOCK_FOR_MESSAGE_TIMESTAMP);
+  }
+
+  /**
+   * Same as {@link #broadcastStartOfPush(boolean, boolean, CompressionStrategy, Optional, Map)} but stamps the
+   * Start-Of-Push control message with the caller-supplied {@code startOfPushMessageTimestamp} instead of the
+   * writer's clock. The server computes a hybrid store's REWIND_FROM_SOP rewind start as
+   * {@code SOP messageTimestamp - rewindTimeInSeconds}, so pinning this timestamp lets a caller (snapshot-at-T)
+   * control the rewind start deterministically, independent of how long the push took to produce the SOP.
+   */
+  public void broadcastStartOfPush(
+      boolean sorted,
+      boolean chunked,
+      CompressionStrategy compressionStrategy,
+      Optional<ByteBuffer> optionalCompressionDictionary,
+      Map<String, String> debugInfo,
+      long startOfPushMessageTimestamp) {
     ControlMessage controlMessage = getEmptyControlMessage(ControlMessageType.START_OF_PUSH);
     StartOfPush startOfPush = new StartOfPush();
     startOfPush.sorted = sorted;
@@ -1503,7 +1535,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     startOfPush.compressionStrategy = compressionStrategy.getValue();
     startOfPush.compressionDictionary = optionalCompressionDictionary.orElse(null);
     controlMessage.controlMessageUnion = startOfPush;
-    broadcastControlMessage(controlMessage, debugInfo);
+    broadcastControlMessage(controlMessage, debugInfo, startOfPushMessageTimestamp);
     // Flush start of push message to avoid data message arrives before it.
     producerAdapter.flush();
   }
@@ -1801,6 +1833,32 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       LeaderMetadataWrapper leaderMetadataWrapper,
       long logicalTs,
       PubSubMessageHeaders pubSubMessageHeaders) {
+    return sendMessage(
+        keyProvider,
+        messageType,
+        payload,
+        isEndOfSegment,
+        partition,
+        callback,
+        updateDIV,
+        leaderMetadataWrapper,
+        logicalTs,
+        pubSubMessageHeaders,
+        USE_WRITER_CLOCK_FOR_MESSAGE_TIMESTAMP);
+  }
+
+  private CompletableFuture<PubSubProduceResult> sendMessage(
+      KeyProvider keyProvider,
+      MessageType messageType,
+      Object payload,
+      boolean isEndOfSegment,
+      int partition,
+      PubSubProducerCallback callback,
+      boolean updateDIV,
+      LeaderMetadataWrapper leaderMetadataWrapper,
+      long logicalTs,
+      PubSubMessageHeaders pubSubMessageHeaders,
+      long messageTimestamp) {
     synchronized (this.partitionLocks[partition]) {
       KafkaMessageEnvelopeProvider kafkaMessageEnvelopeProvider = () -> {
         KafkaMessageEnvelope kafkaValue = getKafkaMessageEnvelope(
@@ -1809,7 +1867,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
             partition,
             updateDIV,
             leaderMetadataWrapper,
-            logicalTs);
+            logicalTs,
+            messageTimestamp);
         kafkaValue.payloadUnion = payload;
         return kafkaValue;
       };
@@ -2261,10 +2320,24 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   private List<CompletableFuture<PubSubProduceResult>> broadcastControlMessage(
       ControlMessage controlMessage,
       Map<String, String> debugInfo) {
+    return broadcastControlMessage(controlMessage, debugInfo, USE_WRITER_CLOCK_FOR_MESSAGE_TIMESTAMP);
+  }
+
+  private List<CompletableFuture<PubSubProduceResult>> broadcastControlMessage(
+      ControlMessage controlMessage,
+      Map<String, String> debugInfo,
+      long messageTimestamp) {
     List<CompletableFuture<PubSubProduceResult>> partitionWriteFuture = new ArrayList<>();
     for (int partition = 0; partition < numberOfPartitions; partition++) {
-      partitionWriteFuture
-          .add(sendControlMessage(controlMessage, partition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER));
+      partitionWriteFuture.add(
+          sendControlMessage(
+              controlMessage,
+              partition,
+              debugInfo,
+              null,
+              DEFAULT_LEADER_METADATA_WRAPPER,
+              EmptyPubSubMessageHeaders.SINGLETON,
+              messageTimestamp));
     }
     logger.info(
         "Successfully broadcast {} Control Message for topic: {}",
@@ -2414,6 +2487,24 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       PubSubProducerCallback callback,
       LeaderMetadataWrapper leaderMetadataWrapper,
       PubSubMessageHeaders pubSubMessageHeaders) {
+    return sendControlMessage(
+        controlMessage,
+        partition,
+        debugInfo,
+        callback,
+        leaderMetadataWrapper,
+        pubSubMessageHeaders,
+        USE_WRITER_CLOCK_FOR_MESSAGE_TIMESTAMP);
+  }
+
+  public CompletableFuture<PubSubProduceResult> sendControlMessage(
+      ControlMessage controlMessage,
+      int partition,
+      Map<String, String> debugInfo,
+      PubSubProducerCallback callback,
+      LeaderMetadataWrapper leaderMetadataWrapper,
+      PubSubMessageHeaders pubSubMessageHeaders,
+      long messageTimestamp) {
     // Work around until we upgrade to a more modern Avro version which supports overriding the
     // String implementation.
     controlMessage.debugInfo = getDebugInfo(debugInfo);
@@ -2429,7 +2520,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
           true,
           leaderMetadataWrapper,
           VENICE_DEFAULT_LOGICAL_TS,
-          pubSubMessageHeaders);
+          pubSubMessageHeaders,
+          messageTimestamp);
     }
   }
 
@@ -2665,6 +2757,24 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       boolean incrementSequenceNumber,
       LeaderMetadataWrapper leaderMetadataWrapper,
       long logicalTs) {
+    return getKafkaMessageEnvelope(
+        messageType,
+        isEndOfSegment,
+        partition,
+        incrementSequenceNumber,
+        leaderMetadataWrapper,
+        logicalTs,
+        USE_WRITER_CLOCK_FOR_MESSAGE_TIMESTAMP);
+  }
+
+  KafkaMessageEnvelope getKafkaMessageEnvelope(
+      MessageType messageType,
+      boolean isEndOfSegment,
+      int partition,
+      boolean incrementSequenceNumber,
+      LeaderMetadataWrapper leaderMetadataWrapper,
+      long logicalTs,
+      long messageTimestamp) {
     // If single-threaded, the kafkaValue could be re-used (and clobbered). TODO: explore GC tuning later.
     KafkaMessageEnvelope kafkaValue = new KafkaMessageEnvelope();
     kafkaValue.messageType = messageType.getValue();
@@ -2679,7 +2789,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     } else {
       producerMetadata.messageSequenceNumber = currentSegment.getSequenceNumber();
     }
-    producerMetadata.messageTimestamp = time.getMilliseconds();
+    producerMetadata.messageTimestamp =
+        messageTimestamp == USE_WRITER_CLOCK_FOR_MESSAGE_TIMESTAMP ? time.getMilliseconds() : messageTimestamp;
     producerMetadata.logicalTimestamp = logicalTs;
     kafkaValue.producerMetadata = producerMetadata;
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -38,6 +38,7 @@ import static org.testng.Assert.fail;
 import com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask;
 import com.linkedin.davinci.kafka.consumer.LeaderProducerCallback;
 import com.linkedin.davinci.kafka.consumer.PartitionConsumptionState;
+import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.exceptions.RecordTooLargeException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.guid.HeartbeatGuidV3Generator;
@@ -85,6 +86,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -195,6 +197,63 @@ public class VeniceWriterUnitTest {
     assertEquals(
         ((Delete) actualValue2.payloadUnion).replicationMetadataPayload,
         WriterChunkingHelper.EMPTY_BYTE_BUFFER);
+  }
+
+  /**
+   * Snapshot-at-T needs the Start-Of-Push to carry a controlled producer timestamp so the server's
+   * REWIND_FROM_SOP rewind lands at a deterministic point regardless of how long the offline merge took. The
+   * timestamped overload must stamp exactly that value on the SOP control message, while the normal overload
+   * keeps using the writer's clock.
+   */
+  @Test(timeOut = TIMEOUT)
+  public void testBroadcastStartOfPushStampsCallerSuppliedTimestamp() {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    CompletableFuture mockedFuture = mock(CompletableFuture.class);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer("\"string\"");
+    VeniceWriterOptions options =
+        new VeniceWriterOptions.Builder("test_sop_timestamp").setKeyPayloadSerializer(serializer)
+            .setValuePayloadSerializer(serializer)
+            .setPartitioner(new DefaultVenicePartitioner())
+            .setTime(SystemTime.INSTANCE)
+            .setPartitionCount(1)
+            .build();
+
+    // The custom timestamp is a small, obviously-not-a-clock value so it is unambiguously the one we passed in.
+    long sopTimestamp = 12345L;
+    VeniceWriter<Object, Object, Object> timestampedWriter =
+        new VeniceWriter(options, VeniceProperties.empty(), mockedProducer);
+    timestampedWriter.broadcastStartOfPush(
+        false,
+        false,
+        CompressionStrategy.NO_OP,
+        Optional.empty(),
+        Collections.emptyMap(),
+        sopTimestamp);
+    assertEquals(
+        startOfPushMessageTimestamp(mockedProducer),
+        sopTimestamp,
+        "SOP must carry the caller-supplied producer messageTimestamp");
+
+    // The normal overload keeps using the writer's real clock (a current epoch-ms value, not the custom value).
+    clearInvocations(mockedProducer);
+    VeniceWriter<Object, Object, Object> defaultWriter =
+        new VeniceWriter(options, VeniceProperties.empty(), mockedProducer);
+    defaultWriter.broadcastStartOfPush(Collections.emptyMap());
+    long defaultSopTimestamp = startOfPushMessageTimestamp(mockedProducer);
+    assertTrue(defaultSopTimestamp > 1_000_000_000_000L, "Default SOP must use the writer's real clock");
+  }
+
+  private static long startOfPushMessageTimestamp(PubSubProducerAdapter mockedProducer) {
+    ArgumentCaptor<KafkaMessageEnvelope> kmeCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    verify(mockedProducer, atLeast(1)).sendMessage(any(), any(), any(), kmeCaptor.capture(), any(), any());
+    for (KafkaMessageEnvelope kme: kmeCaptor.getAllValues()) {
+      if (kme.messageType == MessageType.CONTROL_MESSAGE.getValue()
+          && ((ControlMessage) kme.payloadUnion).controlMessageType == ControlMessageType.START_OF_PUSH.getValue()) {
+        return kme.producerMetadata.messageTimestamp;
+      }
+    }
+    throw new AssertionError("No Start-Of-Push control message was produced");
   }
 
   @Test(timeOut = TIMEOUT)

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -90,6 +90,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.kafka.common.errors.TimeoutException;
@@ -242,6 +243,53 @@ public class VeniceWriterUnitTest {
     defaultWriter.broadcastStartOfPush(Collections.emptyMap());
     long defaultSopTimestamp = startOfPushMessageTimestamp(mockedProducer);
     assertTrue(defaultSopTimestamp > 1_000_000_000_000L, "Default SOP must use the writer's real clock");
+  }
+
+  /**
+   * A VeniceWriter subclass that overrides the public 6-arg getKafkaMessageEnvelope — as the forward-compatibility
+   * test writer (VeniceWriterWithNewerProtocol) does — must have its override invoked on the put() data path. The
+   * snapshot-at-T SOP-timestamp change threads an extra messageTimestamp argument; it must build through the
+   * overridable 6-arg method, not route the data path around it (which silently degraded the newer-protocol writer
+   * to a normal one and broke ConsumerIntegrationTest forward-compatibility).
+   */
+  @Test(timeOut = TIMEOUT)
+  public void testSubclassGetKafkaMessageEnvelopeOverrideIsUsedOnDataPath() {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    CompletableFuture mockedFuture = mock(CompletableFuture.class);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer("\"string\"");
+    VeniceWriterOptions options =
+        new VeniceWriterOptions.Builder("test_override_used").setKeyPayloadSerializer(serializer)
+            .setValuePayloadSerializer(serializer)
+            .setPartitioner(new DefaultVenicePartitioner())
+            .setTime(SystemTime.INSTANCE)
+            .setPartitionCount(1)
+            .build();
+    AtomicInteger overrideInvocations = new AtomicInteger();
+    VeniceWriter<String, String, byte[]> writer =
+        new VeniceWriter<String, String, byte[]>(options, VeniceProperties.empty(), mockedProducer) {
+          @Override
+          public KafkaMessageEnvelope getKafkaMessageEnvelope(
+              MessageType messageType,
+              boolean isEndOfSegment,
+              int partition,
+              boolean incrementSequenceNumber,
+              LeaderMetadataWrapper leaderMetadataWrapper,
+              long logicalTs) {
+            overrideInvocations.incrementAndGet();
+            return super.getKafkaMessageEnvelope(
+                messageType,
+                isEndOfSegment,
+                partition,
+                incrementSequenceNumber,
+                leaderMetadataWrapper,
+                logicalTs);
+          }
+        };
+    writer.put("k", "v", 1);
+    assertTrue(
+        overrideInvocations.get() > 0,
+        "The 6-arg getKafkaMessageEnvelope override must be invoked on the put() path");
   }
 
   private static long startOfPushMessageTimestamp(PubSubProducerAdapter mockedProducer) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/snapshot/SnapshotAtTPushIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/snapshot/SnapshotAtTPushIntegrationTest.java
@@ -11,6 +11,9 @@ import static org.testng.Assert.assertNotNull;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.compression.CompressorFactory;
+import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
@@ -52,6 +55,7 @@ import org.apache.avro.Schema;
 import org.apache.samza.system.SystemProducer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -194,8 +198,9 @@ public class SnapshotAtTPushIntegrationTest {
         IntegrationTestPushUtils.getVeniceWriterFactory(destBroker, producerFactory)
             .createVeniceWriter(new VeniceWriterOptions.Builder(versionTopic).build())) {
       veniceWriter.broadcastStartOfPush(false, Collections.emptyMap());
+      VeniceCompressor compressor = new CompressorFactory().getCompressor(CompressionStrategy.NO_OP);
       SnapshotAtTPushExecutor.Stats stats =
-          new SnapshotAtTPushExecutor().execute(veniceWriter, batchValuesByKey, 1, rtRecords, merger);
+          new SnapshotAtTPushExecutor().execute(veniceWriter, batchValuesByKey, 1, rtRecords, merger, compressor);
       assertEquals(stats.getTotalProduced(), 8, "Expected 8 merged records produced");
       veniceWriter.broadcastEndOfPush(Collections.emptyMap());
     }
@@ -231,13 +236,19 @@ public class SnapshotAtTPushIntegrationTest {
     }
   }
 
+  @DataProvider(name = "compressionStrategies")
+  public static Object[][] compressionStrategies() {
+    return new Object[][] { { CompressionStrategy.NO_OP }, { CompressionStrategy.ZSTD_WITH_DICT } };
+  }
+
   /**
-   * The same scenario driven end to end by a single {@link com.linkedin.venice.hadoop.VenicePushJob} run: the
-   * snapshot-at-T mode (enabled with a 0s threshold so it triggers on the store's 3600s rewind) reads the batch
-   * Avro input and both regions' RT, merges, and produces the new version.
+   * The same scenario driven end to end by a single {@link com.linkedin.venice.hadoop.VenicePushJob} run, for both
+   * NO_OP and ZSTD_WITH_DICT compression: the snapshot-at-T mode (enabled with a 0s threshold so it triggers on the
+   * store's 3600s rewind) reads the batch Avro input and both regions' RT, merges, compresses, and produces the new
+   * version.
    */
-  @Test(timeOut = 300_000)
-  public void testSnapshotAtTViaVenicePushJob() throws Exception {
+  @Test(timeOut = 300_000, dataProvider = "compressionStrategies")
+  public void testSnapshotAtTViaVenicePushJob(CompressionStrategy compressionStrategy) throws Exception {
     String storeName = Utils.getUniqueString("snapshot_at_t_vpj");
     int partitionCount = 2;
     TestUtils.assertCommand(parentControllerClient.createNewStore(storeName, "owner", STRING_SCHEMA, STRING_SCHEMA));
@@ -249,7 +260,8 @@ public class SnapshotAtTPushIntegrationTest {
                 .setPartitionCount(partitionCount)
                 .setReplicationFactor(1)
                 .setNativeReplicationEnabled(true)
-                .setActiveActiveReplicationEnabled(true)));
+                .setActiveActiveReplicationEnabled(true)
+                .setCompressionStrategy(compressionStrategy)));
     VersionCreationResponse v1 = TestUtils.assertCommand(parentControllerClient.emptyPush(storeName, "v1-init", 1000));
     TestUtils.waitForNonDeterministicPushCompletion(v1.getKafkaTopic(), parentControllerClient, 60, TimeUnit.SECONDS);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/snapshot/SnapshotAtTPushIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/snapshot/SnapshotAtTPushIntegrationTest.java
@@ -1,0 +1,251 @@
+package com.linkedin.venice.snapshot;
+
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTPushExecutor;
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRecordMerger;
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRtReader;
+import com.linkedin.venice.hadoop.snapshot.SnapshotAtTRtRecord;
+import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.ReadOnlySchemaRepository;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
+import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.writer.VeniceWriter;
+import com.linkedin.venice.writer.VeniceWriterOptions;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.Schema;
+import org.apache.samza.system.SystemProducer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * End-to-end multi-region test of the snapshot-at-T data plane: produce real-time data to TWO regions of an
+ * Active-Active hybrid store, then run the new-mode push (read both regions' RT, merge with a batch dataset via
+ * {@link SnapshotAtTRecordMerger}, produce the merged value + RMD to a new version with a shortened rewind), and
+ * validate the served data equals the correct merged result (the same state the traditional batch-push + full
+ * rewind would have produced).
+ */
+public class SnapshotAtTPushIntegrationTest {
+  private static final int NUMBER_OF_REGIONS = 2;
+  private static final String STRING_SCHEMA = "\"string\"";
+  private static final long REGION_0_TS = 1000L;
+  private static final long REGION_1_TS = 2000L;
+
+  private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegion;
+  private List<VeniceMultiClusterWrapper> childRegions;
+  private String clusterName;
+  private ControllerClient parentControllerClient;
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    VeniceMultiRegionClusterCreateOptions options =
+        new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(NUMBER_OF_REGIONS)
+            .numberOfClusters(1)
+            .numberOfParentControllers(1)
+            .numberOfChildControllers(1)
+            .numberOfServers(2)
+            .numberOfRouters(1)
+            .replicationFactor(1)
+            .forkServer(false)
+            .build();
+    multiRegion = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(options);
+    childRegions = multiRegion.getChildRegions();
+    clusterName = multiRegion.getClusterNames()[0];
+    parentControllerClient = new ControllerClient(clusterName, multiRegion.getControllerConnectString());
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void tearDown() {
+    Utils.closeQuietlyWithErrorLogged(parentControllerClient);
+    Utils.closeQuietlyWithErrorLogged(multiRegion);
+  }
+
+  @Test(timeOut = 300_000)
+  public void testSnapshotAtTMergeAcrossTwoRegions() throws Exception {
+    String storeName = Utils.getUniqueString("snapshot_at_t");
+    int partitionCount = 2;
+
+    // 1. Create an A/A hybrid store (string -> string).
+    TestUtils.assertCommand(parentControllerClient.createNewStore(storeName, "owner", STRING_SCHEMA, STRING_SCHEMA));
+    TestUtils.assertCommand(
+        parentControllerClient.updateStore(
+            storeName,
+            new UpdateStoreQueryParams().setHybridRewindSeconds(3600L)
+                .setHybridOffsetLagThreshold(2L)
+                .setPartitionCount(partitionCount)
+                .setReplicationFactor(1)
+                .setNativeReplicationEnabled(true)
+                .setActiveActiveReplicationEnabled(true)));
+
+    // Version 1 (empty push) to materialize the store version + RT topics, then wait for it to come online.
+    VersionCreationResponse v1 = TestUtils.assertCommand(parentControllerClient.emptyPush(storeName, "v1-init", 1000));
+    TestUtils.waitForNonDeterministicPushCompletion(v1.getKafkaTopic(), parentControllerClient, 60, TimeUnit.SECONDS);
+
+    StoreInfo storeInfo = TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
+    String rtTopicName = Utils.getRealTimeTopicName(storeInfo);
+
+    // 2. Produce RT to BOTH regions. Region 1's writes use a newer timestamp, so for the key both regions touch
+    // (key 5) region 1 wins under Active-Active conflict resolution.
+    SystemProducer region0Producer = IntegrationTestPushUtils.getSamzaProducerForStream(multiRegion, 0, storeName);
+    SystemProducer region1Producer = IntegrationTestPushUtils.getSamzaProducerForStream(multiRegion, 1, storeName);
+    try {
+      for (int k: new int[] { 3, 4, 5 }) {
+        IntegrationTestPushUtils
+            .sendStreamingRecord(region0Producer, storeName, Integer.toString(k), "r0_" + k, REGION_0_TS);
+      }
+      for (int k: new int[] { 5, 6, 7 }) {
+        IntegrationTestPushUtils
+            .sendStreamingRecord(region1Producer, storeName, Integer.toString(k), "r1_" + k, REGION_1_TS);
+      }
+    } finally {
+      region0Producer.stop();
+      region1Producer.stop();
+    }
+
+    // 3. Batch dataset: keys 1..8 all carry a batch value.
+    VeniceAvroKafkaSerializer stringSerializer = new VeniceAvroKafkaSerializer(STRING_SCHEMA);
+    Map<ByteBuffer, ByteBuffer> batchValuesByKey = new HashMap<>();
+    for (int k = 1; k <= 8; k++) {
+      batchValuesByKey.put(
+          ByteBuffer.wrap(stringSerializer.serialize(null, Integer.toString(k))),
+          ByteBuffer.wrap(stringSerializer.serialize(null, "batch_" + k)));
+    }
+
+    // 4. Read RT from both regions up to now (cutoff <= 0 => read to the current tail), tagging each region's
+    // records with its colo id.
+    SnapshotAtTRtReader rtReader = new SnapshotAtTRtReader();
+    List<SnapshotAtTRtRecord> rtRecords = new ArrayList<>();
+    for (int region = 0; region < NUMBER_OF_REGIONS; region++) {
+      PubSubBrokerWrapper broker = childRegions.get(region).getClusters().get(clusterName).getPubSubBrokerWrapper();
+      VeniceProperties consumerProps = brokerConsumerProps(broker);
+      rtRecords
+          .addAll(rtReader.readRegion(consumerProps, broker.getAddress(), rtTopicName, partitionCount, 0L, region));
+    }
+    // Sanity: 3 records from region 0 + 3 from region 1.
+    assertEquals(rtRecords.size(), 6, "Expected to read 6 RT records across both regions");
+
+    // 5. Request a new version with a short rewind override (the snapshot-at-T optimization), then produce the
+    // merged value + RMD to it with SOP/EOP.
+    int rmdVersion = RmdSchemaGenerator.getLatestVersion();
+    SnapshotAtTRecordMerger merger =
+        new SnapshotAtTRecordMerger(buildSchemaRepository(rmdVersion), storeName, rmdVersion, false);
+
+    VersionCreationResponse v2 = TestUtils.assertCommand(
+        parentControllerClient.requestTopicForWrites(
+            storeName,
+            1024 * 1024,
+            Version.PushType.BATCH,
+            Utils.getUniqueString("snapshot-at-t-push"),
+            false, // sendStartOfPush: we send SOP ourselves
+            false, // sorted
+            false,
+            java.util.Optional.empty(),
+            java.util.Optional.empty(),
+            java.util.Optional.empty(),
+            false,
+            5L, // rewindTimeInSecondsOverride: short rewind, the snapshot-at-T optimization
+            false,
+            null,
+            -1,
+            false,
+            -1));
+    String versionTopic = v2.getKafkaTopic();
+
+    PubSubBrokerWrapper destBroker = childRegions.get(0).getClusters().get(clusterName).getPubSubBrokerWrapper();
+    PubSubProducerAdapterFactory producerFactory = destBroker.getPubSubClientsFactory().getProducerAdapterFactory();
+    try (VeniceWriter<byte[], byte[], byte[]> veniceWriter =
+        IntegrationTestPushUtils.getVeniceWriterFactory(destBroker, producerFactory)
+            .createVeniceWriter(new VeniceWriterOptions.Builder(versionTopic).build())) {
+      veniceWriter.broadcastStartOfPush(false, Collections.emptyMap());
+      SnapshotAtTPushExecutor.Stats stats =
+          new SnapshotAtTPushExecutor().execute(veniceWriter, batchValuesByKey, 1, rtRecords, merger);
+      assertEquals(stats.getTotalProduced(), 8, "Expected 8 merged records produced");
+      veniceWriter.broadcastEndOfPush(Collections.emptyMap());
+    }
+
+    TestUtils.waitForNonDeterministicPushCompletion(versionTopic, parentControllerClient, 90, TimeUnit.SECONDS);
+
+    // 6. Validate the served data equals the correct merged result in each region.
+    Map<String, String> expected = new HashMap<>();
+    expected.put("1", "batch_1");
+    expected.put("2", "batch_2");
+    expected.put("3", "r0_3"); // region 0 RT wins over batch sentinel
+    expected.put("4", "r0_4");
+    expected.put("5", "r1_5"); // region 1 (ts 2000) wins over region 0 (ts 1000) and batch
+    expected.put("6", "r1_6");
+    expected.put("7", "r1_7");
+    expected.put("8", "batch_8");
+
+    for (VeniceMultiClusterWrapper region: childRegions) {
+      VeniceClusterWrapper cluster = region.getClusters().get(clusterName);
+      try (AvroGenericStoreClient<String, Object> client = ClientFactory.getAndStartGenericAvroClient(
+          ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(cluster.getRandomRouterURL()))) {
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
+          for (Map.Entry<String, String> entry: expected.entrySet()) {
+            Object value = client.get(entry.getKey()).get();
+            assertNotNull(value, "Key " + entry.getKey() + " missing in region " + region.getRegionName());
+            assertEquals(
+                value.toString(),
+                entry.getValue(),
+                "Key " + entry.getKey() + " wrong value in region " + region.getRegionName());
+          }
+        });
+      }
+    }
+  }
+
+  private VeniceProperties brokerConsumerProps(PubSubBrokerWrapper broker) {
+    Properties properties = new Properties();
+    properties.setProperty(KAFKA_BOOTSTRAP_SERVERS, broker.getAddress());
+    properties.putAll(PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(broker)));
+    return new VeniceProperties(properties);
+  }
+
+  /** A minimal schema repository over the store's value + RMD schemas, enough for the value-level merge. */
+  private ReadOnlySchemaRepository buildSchemaRepository(int rmdVersion) {
+    Schema valueSchema = new Schema.Parser().parse(STRING_SCHEMA);
+    Schema rmdSchema = RmdSchemaGenerator.generateMetadataSchema(valueSchema, rmdVersion);
+    ReadOnlySchemaRepository repository = mock(ReadOnlySchemaRepository.class);
+    when(repository.getValueSchema(anyString(), anyInt())).thenReturn(new SchemaEntry(1, valueSchema));
+    when(repository.getSupersetOrLatestValueSchema(anyString())).thenReturn(new SchemaEntry(1, valueSchema));
+    when(repository.getSupersetSchema(anyString())).thenReturn(new SchemaEntry(1, valueSchema));
+    when(repository.getReplicationMetadataSchema(anyString(), anyInt(), anyInt()))
+        .thenReturn(new RmdSchemaEntry(1, rmdVersion, rmdSchema));
+    return repository;
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/snapshot/SnapshotAtTPushIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/snapshot/SnapshotAtTPushIntegrationTest.java
@@ -143,6 +143,10 @@ public class SnapshotAtTPushIntegrationTest {
       region1Producer.stop();
     }
 
+    // Age the RT past the short rewind window (set to 5s on v2 below) so the served data reflects only the
+    // snapshot-at-T merge, not the server's post-EOP rewind re-applying the RT.
+    Utils.sleep(10_000L);
+
     // 3. Batch dataset: keys 1..8 all carry a batch value.
     VeniceAvroKafkaSerializer stringSerializer = new VeniceAvroKafkaSerializer(STRING_SCHEMA);
     Map<ByteBuffer, ByteBuffer> batchValuesByKey = new HashMap<>();
@@ -281,6 +285,11 @@ public class SnapshotAtTPushIntegrationTest {
       region1Producer.stop();
     }
 
+    // Let the RT writes age past the short rewind window the snapshot mode applies, so the served data comes
+    // purely from the snapshot-at-T merge and not from the server's post-EOP rewind re-applying the RT. If the
+    // merge were broken (RT not folded in), the served values would be the batch ones and the test would fail.
+    Utils.sleep(10_000L);
+
     // Batch Avro input: keys 1..100 -> "test_name_<k>".
     File inputDir = TestWriteUtils.getTempDataDirectory();
     TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir);
@@ -291,10 +300,19 @@ public class SnapshotAtTPushIntegrationTest {
     Properties vpjProps = IntegrationTestPushUtils.defaultVPJProps(multiRegion, inputDirPath, storeName);
     vpjProps.setProperty("snapshot.at.t.rewind.enabled", "true");
     vpjProps.setProperty("snapshot.at.t.min.rewind.threshold.seconds", "0");
-    vpjProps.setProperty("snapshot.at.t.rewind.buffer.seconds", "5");
+    vpjProps.setProperty("snapshot.at.t.rewind.buffer.seconds", "2");
     vpjProps.setProperty("snapshot.at.t.rt.region.brokers", "0=" + broker0 + ";1=" + broker1);
 
     IntegrationTestPushUtils.runVPJ(vpjProps, 2, parentControllerClient);
+
+    // Prove the snapshot-at-T mode actually triggered: v2's rewind was overridden to the short window (well
+    // below the store's 3600s). A normal push would have left it at 3600s. This is also why the RT, aged out
+    // above, is not re-applied by the rewind.
+    StoreInfo afterPush = TestUtils.assertCommand(parentControllerClient.getStore(storeName)).getStore();
+    long v2RewindSeconds = afterPush.getVersion(2).get().getHybridStoreConfig().getRewindTimeInSeconds();
+    org.testng.Assert.assertTrue(
+        v2RewindSeconds < 60,
+        "Snapshot-at-T should have shortened v2's rewind, but it is " + v2RewindSeconds + "s (store is 3600s)");
 
     Map<String, String> expected = new HashMap<>();
     expected.put("1", "test_name_1");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/snapshot/SnapshotAtTPushIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/snapshot/SnapshotAtTPushIntegrationTest.java
@@ -34,10 +34,12 @@ import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterOptions;
+import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -210,6 +212,87 @@ public class SnapshotAtTPushIntegrationTest {
     expected.put("6", "r1_6");
     expected.put("7", "r1_7");
     expected.put("8", "batch_8");
+
+    for (VeniceMultiClusterWrapper region: childRegions) {
+      VeniceClusterWrapper cluster = region.getClusters().get(clusterName);
+      try (AvroGenericStoreClient<String, Object> client = ClientFactory.getAndStartGenericAvroClient(
+          ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(cluster.getRandomRouterURL()))) {
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
+          for (Map.Entry<String, String> entry: expected.entrySet()) {
+            Object value = client.get(entry.getKey()).get();
+            assertNotNull(value, "Key " + entry.getKey() + " missing in region " + region.getRegionName());
+            assertEquals(
+                value.toString(),
+                entry.getValue(),
+                "Key " + entry.getKey() + " wrong value in region " + region.getRegionName());
+          }
+        });
+      }
+    }
+  }
+
+  /**
+   * The same scenario driven end to end by a single {@link com.linkedin.venice.hadoop.VenicePushJob} run: the
+   * snapshot-at-T mode (enabled with a 0s threshold so it triggers on the store's 3600s rewind) reads the batch
+   * Avro input and both regions' RT, merges, and produces the new version.
+   */
+  @Test(timeOut = 300_000)
+  public void testSnapshotAtTViaVenicePushJob() throws Exception {
+    String storeName = Utils.getUniqueString("snapshot_at_t_vpj");
+    int partitionCount = 2;
+    TestUtils.assertCommand(parentControllerClient.createNewStore(storeName, "owner", STRING_SCHEMA, STRING_SCHEMA));
+    TestUtils.assertCommand(
+        parentControllerClient.updateStore(
+            storeName,
+            new UpdateStoreQueryParams().setHybridRewindSeconds(3600L)
+                .setHybridOffsetLagThreshold(2L)
+                .setPartitionCount(partitionCount)
+                .setReplicationFactor(1)
+                .setNativeReplicationEnabled(true)
+                .setActiveActiveReplicationEnabled(true)));
+    VersionCreationResponse v1 = TestUtils.assertCommand(parentControllerClient.emptyPush(storeName, "v1-init", 1000));
+    TestUtils.waitForNonDeterministicPushCompletion(v1.getKafkaTopic(), parentControllerClient, 60, TimeUnit.SECONDS);
+
+    SystemProducer region0Producer = IntegrationTestPushUtils.getSamzaProducerForStream(multiRegion, 0, storeName);
+    SystemProducer region1Producer = IntegrationTestPushUtils.getSamzaProducerForStream(multiRegion, 1, storeName);
+    try {
+      for (int k: new int[] { 3, 4, 5 }) {
+        IntegrationTestPushUtils
+            .sendStreamingRecord(region0Producer, storeName, Integer.toString(k), "r0_" + k, REGION_0_TS);
+      }
+      for (int k: new int[] { 5, 6, 7 }) {
+        IntegrationTestPushUtils
+            .sendStreamingRecord(region1Producer, storeName, Integer.toString(k), "r1_" + k, REGION_1_TS);
+      }
+    } finally {
+      region0Producer.stop();
+      region1Producer.stop();
+    }
+
+    // Batch Avro input: keys 1..100 -> "test_name_<k>".
+    File inputDir = TestWriteUtils.getTempDataDirectory();
+    TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+
+    String broker0 = childRegions.get(0).getClusters().get(clusterName).getPubSubBrokerWrapper().getAddress();
+    String broker1 = childRegions.get(1).getClusters().get(clusterName).getPubSubBrokerWrapper().getAddress();
+    Properties vpjProps = IntegrationTestPushUtils.defaultVPJProps(multiRegion, inputDirPath, storeName);
+    vpjProps.setProperty("snapshot.at.t.rewind.enabled", "true");
+    vpjProps.setProperty("snapshot.at.t.min.rewind.threshold.seconds", "0");
+    vpjProps.setProperty("snapshot.at.t.rewind.buffer.seconds", "5");
+    vpjProps.setProperty("snapshot.at.t.rt.region.brokers", "0=" + broker0 + ";1=" + broker1);
+
+    IntegrationTestPushUtils.runVPJ(vpjProps, 2, parentControllerClient);
+
+    Map<String, String> expected = new HashMap<>();
+    expected.put("1", "test_name_1");
+    expected.put("2", "test_name_2");
+    expected.put("3", "r0_3");
+    expected.put("4", "r0_4");
+    expected.put("5", "r1_5");
+    expected.put("6", "r1_6");
+    expected.put("7", "r1_7");
+    expected.put("8", "test_name_8");
 
     for (VeniceMultiClusterWrapper region: childRegions) {
       VeniceClusterWrapper cluster = region.getClusters().get(clusterName);

--- a/internal/venice-test-common/test-shard-assignments.json
+++ b/internal/venice-test-common/test-shard-assignments.json
@@ -435,6 +435,9 @@
       "com.linkedin.venice.controller.migration.TestMigrationPushStrategyZKAccessor",
       "com.linkedin.venice.integration.utils.SystemExitPrevention",
       "com.linkedin.venice.controller.server.TestAdminSparkServerWithMultiServers"
+    ],
+    "86": [
+      "com.linkedin.venice.snapshot.SnapshotAtTPushIntegrationTest"
     ]
   }
 }


### PR DESCRIPTION
## Problem Statement

A full (BATCH) push to a hybrid store is not servable when the batch data finishes loading. After End-Of-Push, the new version replays the real-time topic from `(SOP or EOP) - rewindTimeInSeconds` up to the live tail before it can go online. For stores with a multi-day rewind, this replay dominates the push wall-clock and sits on the version-readiness critical path. On a representative A/A + write-compute store with a ~3-day rewind, the rewind measured at ~7 hours, ~84% of each push's wall-clock (two pushes × three fabrics).

A push that fixes a cutoff timestamp `T` and ships a batch dataset already current as of `T` would only need to rewind the short `[T, now]` tail. This PR adds the per-VPJ control knobs for that rewind-shortening. The offline merge that produces the combined dataset is a follow-up (see Solution).

## Solution

Adds per-push-job knobs that, for a hybrid full push, set the existing `rewindTimeInSecondsOverride` to `(now - T) + buffer` (reusing the controller's `handleRewindTimeOverride` path and `REWIND_FROM_SOP` semantics), gated by a threshold so it only triggers when the store's effective rewind is large enough to be worth it.

The gate (`maybeApplySnapshotAtTRewindOverride`) is skipped for incremental/KIF-repush jobs, non-hybrid stores, when an explicit rewind override is already set, or when the store's effective rewind is below the threshold.

Shortening the rewind is correct only when the batch dataset already incorporates real-time data up to `T`. The master flag defaults off and must remain off in production until the merge below is wired end to end, otherwise the shortened rewind would skip nearline writes between the offline cutoff and `T` (a data gap).

### Data plane: offline RT-to-batch merge core

`SnapshotAtTRecordMerger` is the correctness core that produces the merged dataset the shortened rewind relies on. It folds RT PUT/UPDATE/DELETE records onto the batch base by reusing the server's own `MergeConflictResolver` (`da-vinci-client` is already a `venice-push-job` dependency), and emits the merged value **and its RMD**, so the offline result equals what a server produces by replaying the same RT during rewind, including Active-Active field-level timestamps and write-compute partial updates. `seedFromBatch` establishes the batch-sentinel RMD (timestamp 0) exactly as a server stores batch data, so any real RT write folded in afterwards wins. Values are held as `byte[]` so a `ByteBuffer` position the resolver advances while reading inputs cannot corrupt a later operation.

The data plane is built around this engine:
- `SnapshotAtTRtReader` reads a region's RT topic from start to the current tail and normalizes each PUT/UPDATE/DELETE, tagging it with the region's colo id (so the merger does cross-region conflict resolution). Bytes are copied out of the consumed message immediately, since pooled consumer buffers are reused across polls.
- `SnapshotAtTPushExecutor` seeds the merger from the batch value per key, folds in all regions' RT records, and writes the merged value+RMD (or an RMD-carrying delete) via a `VeniceWriter`, which partitions each key itself.

This is wired into `VenicePushJob.run()` as a first-class mode: when the gate triggers, the job verifies the store is hybrid + Active-Active, reads the offline batch input in-process, reads each region's RT (per `snapshot.at.t.rt.region.brokers`), merges, compresses to the version's compression strategy, and produces the merged version through a single writer that owns SOP+data+EOP (so Data-Integrity-Validation stays consistent; the controller skips SOP for this mode). `SnapshotAtTSchemaRepository` supplies the store's real value/RMD/derived schemas to the merge. So a single `VenicePushJob` run performs the whole new-mode push, for `NO_OP` and `ZSTD_WITH_DICT` stores alike.

The remaining productionization is auto-discovering the per-region RT brokers from the controller's Active-Active source-fabric config (today they're passed via `snapshot.at.t.rt.region.brokers`).

### Code changes
- [x] Added new code behind a config. Configs and defaults:
  - `snapshot.at.t.rewind.enabled` (boolean, default `false`) — master switch
  - `snapshot.at.t.min.rewind.threshold.seconds` (long, default 1 day = 86400) — skip when the store's effective rewind is below this
  - `snapshot.at.t.cutoff.epoch.seconds` (long, default = start of push) — the cutoff `T`
  - `snapshot.at.t.rewind.buffer.seconds` (long, default 60) — gap-safety buffer
- [x] Introduced new log lines. Info-level, one per push decision (job setup, not a hot path), so no rate limiting needed.

### Concurrency-Specific Checks
- [x] No race conditions: the gate is a pure function over a single push job's `PushJobSetting`, run once during job setup; no shared mutable state.
- [x] No new synchronization, blocking calls, shared collections, or multi-threaded code is introduced.

## How was this PR tested?
- [x] New unit tests (control plane): gate applied (default cutoff and explicit past cutoff), threshold boundary, below-threshold skip, ineligible jobs (disabled / non-hybrid / incremental / repush / explicit-override), future-cutoff rejection.
- [x] New unit tests (merge core): value-level PUT (batch sentinel, RT write wins, stale write ignored), DELETE tombstone carrying RMD, and write-compute field-level partial update asserting the per-field RMD timestamp.
- [x] New integration test (control plane): `testSnapshotAtTRewindOverrideReachesControllerRequest` exercises config → gate → `createNewStoreVersion` and asserts the shortened rewind reaches `requestTopicForWrites`.
- [x] New integration tests (2-region A/A cluster), both passing (~48s each): `SnapshotAtTPushIntegrationTest` produces RT to **two regions** with logical timestamps (including a cross-region conflict key) and asserts every key's served value in both regions equals the correct merged result —
  - `testSnapshotAtTMergeAcrossTwoRegions` drives the data plane directly (request short-rewind version → read both regions' RT → merge → produce value+RMD → SOP/EOP);
  - `testSnapshotAtTViaVenicePushJob` drives it through a **single `VenicePushJob` run** with `snapshot.at.t.enabled=true` and a 0s threshold (so the mode triggers on the store's 3600s rewind) plus a batch Avro input.
- Ran locally — all pass: `./gradlew :clients:venice-push-job:test --tests "*VenicePushJobTest" --tests "*SnapshotAtTRecordMergerTest"` and `./gradlew :internal:venice-test-common:integrationTest --tests "*SnapshotAtTPushIntegrationTest"`.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. The new behavior is entirely behind `snapshot.at.t.rewind.enabled`, which defaults to `false`; existing pushes are unchanged.



VALIDATION_OVERRIDE: This PR combines the snapshot-at-T feature with its distributed-merge (#6) implementation, so the total added lines exceed the per-PR limit by design.
