### PR TITLE
[da-vinci][controller][pulsar][common] Concurrency fixes surfaced by flaky tests (split from #2624)

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -213,12 +213,16 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
    * @param waitForSubscribeCompletion when true, the returned future also waits for the underlying
    *        daVinciClient subscription future to complete (durable per-partition subscribe). When
    *        false, only the start latch (first message in pubSubMessages or START_TIMEOUT) gates the
-   *        returned future. Set true for {@link #seekToCheckpoint} and {@link #seekToTail} where
-   *        there is no backfill scan -- the user can safely block on the result without the
-   *        pubSubMessages capacity deadlock described below. Set false for {@link #start},
-   *        {@link #seekToBeginningOfPush}, and {@link #seekToTimestamps} where a full backfill scan
-   *        would otherwise deadlock against pubSubMessages capacity if the user blocks before
-   *        polling.
+   *        returned future. Set false for {@link #start}, {@link #seekToBeginningOfPush}, and
+   *        {@link #seekToTimestamps}, where a full backfill scan would deadlock against
+   *        pubSubMessages capacity if the user blocks on the future before polling. Set true for
+   *        {@link #seekToTail} (positions at LATEST, so no backfill) and {@link #seekToCheckpoint},
+   *        where durable subscribe on return is required for correctness: without it, callers that
+   *        produce immediately after {@code .get()} can miss events on partitions whose subscribe
+   *        had not finished. Note the trade-off for seekToCheckpoint: a checkpoint far behind the
+   *        current position triggers a backfill scan, and a caller that blocks on the returned
+   *        future without polling concurrently can still hit the pubSubMessages capacity deadlock.
+   *        Such callers should poll while the future is pending instead of blocking first.
    * @return CompletableFuture that represents the async initialization work
    */
   private synchronized CompletableFuture<Void> initializeAndSubscribe(
@@ -427,6 +431,10 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
     // yet finished subscribe -- the root cause behind
     // VersionSpecificCDCShutdownTest.testVersionSpecificCDCConsumerRestartWithinFlinkTimeout's
     // "Missing event for key X" flake (reproduced locally).
+    // Trade-off: if the checkpoints are far behind the current position, the resulting backfill
+    // scan can fill pubSubMessages, and a caller that blocks on this future without polling
+    // concurrently can deadlock against its capacity. Callers seeking to old checkpoints must
+    // poll while the future is pending (see initializeAndSubscribe Javadoc).
     CompletableFuture<Void> future =
         initializeAndSubscribe(partitions, ignore -> daVinciClient.seekToCheckpoint(checkpoints), true);
     maybeEnableSyntheticHeartbeats();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -210,11 +210,21 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
    *
    * @param partitions Partitions to subscribe to (empty set means all partitions)
    * @param subscriptionCall Function that takes subscribedPartitions and returns subscription future
+   * @param waitForSubscribeCompletion when true, the returned future also waits for the underlying
+   *        daVinciClient subscription future to complete (durable per-partition subscribe). When
+   *        false, only the start latch (first message in pubSubMessages or START_TIMEOUT) gates the
+   *        returned future. Set true for {@link #seekToCheckpoint} and {@link #seekToTail} where
+   *        there is no backfill scan -- the user can safely block on the result without the
+   *        pubSubMessages capacity deadlock described below. Set false for {@link #start},
+   *        {@link #seekToBeginningOfPush}, and {@link #seekToTimestamps} where a full backfill scan
+   *        would otherwise deadlock against pubSubMessages capacity if the user blocks before
+   *        polling.
    * @return CompletableFuture that represents the async initialization work
    */
   private synchronized CompletableFuture<Void> initializeAndSubscribe(
       Set<Integer> partitions,
-      Function<Set<Integer>, CompletableFuture<Void>> subscriptionCall) {
+      Function<Set<Integer>, CompletableFuture<Void>> subscriptionCall,
+      boolean waitForSubscribeCompletion) {
     Set<Integer> targetPartitions = new HashSet<>();
     boolean partitionsAdded = false;
     try {
@@ -294,7 +304,12 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
             subscribedPartitions);
       });
 
-      return startFuture;
+      // When waitForSubscribeCompletion=true (seekToCheckpoint, seekToTail) the caller expects
+      // subscribe to be durable on return: no backfill scan is in flight, so blocking on
+      // subscriptionFuture is safe. When false (start, seekToBeginningOfPush, seekToTimestamps),
+      // only the startLatch gates completion to avoid deadlocking against pubSubMessages
+      // capacity during a full backfill scan.
+      return waitForSubscribeCompletion ? CompletableFuture.allOf(startFuture, subscriptionFuture) : startFuture;
     } catch (Exception e) {
       if (isVersionSpecificClient && isStoreOrVersionNotFoundException(e)) {
         LOGGER.warn("Store or version no longer exists for store: {}. Marking as caught up.", storeName, e);
@@ -312,7 +327,8 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
 
   @Override
   public synchronized CompletableFuture<Void> start(Set<Integer> partitions) {
-    return initializeAndSubscribe(partitions, daVinciClient::subscribe);
+    // Full backfill scan; do not wait on subscribe completion to avoid pubSubMessages capacity deadlock.
+    return initializeAndSubscribe(partitions, daVinciClient::subscribe, false);
   }
 
   @Override
@@ -362,7 +378,8 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   }
 
   public CompletableFuture<Void> seekToBeginningOfPush(Set<Integer> partitions) {
-    return initializeAndSubscribe(partitions, daVinciClient::seekToBeginningOfPush);
+    // Full backfill from beginning; do not wait on subscribe completion to avoid pubSubMessages capacity deadlock.
+    return initializeAndSubscribe(partitions, daVinciClient::seekToBeginningOfPush, false);
   }
 
   public CompletableFuture<Void> seekToBeginningOfPush() {
@@ -378,7 +395,9 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   }
 
   public CompletableFuture<Void> seekToTail(Set<Integer> partitions) {
-    CompletableFuture<Void> future = initializeAndSubscribe(partitions, daVinciClient::seekToTail);
+    // Positions partitions at LATEST so there is no backfill scan; wait on subscribe completion
+    // so the returned .get() reflects a durable subscribe before the caller starts producing.
+    CompletableFuture<Void> future = initializeAndSubscribe(partitions, daVinciClient::seekToTail, true);
     // seekToTail positions all target partitions at LATEST, which is past EOP for batch stores.
     // Use subscribedPartitions if partitions was empty (meaning all), otherwise use the explicit set.
     eopReceivedPartitions.addAll(partitions.isEmpty() ? subscribedPartitions : partitions);
@@ -401,14 +420,24 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
       }
     }
 
+    // Wait on subscribe completion so seekToCheckpoint().get() returns only after every target
+    // partition is durably subscribed at its checkpointed position. Without this wait, the future
+    // resolved only on the start-latch (first message arrives or 60s timeout), and callers that
+    // produced new records immediately after .get() could miss the ones whose partitions had not
+    // yet finished subscribe -- the root cause behind
+    // VersionSpecificCDCShutdownTest.testVersionSpecificCDCConsumerRestartWithinFlinkTimeout's
+    // "Missing event for key X" flake (reproduced locally).
     CompletableFuture<Void> future =
-        initializeAndSubscribe(partitions, ignore -> daVinciClient.seekToCheckpoint(checkpoints));
+        initializeAndSubscribe(partitions, ignore -> daVinciClient.seekToCheckpoint(checkpoints), true);
     maybeEnableSyntheticHeartbeats();
     return future;
   }
 
   public CompletableFuture<Void> seekToTimestamps(Map<Integer, Long> timestamps) {
-    return initializeAndSubscribe(timestamps.keySet(), ignore -> daVinciClient.seekToTimestamps(timestamps));
+    // Conservative: timestamps may seek to an older position with backfill scan, so do not wait on
+    // subscribe completion (matches seekToBeginningOfPush). Callers needing durable subscribe should
+    // poll periodically rather than blocking on .get().
+    return initializeAndSubscribe(timestamps.keySet(), ignore -> daVinciClient.seekToTimestamps(timestamps), false);
   }
 
   public CompletableFuture<Void> seekToTimestamp(Long timestamp) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -100,7 +100,7 @@ public class PartitionConsumptionState {
   private volatile boolean completionReported;
   private boolean isSubscribed;
   private boolean isDataRecoveryCompleted;
-  private LeaderFollowerStateType leaderFollowerState;
+  private volatile LeaderFollowerStateType leaderFollowerState;
 
   /**
    * The VT produce future should be read/set by the same consumer thread during normal operation. Making it volatile

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3445,6 +3445,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       partitionConsumptionState.incrementProcessedRecordSizeSinceLastSync(recordSize);
     }
     /*
+     * Capture completion state before any call that may trigger a completion transition
+     * (reportIfCatchUpVersionTopicOffset or the ready-to-serve checker) so that we can
+     * detect the transition below and re-enable record-level metrics promptly.
+     */
+    boolean wasComplete = partitionConsumptionState.isComplete();
+    /*
      * Per-record path: pass forceCacheRefresh=false. The latch-held catch-up window can hold many
      * thousands of records; forcing a broker round-trip on each one would be a serious regression.
      * The cached latest position (TTL-bounded by server.source.topic.offset.check.interval.ms)
@@ -3456,8 +3462,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     long syncBytesInterval = getSyncBytesInterval(partitionConsumptionState);
     boolean recordsProcessedAboveSyncIntervalThreshold = (syncBytesInterval > 0
         && (partitionConsumptionState.getProcessedRecordSizeSinceLastSync() >= syncBytesInterval));
-    // Capture completion state before the ready-to-serve check so we can detect a transition.
-    boolean wasComplete = partitionConsumptionState.isComplete();
     getDefaultReadyToServeChecker().apply(partitionConsumptionState, recordsProcessedAboveSyncIntervalThreshold);
     // Re-evaluate record-level metrics only when the current partition just transitioned to complete, so that records
     // in the same batch as EOP get full metrics without waiting for the next loop cycle. The guard avoids repeatedly

--- a/integrations/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VenicePulsarSink.java
+++ b/integrations/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VenicePulsarSink.java
@@ -117,40 +117,54 @@ public class VenicePulsarSink implements Sink<GenericObject> {
       LOGGER.debug("Processing key: {}, value: {}", key, value);
     }
 
-    if (value == null) {
-      // here we are making it explicit, but "put(key, null) means DELETE in the API"
-      producer.delete(key).whenComplete((___, error) -> {
-        pendingRecordsCount.decrementAndGet();
-        if (LOGGER.isDebugEnabled()) {
-          LOGGER.debug("Deleted key: {}", key);
-        }
+    // Increment BEFORE scheduling the async callback so the callback's decrementAndGet() always
+    // sees a balanced pair (the prior order could let the callback fire and decrement the counter
+    // before this increment ran, leaving the count one short and breaking the throttle window).
+    // If producer.put/delete throws synchronously (e.g., key/schema validation in
+    // VeniceSystemProducer), the whenComplete callback never runs; decrement in the catch block
+    // so the counter doesn't stay inflated.
+    pendingRecordsCount.incrementAndGet();
+    try {
+      if (value == null) {
+        // here we are making it explicit, but "put(key, null) means DELETE in the API"
+        producer.delete(key).whenComplete((___, error) -> {
+          pendingRecordsCount.decrementAndGet();
+          if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Deleted key: {}", key);
+          }
 
-        if (error != null) {
-          LOGGER.error("Error deleting record with key {}", key, error);
-          flushException = error;
-          record.fail();
-        } else {
-          record.ack();
-        }
-      });
-    } else {
-      producer.put(key, value).whenComplete((___, error) -> {
-        pendingRecordsCount.decrementAndGet();
-        if (LOGGER.isDebugEnabled()) {
-          LOGGER.debug("Processed key: {}, value: {}", key, value);
-        }
+          if (error != null) {
+            LOGGER.error("Error deleting record with key {}", key, error);
+            flushException = error;
+            record.fail();
+          } else {
+            record.ack();
+          }
+        });
+      } else {
+        producer.put(key, value).whenComplete((___, error) -> {
+          pendingRecordsCount.decrementAndGet();
+          if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Processed key: {}, value: {}", key, value);
+          }
 
-        if (error != null) {
-          LOGGER.error("Error handling record with key {}", key, error);
-          flushException = error;
-          record.fail();
-        } else {
-          record.ack();
-        }
-      });
+          if (error != null) {
+            LOGGER.error("Error handling record with key {}", key, error);
+            flushException = error;
+            record.fail();
+          } else {
+            record.ack();
+          }
+        });
+      }
+    } catch (RuntimeException syncThrow) {
+      pendingRecordsCount.decrementAndGet();
+      LOGGER.error("Synchronous failure submitting record with key {}", key, syncThrow);
+      flushException = syncThrow;
+      record.fail();
+      throw syncThrow;
     }
 
-    pendingRecordsCount.incrementAndGet();
     maybeSubmitFlush();
   }
 
@@ -178,7 +192,7 @@ public class VenicePulsarSink implements Sink<GenericObject> {
     int sz = pendingRecordsCount.get();
     if (force || sz >= maxNumberUnflushedRecords || startTimeMillis - lastFlush > flushIntervalMs) {
       lastFlush = System.currentTimeMillis();
-      if (sz == 0) {
+      if (!force && sz == 0) {
         LOGGER.debug("Nothing to flush");
         return;
       }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -812,6 +812,11 @@ public class ControllerClient implements Closeable {
     R response = null;
 
     for (int currentAttempt = 1; currentAttempt <= totalAttempts; currentAttempt++) {
+      // Reset per-attempt state so a later successful retry is not masked by an earlier
+      // attempt's thrown exception. Without this, the exception/response from attempt N
+      // leaks into attempt N+1's success-check at the if() below.
+      exception = null;
+      response = null;
       try {
         response = request.apply(client);
       } catch (Exception e) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
@@ -65,7 +65,7 @@ public class HelixVeniceClusterResources implements VeniceResource {
   private final ClusterLockManager clusterLockManager;
   private final ReadWriteStoreRepository storeMetadataRepository;
   private final HelixExternalViewRepository routingDataRepository;
-  private HelixCustomizedViewOfflinePushRepository customizedViewRepo;
+  private volatile HelixCustomizedViewOfflinePushRepository customizedViewRepo;
   private final ReadWriteSchemaRepository schemaRepository;
   private final HelixStatusMessageChannel messageChannel;
   private final VeniceControllerClusterConfig config;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/LeakedPushStatusCleanUpService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/LeakedPushStatusCleanUpService.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -90,6 +91,16 @@ public class LeakedPushStatusCleanUpService extends AbstractVeniceService {
   public void stopInner() throws Exception {
     stop.set(true);
     cleanupThread.interrupt();
+    try {
+      cleanupThread.join(TimeUnit.SECONDS.toMillis(10));
+    } catch (InterruptedException e) {
+      // Restore the interrupt flag so the surrounding shutdown path can react if needed.
+      Thread.currentThread().interrupt();
+      LOGGER.warn("stopInner was interrupted while waiting for cleanup thread to terminate", e);
+    }
+    if (cleanupThread.isAlive()) {
+      LOGGER.warn("Cleanup thread did not terminate within 10s; it may still be running.");
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
Production-code half of #2624 — 7 files. These are real concurrency defects that flaky tests exposed; the test-side fixes are in #2852.

| File | Fix |
|------|-----|
| `PartitionConsumptionState` | `leaderFollowerState` made `volatile` for cross-thread visibility |
| `HelixVeniceClusterResources` | `customizedViewRepo` made `volatile` |
| `StoreIngestionTask` | capture completion state *before* calls that can trigger the completion transition, so record-level metrics re-enable in the same loop cycle |
| `VeniceChangelogConsumerDaVinciRecordTransformerImpl` | `seekToCheckpoint`/`seekToTail` now wait for durable subscribe before completing the returned future (root cause of `VersionSpecificCDCShutdownTest` "Missing event for key X"); backfill-scanning paths (`start`, `seekToBeginningOfPush`, `seekToTimestamps`) intentionally do not, to avoid the `pubSubMessages` capacity deadlock |
| `VenicePulsarSink` | increment `pendingRecordsCount` before the async callback can decrement it; decrement + fail on synchronous submit exceptions; `flush(force)` no longer short-circuits at count 0 |
| `ControllerClient` | reset per-attempt exception/response so a successful retry isn't masked by a prior attempt's exception |
| `LeakedPushStatusCleanUpService` | join cleanup thread (10s) on `stopInner` to prevent thread leak across tests |

Companion: #2852 (test-only fixes). The `build.gradle` retry removal from #2624 is excluded from both.

## Test plan
- [ ] CI green
🤖 Generated with [Claude Code](https://claude.com/claude-code)