### PR TITLE
[venice-client-common] Add VeniceSchemaProjector for superset-to-writer schema projection

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/projection/VeniceSchemaProjector.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/projection/VeniceSchemaProjector.java
@@ -53,6 +53,12 @@ public class VeniceSchemaProjector {
   /**
    * Project a Replication Metadata (RMD) record down to the writer's RMD schema, in lockstep with the value.
    *
+   * <p>Projection only runs when write compute is <em>not</em> enabled. In that mode the RMD timestamp is always a
+   * whole-record (value-level) {@code long}, so projection reduces to copying the {@code long} timestamp and the
+   * value-independent replication_checkpoint_vector onto a record under the target RMD schema. A per-field timestamp
+   * only arises with write compute (partial updates), where the corresponding superset schema is used and no
+   * projection is needed; encountering one here therefore indicates a misuse and is rejected.</p>
+   *
    * @param srcRmd the source RMD record (generated against the superset value schema), or {@code null} if the record
    *               carries no RMD (e.g. a batch record in a hybrid store)
    * @param targetRmdSchema the writer's RMD schema (generated against the writer value schema)
@@ -75,27 +81,14 @@ public class VeniceSchemaProjector {
     Schema.Field targetTimestampField = targetRmdSchema.getField(TIMESTAMP_FIELD_NAME);
     Object srcTimestamp = srcRmd.get(TIMESTAMP_FIELD_NAME);
     if (RmdUtils.getRmdTimestampType(srcTimestamp) == RmdTimestampType.PER_FIELD_TIMESTAMP) {
-      // Per-field timestamp record: rebuild against the target's per-field schema. The timestamp field is a
-      // union[long, perFieldRecord]; the per-field record is the second union branch.
-      GenericRecord srcPerField = (GenericRecord) srcTimestamp;
-      Schema targetPerFieldSchema = targetTimestampField.schema().getTypes().get(1);
-      GenericRecord targetPerField = new GenericData.Record(targetPerFieldSchema);
-      for (Schema.Field targetField: targetPerFieldSchema.getFields()) {
-        String fieldName = targetField.name();
-        if (srcPerField.getSchema().getField(fieldName) == null) {
-          // Invariant: a surviving value field must have a corresponding per-field RMD entry in the source.
-          throw new VeniceException(
-              "Per-field RMD entry '" + fieldName + "' is absent from the source RMD; source RMD does not cover the "
-                  + "writer schema's fields.");
-        }
-        targetPerField
-            .put(targetField.pos(), GenericData.get().deepCopy(targetField.schema(), srcPerField.get(fieldName)));
-      }
-      projected.put(targetTimestampField.pos(), targetPerField);
-    } else {
-      // Whole-record (value-level) long timestamp: copy as-is.
-      projected.put(targetTimestampField.pos(), srcTimestamp);
+      // Per-field timestamps only occur with write compute, where projection should never run (the superset schema is
+      // used instead). Reject rather than attempt to project a per-field RMD.
+      throw new VeniceException(
+          "Per-field timestamp RMD is not supported for schema projection; projection only applies to value-level "
+              + "(whole-record) timestamps. This indicates projection was attempted on a write-compute enabled store.");
     }
+    // Whole-record (value-level) long timestamp: set the long branch of the union as-is.
+    projected.put(targetTimestampField.pos(), srcTimestamp);
     return projected;
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/projection/VeniceSchemaProjector.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/projection/VeniceSchemaProjector.java
@@ -1,0 +1,101 @@
+package com.linkedin.venice.schema.projection;
+
+import static com.linkedin.venice.schema.rmd.RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.RmdConstants.TIMESTAMP_FIELD_NAME;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.schema.rmd.RmdTimestampType;
+import com.linkedin.venice.schema.rmd.RmdUtils;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+
+
+/**
+ * Projects a value record (and its Replication Metadata) that was serialized against a superset schema down to a
+ * chosen registered writer (target) schema.
+ *
+ * <p>The projection is a pure <em>structural drop</em>. The writer schema is guaranteed (by an upstream preflight
+ * subset check) to be a strict subset of the input schema: every field the writer declares exists in the input and
+ * is deeply, exactly equal; the input may only carry <em>extra top-level fields</em>. Projection therefore reduces
+ * to: build a record under the writer schema, copy each writer field's value from the input by exact name, and let
+ * the input's extra top-level fields fall away.</p>
+ */
+public class VeniceSchemaProjector {
+  /**
+   * Project a value record down to the writer value schema.
+   *
+   * @param src the source value record (serialized against the superset schema), or {@code null} for a tombstone
+   * @param writerValueSchema the chosen registered writer value schema
+   * @return a new record under {@code writerValueSchema}, or {@code null} if {@code src} is {@code null}
+   */
+  public GenericRecord projectValue(GenericRecord src, Schema writerValueSchema) {
+    if (src == null) {
+      // Tombstone (delete) - nothing to project.
+      return null;
+    }
+    Schema srcSchema = src.getSchema();
+    GenericRecord projected = new GenericData.Record(writerValueSchema);
+    for (Schema.Field writerField: writerValueSchema.getFields()) {
+      String fieldName = writerField.name();
+      if (srcSchema.getField(fieldName) == null) {
+        // Invariant: a strict-subset writer schema cannot declare a field absent from the input schema. The preflight
+        // subset check should already have rejected this; backstop it here.
+        throw new VeniceException(
+            "Writer value field '" + fieldName + "' is absent from the input value schema; writer schema is not a "
+                + "subset of the input schema.");
+      }
+      projected.put(writerField.pos(), GenericData.get().deepCopy(writerField.schema(), src.get(fieldName)));
+    }
+    return projected;
+  }
+
+  /**
+   * Project a Replication Metadata (RMD) record down to the writer's RMD schema, in lockstep with the value.
+   *
+   * @param srcRmd the source RMD record (generated against the superset value schema), or {@code null} if the record
+   *               carries no RMD (e.g. a batch record in a hybrid store)
+   * @param targetRmdSchema the writer's RMD schema (generated against the writer value schema)
+   * @return a new RMD record under {@code targetRmdSchema}, or {@code null} if {@code srcRmd} is {@code null}
+   */
+  public GenericRecord projectRmd(GenericRecord srcRmd, Schema targetRmdSchema) {
+    if (srcRmd == null) {
+      // A record may legitimately carry no RMD (e.g. a batch record coexisting with A/A records in a hybrid store).
+      // Mirror projectValue's tombstone handling: nothing to project, so the caller writes the record without RMD.
+      return null;
+    }
+    GenericRecord projected = new GenericData.Record(targetRmdSchema);
+
+    // replication_checkpoint_vector is value-independent; copy verbatim.
+    Schema.Field rcvField = targetRmdSchema.getField(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME);
+    projected.put(
+        rcvField.pos(),
+        GenericData.get().deepCopy(rcvField.schema(), srcRmd.get(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME)));
+
+    Schema.Field targetTimestampField = targetRmdSchema.getField(TIMESTAMP_FIELD_NAME);
+    Object srcTimestamp = srcRmd.get(TIMESTAMP_FIELD_NAME);
+    if (RmdUtils.getRmdTimestampType(srcTimestamp) == RmdTimestampType.PER_FIELD_TIMESTAMP) {
+      // Per-field timestamp record: rebuild against the target's per-field schema. The timestamp field is a
+      // union[long, perFieldRecord]; the per-field record is the second union branch.
+      GenericRecord srcPerField = (GenericRecord) srcTimestamp;
+      Schema targetPerFieldSchema = targetTimestampField.schema().getTypes().get(1);
+      GenericRecord targetPerField = new GenericData.Record(targetPerFieldSchema);
+      for (Schema.Field targetField: targetPerFieldSchema.getFields()) {
+        String fieldName = targetField.name();
+        if (srcPerField.getSchema().getField(fieldName) == null) {
+          // Invariant: a surviving value field must have a corresponding per-field RMD entry in the source.
+          throw new VeniceException(
+              "Per-field RMD entry '" + fieldName + "' is absent from the source RMD; source RMD does not cover the "
+                  + "writer schema's fields.");
+        }
+        targetPerField
+            .put(targetField.pos(), GenericData.get().deepCopy(targetField.schema(), srcPerField.get(fieldName)));
+      }
+      projected.put(targetTimestampField.pos(), targetPerField);
+    } else {
+      // Whole-record (value-level) long timestamp: copy as-is.
+      projected.put(targetTimestampField.pos(), srcTimestamp);
+    }
+    return projected;
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/projection/TestVeniceSchemaProjector.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/projection/TestVeniceSchemaProjector.java
@@ -203,8 +203,9 @@ public class TestVeniceSchemaProjector {
   }
 
   @Test
-  public void testRmdPerFieldDropsExtraSourceEntry() {
-    // Input value has f1 + f2 (extra); writer value has only f1. The per-field RMD entry for f2 is dropped.
+  public void testRmdPerFieldTimestampThrows() {
+    // Per-field timestamps only arise with write compute (partial updates), where the superset schema is used and no
+    // projection runs. Encountering one in the projection path indicates misuse and must be rejected.
     Schema inputValue = parse(
         "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
             + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"},\n"
@@ -223,116 +224,7 @@ public class TestVeniceSchemaProjector {
     srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
     srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>());
 
-    GenericRecord out = projector.projectRmd(srcRmd, writerRmd);
-
-    GenericRecord outPerField = (GenericRecord) out.get(TIMESTAMP_FIELD_NAME);
-    Assert.assertEquals(outPerField.get("f1"), 100L);
-    Assert.assertNull(outPerField.getSchema().getField("f2"));
-  }
-
-  @Test
-  public void testRmdCollectionMetadataReWrappedUnderTargetName() {
-    // Input value has an extra collection field so the CollectionMetadata counter (and record name) differs from
-    // the writer's. The surviving entry must be re-wrapped under the writer's record name.
-    Schema inputValue = parse(
-        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
-            + "  \"fields\": [\n" + "    {\"name\": \"pad\", \"type\": {\"type\": \"array\", \"items\": \"long\"}},\n"
-            + "    {\"name\": \"tags\", \"type\": {\"type\": \"array\", \"items\": \"string\"}}\n" + "  ]\n" + "}");
-    Schema writerValue = parse(
-        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
-            + "  \"fields\": [\n" + "    {\"name\": \"tags\", \"type\": {\"type\": \"array\", \"items\": \"string\"}}\n"
-            + "  ]\n" + "}");
-    Schema inputRmd = RMD_GEN.generateMetadataSchema(inputValue);
-    Schema writerRmd = RMD_GEN.generateMetadataSchema(writerValue);
-
-    Schema srcPerFieldSchema = inputRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
-    Schema srcCollSchema = srcPerFieldSchema.getField("tags").schema();
-    Schema writerPerFieldSchema = writerRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
-    Schema writerCollSchema = writerPerFieldSchema.getField("tags").schema();
-    Assert.assertNotEquals(
-        srcCollSchema.getName(),
-        writerCollSchema.getName(),
-        "precondition: source and target CollectionMetadata record names must differ");
-
-    GenericRecord srcColl = new GenericData.Record(srcCollSchema);
-    srcColl.put("topLevelFieldTimestamp", 55L);
-    srcColl.put("topLevelColoID", -1);
-    srcColl.put("putOnlyPartLength", 2);
-    srcColl.put("activeElementsTimestamps", new ArrayList<>(Arrays.asList(1L, 2L)));
-    srcColl.put("deletedElementsIdentities", new ArrayList<>());
-    srcColl.put("deletedElementsTimestamps", new ArrayList<>());
-
-    GenericRecord perField = new GenericData.Record(srcPerFieldSchema);
-    perField.put("pad", 0L);
-    perField.put("tags", srcColl);
-    GenericRecord srcRmd = new GenericData.Record(inputRmd);
-    srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
-    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>());
-
-    GenericRecord out = projector.projectRmd(srcRmd, writerRmd);
-
-    GenericRecord outPerField = (GenericRecord) out.get(TIMESTAMP_FIELD_NAME);
-    GenericRecord outColl = (GenericRecord) outPerField.get("tags");
-    Assert.assertEquals(outColl.getSchema().getName(), writerCollSchema.getName());
-    Assert.assertEquals(outColl.get("topLevelFieldTimestamp"), 55L);
-    Assert.assertEquals(outColl.get("putOnlyPartLength"), 2);
-  }
-
-  @Test
-  public void testRmdPerFieldMissingSourceEntryThrowsInvariant() {
-    // Writer value declares f1 + f2 but the source per-field RMD only has f1 -> invariant violation.
-    Schema writerValue = parse(
-        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
-            + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"},\n"
-            + "    {\"name\": \"f2\", \"type\": \"string\"}\n" + "  ]\n" + "}");
-    Schema sourceValue = parse(
-        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
-            + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"}\n" + "  ]\n" + "}");
-    Schema writerRmd = RMD_GEN.generateMetadataSchema(writerValue);
-    Schema sourceRmd = RMD_GEN.generateMetadataSchema(sourceValue);
-
-    Schema srcPerFieldSchema = sourceRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
-    GenericRecord perField = new GenericData.Record(srcPerFieldSchema);
-    perField.put("f1", 1L);
-    GenericRecord srcRmd = new GenericData.Record(sourceRmd);
-    srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
-    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>());
-
     Assert.expectThrows(VeniceException.class, () -> projector.projectRmd(srcRmd, writerRmd));
-  }
-
-  @Test
-  public void testRmdPerFieldMultipleSurvivingFieldsCopiedByName() {
-    // Input value has a, b, c; writer drops the MIDDLE field b. So surviving field c is at source position 2 but
-    // target position 1. With distinct timestamps, this proves entries are copied BY NAME (not by position) and that
-    // multiple surviving per-field timestamps are all preserved correctly.
-    Schema inputValue = parse(
-        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
-            + "  \"fields\": [\n" + "    {\"name\": \"a\", \"type\": \"string\"},\n"
-            + "    {\"name\": \"b\", \"type\": [\"null\", \"string\"], \"default\": null},\n"
-            + "    {\"name\": \"c\", \"type\": \"string\"}\n" + "  ]\n" + "}");
-    Schema writerValue = parse(
-        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
-            + "  \"fields\": [\n" + "    {\"name\": \"a\", \"type\": \"string\"},\n"
-            + "    {\"name\": \"c\", \"type\": \"string\"}\n" + "  ]\n" + "}");
-    Schema inputRmd = RMD_GEN.generateMetadataSchema(inputValue);
-    Schema writerRmd = RMD_GEN.generateMetadataSchema(writerValue);
-
-    Schema srcPerFieldSchema = inputRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
-    GenericRecord perField = new GenericData.Record(srcPerFieldSchema);
-    perField.put("a", 100L);
-    perField.put("b", 200L);
-    perField.put("c", 300L);
-    GenericRecord srcRmd = new GenericData.Record(inputRmd);
-    srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
-    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>());
-
-    GenericRecord out = projector.projectRmd(srcRmd, writerRmd);
-
-    GenericRecord outPerField = (GenericRecord) out.get(TIMESTAMP_FIELD_NAME);
-    Assert.assertEquals(outPerField.get("a"), 100L);
-    Assert.assertEquals(outPerField.get("c"), 300L, "surviving field must be copied by name, not by source position");
-    Assert.assertNull(outPerField.getSchema().getField("b"), "dropped field must not appear in the projected RMD");
   }
 
   @Test
@@ -343,90 +235,6 @@ public class TestVeniceSchemaProjector {
             + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"}\n" + "  ]\n" + "}");
     Schema rmdSchema = RMD_GEN.generateMetadataSchema(valueSchema);
     Assert.assertNull(projector.projectRmd(null, rmdSchema));
-  }
-
-  @Test
-  public void testRmdMapCollectionMetadataReWrappedUnderTargetName() {
-    // Same as the array re-home test, but for a MAP field (separate RMD generation path). The extra map field shifts
-    // the CollectionMetadata counter so the surviving field's record name differs between source and writer.
-    Schema inputValue = parse(
-        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
-            + "  \"fields\": [\n" + "    {\"name\": \"pad\", \"type\": {\"type\": \"map\", \"values\": \"long\"}},\n"
-            + "    {\"name\": \"attrs\", \"type\": {\"type\": \"map\", \"values\": \"string\"}}\n" + "  ]\n" + "}");
-    Schema writerValue = parse(
-        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
-            + "  \"fields\": [\n" + "    {\"name\": \"attrs\", \"type\": {\"type\": \"map\", \"values\": \"string\"}}\n"
-            + "  ]\n" + "}");
-    Schema inputRmd = RMD_GEN.generateMetadataSchema(inputValue);
-    Schema writerRmd = RMD_GEN.generateMetadataSchema(writerValue);
-
-    Schema srcPerFieldSchema = inputRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
-    Schema srcCollSchema = srcPerFieldSchema.getField("attrs").schema();
-    Schema writerPerFieldSchema = writerRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
-    Schema writerCollSchema = writerPerFieldSchema.getField("attrs").schema();
-    Assert.assertNotEquals(
-        srcCollSchema.getName(),
-        writerCollSchema.getName(),
-        "precondition: source and target CollectionMetadata record names must differ");
-
-    GenericRecord srcColl = new GenericData.Record(srcCollSchema);
-    srcColl.put("topLevelFieldTimestamp", 77L);
-    srcColl.put("topLevelColoID", -1);
-    srcColl.put("putOnlyPartLength", 3);
-    srcColl.put("activeElementsTimestamps", new ArrayList<>(Arrays.asList(70L, 71L)));
-    srcColl.put("deletedElementsIdentities", new ArrayList<>());
-    srcColl.put("deletedElementsTimestamps", new ArrayList<>());
-
-    GenericRecord perField = new GenericData.Record(srcPerFieldSchema);
-    perField.put("pad", 0L);
-    perField.put("attrs", srcColl);
-    GenericRecord srcRmd = new GenericData.Record(inputRmd);
-    srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
-    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>());
-
-    GenericRecord out = projector.projectRmd(srcRmd, writerRmd);
-
-    GenericRecord outPerField = (GenericRecord) out.get(TIMESTAMP_FIELD_NAME);
-    GenericRecord outColl = (GenericRecord) outPerField.get("attrs");
-    Assert.assertEquals(outColl.getSchema().getName(), writerCollSchema.getName());
-    Assert.assertEquals(outColl.get("topLevelFieldTimestamp"), 77L);
-    Assert.assertEquals(outColl.get("putOnlyPartLength"), 3);
-  }
-
-  @Test
-  public void testRmdCollectionMetadataIsDeepCopiedAndIndependent() {
-    // Mutating a nested list inside the source CollectionMetadata after projection must not affect the output.
-    Schema value = parse(
-        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
-            + "  \"fields\": [\n" + "    {\"name\": \"tags\", \"type\": {\"type\": \"array\", \"items\": \"string\"}}\n"
-            + "  ]\n" + "}");
-    Schema rmdSchema = RMD_GEN.generateMetadataSchema(value);
-    Schema perFieldSchema = rmdSchema.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
-    Schema collSchema = perFieldSchema.getField("tags").schema();
-
-    List<Long> activeTs = new ArrayList<>(Arrays.asList(10L, 20L));
-    GenericRecord srcColl = new GenericData.Record(collSchema);
-    srcColl.put("topLevelFieldTimestamp", 5L);
-    srcColl.put("topLevelColoID", -1);
-    srcColl.put("putOnlyPartLength", 0);
-    srcColl.put("activeElementsTimestamps", activeTs);
-    srcColl.put("deletedElementsIdentities", new ArrayList<>());
-    srcColl.put("deletedElementsTimestamps", new ArrayList<>());
-
-    GenericRecord perField = new GenericData.Record(perFieldSchema);
-    perField.put("tags", srcColl);
-    GenericRecord srcRmd = new GenericData.Record(rmdSchema);
-    srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
-    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>());
-
-    GenericRecord out = projector.projectRmd(srcRmd, rmdSchema);
-
-    GenericRecord outColl = (GenericRecord) ((GenericRecord) out.get(TIMESTAMP_FIELD_NAME)).get("tags");
-    @SuppressWarnings("unchecked")
-    List<Long> outActiveTs = (List<Long>) outColl.get("activeElementsTimestamps");
-    Assert.assertEquals(outActiveTs.size(), 2);
-    activeTs.clear();
-    Assert.assertEquals(outActiveTs.size(), 2, "mutating the source collection metadata must not affect the output");
   }
 
   @Test

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/projection/TestVeniceSchemaProjector.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/projection/TestVeniceSchemaProjector.java
@@ -1,0 +1,478 @@
+package com.linkedin.venice.schema.projection;
+
+import static com.linkedin.venice.schema.rmd.RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.RmdConstants.TIMESTAMP_FIELD_NAME;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.schema.rmd.v1.RmdSchemaGeneratorV1;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link VeniceSchemaProjector}.
+ *
+ * <p>The projector is a pure structural drop: the writer (target) schema is guaranteed to be a strict subset of
+ * the input schema (every retained field is deeply, exactly equal; the input may only carry extra top-level fields).
+ * So projection just builds a record with the writer schema's fields, copies each by name, and drops the input's
+ * extra top-level fields.</p>
+ */
+public class TestVeniceSchemaProjector {
+  private VeniceSchemaProjector projector;
+
+  @BeforeClass
+  public void setUp() {
+    projector = new VeniceSchemaProjector();
+  }
+
+  private static Schema parse(String json) {
+    return AvroCompatibilityHelper.parse(json);
+  }
+
+  // ----------------------------------------------------------------------------------------------------------
+  // Value projection
+  // ----------------------------------------------------------------------------------------------------------
+
+  @Test
+  public void testTombstoneReturnsNull() {
+    Schema target = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"f1\", \"type\": \"string\"}\n" + "  ]\n" + "}");
+    Assert.assertNull(projector.projectValue(null, target));
+  }
+
+  @Test
+  public void testIdenticalSchemaCopiesAllFields() {
+    Schema schema = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"f1\", \"type\": \"string\"},\n" + "    {\"name\": \"f2\", \"type\": \"int\"}\n"
+            + "  ]\n" + "}");
+    GenericRecord src = new GenericData.Record(schema);
+    src.put("f1", "hello");
+    src.put("f2", 42);
+
+    GenericRecord out = projector.projectValue(src, schema);
+
+    Assert.assertEquals(out.getSchema(), schema);
+    Assert.assertEquals(out.get("f1").toString(), "hello");
+    Assert.assertEquals(out.get("f2"), 42);
+  }
+
+  @Test
+  public void testExtraTopLevelSourceFieldIsDropped() {
+    // Input has a resurrected/deleted field f2 that the writer schema does not declare -> dropped.
+    Schema input = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"f1\", \"type\": \"string\"},\n"
+            + "    {\"name\": \"f2\", \"type\": [\"null\", \"string\"], \"default\": null},\n"
+            + "    {\"name\": \"f3\", \"type\": \"int\"}\n" + "  ]\n" + "}");
+    Schema writer = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"f1\", \"type\": \"string\"},\n" + "    {\"name\": \"f3\", \"type\": \"int\"}\n"
+            + "  ]\n" + "}");
+    GenericRecord src = new GenericData.Record(input);
+    src.put("f1", "keep");
+    src.put("f2", "drop");
+    src.put("f3", 7);
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    Assert.assertEquals(out.get("f1").toString(), "keep");
+    Assert.assertEquals(out.get("f3"), 7);
+    Assert.assertNull(out.getSchema().getField("f2"), "extra source field must be dropped");
+  }
+
+  @Test
+  public void testNullableFieldWithNullValuePreserved() {
+    // Shared field is nullable in both input and writer (guaranteed by strict subset), value null -> kept null.
+    Schema schema = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"f1\", \"type\": [\"null\", \"string\"], \"default\": null}\n" + "  ]\n" + "}");
+    GenericRecord src = new GenericData.Record(schema);
+    src.put("f1", null);
+
+    GenericRecord out = projector.projectValue(src, schema);
+
+    Assert.assertNull(out.get("f1"));
+  }
+
+  @Test
+  public void testNestedRecordCopiedWholesale() {
+    // The nested record is identical in input and writer (strict subset); only the extra top-level field differs.
+    Schema input = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"extra\", \"type\": [\"null\", \"string\"], \"default\": null},\n" + "    {\n"
+            + "      \"name\": \"address\",\n" + "      \"type\": {\n" + "        \"type\": \"record\",\n"
+            + "        \"name\": \"Address\",\n" + "        \"fields\": [\n"
+            + "          {\"name\": \"city\", \"type\": \"string\"},\n"
+            + "          {\"name\": \"zip\", \"type\": \"string\"}\n" + "        ]\n" + "      }\n" + "    }\n"
+            + "  ]\n" + "}");
+    Schema writer = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"address\",\n" + "      \"type\": {\n" + "        \"type\": \"record\",\n"
+            + "        \"name\": \"Address\",\n" + "        \"fields\": [\n"
+            + "          {\"name\": \"city\", \"type\": \"string\"},\n"
+            + "          {\"name\": \"zip\", \"type\": \"string\"}\n" + "        ]\n" + "      }\n" + "    }\n"
+            + "  ]\n" + "}");
+    GenericRecord addr = new GenericData.Record(input.getField("address").schema());
+    addr.put("city", "NYC");
+    addr.put("zip", "10001");
+    GenericRecord src = new GenericData.Record(input);
+    src.put("extra", "drop");
+    src.put("address", addr);
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertNull(out.getSchema().getField("extra"));
+    GenericRecord outAddr = (GenericRecord) out.get("address");
+    Assert.assertEquals(outAddr.get("city").toString(), "NYC");
+    Assert.assertEquals(outAddr.get("zip").toString(), "10001");
+  }
+
+  @Test
+  public void testRetainedValuesAreDeepCopiedAndIndependent() {
+    Schema input = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"nums\", \"type\": {\"type\": \"array\", \"items\": \"int\"}},\n"
+            + "    {\"name\": \"extra\", \"type\": [\"null\", \"string\"], \"default\": null}\n" + "  ]\n" + "}");
+    Schema writer = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"nums\", \"type\": {\"type\": \"array\", \"items\": \"int\"}}\n" + "  ]\n" + "}");
+    List<Integer> srcList = new ArrayList<>(Arrays.asList(1, 2, 3));
+    GenericRecord src = new GenericData.Record(input);
+    src.put("nums", srcList);
+    src.put("extra", "drop");
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    @SuppressWarnings("unchecked")
+    List<Object> outList = (List<Object>) out.get("nums");
+    Assert.assertEquals(outList.size(), 3);
+    srcList.clear();
+    Assert.assertEquals(outList.size(), 3, "mutating the source list must not affect the projected output");
+  }
+
+  @Test
+  public void testWriterFieldAbsentInSourceSchemaThrowsInvariant() {
+    // Writer declares f2 but the input schema has no f2 -> writer is not a subset of input -> invalid hint.
+    // Preflight should reject this; the projector backstops it as a VeniceException.
+    Schema input = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"f1\", \"type\": \"string\"}\n" + "  ]\n" + "}");
+    Schema writer = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"f1\", \"type\": \"string\"},\n" + "    {\"name\": \"f2\", \"type\": \"string\"}\n"
+            + "  ]\n" + "}");
+    GenericRecord src = new GenericData.Record(input);
+    src.put("f1", "v");
+
+    Assert.expectThrows(VeniceException.class, () -> projector.projectValue(src, writer));
+  }
+
+  // ----------------------------------------------------------------------------------------------------------
+  // RMD projection
+  // ----------------------------------------------------------------------------------------------------------
+
+  private static final RmdSchemaGeneratorV1 RMD_GEN = new RmdSchemaGeneratorV1();
+
+  @Test
+  public void testRmdWholeRecordLongTimestampCopied() {
+    Schema valueSchema = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"}\n" + "  ]\n" + "}");
+    Schema rmdSchema = RMD_GEN.generateMetadataSchema(valueSchema);
+    GenericRecord srcRmd = new GenericData.Record(rmdSchema);
+    srcRmd.put(TIMESTAMP_FIELD_NAME, 12345L);
+    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>(Arrays.asList(7L, 8L)));
+
+    GenericRecord out = projector.projectRmd(srcRmd, rmdSchema);
+
+    Assert.assertEquals(out.get(TIMESTAMP_FIELD_NAME), 12345L);
+    @SuppressWarnings("unchecked")
+    List<Long> rcv = (List<Long>) out.get(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME);
+    Assert.assertEquals(rcv, Arrays.asList(7L, 8L));
+  }
+
+  @Test
+  public void testRmdPerFieldDropsExtraSourceEntry() {
+    // Input value has f1 + f2 (extra); writer value has only f1. The per-field RMD entry for f2 is dropped.
+    Schema inputValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"},\n"
+            + "    {\"name\": \"f2\", \"type\": [\"null\", \"string\"], \"default\": null}\n" + "  ]\n" + "}");
+    Schema writerValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"}\n" + "  ]\n" + "}");
+    Schema inputRmd = RMD_GEN.generateMetadataSchema(inputValue);
+    Schema writerRmd = RMD_GEN.generateMetadataSchema(writerValue);
+
+    Schema perFieldSchema = inputRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
+    GenericRecord perField = new GenericData.Record(perFieldSchema);
+    perField.put("f1", 100L);
+    perField.put("f2", 200L);
+    GenericRecord srcRmd = new GenericData.Record(inputRmd);
+    srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
+    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>());
+
+    GenericRecord out = projector.projectRmd(srcRmd, writerRmd);
+
+    GenericRecord outPerField = (GenericRecord) out.get(TIMESTAMP_FIELD_NAME);
+    Assert.assertEquals(outPerField.get("f1"), 100L);
+    Assert.assertNull(outPerField.getSchema().getField("f2"));
+  }
+
+  @Test
+  public void testRmdCollectionMetadataReWrappedUnderTargetName() {
+    // Input value has an extra collection field so the CollectionMetadata counter (and record name) differs from
+    // the writer's. The surviving entry must be re-wrapped under the writer's record name.
+    Schema inputValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"pad\", \"type\": {\"type\": \"array\", \"items\": \"long\"}},\n"
+            + "    {\"name\": \"tags\", \"type\": {\"type\": \"array\", \"items\": \"string\"}}\n" + "  ]\n" + "}");
+    Schema writerValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"tags\", \"type\": {\"type\": \"array\", \"items\": \"string\"}}\n"
+            + "  ]\n" + "}");
+    Schema inputRmd = RMD_GEN.generateMetadataSchema(inputValue);
+    Schema writerRmd = RMD_GEN.generateMetadataSchema(writerValue);
+
+    Schema srcPerFieldSchema = inputRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
+    Schema srcCollSchema = srcPerFieldSchema.getField("tags").schema();
+    Schema writerPerFieldSchema = writerRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
+    Schema writerCollSchema = writerPerFieldSchema.getField("tags").schema();
+    Assert.assertNotEquals(
+        srcCollSchema.getName(),
+        writerCollSchema.getName(),
+        "precondition: source and target CollectionMetadata record names must differ");
+
+    GenericRecord srcColl = new GenericData.Record(srcCollSchema);
+    srcColl.put("topLevelFieldTimestamp", 55L);
+    srcColl.put("topLevelColoID", -1);
+    srcColl.put("putOnlyPartLength", 2);
+    srcColl.put("activeElementsTimestamps", new ArrayList<>(Arrays.asList(1L, 2L)));
+    srcColl.put("deletedElementsIdentities", new ArrayList<>());
+    srcColl.put("deletedElementsTimestamps", new ArrayList<>());
+
+    GenericRecord perField = new GenericData.Record(srcPerFieldSchema);
+    perField.put("pad", 0L);
+    perField.put("tags", srcColl);
+    GenericRecord srcRmd = new GenericData.Record(inputRmd);
+    srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
+    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>());
+
+    GenericRecord out = projector.projectRmd(srcRmd, writerRmd);
+
+    GenericRecord outPerField = (GenericRecord) out.get(TIMESTAMP_FIELD_NAME);
+    GenericRecord outColl = (GenericRecord) outPerField.get("tags");
+    Assert.assertEquals(outColl.getSchema().getName(), writerCollSchema.getName());
+    Assert.assertEquals(outColl.get("topLevelFieldTimestamp"), 55L);
+    Assert.assertEquals(outColl.get("putOnlyPartLength"), 2);
+  }
+
+  @Test
+  public void testRmdPerFieldMissingSourceEntryThrowsInvariant() {
+    // Writer value declares f1 + f2 but the source per-field RMD only has f1 -> invariant violation.
+    Schema writerValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"},\n"
+            + "    {\"name\": \"f2\", \"type\": \"string\"}\n" + "  ]\n" + "}");
+    Schema sourceValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"}\n" + "  ]\n" + "}");
+    Schema writerRmd = RMD_GEN.generateMetadataSchema(writerValue);
+    Schema sourceRmd = RMD_GEN.generateMetadataSchema(sourceValue);
+
+    Schema srcPerFieldSchema = sourceRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
+    GenericRecord perField = new GenericData.Record(srcPerFieldSchema);
+    perField.put("f1", 1L);
+    GenericRecord srcRmd = new GenericData.Record(sourceRmd);
+    srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
+    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>());
+
+    Assert.expectThrows(VeniceException.class, () -> projector.projectRmd(srcRmd, writerRmd));
+  }
+
+  @Test
+  public void testRmdPerFieldMultipleSurvivingFieldsCopiedByName() {
+    // Input value has a, b, c; writer drops the MIDDLE field b. So surviving field c is at source position 2 but
+    // target position 1. With distinct timestamps, this proves entries are copied BY NAME (not by position) and that
+    // multiple surviving per-field timestamps are all preserved correctly.
+    Schema inputValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"a\", \"type\": \"string\"},\n"
+            + "    {\"name\": \"b\", \"type\": [\"null\", \"string\"], \"default\": null},\n"
+            + "    {\"name\": \"c\", \"type\": \"string\"}\n" + "  ]\n" + "}");
+    Schema writerValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"a\", \"type\": \"string\"},\n"
+            + "    {\"name\": \"c\", \"type\": \"string\"}\n" + "  ]\n" + "}");
+    Schema inputRmd = RMD_GEN.generateMetadataSchema(inputValue);
+    Schema writerRmd = RMD_GEN.generateMetadataSchema(writerValue);
+
+    Schema srcPerFieldSchema = inputRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
+    GenericRecord perField = new GenericData.Record(srcPerFieldSchema);
+    perField.put("a", 100L);
+    perField.put("b", 200L);
+    perField.put("c", 300L);
+    GenericRecord srcRmd = new GenericData.Record(inputRmd);
+    srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
+    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>());
+
+    GenericRecord out = projector.projectRmd(srcRmd, writerRmd);
+
+    GenericRecord outPerField = (GenericRecord) out.get(TIMESTAMP_FIELD_NAME);
+    Assert.assertEquals(outPerField.get("a"), 100L);
+    Assert.assertEquals(outPerField.get("c"), 300L, "surviving field must be copied by name, not by source position");
+    Assert.assertNull(outPerField.getSchema().getField("b"), "dropped field must not appear in the projected RMD");
+  }
+
+  @Test
+  public void testProjectRmdNullReturnsNull() {
+    // A record may carry no RMD (e.g. a batch record in a hybrid store) -> projection yields no RMD.
+    Schema valueSchema = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"}\n" + "  ]\n" + "}");
+    Schema rmdSchema = RMD_GEN.generateMetadataSchema(valueSchema);
+    Assert.assertNull(projector.projectRmd(null, rmdSchema));
+  }
+
+  @Test
+  public void testRmdMapCollectionMetadataReWrappedUnderTargetName() {
+    // Same as the array re-home test, but for a MAP field (separate RMD generation path). The extra map field shifts
+    // the CollectionMetadata counter so the surviving field's record name differs between source and writer.
+    Schema inputValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"pad\", \"type\": {\"type\": \"map\", \"values\": \"long\"}},\n"
+            + "    {\"name\": \"attrs\", \"type\": {\"type\": \"map\", \"values\": \"string\"}}\n" + "  ]\n" + "}");
+    Schema writerValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"attrs\", \"type\": {\"type\": \"map\", \"values\": \"string\"}}\n"
+            + "  ]\n" + "}");
+    Schema inputRmd = RMD_GEN.generateMetadataSchema(inputValue);
+    Schema writerRmd = RMD_GEN.generateMetadataSchema(writerValue);
+
+    Schema srcPerFieldSchema = inputRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
+    Schema srcCollSchema = srcPerFieldSchema.getField("attrs").schema();
+    Schema writerPerFieldSchema = writerRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
+    Schema writerCollSchema = writerPerFieldSchema.getField("attrs").schema();
+    Assert.assertNotEquals(
+        srcCollSchema.getName(),
+        writerCollSchema.getName(),
+        "precondition: source and target CollectionMetadata record names must differ");
+
+    GenericRecord srcColl = new GenericData.Record(srcCollSchema);
+    srcColl.put("topLevelFieldTimestamp", 77L);
+    srcColl.put("topLevelColoID", -1);
+    srcColl.put("putOnlyPartLength", 3);
+    srcColl.put("activeElementsTimestamps", new ArrayList<>(Arrays.asList(70L, 71L)));
+    srcColl.put("deletedElementsIdentities", new ArrayList<>());
+    srcColl.put("deletedElementsTimestamps", new ArrayList<>());
+
+    GenericRecord perField = new GenericData.Record(srcPerFieldSchema);
+    perField.put("pad", 0L);
+    perField.put("attrs", srcColl);
+    GenericRecord srcRmd = new GenericData.Record(inputRmd);
+    srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
+    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>());
+
+    GenericRecord out = projector.projectRmd(srcRmd, writerRmd);
+
+    GenericRecord outPerField = (GenericRecord) out.get(TIMESTAMP_FIELD_NAME);
+    GenericRecord outColl = (GenericRecord) outPerField.get("attrs");
+    Assert.assertEquals(outColl.getSchema().getName(), writerCollSchema.getName());
+    Assert.assertEquals(outColl.get("topLevelFieldTimestamp"), 77L);
+    Assert.assertEquals(outColl.get("putOnlyPartLength"), 3);
+  }
+
+  @Test
+  public void testRmdCollectionMetadataIsDeepCopiedAndIndependent() {
+    // Mutating a nested list inside the source CollectionMetadata after projection must not affect the output.
+    Schema value = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"tags\", \"type\": {\"type\": \"array\", \"items\": \"string\"}}\n"
+            + "  ]\n" + "}");
+    Schema rmdSchema = RMD_GEN.generateMetadataSchema(value);
+    Schema perFieldSchema = rmdSchema.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
+    Schema collSchema = perFieldSchema.getField("tags").schema();
+
+    List<Long> activeTs = new ArrayList<>(Arrays.asList(10L, 20L));
+    GenericRecord srcColl = new GenericData.Record(collSchema);
+    srcColl.put("topLevelFieldTimestamp", 5L);
+    srcColl.put("topLevelColoID", -1);
+    srcColl.put("putOnlyPartLength", 0);
+    srcColl.put("activeElementsTimestamps", activeTs);
+    srcColl.put("deletedElementsIdentities", new ArrayList<>());
+    srcColl.put("deletedElementsTimestamps", new ArrayList<>());
+
+    GenericRecord perField = new GenericData.Record(perFieldSchema);
+    perField.put("tags", srcColl);
+    GenericRecord srcRmd = new GenericData.Record(rmdSchema);
+    srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
+    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>());
+
+    GenericRecord out = projector.projectRmd(srcRmd, rmdSchema);
+
+    GenericRecord outColl = (GenericRecord) ((GenericRecord) out.get(TIMESTAMP_FIELD_NAME)).get("tags");
+    @SuppressWarnings("unchecked")
+    List<Long> outActiveTs = (List<Long>) outColl.get("activeElementsTimestamps");
+    Assert.assertEquals(outActiveTs.size(), 2);
+    activeTs.clear();
+    Assert.assertEquals(outActiveTs.size(), 2, "mutating the source collection metadata must not affect the output");
+  }
+
+  @Test
+  public void testRmdWholeRecordLongTimestampWithDivergentSchemas() {
+    // Source RMD carries the value-level long branch while source/writer value schemas differ. The long must be
+    // copied as-is and the result must be under the writer RMD schema.
+    Schema inputValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"},\n"
+            + "    {\"name\": \"f2\", \"type\": [\"null\", \"string\"], \"default\": null}\n" + "  ]\n" + "}");
+    Schema writerValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"}\n" + "  ]\n" + "}");
+    Schema inputRmd = RMD_GEN.generateMetadataSchema(inputValue);
+    Schema writerRmd = RMD_GEN.generateMetadataSchema(writerValue);
+
+    GenericRecord srcRmd = new GenericData.Record(inputRmd);
+    srcRmd.put(TIMESTAMP_FIELD_NAME, 999L);
+    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>(Arrays.asList(3L)));
+
+    GenericRecord out = projector.projectRmd(srcRmd, writerRmd);
+
+    Assert.assertEquals(out.getSchema(), writerRmd);
+    Assert.assertEquals(out.get(TIMESTAMP_FIELD_NAME), 999L);
+    @SuppressWarnings("unchecked")
+    List<Long> rcv = (List<Long>) out.get(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME);
+    Assert.assertEquals(rcv, Arrays.asList(3L));
+  }
+
+  @Test
+  public void testReplicationCheckpointVectorIsDeepCopied() {
+    Schema valueSchema = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"}\n" + "  ]\n" + "}");
+    Schema rmdSchema = RMD_GEN.generateMetadataSchema(valueSchema);
+    List<Long> rcv = new ArrayList<>(Arrays.asList(1L, 2L, 3L));
+    GenericRecord srcRmd = new GenericData.Record(rmdSchema);
+    srcRmd.put(TIMESTAMP_FIELD_NAME, 1L);
+    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, rcv);
+
+    GenericRecord out = projector.projectRmd(srcRmd, rmdSchema);
+
+    @SuppressWarnings("unchecked")
+    List<Long> outRcv = (List<Long>) out.get(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME);
+    Assert.assertEquals(outRcv.size(), 3);
+    rcv.clear();
+    Assert.assertEquals(outRcv.size(), 3, "mutating the source RCV must not affect the projected output");
+  }
+}


### PR DESCRIPTION
## Problem Statement
When records are serialized against a store's superset value schema but must be written under a specific registered writer (target) schema which is not registered in the schema registry, there was no safe way to down-convert them. The superset record can carry extra top-level fields the writer schema doesn't declare, and its Replication Metadata (RMD) is generated against the superset schema too. Without a projection step, these records can't be re-serialized against the writer schema, blocking VPJ.


## Solution
Added VeniceSchemaProjector, which performs a pure structural "drop" projection from a superset schema down to a writer schema. It builds a new record under the writer schema, copies each writer field by exact name, and lets extra source fields fall away. It projects RMD (timestamps and checkpoint vectors copied, per-field entries rebuilt under the target), and enforces the strict-subset invariant backed by a comprehensive test suite (TestVeniceSchemaProjector).
This is the first step towards a larger VPJ flow change. In the follow-up work, when input data doesn't match any registered schema, the VPJ flow will take the user's input schema hint, and then use VeniceSchemaProjector to project the data according to that hinted schema.
###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
- [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.