### PR TITLE
[controller] Extract ParentVersionOrchestrator from VeniceParentHelix…

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ParentVersionOrchestrator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ParentVersionOrchestrator.java
@@ -1,0 +1,265 @@
+package com.linkedin.venice.controller;
+
+import static com.linkedin.venice.controller.kafka.consumer.AdminConsumptionTask.IGNORED_CURRENT_VERSION;
+import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
+
+import com.linkedin.venice.controller.kafka.protocol.admin.AdminOperation;
+import com.linkedin.venice.controller.kafka.protocol.admin.DeleteAllVersions;
+import com.linkedin.venice.controller.kafka.protocol.admin.DeleteOldVersion;
+import com.linkedin.venice.controller.kafka.protocol.enums.AdminMessageType;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.RepushInfo;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.controllerapi.VersionResponse;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStatus;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Orchestrates version-related operations on the parent controller. The public {@link Admin} API remains implemented by
+ * {@link VeniceParentHelixAdmin}; this class owns the extracted parent-specific version metadata behavior.
+ */
+class ParentVersionOrchestrator {
+  private static final Logger LOGGER = LogManager.getLogger(ParentVersionOrchestrator.class);
+
+  private final VeniceParentHelixAdmin parent;
+
+  ParentVersionOrchestrator(VeniceParentHelixAdmin parent) {
+    this.parent = parent;
+  }
+
+  int getCurrentVersion(String clusterName, String storeName) {
+    throw new VeniceUnsupportedOperationException(
+        "getCurrentVersion",
+        "Please use getCurrentVersionsForMultiColos in Parent controller.");
+  }
+
+  Map<String, Integer> getCurrentVersionsForMultiColos(String clusterName, String storeName) {
+    Map<String, ControllerClient> controllerClients = parent.getVeniceHelixAdmin().getControllerClientMap(clusterName);
+    return getCurrentVersionForMultiRegions(clusterName, storeName, controllerClients);
+  }
+
+  RepushInfo getRepushInfo(String clusterName, String storeName, Optional<String> fabricName) {
+    Map<String, ControllerClient> controllerClients = parent.getVeniceHelixAdmin().getControllerClientMap(clusterName);
+    String systemSchemaClusterName = parent.getMultiClusterConfigs().getSystemSchemaClusterName();
+    VeniceControllerClusterConfig systemSchemaClusterConfig =
+        parent.getMultiClusterConfigs().getControllerConfig(systemSchemaClusterName);
+
+    if (fabricName.isPresent()) {
+      StoreResponse response = controllerClients.get(fabricName.get()).getStore(storeName);
+      if (response.isError()) {
+        throw new VeniceException(
+            "Could not query store from colo: " + fabricName.get() + " for cluster: " + clusterName + ". "
+                + response.getError());
+      }
+      return RepushInfo.createRepushInfo(
+          response.getStore()
+              .getVersion(response.getStore().getCurrentVersion())
+              .orElseThrow(
+                  () -> new VeniceException(
+                      "Could not find current version " + response.getStore().getCurrentVersion() + " for store "
+                          + storeName + " in colo " + fabricName.get() + " for cluster: " + clusterName)),
+          response.getStore().getKafkaBrokerUrl(),
+          systemSchemaClusterConfig.getClusterToD2Map().get(systemSchemaClusterName),
+          systemSchemaClusterConfig.getChildControllerD2ZkHost(fabricName.get()));
+    }
+    // fabricName not present, get the largest version info among the child colos.
+    Map<String, Integer> currentVersionsMap =
+        getCurrentVersionForMultiRegions(clusterName, storeName, controllerClients);
+    int largestVersion = Integer.MIN_VALUE;
+    String colo = null;
+    for (Map.Entry<String, Integer> mapEntry: currentVersionsMap.entrySet()) {
+      if (mapEntry.getValue() > largestVersion) {
+        largestVersion = mapEntry.getValue();
+        colo = mapEntry.getKey();
+      }
+    }
+    // Before extraction, this no-fabric path still referred back to fabricName.get() in the largest-colo error path,
+    // which would throw because fabricName is absent here. Use the child colo selected from currentVersionsMap for both
+    // diagnostics and child-controller D2 lookup instead.
+    final String largestVersionColo = colo;
+    StoreResponse response = controllerClients.get(largestVersionColo).getStore(storeName);
+    if (response.isError()) {
+      throw new VeniceException(
+          "Could not query store from largest version colo: " + largestVersionColo + " for cluster: " + clusterName
+              + ". " + response.getError());
+    }
+    return RepushInfo.createRepushInfo(
+        response.getStore()
+            .getVersion(response.getStore().getCurrentVersion())
+            .orElseThrow(
+                () -> new VeniceException(
+                    "Could not find current version " + response.getStore().getCurrentVersion() + " for store "
+                        + storeName + " in largest version colo " + largestVersionColo + " for cluster: "
+                        + clusterName)),
+        response.getStore().getKafkaBrokerUrl(),
+        systemSchemaClusterConfig.getClusterToD2Map().get(systemSchemaClusterName),
+        systemSchemaClusterConfig.getChildControllerD2ZkHost(largestVersionColo));
+  }
+
+  Map<String, String> getFutureVersionsForMultiColos(String clusterName, String storeName) {
+    Map<String, ControllerClient> controllerClients = parent.getVeniceHelixAdmin().getControllerClientMap(clusterName);
+    return parent.getVeniceHelixAdmin()
+        .getFabricControllerClientProvider()
+        .queryAllRegions(
+            controllerClients,
+            clusterName,
+            5,
+            controllerClient -> controllerClient.getFutureVersions(clusterName, storeName),
+            response -> response.getStoreStatusMap().get(storeName),
+            String.valueOf(IGNORED_CURRENT_VERSION));
+  }
+
+  Map<String, String> getBackupVersionsForMultiColos(String clusterName, String storeName) {
+    Map<String, ControllerClient> controllerClients = parent.getVeniceHelixAdmin().getControllerClientMap(clusterName);
+    return parent.getVeniceHelixAdmin()
+        .getFabricControllerClientProvider()
+        .queryAllRegions(
+            controllerClients,
+            clusterName,
+            1,
+            controllerClient -> controllerClient.getBackupVersions(clusterName, storeName),
+            response -> response.getStoreStatusMap().get(storeName),
+            String.valueOf(IGNORED_CURRENT_VERSION));
+  }
+
+  int getFutureVersion(String clusterName, String storeName) {
+    return NON_EXISTING_VERSION;
+  }
+
+  int getBackupVersion(String clusterName, String storeName) {
+    return NON_EXISTING_VERSION;
+  }
+
+  Map<String, Integer> getCurrentVersionForMultiRegions(
+      String clusterName,
+      String storeName,
+      Map<String, ControllerClient> controllerClients) {
+    return parent.getVeniceHelixAdmin()
+        .getFabricControllerClientProvider()
+        .queryAllRegions(
+            controllerClients,
+            clusterName,
+            1,
+            controllerClient -> controllerClient.getStore(storeName),
+            response -> response.getStore().getCurrentVersion(),
+            IGNORED_CURRENT_VERSION);
+  }
+
+  List<Version> deleteAllVersionsInStore(String clusterName, String storeName) {
+    parent.acquireAdminMessageLock(clusterName, storeName);
+    try {
+      parent.getVeniceHelixAdmin().checkPreConditionForDeletion(clusterName, storeName);
+
+      DeleteAllVersions deleteAllVersions = (DeleteAllVersions) AdminMessageType.DELETE_ALL_VERSIONS.getNewInstance();
+      deleteAllVersions.clusterName = clusterName;
+      deleteAllVersions.storeName = storeName;
+      AdminOperation message = new AdminOperation();
+      message.operationType = AdminMessageType.DELETE_ALL_VERSIONS.getValue();
+      message.payloadUnion = deleteAllVersions;
+
+      parent.sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
+      return Collections.emptyList();
+    } finally {
+      parent.releaseAdminMessageLock(clusterName, storeName);
+    }
+  }
+
+  void deleteOldVersionInStore(String clusterName, String storeName, int versionNum) {
+    parent.acquireAdminMessageLock(clusterName, storeName);
+    try {
+      parent.getVeniceHelixAdmin().checkPreConditionForSingleVersionDeletion(clusterName, storeName, versionNum);
+
+      DeleteOldVersion deleteOldVersion = (DeleteOldVersion) AdminMessageType.DELETE_OLD_VERSION.getNewInstance();
+      deleteOldVersion.clusterName = clusterName;
+      deleteOldVersion.storeName = storeName;
+      deleteOldVersion.versionNum = versionNum;
+      AdminOperation message = new AdminOperation();
+      message.operationType = AdminMessageType.DELETE_OLD_VERSION.getValue();
+      message.payloadUnion = deleteOldVersion;
+
+      parent.sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
+    } finally {
+      parent.releaseAdminMessageLock(clusterName, storeName);
+    }
+  }
+
+  List<Version> versionsForStore(String clusterName, String storeName) {
+    return parent.getVeniceHelixAdmin().versionsForStore(clusterName, storeName);
+  }
+
+  void setStoreCurrentVersion(String clusterName, String storeName, int versionNumber) {
+    throw new VeniceUnsupportedOperationException(
+        "setStoreCurrentVersion",
+        "Please use set-version only on child controllers, "
+            + "setting version on parent is not supported, since the version list could be different fabric by fabric");
+  }
+
+  void setStoreLargestUsedVersion(String clusterName, String storeName, int versionNumber) {
+    throw new VeniceUnsupportedOperationException(
+        "setStoreLargestUsedVersion",
+        "This is only supported in the Child Controller.");
+  }
+
+  void setStoreLargestUsedRTVersion(String clusterName, String storeName, int versionNumber) {
+    throw new VeniceUnsupportedOperationException(
+        "setStoreLargestUsedRTVersion",
+        "This is only supported in the Child Controller.");
+  }
+
+  int getCurrentVersionInRegion(String clusterName, String storeName, String regionName) {
+    Map<String, ControllerClient> controllerClients = parent.getVeniceHelixAdmin().getControllerClientMap(clusterName);
+    ControllerClient regionClient = controllerClients.get(regionName);
+    if (regionClient == null) {
+      LOGGER.warn("No controller client for region: {} in cluster: {}", regionName, clusterName);
+      return -1;
+    }
+    StoreResponse response = regionClient.getStore(storeName);
+    if (response.isError()) {
+      LOGGER.warn(
+          "Failed to get store {} from region {} in cluster {}: {}",
+          storeName,
+          regionName,
+          clusterName,
+          response.getError());
+      return -1;
+    }
+    return response.getStore().getCurrentVersion();
+  }
+
+  void updateStoreVersionStatus(String clusterName, String storeName, int version, VersionStatus status) {
+    parent.getVeniceHelixAdmin().updateStoreVersionStatus(clusterName, storeName, version, status);
+  }
+
+  int getLargestUsedVersionFromStoreGraveyard(String clusterName, String storeName) {
+    Map<String, ControllerClient> childControllers = parent.getVeniceHelixAdmin().getControllerClientMap(clusterName);
+    int aggregatedLargestUsedVersionNumber = parent.getStoreGraveyard().getLargestUsedVersionNumber(storeName);
+    for (Map.Entry<String, ControllerClient> controller: childControllers.entrySet()) {
+      VersionResponse response = controller.getValue().getStoreLargestUsedVersion(clusterName, storeName);
+      if (response.getVersion() > aggregatedLargestUsedVersionNumber) {
+        aggregatedLargestUsedVersionNumber = response.getVersion();
+      }
+    }
+    return aggregatedLargestUsedVersionNumber;
+  }
+
+  int getLargestUsedVersion(String clusterName, String storeName) {
+    Map<String, ControllerClient> childControllers = parent.getVeniceHelixAdmin().getControllerClientMap(clusterName);
+    int aggregatedLargestUsedVersionNumber = parent.getVeniceHelixAdmin().getLargestUsedVersion(clusterName, storeName);
+    for (Map.Entry<String, ControllerClient> controller: childControllers.entrySet()) {
+      VersionResponse response = controller.getValue().getStoreLargestUsedVersion(clusterName, storeName);
+      if (response.getVersion() > aggregatedLargestUsedVersionNumber) {
+        aggregatedLargestUsedVersionNumber = response.getVersion();
+      }
+    }
+    return aggregatedLargestUsedVersionNumber;
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2238,13 +2238,6 @@ public class VeniceParentHelixAdmin implements Admin {
     return parentVersionOrchestrator.getBackupVersion(clusterName, storeName);
   }
 
-  Map<String, Integer> getCurrentVersionForMultiRegions(
-      String clusterName,
-      String storeName,
-      Map<String, ControllerClient> controllerClients) {
-    return parentVersionOrchestrator.getCurrentVersionForMultiRegions(clusterName, storeName, controllerClients);
-  }
-
   /**
    * @see Admin#deleteAllVersionsInStore(String, String)
    */
@@ -2412,11 +2405,6 @@ public class VeniceParentHelixAdmin implements Admin {
     } finally {
       releaseAdminMessageLock(clusterName, storeName);
     }
-  }
-
-  @FunctionalInterface
-  interface VersionProvider {
-    int getVersion(StoreInfo storeInfo);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.controller;
 
 import static com.linkedin.venice.controller.VeniceHelixAdmin.VERSION_ID_UNSET;
-import static com.linkedin.venice.controller.kafka.consumer.AdminConsumptionTask.IGNORED_CURRENT_VERSION;
 import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 import static com.linkedin.venice.meta.Version.VERSION_SEPARATOR;
 import static com.linkedin.venice.meta.VersionStatus.CREATED;
@@ -52,8 +51,6 @@ import com.linkedin.venice.controller.kafka.protocol.admin.AbortMigration;
 import com.linkedin.venice.controller.kafka.protocol.admin.AddVersion;
 import com.linkedin.venice.controller.kafka.protocol.admin.AdminOperation;
 import com.linkedin.venice.controller.kafka.protocol.admin.CreateStoragePersona;
-import com.linkedin.venice.controller.kafka.protocol.admin.DeleteAllVersions;
-import com.linkedin.venice.controller.kafka.protocol.admin.DeleteOldVersion;
 import com.linkedin.venice.controller.kafka.protocol.admin.DeleteStoragePersona;
 import com.linkedin.venice.controller.kafka.protocol.admin.DeleteStore;
 import com.linkedin.venice.controller.kafka.protocol.admin.DisableStoreRead;
@@ -102,7 +99,6 @@ import com.linkedin.venice.controllerapi.UpdateClusterConfigQueryParams;
 import com.linkedin.venice.controllerapi.UpdateDarkClusterConfigQueryParams;
 import com.linkedin.venice.controllerapi.UpdateStoragePersonaQueryParams;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
-import com.linkedin.venice.controllerapi.VersionResponse;
 import com.linkedin.venice.exceptions.AdminMessageConsumptionTimeoutException;
 import com.linkedin.venice.exceptions.AdminMessageTooLargeException;
 import com.linkedin.venice.exceptions.ConcurrentBatchPushException;
@@ -296,6 +292,7 @@ public class VeniceParentHelixAdmin implements Admin {
   private final LingeringStoreVersionChecker lingeringStoreVersionChecker;
 
   private final ParentSchemaOrchestrator parentSchemaOrchestrator;
+  private final ParentVersionOrchestrator parentVersionOrchestrator;
 
   private final IdentityParser identityParser;
   private final LogContext logContext;
@@ -472,6 +469,7 @@ public class VeniceParentHelixAdmin implements Admin {
         veniceHelixAdmin.getStoreSchemaManager(),
         writeComputeSchemaConverter,
         externalSupersetSchemaGenerator);
+    this.parentVersionOrchestrator = new ParentVersionOrchestrator(this);
     Class<IdentityParser> identityParserClass =
         ReflectUtils.loadClass(multiClusterConfigs.getCommonConfig().getIdentityParserClassName());
     this.identityParser = ReflectUtils.callConstructor(identityParserClass, new Class[0], new Object[0]);
@@ -2194,9 +2192,7 @@ public class VeniceParentHelixAdmin implements Admin {
    */
   @Override
   public int getCurrentVersion(String clusterName, String storeName) {
-    throw new VeniceUnsupportedOperationException(
-        "getCurrentVersion",
-        "Please use getCurrentVersionsForMultiColos in Parent controller.");
+    return parentVersionOrchestrator.getCurrentVersion(clusterName, storeName);
   }
 
   /**
@@ -2205,8 +2201,7 @@ public class VeniceParentHelixAdmin implements Admin {
    */
   @Override
   public Map<String, Integer> getCurrentVersionsForMultiColos(String clusterName, String storeName) {
-    Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
-    return getCurrentVersionForMultiRegions(clusterName, storeName, controllerClients);
+    return parentVersionOrchestrator.getCurrentVersionsForMultiColos(clusterName, storeName);
   }
 
   /**
@@ -2214,46 +2209,7 @@ public class VeniceParentHelixAdmin implements Admin {
    */
   @Override
   public RepushInfo getRepushInfo(String clusterName, String storeName, Optional<String> fabricName) {
-    Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
-    String systemSchemaClusterName = multiClusterConfigs.getSystemSchemaClusterName();
-    VeniceControllerClusterConfig systemSchemaClusterConfig =
-        multiClusterConfigs.getControllerConfig(systemSchemaClusterName);
-
-    if (fabricName.isPresent()) {
-      StoreResponse response = controllerClients.get(fabricName.get()).getStore(storeName);
-      if (response.isError()) {
-        throw new VeniceException(
-            "Could not query store from colo: " + fabricName.get() + " for cluster: " + clusterName + ". "
-                + response.getError());
-      }
-      return RepushInfo.createRepushInfo(
-          response.getStore().getVersion(response.getStore().getCurrentVersion()).get(),
-          response.getStore().getKafkaBrokerUrl(),
-          systemSchemaClusterConfig.getClusterToD2Map().get(systemSchemaClusterName),
-          systemSchemaClusterConfig.getChildControllerD2ZkHost(fabricName.get()));
-    }
-    // fabricName not present, get the largest version info among the child colos.
-    Map<String, Integer> currentVersionsMap =
-        getCurrentVersionForMultiRegions(clusterName, storeName, controllerClients);
-    int largestVersion = Integer.MIN_VALUE;
-    String colo = null;
-    for (Map.Entry<String, Integer> mapEntry: currentVersionsMap.entrySet()) {
-      if (mapEntry.getValue() > largestVersion) {
-        largestVersion = mapEntry.getValue();
-        colo = mapEntry.getKey();
-      }
-    }
-    StoreResponse response = controllerClients.get(colo).getStore(storeName);
-    if (response.isError()) {
-      throw new VeniceException(
-          "Could not query store from largest version colo: " + fabricName.get() + " for cluster: " + clusterName + ". "
-              + response.getError());
-    }
-    return RepushInfo.createRepushInfo(
-        response.getStore().getVersion((response.getStore().getCurrentVersion())).get(),
-        response.getStore().getKafkaBrokerUrl(),
-        systemSchemaClusterConfig.getClusterToD2Map().get(systemSchemaClusterName),
-        systemSchemaClusterConfig.getChildControllerD2ZkHost(colo));
+    return parentVersionOrchestrator.getRepushInfo(clusterName, storeName, fabricName);
   }
 
   /**
@@ -2261,28 +2217,12 @@ public class VeniceParentHelixAdmin implements Admin {
    */
   @Override
   public Map<String, String> getFutureVersionsForMultiColos(String clusterName, String storeName) {
-    Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
-    return getVeniceHelixAdmin().getFabricControllerClientProvider()
-        .queryAllRegions(
-            controllerClients,
-            clusterName,
-            5,
-            controllerClient -> controllerClient.getFutureVersions(clusterName, storeName),
-            response -> response.getStoreStatusMap().get(storeName),
-            String.valueOf(IGNORED_CURRENT_VERSION));
+    return parentVersionOrchestrator.getFutureVersionsForMultiColos(clusterName, storeName);
   }
 
   @Override
   public Map<String, String> getBackupVersionsForMultiColos(String clusterName, String storeName) {
-    Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
-    return getVeniceHelixAdmin().getFabricControllerClientProvider()
-        .queryAllRegions(
-            controllerClients,
-            clusterName,
-            1,
-            controllerClient -> controllerClient.getBackupVersions(clusterName, storeName),
-            response -> response.getStoreStatusMap().get(storeName),
-            String.valueOf(IGNORED_CURRENT_VERSION));
+    return parentVersionOrchestrator.getBackupVersionsForMultiColos(clusterName, storeName);
   }
 
   /**
@@ -2290,26 +2230,19 @@ public class VeniceParentHelixAdmin implements Admin {
    */
   @Override
   public int getFutureVersion(String clusterName, String storeName) {
-    return NON_EXISTING_VERSION;
+    return parentVersionOrchestrator.getFutureVersion(clusterName, storeName);
   }
 
   @Override
   public int getBackupVersion(String clusterName, String storeName) {
-    return NON_EXISTING_VERSION;
+    return parentVersionOrchestrator.getBackupVersion(clusterName, storeName);
   }
 
   Map<String, Integer> getCurrentVersionForMultiRegions(
       String clusterName,
       String storeName,
       Map<String, ControllerClient> controllerClients) {
-    return getVeniceHelixAdmin().getFabricControllerClientProvider()
-        .queryAllRegions(
-            controllerClients,
-            clusterName,
-            1,
-            controllerClient -> controllerClient.getStore(storeName),
-            response -> response.getStore().getCurrentVersion(),
-            IGNORED_CURRENT_VERSION);
+    return parentVersionOrchestrator.getCurrentVersionForMultiRegions(clusterName, storeName, controllerClients);
   }
 
   /**
@@ -2317,22 +2250,7 @@ public class VeniceParentHelixAdmin implements Admin {
    */
   @Override
   public List<Version> deleteAllVersionsInStore(String clusterName, String storeName) {
-    acquireAdminMessageLock(clusterName, storeName);
-    try {
-      getVeniceHelixAdmin().checkPreConditionForDeletion(clusterName, storeName);
-
-      DeleteAllVersions deleteAllVersions = (DeleteAllVersions) AdminMessageType.DELETE_ALL_VERSIONS.getNewInstance();
-      deleteAllVersions.clusterName = clusterName;
-      deleteAllVersions.storeName = storeName;
-      AdminOperation message = new AdminOperation();
-      message.operationType = AdminMessageType.DELETE_ALL_VERSIONS.getValue();
-      message.payloadUnion = deleteAllVersions;
-
-      sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
-      return Collections.emptyList();
-    } finally {
-      releaseAdminMessageLock(clusterName, storeName);
-    }
+    return parentVersionOrchestrator.deleteAllVersionsInStore(clusterName, storeName);
   }
 
   /**
@@ -2340,22 +2258,7 @@ public class VeniceParentHelixAdmin implements Admin {
    */
   @Override
   public void deleteOldVersionInStore(String clusterName, String storeName, int versionNum) {
-    acquireAdminMessageLock(clusterName, storeName);
-    try {
-      getVeniceHelixAdmin().checkPreConditionForSingleVersionDeletion(clusterName, storeName, versionNum);
-
-      DeleteOldVersion deleteOldVersion = (DeleteOldVersion) AdminMessageType.DELETE_OLD_VERSION.getNewInstance();
-      deleteOldVersion.clusterName = clusterName;
-      deleteOldVersion.storeName = storeName;
-      deleteOldVersion.versionNum = versionNum;
-      AdminOperation message = new AdminOperation();
-      message.operationType = AdminMessageType.DELETE_OLD_VERSION.getValue();
-      message.payloadUnion = deleteOldVersion;
-
-      sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
-    } finally {
-      releaseAdminMessageLock(clusterName, storeName);
-    }
+    parentVersionOrchestrator.deleteOldVersionInStore(clusterName, storeName, versionNum);
   }
 
   /**
@@ -2363,7 +2266,7 @@ public class VeniceParentHelixAdmin implements Admin {
    */
   @Override
   public List<Version> versionsForStore(String clusterName, String storeName) {
-    return getVeniceHelixAdmin().versionsForStore(clusterName, storeName);
+    return parentVersionOrchestrator.versionsForStore(clusterName, storeName);
   }
 
   /**
@@ -2403,10 +2306,7 @@ public class VeniceParentHelixAdmin implements Admin {
    */
   @Override
   public void setStoreCurrentVersion(String clusterName, String storeName, int versionNumber) {
-    throw new VeniceUnsupportedOperationException(
-        "setStoreCurrentVersion",
-        "Please use set-version only on child controllers, "
-            + "setting version on parent is not supported, since the version list could be different fabric by fabric");
+    parentVersionOrchestrator.setStoreCurrentVersion(clusterName, storeName, versionNumber);
   }
 
   @Override
@@ -2754,9 +2654,7 @@ public class VeniceParentHelixAdmin implements Admin {
    */
   @Override
   public void setStoreLargestUsedVersion(String clusterName, String storeName, int versionNumber) {
-    throw new VeniceUnsupportedOperationException(
-        "setStoreLargestUsedVersion",
-        "This is only supported in the Child Controller.");
+    parentVersionOrchestrator.setStoreLargestUsedVersion(clusterName, storeName, versionNumber);
   }
 
   /**
@@ -2764,9 +2662,7 @@ public class VeniceParentHelixAdmin implements Admin {
    */
   @Override
   public void setStoreLargestUsedRTVersion(String clusterName, String storeName, int versionNumber) {
-    throw new VeniceUnsupportedOperationException(
-        "setStoreLargestUsedRTVersion",
-        "This is only supported in the Child Controller.");
+    parentVersionOrchestrator.setStoreLargestUsedRTVersion(clusterName, storeName, versionNumber);
   }
 
   /**
@@ -3090,28 +2986,12 @@ public class VeniceParentHelixAdmin implements Admin {
 
   @Override
   public int getCurrentVersionInRegion(String clusterName, String storeName, String regionName) {
-    Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
-    ControllerClient regionClient = controllerClients.get(regionName);
-    if (regionClient == null) {
-      LOGGER.warn("No controller client for region: {} in cluster: {}", regionName, clusterName);
-      return -1;
-    }
-    StoreResponse response = regionClient.getStore(storeName);
-    if (response.isError()) {
-      LOGGER.warn(
-          "Failed to get store {} from region {} in cluster {}: {}",
-          storeName,
-          regionName,
-          clusterName,
-          response.getError());
-      return -1;
-    }
-    return response.getStore().getCurrentVersion();
+    return parentVersionOrchestrator.getCurrentVersionInRegion(clusterName, storeName, regionName);
   }
 
   @Override
   public void updateStoreVersionStatus(String clusterName, String storeName, int version, VersionStatus status) {
-    getVeniceHelixAdmin().updateStoreVersionStatus(clusterName, storeName, version, status);
+    parentVersionOrchestrator.updateStoreVersionStatus(clusterName, storeName, version, status);
   }
 
   public void validateActiveActiveReplicationEnableConfigs(
@@ -4901,28 +4781,12 @@ public class VeniceParentHelixAdmin implements Admin {
 
   @Override
   public int getLargestUsedVersionFromStoreGraveyard(String clusterName, String storeName) {
-    Map<String, ControllerClient> childControllers = getVeniceHelixAdmin().getControllerClientMap(clusterName);
-    int aggregatedLargestUsedVersionNumber = getStoreGraveyard().getLargestUsedVersionNumber(storeName);
-    for (Map.Entry<String, ControllerClient> controller: childControllers.entrySet()) {
-      VersionResponse response = controller.getValue().getStoreLargestUsedVersion(clusterName, storeName);
-      if (response.getVersion() > aggregatedLargestUsedVersionNumber) {
-        aggregatedLargestUsedVersionNumber = response.getVersion();
-      }
-    }
-    return aggregatedLargestUsedVersionNumber;
+    return parentVersionOrchestrator.getLargestUsedVersionFromStoreGraveyard(clusterName, storeName);
   }
 
   @Override
   public int getLargestUsedVersion(String clusterName, String storeName) {
-    Map<String, ControllerClient> childControllers = getVeniceHelixAdmin().getControllerClientMap(clusterName);
-    int aggregatedLargestUsedVersionNumber = getVeniceHelixAdmin().getLargestUsedVersion(clusterName, storeName);
-    for (Map.Entry<String, ControllerClient> controller: childControllers.entrySet()) {
-      VersionResponse response = controller.getValue().getStoreLargestUsedVersion(clusterName, storeName);
-      if (response.getVersion() > aggregatedLargestUsedVersionNumber) {
-        aggregatedLargestUsedVersionNumber = response.getVersion();
-      }
-    }
-    return aggregatedLargestUsedVersionNumber;
+    return parentVersionOrchestrator.getLargestUsedVersion(clusterName, storeName);
   }
 
   /**

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestParentVersionOrchestrator.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestParentVersionOrchestrator.java
@@ -1,0 +1,151 @@
+package com.linkedin.venice.controller;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.controllerapi.VersionResponse;
+import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreGraveyard;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.TestUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link ParentVersionOrchestrator}, exercised through the public version API of
+ * {@link VeniceParentHelixAdmin} which delegates to the orchestrator. These tests were extracted from
+ * {@code TestVeniceParentHelixAdmin} when the parent-controller version metadata orchestration moved into
+ * {@link ParentVersionOrchestrator}.
+ */
+public class TestParentVersionOrchestrator extends AbstractTestVeniceParentHelixAdmin {
+  @BeforeMethod
+  public void setupTestCase() {
+    setupInternalMocks();
+    initializeParentAdmin(Optional.empty(), Optional.empty());
+  }
+
+  @AfterMethod
+  public void cleanupTestCase() {
+    super.cleanupTestCase();
+  }
+
+  @Test
+  public void testGetCurrentVersionInRegionReturnsTheRegionCurrentVersion() {
+    String storeName = "current-version-store";
+    StoreResponse response = new StoreResponse();
+    Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
+    store.setCurrentVersion(5);
+    response.setStore(StoreInfo.fromStore(store));
+    ControllerClient regionClient = mock(ControllerClient.class);
+    doReturn(response).when(regionClient).getStore(storeName);
+    controllerClients.put("region-with-version", regionClient);
+
+    assertEquals(parentAdmin.getCurrentVersionInRegion(clusterName, storeName, "region-with-version"), 5);
+  }
+
+  @Test
+  public void testGetCurrentVersionInRegionReturnsMinusOneWhenRegionClientIsMissing() {
+    // No controller client registered for the requested region -> the orchestrator returns -1 instead of NPEing.
+    assertEquals(parentAdmin.getCurrentVersionInRegion(clusterName, "any-store", "unknown-region"), -1);
+  }
+
+  @Test
+  public void testGetCurrentVersionInRegionReturnsMinusOneWhenRegionQueryErrors() {
+    String storeName = "errored-store";
+    StoreResponse errorResponse = new StoreResponse();
+    errorResponse.setError("Error querying store for testing.");
+    ControllerClient regionClient = mock(ControllerClient.class);
+    doReturn(errorResponse).when(regionClient).getStore(storeName);
+    controllerClients.put("region-error", regionClient);
+
+    assertEquals(parentAdmin.getCurrentVersionInRegion(clusterName, storeName, "region-error"), -1);
+  }
+
+  @Test
+  public void testGetLargestUsedVersionAggregatesMaxAcrossParentAndChildRegions() {
+    String storeName = "largest-used-version-store";
+    // Parent's own largest-used version is 3; the aggregate must climb to the highest child value.
+    doReturn(3).when(internalAdmin).getLargestUsedVersion(clusterName, storeName);
+    controllerClients.clear();
+    controllerClients.put("region-high", childWithLargestUsedVersion(storeName, 7)); // 7 > 3 -> picked up
+    controllerClients.put("region-low", childWithLargestUsedVersion(storeName, 2)); // 2 < 7 -> ignored
+
+    assertEquals(parentAdmin.getLargestUsedVersion(clusterName, storeName), 7);
+  }
+
+  @Test
+  public void testGetLargestUsedVersionFromStoreGraveyardAggregatesMaxAcrossGraveyardAndChildRegions() {
+    String storeName = "graveyard-version-store";
+    StoreGraveyard graveyard = mock(StoreGraveyard.class);
+    doReturn(graveyard).when(internalAdmin).getStoreGraveyard();
+    // The graveyard's largest-used version is 3; the aggregate must climb to the highest child value.
+    doReturn(3).when(graveyard).getLargestUsedVersionNumber(storeName);
+    controllerClients.clear();
+    controllerClients.put("region-high", childWithLargestUsedVersion(storeName, 9)); // 9 > 3 -> picked up
+    controllerClients.put("region-low", childWithLargestUsedVersion(storeName, 1)); // 1 < 9 -> ignored
+
+    assertEquals(parentAdmin.getLargestUsedVersionFromStoreGraveyard(clusterName, storeName), 9);
+  }
+
+  @Test
+  public void testGetCurrentVersionIsUnsupportedOnParent() {
+    Assert.expectThrows(
+        VeniceUnsupportedOperationException.class,
+        () -> parentAdmin.getCurrentVersion(clusterName, "any-store"));
+  }
+
+  @Test
+  public void testFutureAndBackupVersionAreNonExistingOnParent() {
+    assertEquals(parentAdmin.getFutureVersion(clusterName, "any-store"), Store.NON_EXISTING_VERSION);
+    assertEquals(parentAdmin.getBackupVersion(clusterName, "any-store"), Store.NON_EXISTING_VERSION);
+  }
+
+  @Test
+  public void testSetStoreCurrentVersionIsUnsupportedOnParent() {
+    Assert.expectThrows(
+        VeniceUnsupportedOperationException.class,
+        () -> parentAdmin.setStoreCurrentVersion(clusterName, "any-store", 1));
+  }
+
+  @Test
+  public void testSetStoreLargestUsedVersionIsUnsupportedOnParent() {
+    Assert.expectThrows(
+        VeniceUnsupportedOperationException.class,
+        () -> parentAdmin.setStoreLargestUsedVersion(clusterName, "any-store", 1));
+  }
+
+  @Test
+  public void testSetStoreLargestUsedRTVersionIsUnsupportedOnParent() {
+    Assert.expectThrows(
+        VeniceUnsupportedOperationException.class,
+        () -> parentAdmin.setStoreLargestUsedRTVersion(clusterName, "any-store", 1));
+  }
+
+  @Test
+  public void testVersionsForStoreDelegatesToInternalAdmin() {
+    String storeName = "versions-store";
+    List<Version> versions = Collections.emptyList();
+    doReturn(versions).when(internalAdmin).versionsForStore(clusterName, storeName);
+
+    assertEquals(parentAdmin.versionsForStore(clusterName, storeName), versions);
+  }
+
+  private ControllerClient childWithLargestUsedVersion(String storeName, int version) {
+    ControllerClient client = mock(ControllerClient.class);
+    VersionResponse versionResponse = new VersionResponse();
+    versionResponse.setVersion(version);
+    doReturn(versionResponse).when(client).getStoreLargestUsedVersion(clusterName, storeName);
+    return client;
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2696,8 +2696,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   public void testGetCurrentVersionForMultiRegions() {
     int regionCount = 4;
     Map<String, ControllerClient> controllerClientMap = prepareForCurrentVersionTest(regionCount);
+    ParentVersionOrchestrator versionOrchestrator = new ParentVersionOrchestrator(parentAdmin);
     Map<String, Integer> result =
-        parentAdmin.getCurrentVersionForMultiRegions(clusterName, "test", controllerClientMap);
+        versionOrchestrator.getCurrentVersionForMultiRegions(clusterName, "test", controllerClientMap);
     assertEquals(result.size(), regionCount, "Should return the current versions for all regions.");
     for (int i = 0; i < regionCount; i++) {
       assertEquals(result.get("region" + i).intValue(), i);
@@ -2714,8 +2715,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(errorResponse).when(errorClient).getStore(anyString());
     controllerClientMap.put("region4", errorClient);
 
+    ParentVersionOrchestrator versionOrchestrator = new ParentVersionOrchestrator(parentAdmin);
     Map<String, Integer> result =
-        parentAdmin.getCurrentVersionForMultiRegions(clusterName, "test", controllerClientMap);
+        versionOrchestrator.getCurrentVersionForMultiRegions(clusterName, "test", controllerClientMap);
     assertEquals(result.size(), regionCount, "Should return the current versions for all regions.");
     for (int i = 0; i < regionCount - 1; i++) {
       assertEquals(result.get("region" + i).intValue(), i);


### PR DESCRIPTION
## Problem Statement

`VeniceParentHelixAdmin` is a large class that implements the entire parent-side `Admin` API in one place. Parent-controller version metadata operations (current/future/backup version lookups, largest-used-version aggregation, version deletion, and the various parent-unsupported overrides) were interleaved with the rest of the admin surface, which makes the class hard to navigate, reason about, and unit-test in isolation.

While extracting this logic, an existing bug surfaced in `getRepushInfo`: on the no-fabric (largest-version-colo) path, the error branch and `RepushInfo` construction referred back to `fabricName.get()` even though `fabricName` is absent on that path. That call would throw `NoSuchElementException` instead of producing the intended diagnostic, masking the real error.

Theomachy, ~-150LOC.

## Solution

- Extract all parent version metadata behavior from `VeniceParentHelixAdmin` into a new package-private `ParentVersionOrchestrator`. `VeniceParentHelixAdmin` still implements the public `Admin` API and now delegates each version method to the orchestrator, so external behavior is unchanged. This mirrors the recently extracted `ParentSchemaOrchestrator` / `StoreSchemaService` pattern.
- Fix the `getRepushInfo` no-fabric error path to use the child colo selected from `currentVersionsMap` (for both the error diagnostics and the child-controller D2 lookup) instead of the absent `fabricName`. Also use `orElseThrow(...)` with a descriptive message when the current version can't be found, replacing the bare `.get()`.
- Remove the now production-dead `getCurrentVersionForMultiRegions` pass-through shim on `VeniceParentHelixAdmin` (the orchestrator owns its own copy) and the unused `VersionProvider` functional interface.
- Add `TestParentVersionOrchestrator` and migrate the two `getCurrentVersionForMultiRegions` tests to drive `ParentVersionOrchestrator` directly.

This is a pure structural refactor plus one bug fix — no behavioral change to the public API and no new configs or logging.

  ###  Code changes                                                                                                                                                                                                                
  - [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.                                                                                                            
  - [ ] Introduced new **log lines**.                                                                                                                                                                                              
    - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.                                                                                                                                                
                                                                                                                                                                                                                                   
  ###  **Concurrency-Specific Checks**                                                                                                                                                                                             
  Both reviewer and PR author to verify                                                                                                                                                                                            
  - [x] Code has **no race conditions** or **thread safety issues**. (Existing `acquireAdminMessageLock`/`releaseAdminMessageLock` try/finally blocks were moved verbatim into the orchestrator.)                                  
  - [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.                                                                                                                              
  - [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.                                                                                                                    
  - [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).                                                                                                                         
  - [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.                                                                                                                             
                                                                                                                                                                                                                                   
  ## How was this PR tested?                                                                                                                                                                                                       
                                                                                                                                                                                                                                   
  - [x] New unit tests added. (`TestParentVersionOrchestrator`: current-version-in-region happy/missing-client/error paths, largest-used-version aggregation across child regions and the store graveyard, and the unsupported-op /
  non-existing-version delegations.)                                                                                                                                                                                               
  - [ ] New integration tests added.                                                                                                                                                                                               
  - [x] Modified or extended existing tests. (`TestVeniceParentHelixAdmin` updated to drive `ParentVersionOrchestrator` directly for the multi-region tests.)                                                                      
  - [x] Verified backward compatibility (if applicable). (Public `Admin` API and all delegating method signatures unchanged.)                                                                                                      
                                                                                                                                                                                                                                   
  ## Does this PR introduce any user-facing or breaking changes?                                                                                                                                                                   
  - [x] No. You can skip the rest of this section.                                                                                                                                                                                 
  - [ ] Yes. Clearly explain the behavior change and its impact.   