### PR TITLE
[vpj] Support projecting input value schema to registered writer schema in VPJ

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -199,6 +199,22 @@ public class PushJobSetting implements Serializable {
   public ETLValueSchemaTransformation etlValueSchemaTransformation;
   public Map<Integer, String> newKmeSchemasFromController;
 
+  /**
+   * Schema-projection: feature flag controlling whether input records may be projected down to a target
+   * writer value schema (see {@code INPUT_VALUE_SCHEMA_PROJECTION_ENABLED}). When false, projection is never
+   * attempted regardless of {@link #targetWriterValueSchemaId}.
+   */
+  public boolean valueSchemaProjectionEnabled;
+
+  /**
+   * Schema-projection: target writer value schema to project superset
+   * input records down to (see {@code TARGET_WRITER_VALUE_SCHEMA_ID_PROP}).
+   * */
+  public int targetWriterValueSchemaId = -1;
+  public boolean projectInputToWriterSchema;
+  public Schema writerValueSchema;
+  public String writerValueSchemaString;
+
   // Additional inferred properties
   public boolean inputHasRecords;
   public long inputFileDataSizeInBytes;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -200,13 +200,6 @@ public class PushJobSetting implements Serializable {
   public Map<Integer, String> newKmeSchemasFromController;
 
   /**
-   * Schema-projection: feature flag controlling whether input records may be projected down to a target
-   * writer value schema (see {@code INPUT_VALUE_SCHEMA_PROJECTION_ENABLED}). When false, projection is never
-   * attempted regardless of {@link #targetWriterValueSchemaId}.
-   */
-  public boolean valueSchemaProjectionEnabled;
-
-  /**
    * Schema-projection: target writer value schema to project superset
    * input records down to (see {@code TARGET_WRITER_VALUE_SCHEMA_ID_PROP}).
    * */

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -26,7 +26,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_BATCH_BYTES
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_COMPRESSION_DICTIONARY_SAMPLE_SIZE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_COMPRESSION_METRIC_COLLECTION_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_INPUT_VALUE_SCHEMA_PROJECTION_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_JOB_STATUS_IN_UNKNOWN_STATE_TIMEOUT_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_POLL_STATUS_INTERVAL_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_RE_PUSH_REWIND_IN_SECONDS_OVERRIDE;
@@ -42,7 +41,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_RA
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_TIME_WINDOW_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INPUT_PATH_PROP;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.INPUT_VALUE_SCHEMA_PROJECTION_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.JOB_EXEC_ID;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.JOB_EXEC_URL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.JOB_SERVER_NAME;
@@ -429,9 +427,23 @@ public class VenicePushJob implements AutoCloseable {
     pushJobSettingToReturn.repushUseFallbackValueSchemaId =
         props.getBoolean(REPUSH_USE_FALLBACK_VALUE_SCHEMA_ID, false);
     pushJobSettingToReturn.isCompliancePush = props.getBoolean(COMPLIANCE_PUSH, false);
-    pushJobSettingToReturn.valueSchemaProjectionEnabled =
-        props.getBoolean(INPUT_VALUE_SCHEMA_PROJECTION_ENABLED, DEFAULT_INPUT_VALUE_SCHEMA_PROJECTION_ENABLED);
     pushJobSettingToReturn.targetWriterValueSchemaId = props.getInt(TARGET_WRITER_VALUE_SCHEMA_ID_PROP, -1);
+    if (pushJobSettingToReturn.targetWriterValueSchemaId > 0) {
+      // Input value-schema projection is only supported for full (batch) pushes. It is incompatible with write compute
+      // (which relies on the superset schema and per-field-timestamp RMD that projection cannot handle) and with
+      // incremental push (which writes partial updates/RMD to the real-time topic). Fail fast on misconfiguration
+      // rather than projecting silently or failing at a later stage.
+      if (pushJobSettingToReturn.enableWriteCompute) {
+        throw new VeniceException(
+            "Input value schema projection (" + TARGET_WRITER_VALUE_SCHEMA_ID_PROP
+                + ") is not supported together with write compute (" + ENABLE_WRITE_COMPUTE + ").");
+      }
+      if (pushJobSettingToReturn.isIncrementalPush) {
+        throw new VeniceException(
+            "Input value schema projection (" + TARGET_WRITER_VALUE_SCHEMA_ID_PROP
+                + ") is not supported together with incremental push (" + INCREMENTAL_PUSH + ").");
+      }
+    }
     pushJobSettingToReturn.allowRegularPushWithTTLRepush = props.getBoolean(ALLOW_REGULAR_PUSH_WITH_TTL_REPUSH, false);
     pushJobSettingToReturn.enableUncompressedRecordSizeLimit =
         props.getBoolean(VeniceWriter.ENABLE_UNCOMPRESSED_RECORD_SIZE_LIMIT, false);
@@ -2312,15 +2324,14 @@ public class VenicePushJob implements AutoCloseable {
           setting.controllerRetries,
           c -> c.getValueSchemaID(setting.storeName, pushJobSetting.valueSchemaString));
     }
-    if (getValueSchemaIdResponse.isError() && setting.valueSchemaProjectionEnabled
-        && setting.targetWriterValueSchemaId > 0) {
+    if (getValueSchemaIdResponse.isError() && setting.targetWriterValueSchemaId > 0) {
       // Input value schema does not match any registered value schema. The user has supplied a target writer value
       // schema ID to project input records down to; validate the superset relationship and enable projection.
       configureValueSchemaProjection(controllerClient, setting);
       LOGGER.info(
           "Got schema id: {} (projection target) for value schema: {} of store: {}",
-          pushJobSetting.valueSchemaId,
-          pushJobSetting.valueSchemaString,
+          setting.valueSchemaId,
+          setting.valueSchemaString,
           setting.storeName);
       return;
     }
@@ -2358,6 +2369,15 @@ public class VenicePushJob implements AutoCloseable {
     } else {
       // Get value schema ID successfully
       setSchemaIdPropInPushJobSetting(pushJobSetting, getValueSchemaIdResponse, setting.enableWriteCompute);
+      if (setting.targetWriterValueSchemaId > 0
+          && getValueSchemaIdResponse.getId() != setting.targetWriterValueSchemaId) {
+        LOGGER.warn(
+            "Input value schema matches registered value schema id: {} for store: {}, which differs from the supplied "
+                + "target writer value schema id: {}. Skipping projection and pushing with the matched schema id.",
+            getValueSchemaIdResponse.getId(),
+            setting.storeName,
+            setting.targetWriterValueSchemaId);
+      }
     }
     LOGGER.info(
         "Got schema id: {} for value schema: {} of store: {}",
@@ -2375,8 +2395,8 @@ public class VenicePushJob implements AutoCloseable {
   private void configureValueSchemaProjection(ControllerClient controllerClient, PushJobSetting setting) {
     int writerSchemaId = setting.targetWriterValueSchemaId;
     LOGGER.info(
-        "Input value schema is not registered; attempting projection to target writer value schema id: {} for store: {} "
-            + "(input value schema projection feature flag is enabled). Input value schema: {}",
+        "Input value schema is not registered; attempting projection to target writer value schema id: {} for "
+            + "store: {}. Input value schema: {}",
         writerSchemaId,
         setting.storeName,
         setting.valueSchemaString);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -26,6 +26,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_BATCH_BYTES
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_COMPRESSION_DICTIONARY_SAMPLE_SIZE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_COMPRESSION_METRIC_COLLECTION_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_INPUT_VALUE_SCHEMA_PROJECTION_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_JOB_STATUS_IN_UNKNOWN_STATE_TIMEOUT_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_POLL_STATUS_INTERVAL_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_RE_PUSH_REWIND_IN_SECONDS_OVERRIDE;
@@ -41,6 +42,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_RA
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_TIME_WINDOW_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INPUT_PATH_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.INPUT_VALUE_SCHEMA_PROJECTION_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.JOB_EXEC_ID;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.JOB_EXEC_URL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.JOB_SERVER_NAME;
@@ -82,6 +84,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUS
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_LIST;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP_WAIT_TIME_MINUTES;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGET_WRITER_VALUE_SCHEMA_ID_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TEMP_DIR_PREFIX;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.UNCREATED_VERSION_NUMBER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
@@ -426,6 +429,9 @@ public class VenicePushJob implements AutoCloseable {
     pushJobSettingToReturn.repushUseFallbackValueSchemaId =
         props.getBoolean(REPUSH_USE_FALLBACK_VALUE_SCHEMA_ID, false);
     pushJobSettingToReturn.isCompliancePush = props.getBoolean(COMPLIANCE_PUSH, false);
+    pushJobSettingToReturn.valueSchemaProjectionEnabled =
+        props.getBoolean(INPUT_VALUE_SCHEMA_PROJECTION_ENABLED, DEFAULT_INPUT_VALUE_SCHEMA_PROJECTION_ENABLED);
+    pushJobSettingToReturn.targetWriterValueSchemaId = props.getInt(TARGET_WRITER_VALUE_SCHEMA_ID_PROP, -1);
     pushJobSettingToReturn.allowRegularPushWithTTLRepush = props.getBoolean(ALLOW_REGULAR_PUSH_WITH_TTL_REPUSH, false);
     pushJobSettingToReturn.enableUncompressedRecordSizeLimit =
         props.getBoolean(VeniceWriter.ENABLE_UNCOMPRESSED_RECORD_SIZE_LIMIT, false);
@@ -2306,6 +2312,18 @@ public class VenicePushJob implements AutoCloseable {
           setting.controllerRetries,
           c -> c.getValueSchemaID(setting.storeName, pushJobSetting.valueSchemaString));
     }
+    if (getValueSchemaIdResponse.isError() && setting.valueSchemaProjectionEnabled
+        && setting.targetWriterValueSchemaId > 0) {
+      // Input value schema does not match any registered value schema. The user has supplied a target writer value
+      // schema ID to project input records down to; validate the superset relationship and enable projection.
+      configureValueSchemaProjection(controllerClient, setting);
+      LOGGER.info(
+          "Got schema id: {} (projection target) for value schema: {} of store: {}",
+          pushJobSetting.valueSchemaId,
+          pushJobSetting.valueSchemaString,
+          setting.storeName);
+      return;
+    }
     if (getValueSchemaIdResponse.isError() && !schemaAutoRegisterFromPushJobEnabled) {
       MultiSchemaResponse response = controllerClient.getAllValueSchema(setting.storeName);
       if (response.isError()) {
@@ -2346,6 +2364,48 @@ public class VenicePushJob implements AutoCloseable {
         pushJobSetting.valueSchemaId,
         pushJobSetting.valueSchemaString,
         setting.storeName);
+  }
+
+  /**
+   * Configure projection of input records down to a user-specified registered writer (target) value schema, used when
+   * the input value schema does not match any registered value schema. Fetches the writer schema by ID, validates that
+   * the input value schema is a strict superset of it, and enables
+   * {@link com.linkedin.venice.schema.projection.VeniceSchemaProjector}-based projection.
+   */
+  private void configureValueSchemaProjection(ControllerClient controllerClient, PushJobSetting setting) {
+    int writerSchemaId = setting.targetWriterValueSchemaId;
+    LOGGER.info(
+        "Input value schema is not registered; attempting projection to target writer value schema id: {} for store: {} "
+            + "(input value schema projection feature flag is enabled). Input value schema: {}",
+        writerSchemaId,
+        setting.storeName,
+        setting.valueSchemaString);
+    SchemaResponse writerSchemaResponse = ControllerClient.retryableRequest(
+        controllerClient,
+        setting.controllerRetries,
+        c -> c.getValueSchema(setting.storeName, writerSchemaId));
+    if (writerSchemaResponse.isError()) {
+      throw new VeniceException(
+          "Failed to fetch target writer value schema id: " + writerSchemaId + " for store: " + setting.storeName
+              + "\nError from the server: " + writerSchemaResponse.getError());
+    }
+    Schema writerSchema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(writerSchemaResponse.getSchemaStr());
+    if (!validateSubsetValueSchema(writerSchema, setting.valueSchemaString)) {
+      throw new VeniceSchemaMismatchException(
+          "Input value schema is not a superset of the target writer value schema (id: " + writerSchemaId
+              + "). Input value schema: " + setting.valueSchemaString + " , writer schema: "
+              + writerSchemaResponse.getSchemaStr());
+    }
+    setting.writerValueSchema = writerSchema;
+    setting.writerValueSchemaString = writerSchemaResponse.getSchemaStr();
+    setting.valueSchemaId = writerSchemaId;
+    setting.projectInputToWriterSchema = true;
+    LOGGER.info(
+        "Enabled input value schema projection for store: {}. Input value schema is a confirmed superset of target "
+            + "writer value schema id: {}. Resolved writer value schema: {}",
+        setting.storeName,
+        writerSchemaId,
+        setting.writerValueSchemaString);
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/avro/AbstractAvroRecordReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/avro/AbstractAvroRecordReader.java
@@ -212,7 +212,7 @@ public abstract class AbstractAvroRecordReader<INPUT_KEY, INPUT_VALUE>
       }
       return updateBuilder.build();
     }
-    if (schemaProjector != null && valueObject != null) {
+    if (writerValueSchema != null && valueObject != null) {
       if (!(valueObject instanceof GenericRecord)) {
         throw new VeniceException("Retrieved record is not an Avro generic record; cannot project to writer schema");
       }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/avro/AbstractAvroRecordReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/avro/AbstractAvroRecordReader.java
@@ -7,11 +7,13 @@ import com.linkedin.venice.etl.ETLValueSchemaTransformation;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.exceptions.VeniceSchemaFieldNotFoundException;
 import com.linkedin.venice.hadoop.input.recordreader.AbstractVeniceRecordReader;
+import com.linkedin.venice.schema.projection.VeniceSchemaProjector;
 import com.linkedin.venice.writer.update.UpdateBuilder;
 import com.linkedin.venice.writer.update.UpdateBuilderImpl;
 import java.util.LinkedList;
 import java.util.List;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 
 
@@ -31,6 +33,10 @@ public abstract class AbstractAvroRecordReader<INPUT_KEY, INPUT_VALUE>
 
   private final boolean generatePartialUpdateRecordFromInput;
 
+  private final Schema writerValueSchema;
+  private final Schema writerRmdSchema;
+  private final VeniceSchemaProjector schemaProjector;
+
   /**
    * This constructor is used when data is read from HDFS.
    * @param dataSchema Schema of the avro file
@@ -45,6 +51,25 @@ public abstract class AbstractAvroRecordReader<INPUT_KEY, INPUT_VALUE>
       String rmdFieldStr,
       ETLValueSchemaTransformation etlValueSchemaTransformation,
       Schema updateSchema) {
+    this(dataSchema, keyFieldStr, valueFieldStr, rmdFieldStr, etlValueSchemaTransformation, updateSchema, null, null);
+  }
+
+  /**
+   * @param writerValueSchema when non-null, input value records are projected down to this registered writer (target)
+   *                          value schema via {@link VeniceSchemaProjector} and serialized against it.
+   * @param writerRmdSchema when non-null, input RMD records are projected down to this writer RMD schema (the RMD schema
+   *                        generated against {@code writerValueSchema}) in lockstep with the value, and serialized
+   *                        against it.
+   */
+  public AbstractAvroRecordReader(
+      Schema dataSchema,
+      String keyFieldStr,
+      String valueFieldStr,
+      String rmdFieldStr,
+      ETLValueSchemaTransformation etlValueSchemaTransformation,
+      Schema updateSchema,
+      Schema writerValueSchema,
+      Schema writerRmdSchema) {
     this.dataSchema = dataSchema;
     Schema.Field keyField = getField(dataSchema, keyFieldStr);
     keyFieldPos = keyField.pos();
@@ -105,14 +130,22 @@ public abstract class AbstractAvroRecordReader<INPUT_KEY, INPUT_VALUE>
     valueFieldPos = outputValueField.pos();
 
     this.generatePartialUpdateRecordFromInput = updateSchema != null;
+    this.writerValueSchema = writerValueSchema;
+    this.writerRmdSchema = writerRmdSchema;
+    this.schemaProjector = (writerValueSchema != null || writerRmdSchema != null) ? new VeniceSchemaProjector() : null;
     if (generatePartialUpdateRecordFromInput) {
       valueSchema = updateSchema;
+    } else if (writerValueSchema != null) {
+      // Serialize projected records against the writer (target) value schema rather than the superset input schema.
+      valueSchema = writerValueSchema;
     } else {
       valueSchema = outputValueField.schema();
     }
 
     if (rmdSchema != null) {
-      configure(keySchema, valueSchema, rmdSchema);
+      // When projecting, serialize RMD against the writer (target) RMD schema rather than the superset input schema.
+      Schema serializerRmdSchema = writerRmdSchema != null ? writerRmdSchema : rmdSchema;
+      configure(keySchema, valueSchema, serializerRmdSchema);
     } else {
       configure(keySchema, valueSchema);
     }
@@ -155,23 +188,36 @@ public abstract class AbstractAvroRecordReader<INPUT_KEY, INPUT_VALUE>
       return null;
     }
 
-    return getRecordDatum(inputKey, inputValue).get(rmdFieldPos);
+    Object rmdObject = getRecordDatum(inputKey, inputValue).get(rmdFieldPos);
+    if (writerRmdSchema != null && rmdObject != null) {
+      if (!(rmdObject instanceof GenericRecord)) {
+        throw new VeniceException("Retrieved RMD is not an Avro generic record; cannot project to writer RMD schema");
+      }
+      return schemaProjector.projectRmd((GenericRecord) rmdObject, writerRmdSchema);
+    }
+    return rmdObject;
   }
 
   @Override
   public Object getAvroValue(INPUT_KEY inputKey, INPUT_VALUE inputValue) {
     Object valueObject = getRecordDatum(inputKey, inputValue).get(valueFieldPos);
-    if (!generatePartialUpdateRecordFromInput) {
-      return valueObject;
+    if (generatePartialUpdateRecordFromInput) {
+      if (!(valueObject instanceof IndexedRecord)) {
+        throw new VeniceException("Retrieved record is not a Avro indexed record");
+      }
+      UpdateBuilder updateBuilder = new UpdateBuilderImpl(valueSchema);
+      IndexedRecord indexedRecordValue = (IndexedRecord) valueObject;
+      for (Schema.Field field: indexedRecordValue.getSchema().getFields()) {
+        updateBuilder.setNewFieldValue(field.name(), indexedRecordValue.get(field.pos()));
+      }
+      return updateBuilder.build();
     }
-    if (!(valueObject instanceof IndexedRecord)) {
-      throw new VeniceException("Retrieved record is not a Avro indexed record");
+    if (schemaProjector != null && valueObject != null) {
+      if (!(valueObject instanceof GenericRecord)) {
+        throw new VeniceException("Retrieved record is not an Avro generic record; cannot project to writer schema");
+      }
+      return schemaProjector.projectValue((GenericRecord) valueObject, writerValueSchema);
     }
-    UpdateBuilder updateBuilder = new UpdateBuilderImpl(valueSchema);
-    IndexedRecord indexedRecordValue = (IndexedRecord) valueObject;
-    for (Schema.Field field: indexedRecordValue.getSchema().getFields()) {
-      updateBuilder.setNewFieldValue(field.name(), indexedRecordValue.get(field.pos()));
-    }
-    return updateBuilder.build();
+    return valueObject;
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/avro/VeniceAvroRecordReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/recordreader/avro/VeniceAvroRecordReader.java
@@ -9,6 +9,8 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SCHEMA_STRING_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.UPDATE_SCHEMA_STRING_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.WRITER_RMD_SCHEMA_STRING_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.WRITER_VALUE_SCHEMA_STRING_PROP;
 
 import com.linkedin.venice.etl.ETLValueSchemaTransformation;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
@@ -37,7 +39,27 @@ public class VeniceAvroRecordReader extends AbstractAvroRecordReader<AvroWrapper
       String rmdFieldStr,
       ETLValueSchemaTransformation etlValueSchemaTransformation,
       Schema updateSchema) {
-    super(dataSchema, keyFieldStr, valueFieldStr, rmdFieldStr, etlValueSchemaTransformation, updateSchema);
+    this(dataSchema, keyFieldStr, valueFieldStr, rmdFieldStr, etlValueSchemaTransformation, updateSchema, null, null);
+  }
+
+  public VeniceAvroRecordReader(
+      Schema dataSchema,
+      String keyFieldStr,
+      String valueFieldStr,
+      String rmdFieldStr,
+      ETLValueSchemaTransformation etlValueSchemaTransformation,
+      Schema updateSchema,
+      Schema writerValueSchema,
+      Schema writerRmdSchema) {
+    super(
+        dataSchema,
+        keyFieldStr,
+        valueFieldStr,
+        rmdFieldStr,
+        etlValueSchemaTransformation,
+        updateSchema,
+        writerValueSchema,
+        writerRmdSchema);
   }
 
   public static VeniceAvroRecordReader fromProps(VeniceProperties props) {
@@ -59,13 +81,27 @@ public class VeniceAvroRecordReader extends AbstractAvroRecordReader<AvroWrapper
           AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(props.getString(UPDATE_SCHEMA_STRING_PROP));
     }
 
+    Schema writerValueSchema = null;
+    String writerValueSchemaString = props.getString(WRITER_VALUE_SCHEMA_STRING_PROP, "");
+    if (!writerValueSchemaString.isEmpty()) {
+      writerValueSchema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(writerValueSchemaString);
+    }
+
+    Schema writerRmdSchema = null;
+    String writerRmdSchemaString = props.getString(WRITER_RMD_SCHEMA_STRING_PROP, "");
+    if (!writerRmdSchemaString.isEmpty()) {
+      writerRmdSchema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(writerRmdSchemaString);
+    }
+
     return new VeniceAvroRecordReader(
         dataSchema,
         keyFieldStr,
         valueFieldStr,
         rmdFieldStr,
         etlValueSchemaTransformation,
-        updateSchema);
+        updateSchema,
+        writerValueSchema,
+        writerRmdSchema);
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
@@ -54,6 +54,8 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_SCHEMA_ID_PRO
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_PUSH_DESTINATION_PUBSUB_BROKER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VSON_PUSH;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.WRITER_RMD_SCHEMA_STRING_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.WRITER_VALUE_SCHEMA_STRING_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ZSTD_COMPRESSION_LEVEL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ZSTD_DICTIONARY_CREATION_SUCCESS;
 
@@ -299,6 +301,12 @@ public class DataWriterMRJob extends DataWriterComputeJob {
         if (pushJobSetting.generatePartialUpdateRecordFromInput) {
           jobConf.setBoolean(GENERATE_PARTIAL_UPDATE_RECORD_FROM_INPUT, true);
           jobConf.set(UPDATE_SCHEMA_STRING_PROP, pushJobSetting.valueSchemaString);
+        }
+        if (pushJobSetting.projectInputToWriterSchema) {
+          jobConf.set(WRITER_VALUE_SCHEMA_STRING_PROP, pushJobSetting.writerValueSchemaString);
+          if (pushJobSetting.replicationMetadataSchemaString != null) {
+            jobConf.set(WRITER_RMD_SCHEMA_STRING_PROP, pushJobSetting.replicationMetadataSchemaString);
+          }
         }
         jobConf.setClass("avro.serialization.data.model", GenericData.class, GenericData.class);
         jobConf.setInputFormat(AvroInputFormat.class);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -403,6 +403,11 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
    */
   protected void validateRmdSchema(PushJobSetting pushJobSetting) {
     if (RmdPushUtils.rmdFieldPresent(pushJobSetting)) {
+      if (pushJobSetting.projectInputToWriterSchema) {
+        // The input RMD schema is a superset of the writer (target) RMD schema; VeniceSchemaProjector#projectRmd
+        // converts each record's RMD down to the writer RMD schema at read time, so the exact-match check is skipped.
+        return;
+      }
       Schema inputRmdSchema = RmdPushUtils.getInputRmdSchema(pushJobSetting);
       if ((!RmdPushUtils.containsLogicalTimestamp(pushJobSetting) && !AvroSchemaUtils.compareSchema(
           inputRmdSchema,

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJob.java
@@ -22,6 +22,8 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.UPDATE_SCHEMA_STRIN
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VSON_PUSH;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.WRITER_RMD_SCHEMA_STRING_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.WRITER_VALUE_SCHEMA_STRING_PROP;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.hadoop.PushJobSetting;
@@ -96,6 +98,20 @@ public class DataWriterSparkJob extends AbstractDataWriterSparkJob {
         setInputConf(sparkSession, dataFrameReader, GENERATE_PARTIAL_UPDATE_RECORD_FROM_INPUT, String.valueOf(true));
         setInputConf(sparkSession, dataFrameReader, UPDATE_SCHEMA_STRING_PROP, pushJobSetting.valueSchemaString);
       }
+      if (pushJobSetting.projectInputToWriterSchema) {
+        setInputConf(
+            sparkSession,
+            dataFrameReader,
+            WRITER_VALUE_SCHEMA_STRING_PROP,
+            pushJobSetting.writerValueSchemaString);
+        if (pushJobSetting.replicationMetadataSchemaString != null) {
+          setInputConf(
+              sparkSession,
+              dataFrameReader,
+              WRITER_RMD_SCHEMA_STRING_PROP,
+              pushJobSetting.replicationMetadataSchemaString);
+        }
+      }
       setInputConf(sparkSession, dataFrameReader, VSON_PUSH, String.valueOf(false));
     } else {
       setInputConf(sparkSession, dataFrameReader, VSON_PUSH, String.valueOf(true));
@@ -114,6 +130,14 @@ public class DataWriterSparkJob extends AbstractDataWriterSparkJob {
       if (pushJobSetting.generatePartialUpdateRecordFromInput) {
         updateSchema = AvroCompatibilityHelper.parse(pushJobSetting.valueSchemaString);
       }
+      Schema writerValueSchema = null;
+      Schema writerRmdSchema = null;
+      if (pushJobSetting.projectInputToWriterSchema) {
+        writerValueSchema = AvroCompatibilityHelper.parse(pushJobSetting.writerValueSchemaString);
+        if (pushJobSetting.replicationMetadataSchemaString != null) {
+          writerRmdSchema = AvroCompatibilityHelper.parse(pushJobSetting.replicationMetadataSchemaString);
+        }
+      }
 
       GenericRecord rowRecord = RowToAvroConverter.convert(record, pushJobSetting.inputDataSchema);
       VeniceAvroRecordReader recordReader = new VeniceAvroRecordReader(
@@ -122,7 +146,9 @@ public class DataWriterSparkJob extends AbstractDataWriterSparkJob {
           pushJobSetting.valueField,
           pushJobSetting.rmdField,
           pushJobSetting.etlValueSchemaTransformation,
-          updateSchema);
+          updateSchema,
+          writerValueSchema,
+          writerRmdSchema);
 
       AvroWrapper<IndexedRecord> recordAvroWrapper = new AvroWrapper<>(rowRecord);
       final byte[] inputKeyBytes = recordReader.getKeyBytes(recordAvroWrapper, null);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -348,15 +348,6 @@ public final class VenicePushJobConstants {
   public static final String VALUE_SCHEMA_ID_PROP = "value.schema.id";
 
   /**
-   * Feature flag controlling input value-schema projection. When enabled (and {@link #TARGET_WRITER_VALUE_SCHEMA_ID_PROP}
-   * is set to a positive id), input records whose value schema is a strict superset of the target writer value schema
-   * are projected down to it via {@link com.linkedin.venice.schema.projection.VeniceSchemaProjector}. Defaults to
-   * {@link #DEFAULT_INPUT_VALUE_SCHEMA_PROJECTION_ENABLED}; acts as a kill-switch for the feature.
-   */
-  public static final String INPUT_VALUE_SCHEMA_PROJECTION_ENABLED = "input.value.schema.projection.enabled";
-  public static final boolean DEFAULT_INPUT_VALUE_SCHEMA_PROJECTION_ENABLED = false;
-
-  /**
    * Optional writer (target) value schema ID. When set, input records are projected down to this schema
    * via {@link com.linkedin.venice.schema.projection.VeniceSchemaProjector}; the input schema must
    * be a strict superset of it.

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -37,6 +37,10 @@ public final class VenicePushJobConstants {
   public static final String EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED = "extended.schema.validity.check.enabled";
   public static final boolean DEFAULT_EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED = true;
   public static final String UPDATE_SCHEMA_STRING_PROP = "update.schema";
+  /** Serialized writer (target) value schema to project superset input records down to. Set when projection is enabled. */
+  public static final String WRITER_VALUE_SCHEMA_STRING_PROP = "writer.value.schema";
+  /** Serialized writer (target) RMD schema to project superset input RMD down to. Set when projection is enabled and input carries RMD. */
+  public static final String WRITER_RMD_SCHEMA_STRING_PROP = "writer.rmd.schema";
   public static final String RMD_SCHEMA_PROP = "rmd.schema";
 
   // This is a temporary config used to rollout the native input format for Spark. This will be removed soon
@@ -342,6 +346,22 @@ public final class VenicePushJobConstants {
   public static final FsPermission PERMISSION_700 = FsPermission.createImmutable((short) 0700);
 
   public static final String VALUE_SCHEMA_ID_PROP = "value.schema.id";
+
+  /**
+   * Feature flag controlling input value-schema projection. When enabled (and {@link #TARGET_WRITER_VALUE_SCHEMA_ID_PROP}
+   * is set to a positive id), input records whose value schema is a strict superset of the target writer value schema
+   * are projected down to it via {@link com.linkedin.venice.schema.projection.VeniceSchemaProjector}. Defaults to
+   * {@link #DEFAULT_INPUT_VALUE_SCHEMA_PROJECTION_ENABLED}; acts as a kill-switch for the feature.
+   */
+  public static final String INPUT_VALUE_SCHEMA_PROJECTION_ENABLED = "input.value.schema.projection.enabled";
+  public static final boolean DEFAULT_INPUT_VALUE_SCHEMA_PROJECTION_ENABLED = false;
+
+  /**
+   * Optional writer (target) value schema ID. When set, input records are projected down to this schema
+   * via {@link com.linkedin.venice.schema.projection.VeniceSchemaProjector}; the input schema must
+   * be a strict superset of it.
+   */
+  public static final String TARGET_WRITER_VALUE_SCHEMA_ID_PROP = "target.writer.value.schema.id";
 
   public static final String RMD_SCHEMA_ID_PROP = "rmd.schema.id";
   public static final String DERIVED_SCHEMA_ID_PROP = "derived.schema.id";

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENAB
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_UPDATE_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V2_SCHEMA;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ALLOW_REGULAR_PUSH_WITH_TTL_REPUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.COMPLIANCE_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.CONTROLLER_REQUEST_RETRY_ATTEMPTS;
@@ -342,6 +343,125 @@ public class VenicePushJobTest {
     VenicePushJob vpj = mock(VenicePushJob.class);
     doCallRealMethod().when(vpj).validateAndSetRmdSchemas(any(), any());
     vpj.validateAndSetRmdSchemas(mockClient, setting);
+  }
+
+  @Test
+  public void testValidateValueSchemaEnablesProjectionForSupersetInput() {
+    // Input value schema (V2) is a strict superset of the chosen target writer value schema (V1).
+    ControllerClient mockClient = mock(ControllerClient.class);
+
+    // Input value schema does not match any registered value schema.
+    SchemaResponse valueSchemaIdResponse = new SchemaResponse();
+    valueSchemaIdResponse.setError("Could not find any registered value schema for the input value schema.");
+    doReturn(valueSchemaIdResponse).when(mockClient)
+        .getValueSchemaID(eq(TEST_STORE), eq(NAME_RECORD_V2_SCHEMA.toString()));
+
+    // The supplied target writer value schema id resolves to the writer (V1) schema.
+    SchemaResponse writerSchemaResponse = new SchemaResponse();
+    writerSchemaResponse.setId(7);
+    writerSchemaResponse.setSchemaStr(NAME_RECORD_V1_SCHEMA.toString());
+    doReturn(writerSchemaResponse).when(mockClient).getValueSchema(eq(TEST_STORE), eq(7));
+
+    VenicePushJob vpj = getSpyVenicePushJob(new Properties(), mockClient);
+    PushJobSetting setting = vpj.getPushJobSetting();
+    setting.storeName = TEST_STORE;
+    setting.controllerRetries = 1;
+    setting.enableWriteCompute = false;
+    setting.valueSchemaProjectionEnabled = true;
+    setting.targetWriterValueSchemaId = 7;
+    setting.valueSchema = NAME_RECORD_V2_SCHEMA;
+    setting.valueSchemaString = NAME_RECORD_V2_SCHEMA.toString();
+
+    vpj.validateAndRetrieveValueSchemas(mockClient, setting, false);
+
+    Assert.assertTrue(setting.projectInputToWriterSchema);
+    Assert.assertEquals(setting.valueSchemaId, 7);
+    Assert.assertEquals(setting.writerValueSchemaString, NAME_RECORD_V1_SCHEMA.toString());
+    Assert.assertEquals(setting.writerValueSchema, NAME_RECORD_V1_SCHEMA);
+  }
+
+  @Test
+  public void testValidateValueSchemaDoesNotProjectWhenFeatureFlagDisabled() {
+    // Even with a valid superset input and a target writer schema id, projection must NOT happen when the
+    // feature flag is off; the job falls through to the normal "schema not registered" failure path instead.
+    ControllerClient mockClient = mock(ControllerClient.class);
+
+    SchemaResponse valueSchemaIdResponse = new SchemaResponse();
+    valueSchemaIdResponse.setError("Could not find any registered value schema for the input value schema.");
+    doReturn(valueSchemaIdResponse).when(mockClient)
+        .getValueSchemaID(eq(TEST_STORE), eq(NAME_RECORD_V2_SCHEMA.toString()));
+    MultiSchemaResponse allValueSchemaResponse = new MultiSchemaResponse();
+    allValueSchemaResponse.setError("not relevant to this test");
+    doReturn(allValueSchemaResponse).when(mockClient).getAllValueSchema(eq(TEST_STORE));
+
+    VenicePushJob vpj = getSpyVenicePushJob(new Properties(), mockClient);
+    PushJobSetting setting = vpj.getPushJobSetting();
+    setting.storeName = TEST_STORE;
+    setting.controllerRetries = 1;
+    setting.enableWriteCompute = false;
+    setting.valueSchemaProjectionEnabled = false;
+    setting.targetWriterValueSchemaId = 7;
+    setting.valueSchema = NAME_RECORD_V2_SCHEMA;
+    setting.valueSchemaString = NAME_RECORD_V2_SCHEMA.toString();
+
+    Assert.assertThrows(VeniceException.class, () -> vpj.validateAndRetrieveValueSchemas(mockClient, setting, false));
+    Assert.assertFalse(setting.projectInputToWriterSchema);
+    verify(mockClient, never()).getValueSchema(eq(TEST_STORE), eq(7));
+  }
+
+  @Test(expectedExceptions = VeniceSchemaMismatchException.class, expectedExceptionsMessageRegExp = ".*not a superset of the target writer value schema.*")
+  public void testValidateValueSchemaRejectsNonSupersetProjectionInput() {
+    // Input value schema (V1) is NOT a superset of the chosen target writer value schema (V2): V2 requires "age".
+    ControllerClient mockClient = mock(ControllerClient.class);
+
+    SchemaResponse valueSchemaIdResponse = new SchemaResponse();
+    valueSchemaIdResponse.setError("Could not find any registered value schema for the input value schema.");
+    doReturn(valueSchemaIdResponse).when(mockClient)
+        .getValueSchemaID(eq(TEST_STORE), eq(NAME_RECORD_V1_SCHEMA.toString()));
+
+    SchemaResponse writerSchemaResponse = new SchemaResponse();
+    writerSchemaResponse.setId(7);
+    writerSchemaResponse.setSchemaStr(NAME_RECORD_V2_SCHEMA.toString());
+    doReturn(writerSchemaResponse).when(mockClient).getValueSchema(eq(TEST_STORE), eq(7));
+
+    VenicePushJob vpj = getSpyVenicePushJob(new Properties(), mockClient);
+    PushJobSetting setting = vpj.getPushJobSetting();
+    setting.storeName = TEST_STORE;
+    setting.controllerRetries = 1;
+    setting.enableWriteCompute = false;
+    setting.valueSchemaProjectionEnabled = true;
+    setting.targetWriterValueSchemaId = 7;
+    setting.valueSchema = NAME_RECORD_V1_SCHEMA;
+    setting.valueSchemaString = NAME_RECORD_V1_SCHEMA.toString();
+
+    vpj.validateAndRetrieveValueSchemas(mockClient, setting, false);
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Failed to fetch target writer value schema id: 7.*")
+  public void testValidateValueSchemaProjectionFailsWhenWriterSchemaFetchErrors() {
+    // The supplied target writer value schema id cannot be resolved by the controller.
+    ControllerClient mockClient = mock(ControllerClient.class);
+
+    SchemaResponse valueSchemaIdResponse = new SchemaResponse();
+    valueSchemaIdResponse.setError("Could not find any registered value schema for the input value schema.");
+    doReturn(valueSchemaIdResponse).when(mockClient)
+        .getValueSchemaID(eq(TEST_STORE), eq(NAME_RECORD_V2_SCHEMA.toString()));
+
+    SchemaResponse writerSchemaResponse = new SchemaResponse();
+    writerSchemaResponse.setError("No value schema found for id: 7");
+    doReturn(writerSchemaResponse).when(mockClient).getValueSchema(eq(TEST_STORE), eq(7));
+
+    VenicePushJob vpj = getSpyVenicePushJob(new Properties(), mockClient);
+    PushJobSetting setting = vpj.getPushJobSetting();
+    setting.storeName = TEST_STORE;
+    setting.controllerRetries = 1;
+    setting.enableWriteCompute = false;
+    setting.valueSchemaProjectionEnabled = true;
+    setting.targetWriterValueSchemaId = 7;
+    setting.valueSchema = NAME_RECORD_V2_SCHEMA;
+    setting.valueSchemaString = NAME_RECORD_V2_SCHEMA.toString();
+
+    vpj.validateAndRetrieveValueSchemas(mockClient, setting, false);
   }
 
   @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Repush with TTL is only supported while using Kafka Input Format.*")

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -16,6 +16,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_P
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_RMD_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFER_VERSION_SWAP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.ENABLE_WRITE_COMPUTE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INPUT_PATH_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
@@ -34,6 +35,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.SOURCE_KAFKA;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_LIST;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGETED_REGION_PUSH_WITH_DEFERRED_SWAP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGET_WRITER_VALUE_SCHEMA_ID_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_DISCOVER_URL_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
@@ -367,7 +369,6 @@ public class VenicePushJobTest {
     setting.storeName = TEST_STORE;
     setting.controllerRetries = 1;
     setting.enableWriteCompute = false;
-    setting.valueSchemaProjectionEnabled = true;
     setting.targetWriterValueSchemaId = 7;
     setting.valueSchema = NAME_RECORD_V2_SCHEMA;
     setting.valueSchemaString = NAME_RECORD_V2_SCHEMA.toString();
@@ -381,31 +382,30 @@ public class VenicePushJobTest {
   }
 
   @Test
-  public void testValidateValueSchemaDoesNotProjectWhenFeatureFlagDisabled() {
-    // Even with a valid superset input and a target writer schema id, projection must NOT happen when the
-    // feature flag is off; the job falls through to the normal "schema not registered" failure path instead.
+  public void testValidateValueSchemaSkipsProjectionWhenInputMatchesDifferentRegisteredSchemaId() {
+    // Input value schema already matches a registered value schema (id 3), but the supplied target writer value schema
+    // id (7) is different. Projection must be skipped and the matched schema id used.
     ControllerClient mockClient = mock(ControllerClient.class);
 
     SchemaResponse valueSchemaIdResponse = new SchemaResponse();
-    valueSchemaIdResponse.setError("Could not find any registered value schema for the input value schema.");
+    valueSchemaIdResponse.setId(3);
+    valueSchemaIdResponse.setSchemaStr(NAME_RECORD_V2_SCHEMA.toString());
     doReturn(valueSchemaIdResponse).when(mockClient)
         .getValueSchemaID(eq(TEST_STORE), eq(NAME_RECORD_V2_SCHEMA.toString()));
-    MultiSchemaResponse allValueSchemaResponse = new MultiSchemaResponse();
-    allValueSchemaResponse.setError("not relevant to this test");
-    doReturn(allValueSchemaResponse).when(mockClient).getAllValueSchema(eq(TEST_STORE));
 
     VenicePushJob vpj = getSpyVenicePushJob(new Properties(), mockClient);
     PushJobSetting setting = vpj.getPushJobSetting();
     setting.storeName = TEST_STORE;
     setting.controllerRetries = 1;
     setting.enableWriteCompute = false;
-    setting.valueSchemaProjectionEnabled = false;
     setting.targetWriterValueSchemaId = 7;
     setting.valueSchema = NAME_RECORD_V2_SCHEMA;
     setting.valueSchemaString = NAME_RECORD_V2_SCHEMA.toString();
 
-    Assert.assertThrows(VeniceException.class, () -> vpj.validateAndRetrieveValueSchemas(mockClient, setting, false));
+    vpj.validateAndRetrieveValueSchemas(mockClient, setting, false);
+
     Assert.assertFalse(setting.projectInputToWriterSchema);
+    Assert.assertEquals(setting.valueSchemaId, 3);
     verify(mockClient, never()).getValueSchema(eq(TEST_STORE), eq(7));
   }
 
@@ -429,7 +429,6 @@ public class VenicePushJobTest {
     setting.storeName = TEST_STORE;
     setting.controllerRetries = 1;
     setting.enableWriteCompute = false;
-    setting.valueSchemaProjectionEnabled = true;
     setting.targetWriterValueSchemaId = 7;
     setting.valueSchema = NAME_RECORD_V1_SCHEMA;
     setting.valueSchemaString = NAME_RECORD_V1_SCHEMA.toString();
@@ -456,7 +455,6 @@ public class VenicePushJobTest {
     setting.storeName = TEST_STORE;
     setting.controllerRetries = 1;
     setting.enableWriteCompute = false;
-    setting.valueSchemaProjectionEnabled = true;
     setting.targetWriterValueSchemaId = 7;
     setting.valueSchema = NAME_RECORD_V2_SCHEMA;
     setting.valueSchemaString = NAME_RECORD_V2_SCHEMA.toString();
@@ -1070,6 +1068,32 @@ public class VenicePushJobTest {
     props.put(SOURCE_KAFKA, true);
     props.put(SOURCE_ETL, true);
     new VenicePushJob(PUSH_JOB_ID, props);
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*not supported together with write compute.*")
+  public void testGetPushJobSettingThrowsWhenProjectionEnabledWithWriteCompute() {
+    Properties props = getVpjRequiredProperties();
+    props.put(TARGET_WRITER_VALUE_SCHEMA_ID_PROP, 7);
+    props.put(ENABLE_WRITE_COMPUTE, true);
+    new VenicePushJob(PUSH_JOB_ID, props);
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*not supported together with incremental push.*")
+  public void testGetPushJobSettingThrowsWhenProjectionEnabledWithIncrementalPush() {
+    Properties props = getVpjRequiredProperties();
+    props.put(TARGET_WRITER_VALUE_SCHEMA_ID_PROP, 7);
+    props.put(INCREMENTAL_PUSH, true);
+    new VenicePushJob(PUSH_JOB_ID, props);
+  }
+
+  @Test
+  public void testGetPushJobSettingDoesNotThrowWhenProjectionEnabledForBatchPush() {
+    Properties props = getVpjRequiredProperties();
+    props.put(TARGET_WRITER_VALUE_SCHEMA_ID_PROP, 7);
+    try (VenicePushJob vpj = new VenicePushJob(PUSH_JOB_ID, props)) {
+      PushJobSetting setting = vpj.getPushJobSetting();
+      assertEquals(setting.targetWriterValueSchemaId, 7);
+    }
   }
 
   @Test

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/TestDataWriterMRJob.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/TestDataWriterMRJob.java
@@ -1,12 +1,20 @@
 package com.linkedin.venice.hadoop.mapreduce.datawriter.jobs;
 
+import static com.linkedin.venice.vpj.VenicePushJobConstants.WRITER_RMD_SCHEMA_STRING_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.WRITER_VALUE_SCHEMA_STRING_PROP;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import com.linkedin.venice.etl.ETLValueSchemaTransformation;
+import com.linkedin.venice.hadoop.PushJobSetting;
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
+import com.linkedin.venice.utils.TestWriteUtils;
 import java.io.IOException;
+import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -135,5 +143,47 @@ public class TestDataWriterMRJob {
     DataWriterMRJob mrJob = createMRJobWithMockCluster(runningJob);
     // Should not throw when staging dir doesn't exist
     mrJob.close();
+  }
+
+  @Test
+  public void testSetupInputFormatConfPlumbsWriterSchemasWhenProjecting() {
+    Schema writerValueSchema = TestWriteUtils.NAME_RECORD_V1_SCHEMA;
+    Schema writerRmdSchema = RmdSchemaGenerator.generateMetadataSchema(writerValueSchema, 1);
+
+    PushJobSetting setting = avroProjectionPushJobSetting();
+    setting.projectInputToWriterSchema = true;
+    setting.writerValueSchemaString = writerValueSchema.toString();
+    setting.replicationMetadataSchemaString = writerRmdSchema.toString();
+
+    JobConf jobConf = new JobConf();
+    new DataWriterMRJob().setupInputFormatConf(jobConf, setting);
+
+    Assert.assertEquals(jobConf.get(WRITER_VALUE_SCHEMA_STRING_PROP), writerValueSchema.toString());
+    Assert.assertEquals(jobConf.get(WRITER_RMD_SCHEMA_STRING_PROP), writerRmdSchema.toString());
+  }
+
+  @Test
+  public void testSetupInputFormatConfOmitsWriterSchemasWhenNotProjecting() {
+    PushJobSetting setting = avroProjectionPushJobSetting();
+    setting.projectInputToWriterSchema = false;
+
+    JobConf jobConf = new JobConf();
+    new DataWriterMRJob().setupInputFormatConf(jobConf, setting);
+
+    assertNull(jobConf.get(WRITER_VALUE_SCHEMA_STRING_PROP));
+    assertNull(jobConf.get(WRITER_RMD_SCHEMA_STRING_PROP));
+  }
+
+  private PushJobSetting avroProjectionPushJobSetting() {
+    PushJobSetting setting = new PushJobSetting();
+    setting.isSourceKafka = false;
+    setting.isAvro = true;
+    setting.inputURI = System.getProperty("java.io.tmpdir");
+    setting.keyField = "key";
+    setting.valueField = "value";
+    setting.rmdField = "rmd";
+    setting.etlValueSchemaTransformation = ETLValueSchemaTransformation.NONE;
+    setting.inputDataSchemaString = TestWriteUtils.STRING_TO_NAME_RECORD_V2_SCHEMA.toString();
+    return setting;
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/recordreader/avro/TestVeniceAvroRecordReader.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/recordreader/avro/TestVeniceAvroRecordReader.java
@@ -5,25 +5,37 @@ import static com.linkedin.venice.etl.ETLValueSchemaTransformation.NONE;
 import static com.linkedin.venice.etl.ETLValueSchemaTransformation.UNIONIZE_WITH_NULL;
 import static com.linkedin.venice.utils.DataProviderUtils.BOOLEAN;
 import static com.linkedin.venice.utils.TestWriteUtils.INT_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V2_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_TO_NAME_RECORD_V1_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.STRING_TO_NAME_RECORD_V2_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_TO_NAME_WITH_TIMESTAMP_RECORD_V1_SCHEMA;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_RMD_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.KEY_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SCHEMA_STRING_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.WRITER_VALUE_SCHEMA_STRING_PROP;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.RandomRecordGenerator;
 import com.linkedin.venice.etl.ETLValueSchemaTransformation;
 import com.linkedin.venice.hadoop.input.recordreader.avro.VeniceAvroRecordReader;
+import com.linkedin.venice.schema.rmd.RmdConstants;
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.PushInputSchemaBuilder;
 import com.linkedin.venice.utils.RandomGenUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Properties;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -100,6 +112,182 @@ public class TestVeniceAvroRecordReader {
     Assert.assertEquals(
         ((IndexedRecord) result).get(updateSchema.getField("age").pos()),
         new GenericData.Record(updateSchema.getField("age").schema().getTypes().get(0)));
+  }
+
+  @Test
+  public void testGetAvroValueProjectsSupersetInputToWriterSchema() {
+    // Input value schema (V2) is a strict superset of the writer (target) value schema (V1): V2 adds "age".
+    VeniceAvroRecordReader recordReader = new VeniceAvroRecordReader(
+        STRING_TO_NAME_RECORD_V2_SCHEMA,
+        "key",
+        "value",
+        DEFAULT_RMD_FIELD_PROP,
+        NONE,
+        null,
+        NAME_RECORD_V1_SCHEMA,
+        null);
+
+    GenericRecord record = new GenericData.Record(STRING_TO_NAME_RECORD_V2_SCHEMA);
+    record.put("key", "123");
+    GenericRecord valueRecord = new GenericData.Record(NAME_RECORD_V2_SCHEMA);
+    valueRecord.put("firstName", "FN");
+    valueRecord.put("lastName", "LN");
+    valueRecord.put("age", 42);
+    record.put("value", valueRecord);
+
+    Object result = recordReader.getAvroValue(new AvroWrapper<>(record), NullWritable.get());
+    Assert.assertTrue(result instanceof GenericRecord);
+    GenericRecord projected = (GenericRecord) result;
+
+    // Projected record conforms to the writer schema (V1): "age" is dropped, surviving fields retain their values.
+    Assert.assertEquals(projected.getSchema(), NAME_RECORD_V1_SCHEMA);
+    Assert.assertNull(projected.getSchema().getField("age"));
+    Assert.assertEquals(projected.get("firstName").toString(), "FN");
+    Assert.assertEquals(projected.get("lastName").toString(), "LN");
+  }
+
+  @Test
+  public void testGetAvroValueReturnsNullForTombstoneWhenProjecting() {
+    VeniceAvroRecordReader recordReader = new VeniceAvroRecordReader(
+        STRING_TO_NAME_RECORD_V2_SCHEMA,
+        "key",
+        "value",
+        DEFAULT_RMD_FIELD_PROP,
+        NONE,
+        null,
+        NAME_RECORD_V1_SCHEMA,
+        null);
+
+    GenericRecord record = new GenericData.Record(STRING_TO_NAME_RECORD_V2_SCHEMA);
+    record.put("key", "123");
+    record.put("value", null);
+
+    Assert.assertNull(recordReader.getAvroValue(new AvroWrapper<>(record), NullWritable.get()));
+  }
+
+  @Test
+  public void testGetAvroValueWithoutWriterSchemaIsNotProjected() {
+    // No writer value schema supplied: the reader must pass the input value through untouched.
+    VeniceAvroRecordReader recordReader =
+        new VeniceAvroRecordReader(STRING_TO_NAME_RECORD_V1_SCHEMA, "key", "value", DEFAULT_RMD_FIELD_PROP, NONE, null);
+
+    GenericRecord record = new GenericData.Record(STRING_TO_NAME_RECORD_V1_SCHEMA);
+    record.put("key", "123");
+    GenericRecord valueRecord = new GenericData.Record(NAME_RECORD_V1_SCHEMA);
+    valueRecord.put("firstName", "FN");
+    valueRecord.put("lastName", "LN");
+    record.put("value", valueRecord);
+
+    Object result = recordReader.getAvroValue(new AvroWrapper<>(record), NullWritable.get());
+    Assert.assertSame(result, valueRecord);
+  }
+
+  @Test
+  public void testGetRmdValueProjectsSupersetRmdToWriterRmdSchema() {
+    // RMD generated against the superset value schema (V2) is projected down to the writer's RMD schema (V1).
+    Schema writerValueSchema = NAME_RECORD_V1_SCHEMA;
+    Schema inputRmdSchema = RmdSchemaGenerator.generateMetadataSchema(NAME_RECORD_V2_SCHEMA, 1);
+    Schema writerRmdSchema = RmdSchemaGenerator.generateMetadataSchema(writerValueSchema, 1);
+
+    Schema inputFileSchema = new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA)
+        .setValueSchema(NAME_RECORD_V2_SCHEMA)
+        .setFieldSchema(DEFAULT_RMD_FIELD_PROP, inputRmdSchema)
+        .build();
+
+    VeniceAvroRecordReader recordReader = new VeniceAvroRecordReader(
+        inputFileSchema,
+        "key",
+        "value",
+        DEFAULT_RMD_FIELD_PROP,
+        NONE,
+        null,
+        writerValueSchema,
+        writerRmdSchema);
+
+    GenericRecord record = new GenericData.Record(inputFileSchema);
+    record.put("key", "123");
+    GenericRecord valueRecord = new GenericData.Record(NAME_RECORD_V2_SCHEMA);
+    valueRecord.put("firstName", "FN");
+    valueRecord.put("lastName", "LN");
+    valueRecord.put("age", 42);
+    record.put("value", valueRecord);
+
+    GenericRecord rmdRecord = new GenericData.Record(inputRmdSchema);
+    rmdRecord.put(RmdConstants.TIMESTAMP_FIELD_NAME, 9999L);
+    rmdRecord.put(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>(Arrays.asList(1L, 2L)));
+    record.put(DEFAULT_RMD_FIELD_PROP, rmdRecord);
+
+    Object result = recordReader.getRmdValue(new AvroWrapper<>(record), NullWritable.get());
+    Assert.assertTrue(result instanceof GenericRecord);
+    GenericRecord projected = (GenericRecord) result;
+
+    Assert.assertEquals(projected.getSchema(), writerRmdSchema);
+    Assert.assertEquals(projected.get(RmdConstants.TIMESTAMP_FIELD_NAME), 9999L);
+    Assert.assertEquals(
+        projected.get(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME),
+        new ArrayList<>(Arrays.asList(1L, 2L)));
+  }
+
+  @Test
+  public void testGetRmdValueReturnsNullWhenRecordCarriesNoRmd() {
+    Schema writerValueSchema = NAME_RECORD_V1_SCHEMA;
+    Schema inputRmdSchema = RmdSchemaGenerator.generateMetadataSchema(NAME_RECORD_V2_SCHEMA, 1);
+    Schema writerRmdSchema = RmdSchemaGenerator.generateMetadataSchema(writerValueSchema, 1);
+
+    Schema inputFileSchema = new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA)
+        .setValueSchema(NAME_RECORD_V2_SCHEMA)
+        .setFieldSchema(DEFAULT_RMD_FIELD_PROP, inputRmdSchema)
+        .build();
+
+    VeniceAvroRecordReader recordReader = new VeniceAvroRecordReader(
+        inputFileSchema,
+        "key",
+        "value",
+        DEFAULT_RMD_FIELD_PROP,
+        NONE,
+        null,
+        writerValueSchema,
+        writerRmdSchema);
+
+    GenericRecord record = new GenericData.Record(inputFileSchema);
+    record.put("key", "123");
+    GenericRecord valueRecord = new GenericData.Record(NAME_RECORD_V2_SCHEMA);
+    valueRecord.put("firstName", "FN");
+    valueRecord.put("lastName", "LN");
+    valueRecord.put("age", 42);
+    record.put("value", valueRecord);
+    record.put(DEFAULT_RMD_FIELD_PROP, null);
+
+    Assert.assertNull(recordReader.getRmdValue(new AvroWrapper<>(record), NullWritable.get()));
+  }
+
+  @Test
+  public void testFromPropsWiresWriterSchemaAndProjects() {
+    // Closes the loop with the MR/Spark plumbing: the writer value schema prop (set on the job conf) drives fromProps
+    // to build a projecting reader.
+    Schema writerValueSchema = NAME_RECORD_V1_SCHEMA;
+
+    Properties props = new Properties();
+    props.setProperty(SCHEMA_STRING_PROP, STRING_TO_NAME_RECORD_V2_SCHEMA.toString());
+    props.setProperty(KEY_FIELD_PROP, "key");
+    props.setProperty(VALUE_FIELD_PROP, "value");
+    props.setProperty(WRITER_VALUE_SCHEMA_STRING_PROP, writerValueSchema.toString());
+
+    VeniceAvroRecordReader recordReader = VeniceAvroRecordReader.fromProps(new VeniceProperties(props));
+
+    GenericRecord record = new GenericData.Record(STRING_TO_NAME_RECORD_V2_SCHEMA);
+    record.put("key", "123");
+    GenericRecord valueRecord = new GenericData.Record(NAME_RECORD_V2_SCHEMA);
+    valueRecord.put("firstName", "FN");
+    valueRecord.put("lastName", "LN");
+    valueRecord.put("age", 42);
+    record.put("value", valueRecord);
+
+    Object projectedValue = recordReader.getAvroValue(new AvroWrapper<>(record), NullWritable.get());
+    Assert.assertTrue(projectedValue instanceof GenericRecord);
+    Assert.assertEquals(((GenericRecord) projectedValue).getSchema(), writerValueSchema);
+    Assert.assertNull(((GenericRecord) projectedValue).getSchema().getField("age"));
+    Assert.assertEquals(((GenericRecord) projectedValue).get("firstName").toString(), "FN");
   }
 
   @Test(dataProvider = "Boolean-and-EtlTransformations")

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJobTest.java
@@ -26,22 +26,29 @@ import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.etl.ETLValueSchemaTransformation;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.PushJobSetting;
 import com.linkedin.venice.hadoop.exceptions.VeniceInvalidInputException;
 import com.linkedin.venice.jobs.ComputeJob;
 import com.linkedin.venice.jobs.DataWriterComputeJob;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.utils.PushInputSchemaBuilder;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.rdd.RDD;
@@ -106,6 +113,95 @@ public class AbstractDataWriterSparkJobTest {
     pushJobSetting.inputDataSchema = mockSchema;
 
     dataWriterSparkJob.validateRmdSchema(pushJobSetting);
+  }
+
+  @Test
+  public void testValidateRmdSchemaSkippedWhenProjecting() {
+    // When projecting, the input RMD schema is a superset of the writer (server-side) RMD schema, so the exact-match
+    // check must be skipped: VeniceSchemaProjector#projectRmd converts each record's RMD at read time.
+    AbstractDataWriterSparkJob dataWriterSparkJob = spy(AbstractDataWriterSparkJob.class);
+
+    Schema inputRmdSchema = RmdSchemaGenerator.generateMetadataSchema(TestWriteUtils.NAME_RECORD_V2_SCHEMA, 1);
+    Schema writerRmdSchema = RmdSchemaGenerator.generateMetadataSchema(TestWriteUtils.NAME_RECORD_V1_SCHEMA, 1);
+    Schema inputDataSchema = new PushInputSchemaBuilder().setKeySchema(Schema.create(Schema.Type.STRING))
+        .setValueSchema(TestWriteUtils.NAME_RECORD_V2_SCHEMA)
+        .setFieldSchema("rmd", inputRmdSchema)
+        .build();
+
+    PushJobSetting pushJobSetting = new PushJobSetting();
+    pushJobSetting.rmdField = "rmd";
+    pushJobSetting.inputDataSchema = inputDataSchema;
+    // Server-side (writer) RMD schema differs from the input RMD schema; without projection this would mismatch.
+    pushJobSetting.replicationMetadataSchemaString = writerRmdSchema.toString();
+    pushJobSetting.projectInputToWriterSchema = true;
+
+    // Must not throw despite the input/server RMD schema mismatch.
+    dataWriterSparkJob.validateRmdSchema(pushJobSetting);
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Input rmd schema does not match the server side RMD schema.*")
+  public void testValidateRmdSchemaEnforcedWhenNotProjecting() {
+    // Same mismatch as above but without projection: the exact-match check must reject it.
+    AbstractDataWriterSparkJob dataWriterSparkJob = spy(AbstractDataWriterSparkJob.class);
+
+    Schema inputRmdSchema = RmdSchemaGenerator.generateMetadataSchema(TestWriteUtils.NAME_RECORD_V2_SCHEMA, 1);
+    Schema writerRmdSchema = RmdSchemaGenerator.generateMetadataSchema(TestWriteUtils.NAME_RECORD_V1_SCHEMA, 1);
+    Schema inputDataSchema = new PushInputSchemaBuilder().setKeySchema(Schema.create(Schema.Type.STRING))
+        .setValueSchema(TestWriteUtils.NAME_RECORD_V2_SCHEMA)
+        .setFieldSchema("rmd", inputRmdSchema)
+        .build();
+
+    PushJobSetting pushJobSetting = new PushJobSetting();
+    pushJobSetting.rmdField = "rmd";
+    pushJobSetting.inputDataSchema = inputDataSchema;
+    pushJobSetting.replicationMetadataSchemaString = writerRmdSchema.toString();
+    pushJobSetting.projectInputToWriterSchema = false;
+
+    dataWriterSparkJob.validateRmdSchema(pushJobSetting);
+  }
+
+  @Test
+  public void testGetUserInputDataFrameProjectsValuesToWriterSchema() throws IOException {
+    // Drives the real Spark avro input path (getAvroDataFrame) end to end: a V2 (superset) avro input file is read and
+    // each value is projected down to the V1 writer schema, then serialized against V1.
+    File inputDir = TestWriteUtils.getTempDataDirectory();
+    Schema dataSchema = TestWriteUtils.writeSimpleAvroFileWithStringToNameRecordV2Schema(inputDir);
+
+    PushJobSetting setting = getDefaultPushJobSetting(inputDir, dataSchema);
+    setting.projectInputToWriterSchema = true;
+    setting.writerValueSchema = TestWriteUtils.NAME_RECORD_V1_SCHEMA;
+    setting.writerValueSchemaString = TestWriteUtils.NAME_RECORD_V1_SCHEMA.toString();
+    setting.replicationMetadataSchemaString = null;
+
+    RecordDeserializer<CharSequence> keyDeserializer = FastSerializerDeserializerFactory
+        .getFastAvroGenericDeserializer(Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.STRING));
+    RecordDeserializer<GenericRecord> writerValueDeserializer = FastSerializerDeserializerFactory
+        .getFastAvroGenericDeserializer(TestWriteUtils.NAME_RECORD_V1_SCHEMA, TestWriteUtils.NAME_RECORD_V1_SCHEMA);
+    RecordSerializer<GenericRecord> writerValueSerializer =
+        FastSerializerDeserializerFactory.getFastAvroGenericSerializer(TestWriteUtils.NAME_RECORD_V1_SCHEMA);
+
+    try (DataWriterSparkJob job = new DataWriterSparkJob()) {
+      job.configure(new VeniceProperties(new Properties()), setting);
+      List<Row> rows = job.getUserInputDataFrame().collectAsList();
+
+      Assert.assertEquals(rows.size(), TestWriteUtils.DEFAULT_USER_DATA_RECORD_COUNT);
+      for (Row row: rows) {
+        String key = keyDeserializer.deserialize((byte[]) row.getAs("key")).toString();
+        byte[] valueBytes = row.getAs("value");
+
+        GenericRecord projected = writerValueDeserializer.deserialize(valueBytes);
+        // Projected to the writer schema (V1): "age" is dropped, surviving fields retain their values.
+        Assert.assertNull(projected.getSchema().getField("age"));
+        Assert.assertEquals(projected.get("firstName").toString(), "first_name_" + key);
+        Assert.assertEquals(projected.get("lastName").toString(), "last_name_" + key);
+
+        // The emitted bytes must be the V1 encoding (no trailing "age"): a non-projected V2 encoding would differ.
+        GenericRecord expected = new GenericData.Record(TestWriteUtils.NAME_RECORD_V1_SCHEMA);
+        expected.put("firstName", "first_name_" + key);
+        expected.put("lastName", "last_name_" + key);
+        Assert.assertEquals(valueBytes, writerValueSerializer.serialize(expected));
+      }
+    }
   }
 
   @Test(expectedExceptions = VeniceInvalidInputException.class, expectedExceptionsMessageRegExp = "The provided input rmd schema must be BinaryType.*")

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/projection/VeniceSchemaProjector.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/projection/VeniceSchemaProjector.java
@@ -45,7 +45,7 @@ public class VeniceSchemaProjector {
             "Writer value field '" + fieldName + "' is absent from the input value schema; writer schema is not a "
                 + "subset of the input schema.");
       }
-      projected.put(writerField.pos(), GenericData.get().deepCopy(writerField.schema(), src.get(fieldName)));
+      projected.put(writerField.pos(), src.get(fieldName));
     }
     return projected;
   }
@@ -72,11 +72,12 @@ public class VeniceSchemaProjector {
     }
     GenericRecord projected = new GenericData.Record(targetRmdSchema);
 
-    // replication_checkpoint_vector is value-independent; copy verbatim.
+    // NOTE: This only handles the current (v1) RMD schema shape, which has exactly two top-level fields:
+    // {@code timestamp} and {@code replication_checkpoint_vector}. Both are hard-coded below. If the RMD schema is
+    // ever evolved (e.g. a new top-level field is added or these are restructured), this method will silently drop
+    // the new field(s) and MUST be revisited to project them;
     Schema.Field rcvField = targetRmdSchema.getField(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME);
-    projected.put(
-        rcvField.pos(),
-        GenericData.get().deepCopy(rcvField.schema(), srcRmd.get(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME)));
+    projected.put(rcvField.pos(), srcRmd.get(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME));
 
     Schema.Field targetTimestampField = targetRmdSchema.getField(TIMESTAMP_FIELD_NAME);
     Object srcTimestamp = srcRmd.get(TIMESTAMP_FIELD_NAME);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/projection/TestVeniceSchemaProjector.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/projection/TestVeniceSchemaProjector.java
@@ -139,7 +139,7 @@ public class TestVeniceSchemaProjector {
   }
 
   @Test
-  public void testRetainedValuesAreDeepCopiedAndIndependent() {
+  public void testRetainedValuesAreSharedByReference() {
     Schema input = parse(
         "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
             + "    {\"name\": \"nums\", \"type\": {\"type\": \"array\", \"items\": \"int\"}},\n"
@@ -154,11 +154,7 @@ public class TestVeniceSchemaProjector {
 
     GenericRecord out = projector.projectValue(src, writer);
 
-    @SuppressWarnings("unchecked")
-    List<Object> outList = (List<Object>) out.get("nums");
-    Assert.assertEquals(outList.size(), 3);
-    srcList.clear();
-    Assert.assertEquals(outList.size(), 3, "mutating the source list must not affect the projected output");
+    Assert.assertSame(out.get("nums"), srcList);
   }
 
   @Test
@@ -265,7 +261,7 @@ public class TestVeniceSchemaProjector {
   }
 
   @Test
-  public void testReplicationCheckpointVectorIsDeepCopied() {
+  public void testReplicationCheckpointVectorIsSharedByReference() {
     Schema valueSchema = parse(
         "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
             + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"}\n" + "  ]\n" + "}");
@@ -277,10 +273,6 @@ public class TestVeniceSchemaProjector {
 
     GenericRecord out = projector.projectRmd(srcRmd, rmdSchema);
 
-    @SuppressWarnings("unchecked")
-    List<Long> outRcv = (List<Long>) out.get(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME);
-    Assert.assertEquals(outRcv.size(), 3);
-    rcv.clear();
-    Assert.assertEquals(outRcv.size(), 3, "mutating the source RCV must not affect the projected output");
+    Assert.assertSame(out.get(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME), rcv);
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithValueSchemaProjection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithValueSchemaProjection.java
@@ -8,7 +8,6 @@ import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V2_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToNameRecordV1Schema;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToNameRecordV2Schema;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.INPUT_VALUE_SCHEMA_PROJECTION_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGET_WRITER_VALUE_SCHEMA_ID_PROP;
 
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
@@ -39,8 +38,7 @@ import org.testng.annotations.Test;
 /**
  * End-to-end coverage for input value-schema projection in VPJ: input data whose value schema is a strict superset of a
  * registered writer (target) value schema is projected down to the writer schema (via {@code VeniceSchemaProjector})
- * before serialization. Gated by the {@code input.value.schema.projection.enabled} feature flag plus an explicit
- * {@code target.writer.value.schema.id}.
+ * before serialization. Enabled by setting {@code target.writer.value.schema.id} to a positive id.
  */
 public class TestPushJobWithValueSchemaProjection {
   private static final int TEST_TIMEOUT = 90 * Time.MS_PER_SECOND;
@@ -62,7 +60,7 @@ public class TestPushJobWithValueSchemaProjection {
 
   /**
    * Happy path: store is registered with the writer schema (V1); input data uses a strict superset schema (V2, which
-   * adds {@code age}). With the feature flag on and the target writer schema id supplied, each record is projected down
+   * adds {@code age}). With the target writer schema id supplied, each record is projected down
    * to V1 and the push completes. Reading the data back returns V1 records with the {@code age} field dropped.
    */
   @Test(timeOut = TEST_TIMEOUT)
@@ -85,7 +83,6 @@ public class TestPushJobWithValueSchemaProjection {
       Assert.assertTrue(writerSchemaId > 0);
     }
 
-    props.setProperty(INPUT_VALUE_SCHEMA_PROJECTION_ENABLED, "true");
     props.setProperty(TARGET_WRITER_VALUE_SCHEMA_ID_PROP, Integer.toString(writerSchemaId));
 
     try (VenicePushJob job = new VenicePushJob("test-push-projection-happy-path", props)) {
@@ -122,7 +119,6 @@ public class TestPushJobWithValueSchemaProjection {
     createStoreForJob(veniceCluster, STRING_SCHEMA.toString(), NAME_RECORD_V1_SCHEMA.toString(), props).close();
 
     int nonExistentWriterSchemaId = 9999;
-    props.setProperty(INPUT_VALUE_SCHEMA_PROJECTION_ENABLED, "true");
     props.setProperty(TARGET_WRITER_VALUE_SCHEMA_ID_PROP, Integer.toString(nonExistentWriterSchemaId));
 
     try (VenicePushJob job = new VenicePushJob("test-push-projection-missing-id", props)) {
@@ -156,7 +152,6 @@ public class TestPushJobWithValueSchemaProjection {
       writerSchemaId = writerSchemaIdResponse.getId();
     }
 
-    props.setProperty(INPUT_VALUE_SCHEMA_PROJECTION_ENABLED, "true");
     props.setProperty(TARGET_WRITER_VALUE_SCHEMA_ID_PROP, Integer.toString(writerSchemaId));
 
     try (VenicePushJob job = new VenicePushJob("test-push-projection-not-superset", props)) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithValueSchemaProjection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithValueSchemaProjection.java
@@ -1,0 +1,169 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
+import static com.linkedin.venice.utils.TestWriteUtils.DEFAULT_USER_DATA_RECORD_COUNT;
+import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V2_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToNameRecordV1Schema;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToNameRecordV2Schema;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.INPUT_VALUE_SCHEMA_PROJECTION_ENABLED;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGET_WRITER_VALUE_SCHEMA_ID_PROP;
+
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.SchemaResponse;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.hadoop.VenicePushJob;
+import com.linkedin.venice.hadoop.exceptions.VeniceSchemaMismatchException;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
+import java.io.File;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.IOUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * End-to-end coverage for input value-schema projection in VPJ: input data whose value schema is a strict superset of a
+ * registered writer (target) value schema is projected down to the writer schema (via {@code VeniceSchemaProjector})
+ * before serialization. Gated by the {@code input.value.schema.projection.enabled} feature flag plus an explicit
+ * {@code target.writer.value.schema.id}.
+ */
+public class TestPushJobWithValueSchemaProjection {
+  private static final int TEST_TIMEOUT = 90 * Time.MS_PER_SECOND;
+
+  private VeniceClusterWrapper veniceCluster;
+
+  @BeforeClass
+  public void setUp() {
+    Utils.thisIsLocalhost();
+    VeniceClusterCreateOptions options =
+        new VeniceClusterCreateOptions.Builder().numberOfControllers(1).numberOfServers(1).numberOfRouters(1).build();
+    veniceCluster = ServiceFactory.getVeniceCluster(options);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    IOUtils.closeQuietly(veniceCluster);
+  }
+
+  /**
+   * Happy path: store is registered with the writer schema (V1); input data uses a strict superset schema (V2, which
+   * adds {@code age}). With the feature flag on and the target writer schema id supplied, each record is projected down
+   * to V1 and the push completes. Reading the data back returns V1 records with the {@code age} field dropped.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testProjectsSupersetInputToWriterSchemaEndToEnd() throws Exception {
+    File inputDir = Utils.getTempDataDirectory();
+    // Input data file uses the V2 (superset) value schema.
+    writeSimpleAvroFileWithStringToNameRecordV2Schema(inputDir);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("schema-projection-store");
+
+    Properties props = defaultVPJProps(veniceCluster, inputDirPath, storeName);
+    int writerSchemaId;
+    try (ControllerClient controllerClient =
+        createStoreForJob(veniceCluster, STRING_SCHEMA.toString(), NAME_RECORD_V1_SCHEMA.toString(), props)) {
+      // The store's single registered value schema (V1) is the projection target.
+      SchemaResponse writerSchemaIdResponse =
+          controllerClient.getValueSchemaID(storeName, NAME_RECORD_V1_SCHEMA.toString());
+      Assert.assertFalse(writerSchemaIdResponse.isError(), writerSchemaIdResponse.getError());
+      writerSchemaId = writerSchemaIdResponse.getId();
+      Assert.assertTrue(writerSchemaId > 0);
+    }
+
+    props.setProperty(INPUT_VALUE_SCHEMA_PROJECTION_ENABLED, "true");
+    props.setProperty(TARGET_WRITER_VALUE_SCHEMA_ID_PROP, Integer.toString(writerSchemaId));
+
+    try (VenicePushJob job = new VenicePushJob("test-push-projection-happy-path", props)) {
+      job.run();
+    }
+
+    try (AvroGenericStoreClient<String, GenericRecord> avroClient = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceCluster.getRandomRouterURL()))) {
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, true, true, () -> {
+        for (int i = 1; i <= DEFAULT_USER_DATA_RECORD_COUNT; i++) {
+          GenericRecord value = avroClient.get(Integer.toString(i)).get();
+          Assert.assertNotNull(value, "Missing value for key: " + i);
+          Assert.assertEquals(value.get("firstName").toString(), "first_name_" + i);
+          Assert.assertEquals(value.get("lastName").toString(), "last_name_" + i);
+          // The value was projected to the writer (V1) schema, which has no "age" field.
+          Assert.assertNull(value.getSchema().getField("age"), "Projected record should not retain the 'age' field");
+        }
+      });
+    }
+  }
+
+  /**
+   * The supplied target writer value schema id does not exist in the store: projection cannot be configured and the
+   * push fails fast with a clear error.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testProjectionFailsWhenTargetWriterSchemaIdNotFound() throws Exception {
+    File inputDir = Utils.getTempDataDirectory();
+    writeSimpleAvroFileWithStringToNameRecordV2Schema(inputDir);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("schema-projection-missing-id-store");
+
+    Properties props = defaultVPJProps(veniceCluster, inputDirPath, storeName);
+    createStoreForJob(veniceCluster, STRING_SCHEMA.toString(), NAME_RECORD_V1_SCHEMA.toString(), props).close();
+
+    int nonExistentWriterSchemaId = 9999;
+    props.setProperty(INPUT_VALUE_SCHEMA_PROJECTION_ENABLED, "true");
+    props.setProperty(TARGET_WRITER_VALUE_SCHEMA_ID_PROP, Integer.toString(nonExistentWriterSchemaId));
+
+    try (VenicePushJob job = new VenicePushJob("test-push-projection-missing-id", props)) {
+      VeniceException exception = Assert.expectThrows(VeniceException.class, job::run);
+      Assert.assertTrue(
+          exception.getMessage()
+              .contains("Failed to fetch target writer value schema id: " + nonExistentWriterSchemaId),
+          "Unexpected exception message: " + exception.getMessage());
+    }
+  }
+
+  /**
+   * The input value schema is not a strict superset of the target writer value schema (input is V1, writer is V2 which
+   * additionally requires {@code age}): the superset preflight check rejects the push.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testProjectionFailsWhenInputNotSupersetOfWriterSchema() throws Exception {
+    File inputDir = Utils.getTempDataDirectory();
+    // Input data file uses the V1 schema, which is NOT a superset of the V2 writer schema.
+    writeSimpleAvroFileWithStringToNameRecordV1Schema(inputDir);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("schema-projection-not-superset-store");
+
+    Properties props = defaultVPJProps(veniceCluster, inputDirPath, storeName);
+    int writerSchemaId;
+    try (ControllerClient controllerClient =
+        createStoreForJob(veniceCluster, STRING_SCHEMA.toString(), NAME_RECORD_V2_SCHEMA.toString(), props)) {
+      SchemaResponse writerSchemaIdResponse =
+          controllerClient.getValueSchemaID(storeName, NAME_RECORD_V2_SCHEMA.toString());
+      Assert.assertFalse(writerSchemaIdResponse.isError(), writerSchemaIdResponse.getError());
+      writerSchemaId = writerSchemaIdResponse.getId();
+    }
+
+    props.setProperty(INPUT_VALUE_SCHEMA_PROJECTION_ENABLED, "true");
+    props.setProperty(TARGET_WRITER_VALUE_SCHEMA_ID_PROP, Integer.toString(writerSchemaId));
+
+    try (VenicePushJob job = new VenicePushJob("test-push-projection-not-superset", props)) {
+      VeniceSchemaMismatchException exception = Assert.expectThrows(VeniceSchemaMismatchException.class, job::run);
+      Assert.assertTrue(
+          exception.getMessage().contains("not a superset of the target writer value schema"),
+          "Unexpected exception message: " + exception.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
## Problem Statement

VPJ required the input data's value schema to exactly match a registered value schema. Users whose input carried extra fields (a strict superset of a registered schema) couldn't push without first re-registering or stripping fields — there was no way to map richer input down to an existing writer schema at push time.


## Solution

Added input value-schema projection to VPJ. When the input value schema doesn't match a registered schema, the user can supply a target writer schema id (target.writer.value.schema.id); VPJ validates the input is a strict superset of that writer schema and projects each record (and its RMD) down to the writer schema via VeniceSchemaProjector before serialization. Wired consistently across the MapReduce and Spark data-writer paths and the Avro record reader, gated behind a feature flag (input.value.schema.projection.enabled, default off), with unit and end-to-end integration test coverage.

New config and it's default:
target.writer.value.schema.id=-1


###  Code changes
- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
- [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [x] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.