### PR TITLE
[consumer] Add dedicated producerTimestamp field to ImmutableChangeCapturePubSubMessage for heartbeat freshness

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/InternalDaVinciRecordTransformer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/InternalDaVinciRecordTransformer.java
@@ -121,9 +121,22 @@ public class InternalDaVinciRecordTransformer<K, V, O> extends DaVinciRecordTran
       PubSubPosition offset,
       ControlMessage controlMessage,
       long pubSubMessageTimestamp) {
+    onControlMessage(partition, offset, controlMessage, pubSubMessageTimestamp, 0L);
+  }
+
+  /**
+   * On receiving a control message with a known producer timestamp (e.g. heartbeats where the
+   * upstream RT producer time is preserved end-to-end), propagate both timestamps to the buffer.
+   */
+  public void onControlMessage(
+      int partition,
+      PubSubPosition offset,
+      ControlMessage controlMessage,
+      long pubSubMessageTimestamp,
+      long producerTimestamp) {
     if (this.recordTransformer instanceof VeniceChangelogConsumerDaVinciRecordTransformerImpl.DaVinciRecordTransformerChangelogConsumer) {
       ((VeniceChangelogConsumerDaVinciRecordTransformerImpl.DaVinciRecordTransformerChangelogConsumer) this.recordTransformer)
-          .onControlMessage(partition, offset, controlMessage, pubSubMessageTimestamp);
+          .onControlMessage(partition, offset, controlMessage, pubSubMessageTimestamp, producerTimestamp);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ImmutableChangeCapturePubSubMessage.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ImmutableChangeCapturePubSubMessage.java
@@ -18,6 +18,7 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
   private final int writerSchemaId;
   private final java.nio.ByteBuffer replicationMetadataPayload;
   private final ControlMessage controlMessage;
+  private final long producerTimestamp;
 
   public ImmutableChangeCapturePubSubMessage(
       K key,
@@ -39,7 +40,8 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
         consumerSequenceId,
         -1,
         null,
-        null);
+        null,
+        0L);
   }
 
   public ImmutableChangeCapturePubSubMessage(
@@ -64,7 +66,8 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
         consumerSequenceId,
         writerSchemaId,
         replicationMetadataPayload,
-        null);
+        null,
+        0L);
   }
 
   public ImmutableChangeCapturePubSubMessage(
@@ -79,6 +82,34 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
       int writerSchemaId,
       java.nio.ByteBuffer replicationMetadataPayload,
       ControlMessage controlMessage) {
+    this(
+        key,
+        value,
+        topicPartition,
+        pubSubPosition,
+        timestamp,
+        payloadSize,
+        isEndOfBootstrap,
+        consumerSequenceId,
+        writerSchemaId,
+        replicationMetadataPayload,
+        controlMessage,
+        0L);
+  }
+
+  public ImmutableChangeCapturePubSubMessage(
+      K key,
+      V value,
+      PubSubTopicPartition topicPartition,
+      PubSubPosition pubSubPosition,
+      long timestamp,
+      int payloadSize,
+      boolean isEndOfBootstrap,
+      long consumerSequenceId,
+      int writerSchemaId,
+      java.nio.ByteBuffer replicationMetadataPayload,
+      ControlMessage controlMessage,
+      long producerTimestamp) {
     this.key = key;
     this.value = value;
     this.topicPartition = Objects.requireNonNull(topicPartition);
@@ -93,6 +124,7 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
     this.writerSchemaId = writerSchemaId;
     this.replicationMetadataPayload = replicationMetadataPayload;
     this.controlMessage = controlMessage;
+    this.producerTimestamp = producerTimestamp;
   }
 
   @Override
@@ -140,6 +172,10 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
 
   public ControlMessage getControlMessage() {
     return controlMessage;
+  }
+
+  public long getProducerTimestamp() {
+    return producerTimestamp;
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -588,7 +588,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
             ControlMessage heartbeatControlMessage = new ControlMessage();
             heartbeatControlMessage.setControlMessageType(ControlMessageType.START_OF_SEGMENT.getValue());
             syntheticHeartbeatRecordTransformer
-                .onControlMessage(partitionId, PubSubSymbolicPosition.LATEST, heartbeatControlMessage, now);
+                .onControlMessage(partitionId, PubSubSymbolicPosition.LATEST, heartbeatControlMessage, now, now);
           }
         }
       }
@@ -748,7 +748,8 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
         int partitionId,
         PubSubPosition offset,
         ControlMessage controlMessage,
-        long pubSubMessageTimestamp) {
+        long pubSubMessageTimestamp,
+        long producerTimestamp) {
       if (partitionToVersionToServe.get(partitionId) == getStoreVersion()) {
         ImmutableChangeCapturePubSubMessage<K, ChangeEvent<V>> pubSubMessage =
             new ImmutableChangeCapturePubSubMessage<>(
@@ -762,7 +763,8 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
                 getNextConsumerSequenceId(partitionId),
                 -1,
                 null,
-                controlMessage);
+                controlMessage,
+                producerTimestamp);
         internalAddMessageToBuffer(partitionId, pubSubMessage);
       }
     }
@@ -846,6 +848,15 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
         PubSubPosition offset,
         ControlMessage controlMessage,
         long pubSubMessageTimestamp) {
+      onControlMessage(partitionId, offset, controlMessage, pubSubMessageTimestamp, 0L);
+    }
+
+    public void onControlMessage(
+        int partitionId,
+        PubSubPosition offset,
+        ControlMessage controlMessage,
+        long pubSubMessageTimestamp,
+        long producerTimestamp) {
       // Track EOP per partition to enable synthetic heartbeats for batch stores.
       // This runs before the includeControlMessages gate since it's internal state tracking.
       if (controlMessage.getControlMessageType() == ControlMessageType.END_OF_PUSH.getValue()) {
@@ -855,7 +866,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
       if (!isVersionSpecificClient || !includeControlMessages) {
         return;
       }
-      addControlMessageToBuffer(partitionId, offset, controlMessage, pubSubMessageTimestamp);
+      addControlMessageToBuffer(partitionId, offset, controlMessage, pubSubMessageTimestamp, producerTimestamp);
     }
 
     public void onVersionSwap(int currentVersion, int futureVersion, int partitionId) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4293,7 +4293,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
               partition,
               offset,
               controlMessage,
-              resolveTimestamp(kafkaMessageEnvelope, pubSubMessageTime));
+              pubSubMessageTime,
+              getHeartbeatProducerTimestamp(kafkaMessageEnvelope));
         }
         break;
       case END_OF_SEGMENT:
@@ -6716,20 +6717,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return daVinciClientCustomLifecycleEnabled;
   }
 
-  /**
-   * Returns the producer metadata timestamp from the given {@link KafkaMessageEnvelope}, falling back
-   * to {@code fallbackTimestamp} when producer metadata is absent or its timestamp is non-positive.
-   *
-   * <p>For control messages such as heartbeats, the producer metadata timestamp represents the original
-   * upstream time preserved end-to-end (RT → leader → VT), making it more accurate than the VT pubsub
-   * broker enqueue time for freshness/watermark signalling.
-   */
   @VisibleForTesting
-  static long resolveTimestamp(KafkaMessageEnvelope kafkaMessageEnvelope, long fallbackTimestamp) {
-    if (kafkaMessageEnvelope.getProducerMetadata() != null
-        && kafkaMessageEnvelope.getProducerMetadata().getMessageTimestamp() > 0) {
-      return kafkaMessageEnvelope.getProducerMetadata().getMessageTimestamp();
-    }
-    return fallbackTimestamp;
+  static long getHeartbeatProducerTimestamp(KafkaMessageEnvelope kafkaMessageEnvelope) {
+    return kafkaMessageEnvelope.getProducerMetadata() != null
+        && kafkaMessageEnvelope.getProducerMetadata().getMessageTimestamp() > 0
+            ? kafkaMessageEnvelope.getProducerMetadata().getMessageTimestamp()
+            : 0L;
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VersionSpecificVeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VersionSpecificVeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
@@ -260,9 +260,14 @@ public class VersionSpecificVeniceChangelogConsumerDaVinciRecordTransformerImplT
 
     ControlMessage heartbeat = new ControlMessage();
     heartbeat.setControlMessageType(ControlMessageType.START_OF_SEGMENT.getValue());
-    long heartbeatTimestamp = 1000;
-    recordTransformer
-        .onControlMessage(targetPartitionId, recordMetadata.getPubSubPosition(), heartbeat, heartbeatTimestamp);
+    long pubSubTimestamp = 1000;
+    long producerTimestamp = 900;
+    recordTransformer.onControlMessage(
+        targetPartitionId,
+        recordMetadata.getPubSubPosition(),
+        heartbeat,
+        pubSubTimestamp,
+        producerTimestamp);
 
     Collection<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> pubSubMessages =
         versionSpecificVeniceChangelogConsumer.poll(POLL_TIMEOUT);
@@ -270,7 +275,31 @@ public class VersionSpecificVeniceChangelogConsumerDaVinciRecordTransformerImplT
     ImmutableChangeCapturePubSubMessage message =
         (ImmutableChangeCapturePubSubMessage<Integer, ChangeEvent<Integer>>) pubSubMessages.iterator().next();
     assertEquals(message.getControlMessage().getControlMessageType(), ControlMessageType.START_OF_SEGMENT.getValue());
-    assertEquals(message.getPubSubMessageTime(), heartbeatTimestamp);
+    assertEquals(message.getPubSubMessageTime(), pubSubTimestamp);
+    assertEquals(message.getProducerTimestamp(), producerTimestamp);
+  }
+
+  @Test
+  public void testNonHeartbeatControlMessageHasNoProducerTimestamp() {
+    int targetPartitionId = 0;
+    versionSpecificVeniceChangelogConsumer.start();
+    recordTransformer.onStartVersionIngestion(targetPartitionId, true);
+
+    // Use the 4-arg overload to exercise the default producerTimestamp=0 path
+    recordTransformer.onControlMessage(
+        targetPartitionId,
+        recordMetadata.getPubSubPosition(),
+        createEndOfPushControlMessage(),
+        1000L);
+
+    Collection<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> pubSubMessages =
+        versionSpecificVeniceChangelogConsumer.poll(POLL_TIMEOUT);
+    assertEquals(pubSubMessages.size(), 1);
+    ImmutableChangeCapturePubSubMessage message =
+        (ImmutableChangeCapturePubSubMessage<Integer, ChangeEvent<Integer>>) pubSubMessages.iterator().next();
+    assertEquals(message.getControlMessage().getControlMessageType(), ControlMessageType.END_OF_PUSH.getValue());
+    assertEquals(message.getPubSubMessageTime(), 1000L);
+    assertEquals(message.getProducerTimestamp(), 0L, "Non-heartbeat control messages should have producerTimestamp=0");
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -7659,27 +7659,33 @@ public abstract class StoreIngestionTaskTest {
   }
 
   @Test
-  public void testResolveTimestamp() {
+  public void testGetHeartbeatProducerTimestamp() {
     long producerTimestamp = 1780749996366L;
-    long fallback = 1000L;
 
-    // Non-null ProducerMetadata with positive timestamp: use messageTimestamp
-    KafkaMessageEnvelope envelopeWithMetadata = new KafkaMessageEnvelope();
-    ProducerMetadata producerMetadata = new ProducerMetadata();
-    producerMetadata.messageTimestamp = producerTimestamp;
-    envelopeWithMetadata.producerMetadata = producerMetadata;
-    assertEquals(StoreIngestionTask.resolveTimestamp(envelopeWithMetadata, fallback), producerTimestamp);
+    // Non-null ProducerMetadata with positive timestamp: return it
+    KafkaMessageEnvelope withMetadata = new KafkaMessageEnvelope();
+    ProducerMetadata metadata = new ProducerMetadata();
+    metadata.messageTimestamp = producerTimestamp;
+    withMetadata.producerMetadata = metadata;
+    assertEquals(StoreIngestionTask.getHeartbeatProducerTimestamp(withMetadata), producerTimestamp);
 
-    // Null ProducerMetadata: fall back
-    KafkaMessageEnvelope envelopeWithoutMetadata = new KafkaMessageEnvelope();
-    envelopeWithoutMetadata.producerMetadata = null;
-    assertEquals(StoreIngestionTask.resolveTimestamp(envelopeWithoutMetadata, fallback), fallback);
+    // Null ProducerMetadata: return 0
+    KafkaMessageEnvelope noMetadata = new KafkaMessageEnvelope();
+    noMetadata.producerMetadata = null;
+    assertEquals(StoreIngestionTask.getHeartbeatProducerTimestamp(noMetadata), 0L);
 
-    // ProducerMetadata present but messageTimestamp == 0: fall back
-    KafkaMessageEnvelope envelopeWithZeroTs = new KafkaMessageEnvelope();
+    // ProducerMetadata present but messageTimestamp == 0: return 0
+    KafkaMessageEnvelope zeroTs = new KafkaMessageEnvelope();
     ProducerMetadata zeroMetadata = new ProducerMetadata();
     zeroMetadata.messageTimestamp = 0;
-    envelopeWithZeroTs.producerMetadata = zeroMetadata;
-    assertEquals(StoreIngestionTask.resolveTimestamp(envelopeWithZeroTs, fallback), fallback);
+    zeroTs.producerMetadata = zeroMetadata;
+    assertEquals(StoreIngestionTask.getHeartbeatProducerTimestamp(zeroTs), 0L);
+
+    // ProducerMetadata present but messageTimestamp < 0: return 0
+    KafkaMessageEnvelope negativeTs = new KafkaMessageEnvelope();
+    ProducerMetadata negativeMetadata = new ProducerMetadata();
+    negativeMetadata.messageTimestamp = -1;
+    negativeTs.producerMetadata = negativeMetadata;
+    assertEquals(StoreIngestionTask.getHeartbeatProducerTimestamp(negativeTs), 0L);
   }
 }


### PR DESCRIPTION
## Problem Statement

When a Venice store undergoes a full repush, all records get their pub-sub timestamp
updated to the repush time. This makes heartbeat messages appear "fresh" to downstream
consumers even when only a fraction of data has been ingested, causing premature version
promotion.

The fix in #2857 addressed this by passing the original upstream producer timestamp
through `getPubSubMessageTime()`. However, overloading that field breaks its existing
semantics (broker enqueue time), which other consumers rely on.

## Solution

Add a dedicated `producerTimestamp` field to `ImmutableChangeCapturePubSubMessage`:

- `getProducerTimestamp() > 0` → the original upstream RT producer time, preserved
  end-to-end (RT → leader → VT). Use this for freshness/watermark signals.
- `getProducerTimestamp() == 0` → not available (non-heartbeat messages, or missing
  producer metadata).
- `getPubSubMessageTime()` → unchanged, still returns the VT broker enqueue time.

Two `onControlMessage` overloads are provided:
- 4-param (existing callers): defaults `producerTimestamp = 0`
- 5-param (heartbeat path): accepts an explicit `producerTimestamp`

Also removes the `resolveTimestamp()` helper from #2857 (no longer needed).

### Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

Updated `testHeartbeatControlMessage` to assert `getProducerTimestamp()` and
`getPubSubMessageTime()` return distinct values. Added
`testNonHeartbeatControlMessageHasNoProducerTimestamp` asserting `getProducerTimestamp() == 0`
for non-heartbeat control messages.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
