### PR TITLE
[server] Log request URI on BAD_REQUEST parse failures

### DIFF
--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
@@ -28,6 +28,7 @@ import com.linkedin.venice.throttle.TokenBucket;
 import com.linkedin.venice.throttle.VeniceRateLimiter;
 import com.linkedin.venice.throttle.VeniceRateLimiter.RateLimiterType;
 import com.linkedin.venice.utils.DaemonThreadFactory;
+import com.linkedin.venice.utils.RedundantExceptionFilter;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -51,6 +52,8 @@ import org.apache.logging.log4j.Logger;
 public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<RouterRequest>
     implements RoutingDataRepository.RoutingDataChangedListener, StoreDataChangedListener {
   private static final Logger LOGGER = LogManager.getLogger(ReadQuotaEnforcementHandler.class);
+  private static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER =
+      RedundantExceptionFilter.getRedundantExceptionFilter();
   public static final String SERVER_OVER_CAPACITY_MSG = "Server over capacity";
   public static final String INVALID_REQUEST_RESOURCE_MSG = "Invalid request resource: ";
   private static final long WAIT_FOR_CUSTOMIZED_VIEW_TIMEOUT_SECONDS = 180;
@@ -298,6 +301,10 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
     QuotaEnforcementResult result = enforceQuota(request);
 
     if (result == QuotaEnforcementResult.BAD_REQUEST) {
+      String msg = INVALID_REQUEST_RESOURCE_MSG + request.getResourceName();
+      if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
+        LOGGER.warn("Rejecting request from {} - {}", ctx.channel(), msg);
+      }
       ctx.writeAndFlush(
           new HttpShortcutResponse(
               INVALID_REQUEST_RESOURCE_MSG + request.getResourceName(),

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
@@ -18,6 +18,7 @@ import com.linkedin.venice.listener.response.HttpShortcutResponse;
 import com.linkedin.venice.meta.QueryAction;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.request.RequestHelper;
+import com.linkedin.venice.utils.RedundantExceptionFilter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -45,6 +46,8 @@ import org.apache.logging.log4j.Logger;
  */
 public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
   private static final Logger LOGGER = LogManager.getLogger(RouterRequestHttpHandler.class);
+  private static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER =
+      RedundantExceptionFilter.getRedundantExceptionFilter();
   private final StatsHandler statsHandler;
   private final Map<String, Integer> storeToEarlyTerminationThresholdMSMap;
 
@@ -171,6 +174,10 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           throw new VeniceException("Unrecognized query action");
       }
     } catch (VeniceException e) {
+      String msg = "Failed to parse request URI '" + req.uri() + "' from " + ctx.channel() + ": " + e.getMessage();
+      if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
+        LOGGER.warn(msg);
+      }
       ctx.writeAndFlush(new HttpShortcutResponse(e.getMessage(), HttpResponseStatus.BAD_REQUEST));
     }
   }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
@@ -174,9 +174,10 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           throw new VeniceException("Unrecognized query action");
       }
     } catch (VeniceException e) {
-      String msg = "Failed to parse request URI '" + req.uri() + "' from " + ctx.channel() + ": " + e.getMessage();
-      if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
-        LOGGER.warn(msg);
+      Object remote = ctx.channel().remoteAddress();
+      String filterKey = "URI parse failure: " + e.getMessage() + " uri=" + req.uri() + " remote=" + remote;
+      if (!REDUNDANT_LOGGING_FILTER.isRedundantException(filterKey)) {
+        LOGGER.warn("Failed to parse request URI '{}' from {}: {}", req.uri(), remote, e.getMessage(), e);
       }
       ctx.writeAndFlush(new HttpShortcutResponse(e.getMessage(), HttpResponseStatus.BAD_REQUEST));
     }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
@@ -174,7 +174,7 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           throw new VeniceException("Unrecognized query action");
       }
     } catch (VeniceException e) {
-      Object remote = ctx.channel().remoteAddress();
+      Object remote = ctx.channel() == null ? null : ctx.channel().remoteAddress();
       String filterKey = "URI parse failure: " + e.getMessage() + " uri=" + req.uri() + " remote=" + remote;
       if (!REDUNDANT_LOGGING_FILTER.isRedundantException(filterKey)) {
         LOGGER.warn("Failed to parse request URI '{}' from {}: {}", req.uri(), remote, e.getMessage(), e);


### PR DESCRIPTION
## Problem

Two BAD_REQUEST paths in venice-server are silent — they write HTTP 400 to the client and return without any log entry.

The server-side `error_request.OccurrenceRate` counter (under the `unknown_store` tag) can spike from baseline to hundreds of req/s, yet a Kusto sweep across every venice-server WAR log returns zero matching entries — the malformed URLs are unattributable, and there is no record of which client(s) caused the spike or what URLs they sent.

The two silent paths:

1. **`RouterRequestHttpHandler.channelRead0`** — when URI / QueryAction parsing throws `VeniceException`, the handler writes HTTP 400 with no log call. (The class declared a `LOGGER` field that was never used.)
2. **`ReadQuotaEnforcementHandler.channelRead0` BAD_REQUEST branch** — when `enforceQuota()` returns `BAD_REQUEST` because the store is unknown to `storeRepository`, the handler writes HTTP 400 with no log.

Together these two paths drive the entire `unknown_store`-tagged HTTP 400 counter (confirmed via OTel `Venice.Server.Read.CallCount` with the `Http.Response.StatusCode` dimension).

## Change

Both paths now log the offending URI / resource name plus the channel at `WARN` level, deduped through `REDUNDANT_LOGGING_FILTER` — the same pattern used in `StorageReadRequestHandler` for analogous error classes (`VeniceNoStoreException`, `OperationNotAllowedException`, etc.).

The dedup wrapper keeps the high-volume path safe from log flood — identical messages within the filter's window collapse to one line.

## Verification plan

- Local build passes with JDK 17
- Manually verify the new log lines fire on a malformed request in a test environment
