### PR TITLE
[CI][build] Retry transient Gradle wrapper and dependency downloads

### DIFF
--- a/.github/actions/gradle-test-setup/action.yml
+++ b/.github/actions/gradle-test-setup/action.yml
@@ -43,8 +43,10 @@ runs:
           if ./gradlew --version; then
             exit 0
           fi
-          echo "Gradle wrapper bootstrap failed (attempt ${attempt}/3); retrying in $((attempt * 20))s..."
-          sleep $((attempt * 20))
+          if [ "$attempt" -lt 3 ]; then
+            echo "Gradle wrapper bootstrap failed (attempt ${attempt}/3); retrying in $((attempt * 20))s..."
+            sleep $((attempt * 20))
+          fi
         done
         echo "Gradle wrapper bootstrap failed after 3 attempts"
         exit 1

--- a/.github/actions/gradle-test-setup/action.yml
+++ b/.github/actions/gradle-test-setup/action.yml
@@ -32,6 +32,22 @@ runs:
       uses: gradle/actions/setup-gradle@v5
       with:
         add-job-summary: never
+    - name: Bootstrap Gradle wrapper with retry
+      # On a wrapper cache miss the distribution is fetched from services.gradle.org,
+      # which intermittently times out and kills the shard before any test runs
+      # (e.g. run 27256713265). Warm it up with retries so a transient timeout
+      # costs seconds instead of the whole job.
+      shell: bash
+      run: |
+        for attempt in 1 2 3; do
+          if ./gradlew --version; then
+            exit 0
+          fi
+          echo "Gradle wrapper bootstrap failed (attempt ${attempt}/3); retrying in $((attempt * 20))s..."
+          sleep $((attempt * 20))
+        done
+        echo "Gradle wrapper bootstrap failed after 3 attempts"
+        exit 1
     - name: Free up disk space in the background
       shell: bash
       run: |

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,10 @@
 org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g
+# Retry transient HTTP failures when resolving dependencies from remote repositories
+# (Maven Central et al.) instead of failing the build on the first timeout/reset.
+# Gradle's default is 3 attempts with 125ms initial backoff; CI shards fan out 80+
+# concurrent jobs, so give flaky mirrors more room: 5 attempts, 2s initial backoff
+# (exponential: 2s/4s/8s/16s).
+org.gradle.internal.repository.max.tentatives=5
+org.gradle.internal.repository.initial.backoff=2000


### PR DESCRIPTION
## Summary
Protects CI against transient download failures at the two layers where recent runs actually failed.

**Evidence:** in [run 27256713265](https://github.com/linkedin/venice/actions/runs/27256713265) (main, today), `IntegrationTests_2` failed before running a single test:
```
##[error]Exception in thread "main" java.io.IOException: Downloading from https://services.gradle.org/distributions/gradle-7.3-bin.zip failed: timeout
Caused by: java.net.SocketTimeoutException: Read timed out
```

## Changes
1. **`gradle-test-setup` composite action** — new "Bootstrap Gradle wrapper with retry" step: `./gradlew --version` with 3 attempts and 20s/40s backoff. On a wrapper cache miss, one flaky download now costs seconds instead of the whole shard. Covers every test workflow (E2E shards via `integration-test-run`, UnitTests-core, StaticAnalysis, Compatibility, FeatureMatrix).
2. **`gradle.properties`** — raise Gradle's internal HTTP repository retry from the default 3 attempts / 125ms initial backoff to **5 attempts / 2s initial backoff** (exponential), so transient Maven Central timeouts/resets during dependency resolution self-heal. (The wrapper `networkTimeout` property isn't available on Gradle 7.3, hence the step-level retry for layer 1.)

Deliberately **not** retrying the test execution step itself — that would mask flakies rather than surface them.

## Test plan
- [ ] CI green; "Bootstrap Gradle wrapper with retry" step visible in shard logs
🤖 Generated with [Claude Code](https://claude.com/claude-code)