### PR TITLE
Add VENICE_EXTERNAL_STORAGE_READ_MODE dimension

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceExternalStorageReadMode.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceExternalStorageReadMode.java
@@ -1,0 +1,30 @@
+package com.linkedin.venice.stats.dimensions;
+
+/**
+ * Dimension values for the {@link VeniceMetricsDimensions#VENICE_EXTERNAL_STORAGE_READ_MODE}
+ * dimension, mirroring {@link com.linkedin.venice.meta.ExternalStorageReadMode} for OTel emission.
+ *
+ * <p>Used by client-side stats to tag metrics with the active read mode (e.g., to break down
+ * read counts, failures, and latency by mode).
+ *
+ * @see com.linkedin.venice.meta.ExternalStorageReadMode
+ */
+public enum VeniceExternalStorageReadMode implements VeniceDimensionInterface {
+  /** All reads served from Venice local storage. */
+  VENICE_ONLY,
+  /** All user-data reads served from the external storage system. */
+  EXTERNAL_ONLY,
+  /** Reads served from both Venice and external storage in parallel; external result used for correctness comparison only. */
+  DUAL_MODE_CONSISTENCY_CHECK,
+  /** Reads served from both Venice and external storage in parallel; first response wins. */
+  DUAL_MODE_EARLY_RETURN;
+
+  /**
+   * All instances of this enum share the same dimension name.
+   * Refer to {@link VeniceDimensionInterface#getDimensionName()} for more details.
+   */
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VeniceMetricsDimensions.VENICE_EXTERNAL_STORAGE_READ_MODE;
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -186,7 +186,10 @@ public enum VeniceMetricsDimensions {
   VENICE_RECORD_TRANSFORMER_OPERATION("venice.record_transformer.operation"),
 
   /** {@link VeniceStoreWriteType} Store write type: regular or write_compute. */
-  VENICE_STORE_WRITE_TYPE("venice.store.write_type");
+  VENICE_STORE_WRITE_TYPE("venice.store.write_type"),
+
+  /** Read mode for external storage routing — see {@link com.linkedin.venice.meta.ExternalStorageReadMode}. */
+  VENICE_EXTERNAL_STORAGE_READ_MODE("venice.external_storage.read_mode");
 
   private final String[] dimensionName = new String[VeniceOpenTelemetryMetricNamingFormat.SIZE];
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceExternalStorageReadModeTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceExternalStorageReadModeTest.java
@@ -1,0 +1,23 @@
+package com.linkedin.venice.stats.dimensions;
+
+import com.linkedin.venice.utils.CollectionUtils;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class VeniceExternalStorageReadModeTest {
+  @Test
+  public void testDimensionInterface() {
+    Map<VeniceExternalStorageReadMode, String> expectedValues =
+        CollectionUtils.<VeniceExternalStorageReadMode, String>mapBuilder()
+            .put(VeniceExternalStorageReadMode.VENICE_ONLY, "venice_only")
+            .put(VeniceExternalStorageReadMode.EXTERNAL_ONLY, "external_only")
+            .put(VeniceExternalStorageReadMode.DUAL_MODE_CONSISTENCY_CHECK, "dual_mode_consistency_check")
+            .put(VeniceExternalStorageReadMode.DUAL_MODE_EARLY_RETURN, "dual_mode_early_return")
+            .build();
+    new VeniceDimensionTestFixture<>(
+        VeniceExternalStorageReadMode.class,
+        VeniceMetricsDimensions.VENICE_EXTERNAL_STORAGE_READ_MODE,
+        expectedValues).assertAll();
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -190,6 +190,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_STORE_WRITE_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.store.write_type");
           break;
+        case VENICE_EXTERNAL_STORAGE_READ_MODE:
+          assertEquals(dimension.getDimensionName(format), "venice.external_storage.read_mode");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -378,6 +381,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_STORE_WRITE_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.store.writeType");
           break;
+        case VENICE_EXTERNAL_STORAGE_READ_MODE:
+          assertEquals(dimension.getDimensionName(format), "venice.externalStorage.readMode");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -565,6 +571,9 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_STORE_WRITE_TYPE:
           assertEquals(dimension.getDimensionName(format), "Venice.Store.WriteType");
+          break;
+        case VENICE_EXTERNAL_STORAGE_READ_MODE:
+          assertEquals(dimension.getDimensionName(format), "Venice.ExternalStorage.ReadMode");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);


### PR DESCRIPTION
## Summary

Add an OTel dimension constant so client-side stats can tag metrics with the active `ExternalStorageReadMode`. Three read-path metrics on the client side currently carry only `venice.store.name`; with this constant landed, those metrics can be split by mode (`VENICE_ONLY`, `EXTERNAL_ONLY`, `DUAL_MODE_CONSISTENCY_CHECK`, `DUAL_MODE_EARLY_RETURN`).

## Changes

- New `VENICE_EXTERNAL_STORAGE_READ_MODE` entry in `VeniceMetricsDimensions` (key: `venice.external_storage.read_mode`).
- New `VeniceExternalStorageReadMode` enum implementing `VeniceDimensionInterface` (mirrors `com.linkedin.venice.meta.ExternalStorageReadMode`; lowercase-snake values: `venice_only`, `external_only`, `dual_mode_consistency_check`, `dual_mode_early_return`).

## Testing Done

`./gradlew :internal:venice-client-common:test` — 673 tests pass.
New `VeniceExternalStorageReadModeTest` covers all 4 mode → string mappings; `VeniceMetricsDimensionsTest` updated with snake/camel/pascal validations for the new entry.