### PR TITLE
[da-vinci][server][common] Stateful CDC client direct blob transfer from Venice server

### DIFF
--- a/clients/da-vinci-client/build.gradle
+++ b/clients/da-vinci-client/build.gradle
@@ -48,6 +48,7 @@ dependencies {
   testImplementation libraries.kafkaClientsTest
   testImplementation libraries.classgraph
   testImplementation libraries.openTelemetryTestSdk
+  testImplementation libraries.bouncyCastleBcpkix
 }
 
 ext {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -319,7 +319,9 @@ public class DaVinciBackend implements Closeable {
             backendConfig.getBlobTransferServiceWriteLimitBytesPerSec(),
             backendConfig.getSnapshotCleanupIntervalInMins(),
             backendConfig.getMaxConcurrentBlobReceiveReplicas(),
-            backendConfig.getBlobTransferClientNettyWorkerThreadCount());
+            backendConfig.getBlobTransferClientNettyWorkerThreadCount(),
+            backendConfig.getBlobTransferClientCapacityPercent(),
+            backendConfig.isServerAcceptClientBlobRequestEnabled());
 
         blobTransferManager = new BlobTransferManagerBuilder().setBlobTransferConfig(p2PBlobTransferConfig)
             .setClientConfig(clientConfig)
@@ -328,7 +330,12 @@ public class DaVinciBackend implements Closeable {
             .setStorageEngineRepository(storageService.getStorageEngineRepository())
             .setAggBlobTransferStats(aggBlobTransferStats)
             .setBlobTransferSSLFactory(BlobTransferUtils.createSSLFactoryForBlobTransferInDVC(configLoader))
-            .setBlobTransferAclHandler(BlobTransferUtils.createAclHandler(configLoader))
+            .setBlobTransferAclHandler(
+                BlobTransferUtils.createAclHandler(
+                    configLoader,
+                    Optional.empty(),
+                    backendConfig.isServerAcceptClientBlobRequestEnabled()))
+            .setServerFallbackEnabled(backendConfig.isDavinciBlobTransferServerFallbackEnabled())
             .setPushStatusNotifierSupplier(() -> ingestionListener)
             .setLogContext(backendConfig.getLogContext())
             .build();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferAclHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferAclHandler.java
@@ -1,6 +1,13 @@
 package com.linkedin.davinci.blobtransfer;
 
+import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BLOB_TRANSFER_REQUEST_ORIGIN;
+
+import com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferRequestOrigin;
+import com.linkedin.venice.acl.AclException;
+import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authorization.IdentityParser;
 import com.linkedin.venice.listener.ServerHandlerUtils;
+import com.linkedin.venice.request.RequestHelper;
 import com.linkedin.venice.utils.NettyUtils;
 import com.linkedin.venice.utils.SslUtils;
 import io.netty.channel.ChannelHandler;
@@ -10,7 +17,9 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.ReferenceCountUtil;
+import java.net.URI;
 import java.security.cert.X509Certificate;
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -21,8 +30,31 @@ import org.apache.logging.log4j.Logger;
 @ChannelHandler.Sharable
 public class BlobTransferAclHandler extends SimpleChannelInboundHandler<HttpRequest> {
   private static final Logger LOGGER = LogManager.getLogger(BlobTransferAclHandler.class);
+  private static final int STORE_NAME_PART_INDEX = 1;
 
-  public BlobTransferAclHandler() {
+  /** Per-store ACL controller for CLIENT-origin requests; empty on DVC peers, which admit same-issuer peers. */
+  private final Optional<DynamicAccessController> storeAccessController;
+
+  /**
+   * Resolves the application identity from a caller's certificate. The format is parser-defined: the default returns
+   * the subject DN, while a deployment may configure a parser that returns an application name (e.g. "venice-server").
+   * Used to classify SERVER- vs CLIENT-origin by application identity.
+   */
+  private final IdentityParser identityParser;
+
+  /**
+   * Whether this server accepts client-origin blob requests. When false, a request classified as client-origin is
+   * rejected with 403 and the per-store read ACL is not consulted.
+   */
+  private final boolean serverAcceptClientBlobRequestEnabled;
+
+  public BlobTransferAclHandler(
+      Optional<DynamicAccessController> storeAccessController,
+      IdentityParser identityParser,
+      boolean serverAcceptClientBlobRequestEnabled) {
+    this.storeAccessController = storeAccessController;
+    this.identityParser = identityParser;
+    this.serverAcceptClientBlobRequestEnabled = serverAcceptClientBlobRequestEnabled;
   }
 
   @Override
@@ -41,6 +73,10 @@ public class BlobTransferAclHandler extends SimpleChannelInboundHandler<HttpRequ
 
       boolean samePrincipal = clientCert.getIssuerX500Principal().equals(localCert.getIssuerX500Principal());
       if (samePrincipal) {
+        // Servers classify same-issuer callers so the accept flag can reject CLIENT-origin requests when disabled.
+        if (storeAccessController.isPresent() && rejectClientOrigin(ctx, req, clientCert, localCert)) {
+          return;
+        }
         LOGGER.info(
             "Client certification {} and local certification {} are the same. Acl check passed.",
             clientCert.getIssuerX500Principal(),
@@ -61,6 +97,111 @@ public class BlobTransferAclHandler extends SimpleChannelInboundHandler<HttpRequ
     } catch (Exception e) {
       LOGGER.error("Error validating client certificate for blob transfer from {}", ctx.channel().remoteAddress(), e);
       NettyUtils.setupResponseAndFlush(HttpResponseStatus.FORBIDDEN, new byte[0], false, ctx, true);
+    }
+  }
+
+  /**
+   * For a same-issuer request on a server, classify the origin (tagging the channel for the downstream handler) and
+   * apply the client-origin gates. Returns {@code true} — after sending a 403 — when a client-origin request is
+   * rejected because the server is not accepting client requests or the per-store read ACL denies it. Returns
+   * {@code false} when the request may proceed: a server-origin peer, or an authorized client-origin request.
+   */
+  private boolean rejectClientOrigin(
+      ChannelHandlerContext ctx,
+      HttpRequest req,
+      X509Certificate clientCert,
+      X509Certificate localCert) {
+    if (classifyAndTagOrigin(ctx, clientCert, localCert) != BlobTransferRequestOrigin.CLIENT) {
+      return false;
+    }
+    if (!serverAcceptClientBlobRequestEnabled) {
+      LOGGER.warn(
+          "Rejecting client-origin blob transfer request from {}: this server is not configured to accept client "
+              + "requests.",
+          ctx.channel().remoteAddress());
+      NettyUtils.setupResponseAndFlush(HttpResponseStatus.FORBIDDEN, new byte[0], false, ctx, true);
+      return true;
+    }
+    if (!isClientRequestAuthorized(ctx, req, clientCert)) {
+      NettyUtils.setupResponseAndFlush(HttpResponseStatus.FORBIDDEN, new byte[0], false, ctx, true);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Resolve the caller and local application identities, classify the request origin, and tag the channel with it so
+   * downstream handlers can read it.
+   */
+  private BlobTransferRequestOrigin classifyAndTagOrigin(
+      ChannelHandlerContext ctx,
+      X509Certificate clientCert,
+      X509Certificate localCert) {
+    String callerApplication = identityParser.parseIdentityFromCert(clientCert);
+    String localApplication = identityParser.parseIdentityFromCert(localCert);
+    BlobTransferRequestOrigin origin = determineRequestOrigin(callerApplication, localApplication);
+    ctx.channel().attr(BLOB_TRANSFER_REQUEST_ORIGIN).set(origin);
+    LOGGER.info("Classified blob transfer request from {} as {}-origin.", ctx.channel().remoteAddress(), origin);
+    return origin;
+  }
+
+  /**
+   * Whether a client-origin request passes the per-store read ACL. Logs the rejection reason and returns {@code false}
+   * when the store name is unparseable or access is denied; logs a grant and returns {@code true} otherwise.
+   */
+  private boolean isClientRequestAuthorized(ChannelHandlerContext ctx, HttpRequest req, X509Certificate clientCert) {
+    String storeName = extractStoreName(req.uri());
+    if (storeName == null || !isClientStoreAccessAllowed(clientCert, storeName, req.method().name())) {
+      LOGGER.warn(
+          "Unauthorized client-origin blob transfer access rejected: {} requested from {} for store {}.",
+          req.uri(),
+          ctx.channel().remoteAddress(),
+          storeName);
+      return false;
+    }
+    LOGGER.debug("Client-origin blob transfer request granted store-level ACL for store {}.", storeName);
+    return true;
+  }
+
+  /**
+   * Classify the caller as SERVER- or CLIENT-origin by comparing application identities (resolved by the configured
+   * {@link IdentityParser}). A caller whose application matches the local host's is a trusted peer (server-to-server or
+   * same-application peer-to-peer) and is SERVER-origin; a different application is an external consumer and is
+   * CLIENT-origin, subject to the per-store ACL and accept gate. Fails closed: a null or unresolved local application
+   * yields CLIENT.
+   */
+  static BlobTransferRequestOrigin determineRequestOrigin(String callerApplication, String localApplication) {
+    return localApplication != null && localApplication.equals(callerApplication)
+        ? BlobTransferRequestOrigin.SERVER
+        : BlobTransferRequestOrigin.CLIENT;
+  }
+
+  /**
+   * Extract the Venice store name from a blob transfer request URI of the form
+   * {@code /<store>/<version>/<partition>/<tableFormat>}. Returns {@code null} if the URI is malformed.
+   */
+  static String extractStoreName(String uri) {
+    try {
+      String[] requestParts = RequestHelper.getRequestParts(URI.create(uri));
+      if (requestParts.length > STORE_NAME_PART_INDEX && !requestParts[STORE_NAME_PART_INDEX].isEmpty()) {
+        return requestParts[STORE_NAME_PART_INDEX];
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Failed to parse store name from blob transfer URI {}", uri, e);
+    }
+    return null;
+  }
+
+  /**
+   * Enforce the per-store read ACL for a client-origin request. Fails closed when the ACL lookup errors.
+   */
+  boolean isClientStoreAccessAllowed(X509Certificate clientCert, String storeName, String method) {
+    try {
+      return storeAccessController.get().hasAccess(clientCert, storeName, method);
+    } catch (AclException e) {
+      LOGGER
+          .error("Error checking store-level ACL for blob transfer of store {}; denying client request.", storeName, e);
+      return false;
     }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferManagerBuilder.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferManagerBuilder.java
@@ -10,6 +10,7 @@ import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.venice.blobtransfer.BlobFinder;
 import com.linkedin.venice.blobtransfer.DaVinciBlobFinder;
+import com.linkedin.venice.blobtransfer.ServerAndDaVinciBlobFinder;
 import com.linkedin.venice.blobtransfer.ServerBlobFinder;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
@@ -44,6 +45,7 @@ public class BlobTransferManagerBuilder {
   private VeniceAdaptiveBlobTransferTrafficThrottler adaptiveBlobTransferReadTrafficThrottler;
   private Supplier<VeniceNotifier> veniceNotifier;
   private LogContext logContext;
+  private boolean serverFallbackEnabled = false;
 
   public BlobTransferManagerBuilder() {
   }
@@ -122,6 +124,15 @@ public class BlobTransferManagerBuilder {
     return aggBlobTransferStats;
   }
 
+  /**
+   * Enable the client-side fallback to include Venice servers after Da Vinci peers in the discovered host list. Defaults
+   * to false; typically set only on the Da Vinci / Stateful CDC client path.
+   */
+  public BlobTransferManagerBuilder setServerFallbackEnabled(boolean serverFallbackEnabled) {
+    this.serverFallbackEnabled = serverFallbackEnabled;
+    return this;
+  }
+
   public BlobTransferManager<Void> build() {
     try {
       validateFields();
@@ -130,7 +141,11 @@ public class BlobTransferManagerBuilder {
       if (customizedViewFuture != null && clientConfig == null) {
         blobFinder = new ServerBlobFinder(customizedViewFuture);
       } else if (customizedViewFuture == null && clientConfig != null) {
-        blobFinder = new DaVinciBlobFinder(clientConfig);
+        if (serverFallbackEnabled) {
+          blobFinder = new ServerAndDaVinciBlobFinder(clientConfig);
+        } else {
+          blobFinder = new DaVinciBlobFinder(clientConfig);
+        }
       } else {
         throw new IllegalArgumentException(
             "The client config and customized view future must one of them be null during the initialization for blob transfer manager.");
@@ -164,7 +179,9 @@ public class BlobTransferManagerBuilder {
               getAggBlobTransferStats(),
               sslFactory,
               aclHandler,
-              blobTransferConfig.getMaxConcurrentSnapshotUser()),
+              blobTransferConfig.getMaxConcurrentSnapshotUser(),
+              blobTransferConfig.getClientCapacityPercent(),
+              blobTransferConfig.isServerAcceptClientBlobRequestEnabled()),
           new NettyFileTransferClient(
               blobTransferConfig.getP2pTransferClientPort(),
               blobTransferConfig.getBaseDir(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferUtils.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.blobtransfer;
 import static com.linkedin.venice.CommonConfigKeys.SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_ACL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_SSL_ENABLED;
+import static com.linkedin.venice.ConfigKeys.IDENTITY_PARSER_CLASS;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.store.rocksdb.RocksDBUtils.composePartitionDbDir;
 import static org.apache.commons.codec.digest.DigestUtils.md5Hex;
@@ -10,14 +11,19 @@ import static org.apache.commons.codec.digest.DigestUtils.md5Hex;
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.venice.SSLConfig;
+import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authorization.DefaultIdentityParser;
+import com.linkedin.venice.authorization.IdentityParser;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.utils.ReflectUtils;
 import com.linkedin.venice.utils.SslUtils;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.util.AttributeKey;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,6 +52,14 @@ public class BlobTransferUtils {
       "X-Blob-Transfer-Store-Version-State-Schema-Version";
   /** Sentinel returned by {@link #parseProtocolVersionHeader} when the header is missing or unparseable. */
   private static final int VERSION_UNKNOWN = -1;
+
+  /**
+   * Channel attribute carrying the {@link BlobTransferRequestOrigin} of an inbound request. Set by
+   * {@code BlobTransferAclHandler} during the TLS/ACL stage and read by downstream handlers
+   * ({@code P2PFileTransferServerHandler}, admission control) for prioritization and store-level ACL.
+   */
+  public static final AttributeKey<BlobTransferRequestOrigin> BLOB_TRANSFER_REQUEST_ORIGIN =
+      AttributeKey.valueOf("blobTransferRequestOrigin");
 
   public enum BlobTransferType {
     FILE, METADATA
@@ -88,6 +102,24 @@ public class BlobTransferUtils {
      * - No cancellation was requested
      */
     TRANSFER_COMPLETED
+  }
+
+  /**
+   * Identifies the origin (caller type) of an inbound blob transfer request, as observed
+   * by the receiving Venice Server or DaVinci instance.
+   */
+  public enum BlobTransferRequestOrigin {
+    /**
+     * A peer Venice server or same-application DaVinci instance (server-to-server or DVC-to-DVC bootstrap). Bypasses
+     * the store-level ACL and counts against the server-origin concurrency cap.
+     */
+    SERVER,
+
+    /**
+     * An external consumer (e.g. a Stateful CDC client) bootstrapping a snapshot. Subject to the per-store read ACL
+     * and counted against the client-origin concurrency cap.
+     */
+    CLIENT
   }
 
   /**
@@ -282,19 +314,47 @@ public class BlobTransferUtils {
   }
 
   /**
-   * Create the acl handler for blob transfer, for both DVC peers and server peers
+   * Create the acl handler for blob transfer, for both DVC peers and server peers.
+   *
+   * @param serverAcceptClientBlobRequestEnabled whether this server accepts client-origin requests; gates the
+   *        client-origin accept check and per-store read ACL in the returned handler.
    */
-  public static Optional<BlobTransferAclHandler> createAclHandler(VeniceConfigLoader configLoader) {
+  public static Optional<BlobTransferAclHandler> createAclHandler(
+      VeniceConfigLoader configLoader,
+      Optional<DynamicAccessController> storeAccessController,
+      boolean serverAcceptClientBlobRequestEnabled) {
     if (!isBlobTransferDVCSslEnabled(configLoader) || !isBlobTransferAclValidationEnabled(configLoader)) {
       String errorMsg =
           "Blob transfer SSL or ACL validation is not enabled. sslEnabled: " + isBlobTransferDVCSslEnabled(configLoader)
               + ", aclEnabled: " + isBlobTransferAclValidationEnabled(configLoader) + ", skip create ACL handler.";
       throw new IllegalArgumentException(errorMsg);
     }
+    String identityParserClassName =
+        configLoader.getCombinedProperties().getString(IDENTITY_PARSER_CLASS, DefaultIdentityParser.class.getName());
+    Class<IdentityParser> identityParserClass = ReflectUtils.loadClass(identityParserClassName);
+    validateAclHandlerConfig(storeAccessController, serverAcceptClientBlobRequestEnabled, identityParserClass);
     try {
-      return Optional.of(new BlobTransferAclHandler());
+      IdentityParser identityParser = ReflectUtils.callConstructor(identityParserClass, new Class[0], new Object[0]);
+      return Optional
+          .of(new BlobTransferAclHandler(storeAccessController, identityParser, serverAcceptClientBlobRequestEnabled));
     } catch (Exception e) {
       throw new IllegalArgumentException("Failed to create ACL handler for blob transfer", e);
+    }
+  }
+
+  private static void validateAclHandlerConfig(
+      Optional<DynamicAccessController> storeAccessController,
+      boolean serverAcceptClientBlobRequestEnabled,
+      Class<IdentityParser> identityParserClass) {
+    if (serverAcceptClientBlobRequestEnabled && !storeAccessController.isPresent()) {
+      throw new IllegalArgumentException(
+          "storeAccessController is required when accepting client-origin blob transfer requests");
+    }
+    if (storeAccessController.isPresent() && DefaultIdentityParser.class.isAssignableFrom(identityParserClass)) {
+      throw new IllegalArgumentException(
+          "Blob transfer requires a non-default identity.parser.class when a store access controller is present; "
+              + "DefaultIdentityParser parses the cert subject DN and can misclassify same-issuer peers as "
+              + "CLIENT-origin");
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/NettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/NettyP2PBlobTransferManager.java
@@ -23,8 +23,10 @@ import com.linkedin.venice.utils.Utils;
 import java.io.InputStream;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -32,7 +34,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -131,7 +132,7 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
     List<String> discoverPeers = response.getDiscoveryResult();
     List<String> connectablePeers = getConnectableHosts(discoverPeers, storeName, version, partition);
 
-    // 2: Process peers sequentially to fetch the blob
+    // 2. Process the discovered peers sequentially in finder-provided priority order.
     processPeersSequentially(connectablePeers, storeName, version, partition, tableFormat, perPartitionTransferFuture);
 
     return perPartitionTransferFuture;
@@ -242,19 +243,20 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
       }, replicaBlobFetchExecutor);
     }
 
-    // error case 2: all hosts have been tried and failed for blob transfer
+    // error case 2: all hosts in this pass have been tried and failed for blob transfer
     chainOfPeersFuture.thenRun(() -> {
-      if (!perPartitionTransferFuture.isDone()) {
-        if (statusTrackingManager.isBlobTransferCancelRequested(replicaId)) {
-          // Receive cancellation request, skip Kafka bootstrapping
-          perPartitionTransferFuture.completeExceptionally(
-              new VeniceBlobTransferCancelledException(String.format(TRANSFER_CANCELLED_MSG_FORMAT, replicaId)));
-        } else {
-          // All hosts failed, fall back to Kafka bootstrapping
-          perPartitionTransferFuture.completeExceptionally(
-              new VenicePeersAllFailedException(String.format(NO_VALID_PEERS_MSG_FORMAT, replicaId)));
-        }
+      if (perPartitionTransferFuture.isDone()) {
+        return;
       }
+      if (statusTrackingManager.isBlobTransferCancelRequested(replicaId)) {
+        // Receive cancellation request, skip Kafka bootstrapping
+        perPartitionTransferFuture.completeExceptionally(
+            new VeniceBlobTransferCancelledException(String.format(TRANSFER_CANCELLED_MSG_FORMAT, replicaId)));
+        return;
+      }
+      // No usable peers available, fall back to Kafka bootstrapping.
+      perPartitionTransferFuture.completeExceptionally(
+          new VenicePeersAllFailedException(String.format(NO_VALID_PEERS_MSG_FORMAT, replicaId)));
     });
   }
 
@@ -337,15 +339,19 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
    * @return the set of unique connectable hosts
    */
   private List<String> getConnectableHosts(List<String> discoverPeers, String storeName, int version, int partition) {
-    // Extract unique hosts from the discovered peers
-    Set<String> uniquePeers = discoverPeers.stream().map(peer -> peer.split("_")[0]).collect(Collectors.toSet());
+    // Extract unique hosts from the discovered peers while preserving discovery order. Composite finders can mark this
+    // order as meaningful (for example, Da Vinci peers before Venice servers); otherwise we shuffle as before.
+    Set<String> uniquePeers = new LinkedHashSet<>();
+    for (String peer: discoverPeers) {
+      uniquePeers.add(peer.split("_")[0]);
+    }
     String replicaId = Utils.getReplicaId(Version.composeKafkaTopic(storeName, version), partition);
 
     LOGGER.info("Discovered {} unique peers for replica {}, peers are {}", uniquePeers.size(), replicaId, uniquePeers);
 
     // Get the connectable hosts for this store, version, and partition
     Set<String> connectablePeers =
-        nettyClient.getConnectableHosts((HashSet<String>) uniquePeers, storeName, version, partition);
+        nettyClient.getConnectableHosts(new HashSet<>(uniquePeers), storeName, version, partition);
 
     LOGGER.info(
         "Total {} unique connectable peers for replica {}, peers are {}",
@@ -353,10 +359,15 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
         replicaId,
         connectablePeers);
 
-    // Change to list and shuffle the list
-    List<String> connectablePeersList = connectablePeers.stream().collect(Collectors.toList());
-    Collections.shuffle(connectablePeersList);
-
+    List<String> connectablePeersList = new ArrayList<>();
+    for (String peer: uniquePeers) {
+      if (connectablePeers.contains(peer)) {
+        connectablePeersList.add(peer);
+      }
+    }
+    if (!peerFinder.shouldPreservePeerOrder()) {
+      Collections.shuffle(connectablePeersList);
+    }
     return connectablePeersList;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/P2PBlobTransferConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/P2PBlobTransferConfig.java
@@ -34,6 +34,10 @@ public class P2PBlobTransferConfig {
   private final int maxConcurrentBlobReceiveReplicas;
   // Number of Netty worker (event-loop) threads for the blob transfer client.
   private final int p2pTransferClientNettyWorkerThreadCount;
+  // Client-origin share (percentage) of the host blob-transfer budget; server-origin may use the full budget.
+  private final int clientCapacityPercent;
+  // Whether the server accepts client-origin (e.g. Stateful CDC) blob transfer requests.
+  private final boolean serverAcceptClientBlobRequestEnabled;
 
   public P2PBlobTransferConfig(
       int p2pTransferServerPort,
@@ -50,7 +54,9 @@ public class P2PBlobTransferConfig {
       long blobTransferServiceWriteLimitBytesPerSec,
       int snapshotCleanupIntervalInMins,
       int maxConcurrentBlobReceiveReplicas,
-      int p2pTransferClientNettyWorkerThreadCount) {
+      int p2pTransferClientNettyWorkerThreadCount,
+      int clientCapacityPercent,
+      boolean serverAcceptClientBlobRequestEnabled) {
     this.p2pTransferServerPort = p2pTransferServerPort;
     this.p2pTransferClientPort = p2pTransferClientPort;
     this.baseDir = baseDir;
@@ -66,6 +72,8 @@ public class P2PBlobTransferConfig {
     this.snapshotCleanupIntervalInMins = snapshotCleanupIntervalInMins;
     this.maxConcurrentBlobReceiveReplicas = maxConcurrentBlobReceiveReplicas;
     this.p2pTransferClientNettyWorkerThreadCount = p2pTransferClientNettyWorkerThreadCount;
+    this.clientCapacityPercent = clientCapacityPercent;
+    this.serverAcceptClientBlobRequestEnabled = serverAcceptClientBlobRequestEnabled;
   }
 
   public int getP2pTransferServerPort() {
@@ -126,5 +134,13 @@ public class P2PBlobTransferConfig {
 
   public int getP2pTransferClientNettyWorkerThreadCount() {
     return p2pTransferClientNettyWorkerThreadCount;
+  }
+
+  public int getClientCapacityPercent() {
+    return clientCapacityPercent;
+  }
+
+  public boolean isServerAcceptClientBlobRequestEnabled() {
+    return serverAcceptClientBlobRequestEnabled;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/BlobTransferAdmissionController.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/BlobTransferAdmissionController.java
@@ -1,0 +1,87 @@
+package com.linkedin.davinci.blobtransfer.server;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Host-level admission control for <b>client-origin</b> (Stateful CDC / external consumer) blob transfer requests.
+ *
+ * <p>This controller governs only the new client-request feature: it bounds concurrent client-origin transfers to
+ * their own reserved cap, which is a percentage of the host blob-transfer budget. Server-to-server (and DVC-to-DVC)
+ * transfers are <b>not</b> tracked here -- they keep using the pre-existing global concurrency counter in
+ * {@code P2PFileTransferServerHandler}. The two budgets are intentionally independent so client traffic can never
+ * perturb the tuned server-to-server path.
+ *
+ * <p>The client cap is decided atomically under a single lock. Admission frequency is low (a handful of concurrent
+ * cold-start transfers, each lasting minutes), so {@code synchronized} carries no meaningful cost.
+ */
+public class BlobTransferAdmissionController {
+  private static final Logger LOGGER = LogManager.getLogger(BlobTransferAdmissionController.class);
+
+  /**
+   * Upper bound on the configurable client capacity percentage. Client-origin transfers share the host's disk and
+   * network bandwidth with server-to-server transfers.
+   */
+  static final int MAX_CLIENT_CAPACITY_PERCENT = 50;
+
+  // Hard cap on concurrent client-origin transfers. Derived from the client capacity percentage of the host budget.
+  private final int maxClientTransfers;
+
+  private int clientInFlight = 0;
+
+  /**
+   * @param maxConcurrentTransfers the host-wide concurrency budget {@code N} (must be > 0) that the client cap is
+   *        expressed as a percentage of.
+   * @param clientCapacityPercent the percentage [0, {@value #MAX_CLIENT_CAPACITY_PERCENT}] of {@code N} reserved as the
+   *        client-origin cap. {@code 0} disables client-origin transfers entirely; any positive percentage yields a cap
+   *        of at least 1 so a small budget does not silently round the client reservation down to zero. Capped at
+   *        {@value #MAX_CLIENT_CAPACITY_PERCENT}% so client transfers cannot dominate shared host I/O.
+   */
+  public BlobTransferAdmissionController(int maxConcurrentTransfers, int clientCapacityPercent) {
+    if (maxConcurrentTransfers <= 0) {
+      throw new IllegalArgumentException("maxConcurrentTransfers must be > 0, got " + maxConcurrentTransfers);
+    }
+    if (clientCapacityPercent < 0 || clientCapacityPercent > MAX_CLIENT_CAPACITY_PERCENT) {
+      throw new IllegalArgumentException(
+          "clientCapacityPercent must be in [0, " + MAX_CLIENT_CAPACITY_PERCENT + "], got " + clientCapacityPercent);
+    }
+    this.maxClientTransfers = clientCapacityPercent == 0
+        ? 0
+        : Math.max(1, (int) Math.floor(maxConcurrentTransfers * clientCapacityPercent / 100.0));
+  }
+
+  /**
+   * Attempt to admit a client-origin transfer, incrementing the in-flight count on success. The caller must invoke
+   * {@link #releaseClient()} exactly once for every {@code true} result, when the transfer finishes.
+   *
+   * @return {@code true} if admitted, {@code false} if the client-origin reservation is full.
+   */
+  public synchronized boolean tryAdmitClient() {
+    if (clientInFlight >= maxClientTransfers) {
+      return false;
+    }
+    clientInFlight++;
+    return true;
+  }
+
+  /**
+   * Release a previously admitted client-origin slot. Clamped at 0 to defend against a double release.
+   */
+  public synchronized void releaseClient() {
+    if (clientInFlight <= 0) {
+      LOGGER.warn("Attempted to release a client-origin blob transfer slot while none were in flight.");
+      clientInFlight = 0;
+    } else {
+      clientInFlight--;
+    }
+  }
+
+  public synchronized int getClientInFlight() {
+    return clientInFlight;
+  }
+
+  public int getMaxClientTransfers() {
+    return maxClientTransfers;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/BlobTransferNettyChannelInitializer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/BlobTransferNettyChannelInitializer.java
@@ -36,7 +36,9 @@ public class BlobTransferNettyChannelInitializer extends ChannelInitializer<Sock
       AggBlobTransferStats aggBlobTransferStats,
       Optional<SSLFactory> sslFactory,
       Optional<BlobTransferAclHandler> aclHandler,
-      int maxAllowedConcurrentSnapshotUsers) {
+      int maxAllowedConcurrentSnapshotUsers,
+      BlobTransferAdmissionController admissionController,
+      boolean serverAcceptClientBlobRequestEnabled) {
     this.globalChannelTrafficShapingHandler = globalChannelTrafficShapingHandler;
     this.sslFactory = sslFactory;
     this.alpiniSslFactory = sslFactory.isPresent() ? SslUtils.toAlpiniSSLFactory(sslFactory.get()) : null;
@@ -46,7 +48,9 @@ public class BlobTransferNettyChannelInitializer extends ChannelInitializer<Sock
         blobTransferMaxTimeoutInMin,
         blobSnapshotManager,
         aggBlobTransferStats,
-        maxAllowedConcurrentSnapshotUsers);
+        maxAllowedConcurrentSnapshotUsers,
+        admissionController,
+        serverAcceptClientBlobRequestEnabled);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PBlobTransferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PBlobTransferService.java
@@ -52,7 +52,9 @@ public class P2PBlobTransferService extends AbstractVeniceService {
       AggBlobTransferStats aggBlobTransferStats,
       Optional<SSLFactory> sslFactory,
       Optional<BlobTransferAclHandler> aclHandler,
-      int maxAllowedConcurrentSnapshotUsers) {
+      int maxAllowedConcurrentSnapshotUsers,
+      int clientCapacityPercent,
+      boolean serverAcceptClientBlobRequestEnabled) {
     this.port = port;
     this.serverBootstrap = new ServerBootstrap();
     this.blobSnapshotManager = blobSnapshotManager;
@@ -88,7 +90,11 @@ public class P2PBlobTransferService extends AbstractVeniceService {
                 aggBlobTransferStats,
                 sslFactory,
                 aclHandler,
-                maxAllowedConcurrentSnapshotUsers))
+                maxAllowedConcurrentSnapshotUsers,
+                serverAcceptClientBlobRequestEnabled
+                    ? new BlobTransferAdmissionController(maxAllowedConcurrentSnapshotUsers, clientCapacityPercent)
+                    : null,
+                serverAcceptClientBlobRequestEnabled))
         .option(ChannelOption.SO_BACKLOG, 1000)
         .option(ChannelOption.SO_REUSEADDR, true)
         .childOption(ChannelOption.SO_KEEPALIVE, true)

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
@@ -1,8 +1,10 @@
 package com.linkedin.davinci.blobtransfer.server;
 
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BLOB_TRANSFER_COMPLETED;
+import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BLOB_TRANSFER_REQUEST_ORIGIN;
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BLOB_TRANSFER_STATUS;
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BLOB_TRANSFER_TYPE;
+import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferRequestOrigin;
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferTableFormat;
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferType;
 import static com.linkedin.venice.utils.NettyUtils.setupResponseAndFlush;
@@ -68,22 +70,36 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
   // Global counter for all active transfer requests across all topics and partitions
   private final AtomicInteger globalConcurrentTransferRequests = new AtomicInteger(0);
   private final AggBlobTransferStats aggBlobTransferStats;
+  // Admission control bounding concurrent client-origin (Stateful CDC) transfers against their own reservation.
+  private final BlobTransferAdmissionController admissionController;
+  // Whether this server accepts client-origin (e.g. Stateful CDC) blob requests.
+  private final boolean serverAcceptClientBlobRequestEnabled;
   private static final AttributeKey<BlobTransferPayload> BLOB_TRANSFER_REQUEST =
       AttributeKey.valueOf("blobTransferRequest");
   private static final AttributeKey<AtomicBoolean> SUCCESS_COUNTED =
       AttributeKey.valueOf("successCountedAsActiveCurrentUser");
+  // Set when a client-origin request is admitted, so channelInactive releases exactly that slot.
+  private static final AttributeKey<Boolean> CLIENT_ADMITTED = AttributeKey.valueOf("blobTransferClientAdmitted");
 
   public P2PFileTransferServerHandler(
       String baseDir,
       int blobTransferMaxTimeoutInMin,
       BlobSnapshotManager blobSnapshotManager,
       AggBlobTransferStats aggBlobTransferStats,
-      int maxAllowedConcurrentSnapshotUsers) {
+      int maxAllowedConcurrentSnapshotUsers,
+      BlobTransferAdmissionController admissionController,
+      boolean serverAcceptClientBlobRequestEnabled) {
     this.baseDir = baseDir;
     this.blobTransferMaxTimeoutInMin = blobTransferMaxTimeoutInMin;
     this.blobSnapshotManager = blobSnapshotManager;
     this.aggBlobTransferStats = aggBlobTransferStats;
     this.maxAllowedConcurrentSnapshotUsers = maxAllowedConcurrentSnapshotUsers;
+    if (serverAcceptClientBlobRequestEnabled && admissionController == null) {
+      throw new IllegalArgumentException(
+          "admissionController is required when client-origin blob requests are enabled");
+    }
+    this.admissionController = admissionController;
+    this.serverAcceptClientBlobRequestEnabled = serverAcceptClientBlobRequestEnabled;
   }
 
   /**
@@ -143,39 +159,75 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
         return;
       }
 
-      // Check the concurrent request limit
-      if (globalConcurrentTransferRequests.get() >= maxAllowedConcurrentSnapshotUsers) {
-        String errMessage =
-            "The number of concurrent snapshot users exceeds the limit of " + maxAllowedConcurrentSnapshotUsers
-                + ", wont be able to process the request for " + blobTransferRequest.getFullResourceName();
-        LOGGER.error(errMessage);
-        setupResponseAndFlush(HttpResponseStatus.TOO_MANY_REQUESTS, errMessage.getBytes(), false, ctx);
-        return;
-      }
-
-      try {
-        transferPartitionMetadata =
-            blobSnapshotManager.getTransferMetadata(blobTransferRequest, successCountedAsActiveCurrentUser);
-        ctx.channel().attr(SUCCESS_COUNTED).set(successCountedAsActiveCurrentUser);
-        ctx.channel().attr(BLOB_TRANSFER_REQUEST).set(blobTransferRequest);
-        if (successCountedAsActiveCurrentUser.get()) {
-          if (globalConcurrentTransferRequests.incrementAndGet() >= maxAllowedConcurrentSnapshotUsers) {
-            String errMessage =
-                "The number of concurrent snapshot users exceeds the limit of " + maxAllowedConcurrentSnapshotUsers
-                    + ", wont be able to process the request for " + blobTransferRequest.getFullResourceName();
-            LOGGER.error(errMessage);
-            setupResponseAndFlush(HttpResponseStatus.TOO_MANY_REQUESTS, errMessage.getBytes(), false, ctx);
-            return;
-          }
+      // Client-origin requests (Stateful CDC server-fallback) are admitted against their own reservation; all other
+      // requests use the global concurrent-user counter.
+      BlobTransferRequestOrigin origin = ctx.channel().attr(BLOB_TRANSFER_REQUEST_ORIGIN).get();
+      if (serverAcceptClientBlobRequestEnabled && origin == BlobTransferRequestOrigin.CLIENT) {
+        // Reserve a client-admission slot before any snapshot work, on a budget separate from the global counter so
+        // client traffic cannot delay server-to-server transfers. Released in channelInactive via CLIENT_ADMITTED.
+        if (!admissionController.tryAdmitClient()) {
+          String errMessage = "Client-origin blob transfer rejected (client reservation full) for "
+              + blobTransferRequest.getFullResourceName();
+          LOGGER.warn(errMessage);
+          setupResponseAndFlush(HttpResponseStatus.TOO_MANY_REQUESTS, errMessage.getBytes(), false, ctx);
+          return;
         }
-      } catch (Exception e) {
-        setupResponseAndFlush(HttpResponseStatus.NOT_FOUND, e.getMessage().getBytes(), false, ctx);
-        return;
+        ctx.channel().attr(CLIENT_ADMITTED).set(Boolean.TRUE);
+        LOGGER.info(
+            "Admitted client-origin (server-fallback) blob transfer request for {}; client in-flight {}/{}.",
+            blobTransferRequest.getFullResourceName(),
+            admissionController.getClientInFlight(),
+            admissionController.getMaxClientTransfers());
+        try {
+          // getTransferMetadata increments the snapshot-user count and sets the success flag, then can still throw
+          // (stale snapshot in use); stamp the cleanup attributes first so channelInactive releases that count.
+          ctx.channel().attr(SUCCESS_COUNTED).set(successCountedAsActiveCurrentUser);
+          ctx.channel().attr(BLOB_TRANSFER_REQUEST).set(blobTransferRequest);
+          transferPartitionMetadata =
+              blobSnapshotManager.getTransferMetadata(blobTransferRequest, successCountedAsActiveCurrentUser);
+        } catch (Exception e) {
+          // Close the channel (last arg) so channelInactive runs the existing cleanup and releases any
+          // snapshot-user count and admission slot getTransferMetadata may have taken before throwing.
+          String message = e.getMessage() == null ? "Failed to fetch transfer metadata" : e.getMessage();
+          setupResponseAndFlush(HttpResponseStatus.NOT_FOUND, message.getBytes(), false, ctx, true);
+          return;
+        }
+      } else {
+        // Check the concurrent request limit
+        if (globalConcurrentTransferRequests.get() >= maxAllowedConcurrentSnapshotUsers) {
+          String errMessage =
+              "The number of concurrent snapshot users exceeds the limit of " + maxAllowedConcurrentSnapshotUsers
+                  + ", won't be able to process the request for " + blobTransferRequest.getFullResourceName();
+          LOGGER.error(errMessage);
+          setupResponseAndFlush(HttpResponseStatus.TOO_MANY_REQUESTS, errMessage.getBytes(), false, ctx);
+          return;
+        }
+
+        try {
+          transferPartitionMetadata =
+              blobSnapshotManager.getTransferMetadata(blobTransferRequest, successCountedAsActiveCurrentUser);
+          ctx.channel().attr(SUCCESS_COUNTED).set(successCountedAsActiveCurrentUser);
+          ctx.channel().attr(BLOB_TRANSFER_REQUEST).set(blobTransferRequest);
+          if (successCountedAsActiveCurrentUser.get()) {
+            if (globalConcurrentTransferRequests.incrementAndGet() >= maxAllowedConcurrentSnapshotUsers) {
+              String errMessage =
+                  "The number of concurrent snapshot users exceeds the limit of " + maxAllowedConcurrentSnapshotUsers
+                      + ", won't be able to process the request for " + blobTransferRequest.getFullResourceName();
+              LOGGER.error(errMessage);
+              setupResponseAndFlush(HttpResponseStatus.TOO_MANY_REQUESTS, errMessage.getBytes(), false, ctx);
+              return;
+            }
+          }
+        } catch (Exception e) {
+          setupResponseAndFlush(HttpResponseStatus.NOT_FOUND, e.getMessage().getBytes(), false, ctx);
+          return;
+        }
       }
 
       if (!snapshotDir.exists() || !snapshotDir.isDirectory()) {
         byte[] errBody = ("Snapshot for " + blobTransferRequest.getFullResourceName() + " doesn't exist").getBytes();
-        setupResponseAndFlush(HttpResponseStatus.NOT_FOUND, errBody, false, ctx);
+        LOGGER.debug("Snapshot missing for {}; returning NOT_FOUND.", blobTransferRequest.getFullResourceName());
+        setupResponseAndFlush(HttpResponseStatus.NOT_FOUND, errBody, false, ctx, isAdmittedClientOrigin(ctx));
         return;
       }
     } catch (IllegalArgumentException e) {
@@ -192,7 +244,8 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
           HttpResponseStatus.INTERNAL_SERVER_ERROR,
           ("Failed to access files at " + snapshotDir).getBytes(),
           false,
-          ctx);
+          ctx,
+          isAdmittedClientOrigin(ctx));
       return;
     }
 
@@ -211,7 +264,12 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
         String errMessage =
             String.format(TRANSFER_TIMEOUT_ERROR_MSG_FORMAT, blobTransferRequest.getFullResourceName(), file.getName());
         LOGGER.error(errMessage);
-        setupResponseAndFlush(HttpResponseStatus.REQUEST_TIMEOUT, errMessage.getBytes(), false, ctx);
+        setupResponseAndFlush(
+            HttpResponseStatus.REQUEST_TIMEOUT,
+            errMessage.getBytes(),
+            false,
+            ctx,
+            isAdmittedClientOrigin(ctx));
         return;
       }
       // send file
@@ -246,16 +304,26 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
   public void channelInactive(ChannelHandlerContext ctx) {
     AtomicBoolean successCountedAsActiveCurrentUser = ctx.channel().attr(SUCCESS_COUNTED).get();
     BlobTransferPayload blobTransferRequest = ctx.channel().attr(BLOB_TRANSFER_REQUEST).get();
+    boolean clientOrigin = Boolean.TRUE.equals(ctx.channel().attr(CLIENT_ADMITTED).get());
     if (successCountedAsActiveCurrentUser != null && successCountedAsActiveCurrentUser.get()
         && blobTransferRequest != null) {
       try {
         blobSnapshotManager.decreaseConcurrentUserCount(blobTransferRequest);
-        globalConcurrentTransferRequests.decrementAndGet();
+        if (!clientOrigin) {
+          globalConcurrentTransferRequests.decrementAndGet();
+        }
       } catch (Exception e) {
         LOGGER.error("Failed to decrease the snapshot concurrent user count for request {}", blobTransferRequest, e);
       }
     }
+    if (clientOrigin) {
+      admissionController.releaseClient();
+    }
     ctx.fireChannelInactive();
+  }
+
+  private boolean isAdmittedClientOrigin(ChannelHandlerContext ctx) {
+    return Boolean.TRUE.equals(ctx.channel().attr(CLIENT_ADMITTED).get());
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -22,6 +22,7 @@ import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_SNAPSHOT_CLEANUP_INTE
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_SNAPSHOT_RETENTION_TIME_IN_MIN;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_BLOB_TRANSFER_SERVER_FALLBACK_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_CHECK_INTERVAL_IN_MS;
@@ -83,8 +84,10 @@ import static com.linkedin.venice.ConfigKeys.SERVER_ADAPTIVE_THROTTLER_SINGLE_GE
 import static com.linkedin.venice.ConfigKeys.SERVER_ADD_RMD_TO_BATCH_PUSH_FOR_HYBRID_STORES;
 import static com.linkedin.venice.ConfigKeys.SERVER_BATCH_PUSH_RECORD_COUNT_VERIFICATION_FAIL_ON_MISMATCH_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_BLOB_TRANSFER_ACCEPT_CLIENT_REQUEST_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_BLOB_TRANSFER_ADAPTIVE_THROTTLER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_BLOB_TRANSFER_ADAPTIVE_THROTTLER_UPDATE_PERCENTAGE;
+import static com.linkedin.venice.ConfigKeys.SERVER_BLOB_TRANSFER_CLIENT_CAPACITY_PERCENT;
 import static com.linkedin.venice.ConfigKeys.SERVER_BLOCKING_QUEUE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_CHANNEL_OPTION_WRITE_BUFFER_WATERMARK_HIGH_BYTES;
 import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_FAST_AVRO_ENABLED;
@@ -679,6 +682,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final ConfigCommonUtils.ActivationState blobTransferReceiverServerPolicy;
   private final boolean blobTransferSslEnabled;
   private final boolean blobTransferAclEnabled;
+  private final boolean serverAcceptClientBlobRequestEnabled;
+  private final boolean davinciBlobTransferServerFallbackEnabled;
+  private final int blobTransferClientCapacityPercent;
   private final int snapshotRetentionTimeInMin;
   private final int maxConcurrentSnapshotUser;
   private final int blobTransferMaxTimeoutInMin;
@@ -814,6 +820,11 @@ public class VeniceServerConfig extends VeniceClusterConfig {
             .getString(BLOB_TRANSFER_RECEIVER_SERVER_POLICY, ConfigCommonUtils.ActivationState.NOT_SPECIFIED.name()));
     blobTransferSslEnabled = serverProperties.getBoolean(BLOB_TRANSFER_SSL_ENABLED, false);
     blobTransferAclEnabled = serverProperties.getBoolean(BLOB_TRANSFER_ACL_ENABLED, false);
+    serverAcceptClientBlobRequestEnabled =
+        serverProperties.getBoolean(SERVER_BLOB_TRANSFER_ACCEPT_CLIENT_REQUEST_ENABLED, false);
+    davinciBlobTransferServerFallbackEnabled =
+        serverProperties.getBoolean(DAVINCI_BLOB_TRANSFER_SERVER_FALLBACK_ENABLED, false);
+    blobTransferClientCapacityPercent = serverProperties.getInt(SERVER_BLOB_TRANSFER_CLIENT_CAPACITY_PERCENT, 25);
 
     snapshotRetentionTimeInMin = serverProperties.getInt(BLOB_TRANSFER_SNAPSHOT_RETENTION_TIME_IN_MIN, 60);
     maxConcurrentSnapshotUser = serverProperties.getInt(BLOB_TRANSFER_MAX_CONCURRENT_SNAPSHOT_USER, 15);
@@ -1405,6 +1416,18 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getMaxConcurrentSnapshotUser() {
     return maxConcurrentSnapshotUser;
+  }
+
+  public boolean isServerAcceptClientBlobRequestEnabled() {
+    return serverAcceptClientBlobRequestEnabled;
+  }
+
+  public boolean isDavinciBlobTransferServerFallbackEnabled() {
+    return davinciBlobTransferServerFallbackEnabled;
+  }
+
+  public int getBlobTransferClientCapacityPercent() {
+    return blobTransferClientCapacityPercent;
   }
 
   public int getSnapshotRetentionTimeInMin() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestBlobTransferAclHandler.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestBlobTransferAclHandler.java
@@ -1,0 +1,260 @@
+package com.linkedin.davinci.blobtransfer;
+
+import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferRequestOrigin.CLIENT;
+import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferRequestOrigin.SERVER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.davinci.config.VeniceConfigLoader;
+import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.acl.AclException;
+import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authorization.DefaultIdentityParser;
+import com.linkedin.venice.authorization.IdentityParser;
+import com.linkedin.venice.utils.VeniceProperties;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.util.ReferenceCountUtil;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
+import javax.security.auth.x500.X500Principal;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestBlobTransferAclHandler {
+  private static final String REQUEST_URI = "/myStore/1/10/BLOCK_BASED_TABLE";
+
+  @Test
+  public void testServerOriginWhenApplicationsMatch() {
+    // A peer whose application matches the local host's application is a trusted peer: a peer Venice server (both
+    // "venice-server"), or two DVC peers of the same application for DVC-to-DVC transfer.
+    Assert.assertEquals(BlobTransferAclHandler.determineRequestOrigin("venice-server", "venice-server"), SERVER);
+    Assert.assertEquals(BlobTransferAclHandler.determineRequestOrigin("cdc-client-app", "cdc-client-app"), SERVER);
+  }
+
+  @Test
+  public void testClientOriginWhenApplicationsDiffer() {
+    // A Stateful CDC / Da Vinci client carries a different application identity than the server, so it is CLIENT.
+    Assert.assertEquals(BlobTransferAclHandler.determineRequestOrigin("stateful-cdc-client", "venice-server"), CLIENT);
+  }
+
+  @Test
+  public void testClientOriginWhenLocalApplicationUnresolved() {
+    // Fail closed: a null/unresolved local application must never grant SERVER trust.
+    Assert.assertEquals(BlobTransferAclHandler.determineRequestOrigin("venice-server", null), CLIENT);
+    Assert.assertEquals(BlobTransferAclHandler.determineRequestOrigin(null, null), CLIENT);
+  }
+
+  @Test
+  public void testCreateAclHandlerRequiresStoreAccessControllerWhenAcceptingClientRequests() {
+    VeniceConfigLoader configLoader = mockAclConfigLoader(NonDefaultIdentityParser.class);
+    IllegalArgumentException exception = Assert.expectThrows(
+        IllegalArgumentException.class,
+        () -> BlobTransferUtils.createAclHandler(configLoader, Optional.empty(), true));
+    Assert.assertTrue(exception.getMessage().contains("storeAccessController is required"));
+  }
+
+  @Test
+  public void testCreateAclHandlerRejectsDefaultIdentityParserOnServerPath() {
+    VeniceConfigLoader configLoader = mockAclConfigLoader(DefaultIdentityParser.class);
+    IllegalArgumentException exception = Assert.expectThrows(
+        IllegalArgumentException.class,
+        () -> BlobTransferUtils
+            .createAclHandler(configLoader, Optional.of(mock(DynamicAccessController.class)), false));
+    Assert.assertTrue(exception.getMessage().contains("non-default identity.parser.class"));
+  }
+
+  @Test
+  public void testClientStoreAccessAllowedWhenControllerGrants() throws Exception {
+    DynamicAccessController controller = mock(DynamicAccessController.class);
+    when(controller.hasAccess(any(), eq("myStore"), eq("GET"))).thenReturn(true);
+    BlobTransferAclHandler handler =
+        new BlobTransferAclHandler(Optional.of(controller), new DefaultIdentityParser(), true);
+    Assert.assertTrue(handler.isClientStoreAccessAllowed(mock(X509Certificate.class), "myStore", "GET"));
+  }
+
+  @Test
+  public void testClientStoreAccessDeniedWhenControllerRejects() throws Exception {
+    DynamicAccessController controller = mock(DynamicAccessController.class);
+    when(controller.hasAccess(any(), eq("myStore"), eq("GET"))).thenReturn(false);
+    BlobTransferAclHandler handler =
+        new BlobTransferAclHandler(Optional.of(controller), new DefaultIdentityParser(), true);
+    Assert.assertFalse(handler.isClientStoreAccessAllowed(mock(X509Certificate.class), "myStore", "GET"));
+  }
+
+  @Test
+  public void testClientStoreAccessDeniedOnAclException() throws Exception {
+    DynamicAccessController controller = mock(DynamicAccessController.class);
+    when(controller.hasAccess(any(), eq("myStore"), eq("GET"))).thenThrow(new AclException("boom"));
+    BlobTransferAclHandler handler =
+        new BlobTransferAclHandler(Optional.of(controller), new DefaultIdentityParser(), true);
+    Assert.assertFalse(handler.isClientStoreAccessAllowed(mock(X509Certificate.class), "myStore", "GET"));
+  }
+
+  @Test
+  public void testExtractStoreName() {
+    Assert.assertEquals(BlobTransferAclHandler.extractStoreName("/myStore/1/10/BLOCK_BASED_TABLE"), "myStore");
+    Assert.assertNull(BlobTransferAclHandler.extractStoreName("/"));
+  }
+
+  @Test
+  public void testClientOriginDeniedStoreAclReturns403AndDoesNotForward() throws Exception {
+    // End-to-end through channelRead0: a CLIENT-origin caller (different subject, same issuer) whose store ACL is
+    // denied must get 403 FORBIDDEN and must NOT be forwarded downstream.
+    SslHandler sslHandler = mockSslHandler("CN=stateful-cdc-client, O=linkedin", "CN=venice-server, O=linkedin");
+    DynamicAccessController controller = mock(DynamicAccessController.class);
+    when(controller.hasAccess(any(), eq("myStore"), any())).thenReturn(false);
+    BlobTransferAclHandler handler =
+        new BlobTransferAclHandler(Optional.of(controller), new DefaultIdentityParser(), true);
+
+    // sslHandler is placed AFTER the ACL handler so extractSslHandler (pipeline.get(SslHandler.class)) can find it,
+    // without the mock intercepting the inbound request before the ACL handler runs.
+    EmbeddedChannel channel = new EmbeddedChannel(handler, sslHandler);
+    channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, REQUEST_URI));
+
+    Object outbound = channel.readOutbound();
+    Assert.assertTrue(outbound instanceof FullHttpResponse, "Expected an HTTP response");
+    Assert.assertEquals(((FullHttpResponse) outbound).status(), HttpResponseStatus.FORBIDDEN);
+    Assert.assertNull(channel.readInbound(), "Denied client-origin request must not be forwarded downstream");
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  public void testClientOriginRejectedWhenAcceptDisabled() throws Exception {
+    // A server has a store access controller, so it classifies same-issuer callers even when the accept flag is off:
+    // client-origin requests are rejected before the store ACL is consulted.
+    SslHandler sslHandler = mockSslHandler("CN=stateful-cdc-client, O=linkedin", "CN=venice-server, O=linkedin");
+    DynamicAccessController controller = mock(DynamicAccessController.class);
+    when(controller.hasAccess(any(), anyString(), anyString())).thenReturn(true);
+    BlobTransferAclHandler handler =
+        new BlobTransferAclHandler(Optional.of(controller), new DefaultIdentityParser(), false);
+
+    EmbeddedChannel channel = new EmbeddedChannel(handler, sslHandler);
+    channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, REQUEST_URI));
+
+    Object outbound = channel.readOutbound();
+    Assert.assertTrue(outbound instanceof FullHttpResponse, "Expected an HTTP response");
+    Assert.assertEquals(((FullHttpResponse) outbound).status(), HttpResponseStatus.FORBIDDEN);
+    Assert.assertNull(channel.readInbound(), "Client-origin request must not be forwarded when accept flag is off");
+    verify(controller, never()).hasAccess(any(), anyString(), anyString());
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  public void testServerOriginForwardedWhenAcceptDisabled() throws Exception {
+    // The accept flag gates only client-origin requests: a peer server (same application identity) is forwarded even
+    // when the flag is off, so server-to-server transfer is unaffected.
+    SslHandler sslHandler = mockSslHandler("CN=venice-server, O=linkedin", "CN=venice-server, O=linkedin");
+    DynamicAccessController controller = mock(DynamicAccessController.class);
+    BlobTransferAclHandler handler =
+        new BlobTransferAclHandler(Optional.of(controller), new DefaultIdentityParser(), false);
+
+    AtomicReference<Object> forwarded = new AtomicReference<>();
+    EmbeddedChannel channel = new EmbeddedChannel(handler, captureHandler(forwarded), sslHandler);
+    channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, REQUEST_URI));
+
+    Assert.assertNull(channel.readOutbound(), "A peer server must not be rejected when accept flag is off");
+    Assert.assertNotNull(forwarded.get(), "A peer server must be forwarded downstream");
+    verify(controller, never()).hasAccess(any(), anyString(), anyString());
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  public void testSameIssuerAdmittedWhenNoControllerEvenIfIdentityDiffers() throws Exception {
+    // Regression: a node with no store access controller (e.g. a Da Vinci peer) must admit any same-issuer peer, even
+    // when the peer's certificate identity differs from the local node's (distinct per-host/per-application certs).
+    // It must NOT reclassify the peer as CLIENT and reject it -- that would break pre-existing DVC-to-DVC transfer.
+    SslHandler sslHandler = mockSslHandler("CN=davinci-host-a, O=linkedin", "CN=davinci-host-b, O=linkedin");
+    // No store access controller -> legacy same-issuer trust applies.
+    BlobTransferAclHandler handler = new BlobTransferAclHandler(Optional.empty(), new DefaultIdentityParser(), false);
+
+    AtomicReference<Object> forwarded = new AtomicReference<>();
+    EmbeddedChannel channel = new EmbeddedChannel(handler, captureHandler(forwarded), sslHandler);
+    channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, REQUEST_URI));
+
+    Assert.assertNull(channel.readOutbound(), "A same-issuer peer must not be rejected when no controller is present");
+    Assert.assertNotNull(forwarded.get(), "A same-issuer peer must be forwarded downstream");
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  public void testSameIssuerForwardedWhenNoController() throws Exception {
+    SslHandler sslHandler = mockSslHandler("CN=stateful-cdc-client, O=linkedin", "CN=venice-server, O=linkedin");
+    BlobTransferAclHandler handler = new BlobTransferAclHandler(Optional.empty(), new DefaultIdentityParser(), true);
+
+    AtomicReference<Object> forwarded = new AtomicReference<>();
+    EmbeddedChannel channel = new EmbeddedChannel(handler, captureHandler(forwarded), sslHandler);
+    channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, REQUEST_URI));
+
+    Assert.assertNull(channel.readOutbound(), "No-controller path keeps legacy same-issuer behavior");
+    Assert.assertNotNull(forwarded.get(), "Same-issuer request must be forwarded when no controller is present");
+    channel.finishAndReleaseAll();
+  }
+
+  /** Build a mock {@link SslHandler} whose session presents a caller and local certificate with the given subjects
+   * and a shared issuer, as the ACL handler reads them. */
+  private static SslHandler mockSslHandler(String callerSubject, String localSubject) throws Exception {
+    X500Principal issuer = new X500Principal("CN=venice-ca, O=linkedin");
+    X509Certificate caller = mock(X509Certificate.class);
+    X509Certificate local = mock(X509Certificate.class);
+    when(caller.getIssuerX500Principal()).thenReturn(issuer);
+    when(local.getIssuerX500Principal()).thenReturn(issuer);
+    when(caller.getSubjectX500Principal()).thenReturn(new X500Principal(callerSubject));
+    when(local.getSubjectX500Principal()).thenReturn(new X500Principal(localSubject));
+
+    SSLSession session = mock(SSLSession.class);
+    when(session.getPeerCertificates()).thenReturn(new Certificate[] { caller });
+    when(session.getLocalCertificates()).thenReturn(new Certificate[] { local });
+    SSLEngine engine = mock(SSLEngine.class);
+    when(engine.getSession()).thenReturn(session);
+    SslHandler sslHandler = mock(SslHandler.class);
+    when(sslHandler.engine()).thenReturn(engine);
+    return sslHandler;
+  }
+
+  /** A capture handler that records the first request forwarded past the ACL handler. */
+  private static ChannelInboundHandlerAdapter captureHandler(AtomicReference<Object> forwarded) {
+    return new ChannelInboundHandlerAdapter() {
+      @Override
+      public void channelRead(ChannelHandlerContext context, Object msg) {
+        forwarded.set(msg);
+        ReferenceCountUtil.release(msg);
+      }
+    };
+  }
+
+  private static VeniceConfigLoader mockAclConfigLoader(Class<? extends IdentityParser> identityParserClass) {
+    Properties properties = new Properties();
+    properties.setProperty(ConfigKeys.BLOB_TRANSFER_SSL_ENABLED, "true");
+    properties.setProperty(ConfigKeys.BLOB_TRANSFER_ACL_ENABLED, "true");
+    properties.setProperty(ConfigKeys.IDENTITY_PARSER_CLASS, identityParserClass.getName());
+    VeniceConfigLoader configLoader = mock(VeniceConfigLoader.class);
+    when(configLoader.getCombinedProperties()).thenReturn(new VeniceProperties(properties));
+    return configLoader;
+  }
+
+  public static class NonDefaultIdentityParser implements IdentityParser {
+    @Override
+    public String parseIdentityFromCert(X509Certificate certificate) {
+      return certificate.getSubjectX500Principal().getName();
+    }
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestBlobTransferAdmissionController.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestBlobTransferAdmissionController.java
@@ -1,0 +1,69 @@
+package com.linkedin.davinci.blobtransfer;
+
+import com.linkedin.davinci.blobtransfer.server.BlobTransferAdmissionController;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestBlobTransferAdmissionController {
+  @Test
+  public void testClientCapacityComputation() {
+    // 25% of 15 -> floor(3.75) = 3
+    Assert.assertEquals(new BlobTransferAdmissionController(15, 25).getMaxClientTransfers(), 3);
+    // 25% of 4 -> floor(1.0) = 1
+    Assert.assertEquals(new BlobTransferAdmissionController(4, 25).getMaxClientTransfers(), 1);
+    // 25% of 2 -> floor(0.5) = 0, but a positive percentage floors at 1
+    Assert.assertEquals(new BlobTransferAdmissionController(2, 25).getMaxClientTransfers(), 1);
+    // 0% explicitly disables client-origin capacity
+    Assert.assertEquals(new BlobTransferAdmissionController(15, 0).getMaxClientTransfers(), 0);
+    // 50% (the max allowed) of 15 -> floor(7.5) = 7
+    Assert.assertEquals(new BlobTransferAdmissionController(15, 50).getMaxClientTransfers(), 7);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testRejectsNonPositiveBudget() {
+    new BlobTransferAdmissionController(0, 25);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testRejectsOutOfRangePercent() {
+    // 51 is just above the 50% ceiling, so it must be rejected
+    new BlobTransferAdmissionController(15, 51);
+  }
+
+  @Test
+  public void testClientAdmittedUpToCap() {
+    BlobTransferAdmissionController controller = new BlobTransferAdmissionController(15, 25); // clientCap = 3
+    for (int i = 0; i < 3; i++) {
+      Assert.assertTrue(controller.tryAdmitClient());
+    }
+    Assert.assertEquals(controller.getClientInFlight(), 3);
+    // 4th client rejected once the reservation is full.
+    Assert.assertFalse(controller.tryAdmitClient());
+  }
+
+  @Test
+  public void testReleaseFreesClientSlot() {
+    BlobTransferAdmissionController controller = new BlobTransferAdmissionController(4, 25); // clientCap = 1
+    Assert.assertTrue(controller.tryAdmitClient());
+    Assert.assertFalse(controller.tryAdmitClient());
+    controller.releaseClient();
+    Assert.assertEquals(controller.getClientInFlight(), 0);
+    Assert.assertTrue(controller.tryAdmitClient());
+  }
+
+  @Test
+  public void testReleaseUnderflowIsClamped() {
+    BlobTransferAdmissionController controller = new BlobTransferAdmissionController(15, 25);
+    // Releasing with nothing in flight must not throw or go negative.
+    controller.releaseClient();
+    Assert.assertEquals(controller.getClientInFlight(), 0);
+  }
+
+  @Test
+  public void testZeroPercentRejectsAllClients() {
+    BlobTransferAdmissionController controller = new BlobTransferAdmissionController(15, 0);
+    Assert.assertFalse(controller.tryAdmitClient());
+    Assert.assertEquals(controller.getClientInFlight(), 0);
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestBlobTransferManagerBuilder.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestBlobTransferManagerBuilder.java
@@ -6,6 +6,7 @@ import com.linkedin.davinci.notifier.VeniceNotifier;
 import com.linkedin.davinci.stats.AggBlobTransferStats;
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.storage.StorageMetadataService;
+import com.linkedin.venice.blobtransfer.ServerAndDaVinciBlobFinder;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
@@ -51,9 +52,12 @@ public class TestBlobTransferManagerBuilder {
         2000000,
         2,
         5,
-        Math.max(4, Runtime.getRuntime().availableProcessors() / 5));
+        Math.max(4, Runtime.getRuntime().availableProcessors() / 5),
+        25,
+        true);
 
     BlobTransferManager blobTransferManager = new BlobTransferManagerBuilder().setBlobTransferConfig(blobTransferConfig)
+        .setServerFallbackEnabled(true)
         .setClientConfig(clientConfig)
         .setCustomizedViewFuture(null)
         .setStorageMetadataService(storageMetadataService)
@@ -66,6 +70,8 @@ public class TestBlobTransferManagerBuilder {
         .build();
 
     Assert.assertNotNull(blobTransferManager);
+    Assert.assertTrue(
+        ((NettyP2PBlobTransferManager) blobTransferManager).peerFinder instanceof ServerAndDaVinciBlobFinder);
   }
 
   @Test
@@ -95,7 +101,9 @@ public class TestBlobTransferManagerBuilder {
         2000000,
         2,
         5,
-        Math.max(4, Runtime.getRuntime().availableProcessors() / 5));
+        Math.max(4, Runtime.getRuntime().availableProcessors() / 5),
+        25,
+        true);
 
     // Case 1: expect exception is thrown due to both clientConfig and customizedViewFuture are not null
     try {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestClientOriginServerBlobTransfer.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestClientOriginServerBlobTransfer.java
@@ -1,0 +1,430 @@
+package com.linkedin.davinci.blobtransfer;
+
+import static com.linkedin.davinci.blobtransfer.BlobTransferGlobalTrafficShapingHandlerHolder.getGlobalChannelTrafficShapingHandlerInstance;
+import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferTableFormat;
+import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.createAclHandler;
+import static com.linkedin.venice.CommonConfigKeys.SSL_ENABLED;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYMANAGER_ALGORITHM;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_LOCATION;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_PASSWORD;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_TYPE;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEY_PASSWORD;
+import static com.linkedin.venice.CommonConfigKeys.SSL_SECURE_RANDOM_IMPLEMENTATION;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTMANAGER_ALGORITHM;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_LOCATION;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_PASSWORD;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_TYPE;
+import static com.linkedin.venice.utils.TestUtils.DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.davinci.blobtransfer.client.NettyFileTransferClient;
+import com.linkedin.davinci.blobtransfer.server.P2PBlobTransferService;
+import com.linkedin.davinci.config.VeniceConfigLoader;
+import com.linkedin.davinci.notifier.VeniceNotifier;
+import com.linkedin.davinci.stats.AggBlobTransferStats;
+import com.linkedin.davinci.stats.AggVersionedBlobTransferStats;
+import com.linkedin.davinci.storage.StorageEngineRepository;
+import com.linkedin.davinci.storage.StorageMetadataService;
+import com.linkedin.davinci.store.StorageEngine;
+import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.acl.VeniceComponent;
+import com.linkedin.venice.authorization.IdentityParser;
+import com.linkedin.venice.blobtransfer.BlobFinder;
+import com.linkedin.venice.blobtransfer.BlobPeersDiscoveryResponse;
+import com.linkedin.venice.kafka.protocol.state.PartitionState;
+import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
+import com.linkedin.venice.offsets.OffsetRecord;
+import com.linkedin.venice.security.DefaultSSLFactory;
+import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
+import com.linkedin.venice.store.rocksdb.RocksDBUtils;
+import com.linkedin.venice.utils.LogContext;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.VeniceProperties;
+import io.netty.handler.traffic.GlobalChannelTrafficShapingHandler;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests the client-origin server blob transfer path over Netty. The test generates same-issuer but different-identity
+ * client/server certs so the server classifies the request as CLIENT-origin and exercises the accept flag, store ACL,
+ * and client-capacity gates.
+ */
+public class TestClientOriginServerBlobTransfer {
+  private static final String STORE = "test_store";
+  private static final int VERSION = 1;
+  private static final int PARTITION = 0;
+  private static final String KEYSTORE_PASSWORD = "dev_pass";
+  private static final int MAX_TRANSFER_TIMEOUT_MIN = 30;
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+  private Path snapshotDir;
+  private Path partitionDir;
+  private Path sslDir;
+  private Path srcFile;
+  private Path destFile;
+
+  private StorageMetadataService storageMetadataService;
+  private AggBlobTransferStats blobTransferStats;
+  private AggVersionedBlobTransferStats versionedBlobTransferStats;
+  private VeniceNotifier notifier;
+  private SSLFactory serverSslFactory;
+  private SSLFactory clientSslFactory;
+
+  private P2PBlobTransferService server;
+  private NettyP2PBlobTransferManager manager;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    snapshotDir = Files.createTempDirectory("clientOriginSnapshot");
+    partitionDir = Files.createTempDirectory("clientOriginPartition");
+
+    storageMetadataService = mock(StorageMetadataService.class);
+    blobTransferStats = mock(AggBlobTransferStats.class);
+    versionedBlobTransferStats = mock(AggVersionedBlobTransferStats.class);
+    notifier = mock(VeniceNotifier.class);
+
+    StoreVersionState storeVersionState = new StoreVersionState();
+    doReturn(storeVersionState).when(storageMetadataService).getStoreVersionState(any());
+    InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer =
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer();
+    OffsetRecord offsetRecord = new OffsetRecord(partitionStateSerializer, DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
+    offsetRecord.setOffsetLag(1000L);
+    doReturn(offsetRecord).when(storageMetadataService).getLastOffset(any(), anyInt(), any());
+
+    sslDir = Files.createTempDirectory("clientOriginSsl");
+    TestSslMaterial sslMaterial = generateSslMaterial(sslDir);
+    serverSslFactory = buildSslFactory(sslMaterial.serverKeyStorePath, sslMaterial.trustStorePath);
+    clientSslFactory = buildSslFactory(sslMaterial.clientKeyStorePath, sslMaterial.trustStorePath);
+
+    prepareSnapshotFile();
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    if (manager != null) {
+      manager.close();
+    }
+    deleteRecursively(snapshotDir);
+    deleteRecursively(partitionDir);
+    deleteRecursively(sslDir);
+  }
+
+  @Test
+  public void testClientOriginTransferSucceedsWhenAcceptedAndAclGranted() throws Exception {
+    DynamicAccessController accessController = mockAccessController(true);
+    manager = startManager(true, accessController);
+
+    CompletionStage<InputStream> future =
+        manager.get(STORE, VERSION, PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
+    future.toCompletableFuture().get(1, TimeUnit.MINUTES);
+
+    Assert.assertTrue(Files.exists(destFile), "Client should have received the snapshot file from the server");
+    Assert.assertEquals(Files.readAllBytes(destFile), Files.readAllBytes(srcFile));
+    // The request was classified CLIENT-origin and went through the per-store read ACL.
+    verify(accessController, atLeastOnce()).hasAccess(any(X509Certificate.class), anyString(), anyString());
+  }
+
+  @Test
+  public void testClientOriginRejectedWhenAcceptFlagOff() throws Exception {
+    DynamicAccessController accessController = mockAccessController(true);
+    manager = startManager(false, accessController);
+
+    assertTransferRejected();
+  }
+
+  @Test
+  public void testClientOriginRejectedWhenAclDenied() throws Exception {
+    DynamicAccessController accessController = mockAccessController(false);
+    manager = startManager(true, accessController);
+
+    assertTransferRejected();
+    verify(accessController, atLeastOnce()).hasAccess(any(X509Certificate.class), anyString(), anyString());
+  }
+
+  private void assertTransferRejected() {
+    try {
+      manager.get(STORE, VERSION, PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE)
+          .toCompletableFuture()
+          .get(10, TimeUnit.SECONDS);
+      Assert.fail("Expected the client-origin request to be rejected by the server");
+    } catch (ExecutionException expected) {
+      // Server rejected the client-origin request with 403, so the transfer fails.
+    } catch (InterruptedException | java.util.concurrent.TimeoutException e) {
+      Assert.fail("Transfer did not fail promptly: " + e);
+    }
+    Assert.assertTrue(Files.notExists(destFile), "No file should be transferred when the request is rejected");
+  }
+
+  /**
+   * Boot the real blob-transfer server (with the given accept flag and access controller) and a client that presents a
+   * distinct certificate, wired through the real {@link NettyP2PBlobTransferManager} server-fallback path with no peer.
+   */
+  private NettyP2PBlobTransferManager startManager(
+      boolean acceptClientRequest,
+      DynamicAccessController accessController) throws Exception {
+    int port = TestUtils.getFreePort();
+    GlobalChannelTrafficShapingHandler trafficHandler = getGlobalChannelTrafficShapingHandlerInstance(2000000, 2000000);
+
+    StorageEngineRepository storageEngineRepository = mock(StorageEngineRepository.class);
+    StorageEngine storageEngine = mock(StorageEngine.class);
+    doReturn(storageEngine).when(storageEngineRepository).getLocalStorageEngine(anyString());
+    doReturn(true).when(storageEngine).containsPartition(anyInt());
+    BlobSnapshotManager blobSnapshotManager =
+        spy(new BlobSnapshotManager(storageEngineRepository, storageMetadataService));
+    doNothing().when(blobSnapshotManager).createSnapshot(anyString(), anyInt());
+
+    Optional<BlobTransferAclHandler> aclHandler =
+        createAclHandler(aclConfigLoader(), Optional.of(accessController), acceptClientRequest);
+
+    server = new P2PBlobTransferService(
+        port,
+        snapshotDir.toString(),
+        MAX_TRANSFER_TIMEOUT_MIN,
+        blobSnapshotManager,
+        trafficHandler,
+        blobTransferStats,
+        Optional.of(serverSslFactory),
+        aclHandler,
+        20,
+        25,
+        acceptClientRequest);
+
+    NettyFileTransferClient client = new NettyFileTransferClient(
+        port,
+        partitionDir.toString(),
+        storageMetadataService,
+        30,
+        60,
+        MAX_TRANSFER_TIMEOUT_MIN,
+        Math.max(4, Runtime.getRuntime().availableProcessors() / 5),
+        trafficHandler,
+        blobTransferStats,
+        Optional.of(clientSslFactory),
+        () -> notifier,
+        LogContext.forTests(VeniceComponent.DAVINCI_CLIENT.name()));
+
+    BlobFinder peerFinder = mock(BlobFinder.class);
+    BlobPeersDiscoveryResponse discoveryResponse = new BlobPeersDiscoveryResponse();
+    discoveryResponse.setDiscoveryResult(Collections.singletonList("localhost"));
+    doReturn(discoveryResponse).when(peerFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
+
+    NettyP2PBlobTransferManager blobTransferManager = new NettyP2PBlobTransferManager(
+        server,
+        client,
+        peerFinder,
+        partitionDir.toString(),
+        versionedBlobTransferStats,
+        5,
+        LogContext.forTests(VeniceComponent.DAVINCI_CLIENT.name()));
+    blobTransferManager.start();
+    return blobTransferManager;
+  }
+
+  private DynamicAccessController mockAccessController(boolean grant) throws Exception {
+    DynamicAccessController accessController = mock(DynamicAccessController.class);
+    when(accessController.hasAccess(any(X509Certificate.class), anyString(), anyString())).thenReturn(grant);
+    return accessController;
+  }
+
+  private VeniceConfigLoader aclConfigLoader() {
+    Properties properties = new Properties();
+    properties.setProperty(ConfigKeys.BLOB_TRANSFER_SSL_ENABLED, "true");
+    properties.setProperty(ConfigKeys.BLOB_TRANSFER_ACL_ENABLED, "true");
+    properties.setProperty(ConfigKeys.IDENTITY_PARSER_CLASS, TestBlobTransferIdentityParser.class.getName());
+    VeniceConfigLoader configLoader = mock(VeniceConfigLoader.class);
+    when(configLoader.getCombinedProperties()).thenReturn(new VeniceProperties(properties));
+    return configLoader;
+  }
+
+  private static SSLFactory buildSslFactory(Path keyStorePath, Path trustStorePath) throws Exception {
+    Properties properties = new Properties();
+    properties.setProperty(SSL_ENABLED, "true");
+    properties.setProperty(SSL_KEYSTORE_TYPE, "JKS");
+    properties.setProperty(SSL_KEYSTORE_LOCATION, keyStorePath.toString());
+    properties.setProperty(SSL_KEYSTORE_PASSWORD, KEYSTORE_PASSWORD);
+    properties.setProperty(SSL_TRUSTSTORE_TYPE, "JKS");
+    properties.setProperty(SSL_TRUSTSTORE_LOCATION, trustStorePath.toString());
+    properties.setProperty(SSL_TRUSTSTORE_PASSWORD, KEYSTORE_PASSWORD);
+    properties.setProperty(SSL_KEY_PASSWORD, KEYSTORE_PASSWORD);
+    properties.setProperty(SSL_KEYMANAGER_ALGORITHM, "SunX509");
+    properties.setProperty(SSL_TRUSTMANAGER_ALGORITHM, "SunX509");
+    properties.setProperty(SSL_SECURE_RANDOM_IMPLEMENTATION, "SHA1PRNG");
+    return new DefaultSSLFactory(properties);
+  }
+
+  private static TestSslMaterial generateSslMaterial(Path outputDir) throws Exception {
+    char[] password = KEYSTORE_PASSWORD.toCharArray();
+    KeyPair caKeyPair = generateRsaKeyPair();
+    X500Name caSubject = new X500Name("CN=venice-blob-test-ca, O=linkedin");
+    X509Certificate caCertificate = generateCertificate(caSubject, caKeyPair.getPrivate(), caSubject, caKeyPair, true);
+
+    KeyPair serverKeyPair = generateRsaKeyPair();
+    X509Certificate serverCertificate = generateCertificate(
+        caSubject,
+        caKeyPair.getPrivate(),
+        new X500Name("CN=venice-server, O=linkedin"),
+        serverKeyPair,
+        false);
+
+    KeyPair clientKeyPair = generateRsaKeyPair();
+    X509Certificate clientCertificate = generateCertificate(
+        caSubject,
+        caKeyPair.getPrivate(),
+        new X500Name("CN=venice-client, O=linkedin"),
+        clientKeyPair,
+        false);
+
+    Path serverKeyStorePath = outputDir.resolve("blob-transfer-server.jks");
+    Path clientKeyStorePath = outputDir.resolve("blob-transfer-client.jks");
+    Path trustStorePath = outputDir.resolve("blob-transfer-truststore.jks");
+    writeKeyStore(serverKeyStorePath, "server", serverKeyPair.getPrivate(), serverCertificate, caCertificate, password);
+    writeKeyStore(clientKeyStorePath, "client", clientKeyPair.getPrivate(), clientCertificate, caCertificate, password);
+    writeTrustStore(trustStorePath, caCertificate, password);
+    return new TestSslMaterial(serverKeyStorePath, clientKeyStorePath, trustStorePath);
+  }
+
+  private static KeyPair generateRsaKeyPair() throws Exception {
+    KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+    keyPairGenerator.initialize(2048);
+    return keyPairGenerator.generateKeyPair();
+  }
+
+  private static X509Certificate generateCertificate(
+      X500Name issuer,
+      PrivateKey issuerPrivateKey,
+      X500Name subject,
+      KeyPair subjectKeyPair,
+      boolean isCa) throws Exception {
+    Date notBefore = new Date(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(1));
+    Date notAfter = new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1));
+    JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+        issuer,
+        new BigInteger(160, SECURE_RANDOM),
+        notBefore,
+        notAfter,
+        subject,
+        subjectKeyPair.getPublic());
+    builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(isCa));
+    ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(issuerPrivateKey);
+    return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+  }
+
+  private static void writeKeyStore(
+      Path keyStorePath,
+      String alias,
+      PrivateKey privateKey,
+      X509Certificate certificate,
+      X509Certificate caCertificate,
+      char[] password) throws Exception {
+    KeyStore keyStore = KeyStore.getInstance("JKS");
+    keyStore.load(null, password);
+    keyStore.setKeyEntry(alias, privateKey, password, new Certificate[] { certificate, caCertificate });
+    try (OutputStream outputStream = Files.newOutputStream(keyStorePath)) {
+      keyStore.store(outputStream, password);
+    }
+  }
+
+  private static void writeTrustStore(Path trustStorePath, X509Certificate caCertificate, char[] password)
+      throws Exception {
+    KeyStore trustStore = KeyStore.getInstance("JKS");
+    trustStore.load(null, password);
+    trustStore.setCertificateEntry("venice-blob-test-ca", caCertificate);
+    try (OutputStream outputStream = Files.newOutputStream(trustStorePath)) {
+      trustStore.store(outputStream, password);
+    }
+  }
+
+  private static final class TestSslMaterial {
+    private final Path serverKeyStorePath;
+    private final Path clientKeyStorePath;
+    private final Path trustStorePath;
+
+    private TestSslMaterial(Path serverKeyStorePath, Path clientKeyStorePath, Path trustStorePath) {
+      this.serverKeyStorePath = serverKeyStorePath;
+      this.clientKeyStorePath = clientKeyStorePath;
+      this.trustStorePath = trustStorePath;
+    }
+  }
+
+  public static class TestBlobTransferIdentityParser implements IdentityParser {
+    @Override
+    public String parseIdentityFromCert(X509Certificate certificate) {
+      String subjectName = certificate.getSubjectX500Principal().getName();
+      if (subjectName.contains("CN=venice-client")) {
+        return "venice-client";
+      }
+      if (subjectName.contains("CN=venice-server")) {
+        return "venice-server";
+      }
+      return subjectName;
+    }
+  }
+
+  private void prepareSnapshotFile() throws Exception {
+    Path versionSnapshotDir =
+        Paths.get(RocksDBUtils.composeSnapshotDir(snapshotDir.toString(), STORE + "_v" + VERSION, PARTITION));
+    Path versionPartitionDir =
+        Paths.get(RocksDBUtils.composePartitionDbDir(partitionDir.toString(), STORE + "_v" + VERSION, PARTITION));
+    Files.createDirectories(versionSnapshotDir);
+    srcFile = versionSnapshotDir.resolve("snapshot.sst");
+    destFile = versionPartitionDir.resolve("snapshot.sst");
+    Files.write(srcFile, "client-origin-blob-payload".getBytes(StandardCharsets.UTF_8));
+    Assert.assertTrue(Files.notExists(destFile));
+  }
+
+  private static void deleteRecursively(Path dir) throws Exception {
+    if (Files.exists(dir)) {
+      Files.walk(dir).sorted(Comparator.reverseOrder()).forEach(path -> {
+        try {
+          Files.delete(path);
+        } catch (Exception e) {
+          // best effort cleanup
+        }
+      });
+    }
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
@@ -55,6 +55,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -64,6 +65,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -127,7 +129,7 @@ public class TestNettyP2PBlobTransferManager {
     VeniceConfigLoader configLoader = Mockito.mock(VeniceConfigLoader.class);
 
     Mockito.when(configLoader.getCombinedProperties()).thenReturn(veniceProperties);
-    aclHandler = createAclHandler(configLoader);
+    aclHandler = createAclHandler(configLoader, Optional.empty(), false);
 
     blobSnapshotManager = Mockito.spy(new BlobSnapshotManager(storageEngineRepository, storageMetadataService));
     notifier = Mockito.mock(VeniceNotifier.class);
@@ -143,7 +145,9 @@ public class TestNettyP2PBlobTransferManager {
         blobTransferStats,
         sslFactory,
         aclHandler,
-        20);
+        20,
+        25,
+        true);
     client = Mockito.spy(
         new NettyFileTransferClient(
             port,
@@ -375,6 +379,37 @@ public class TestNettyP2PBlobTransferManager {
     verifyFileTransferSuccess(expectOffsetRecord);
   }
 
+  @Test
+  public void testFallsBackFromDaVinciPeerToServerAfterTransferFailure() throws Exception {
+    List<String> hostlist = Arrays.asList("dvc-host", "server-host");
+    BlobPeersDiscoveryResponse response = new BlobPeersDiscoveryResponse();
+    response.setDiscoveryResult(hostlist);
+    doReturn(response).when(finder).discoverBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    doReturn(true).when(finder).shouldPreservePeerOrder();
+    doReturn(new HashSet<>(hostlist)).when(client)
+        .getConnectableHosts(any(), eq(TEST_STORE), eq(TEST_VERSION), eq(TEST_PARTITION));
+
+    CompletableFuture<InputStream> daVinciFailure = new CompletableFuture<>();
+    daVinciFailure.completeExceptionally(new VeniceBlobTransferFileNotFoundException("DVC snapshot unavailable"));
+    InputStream serverResponse = mock(InputStream.class);
+    doReturn(daVinciFailure).when(client)
+        .get("dvc-host", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
+    doReturn(CompletableFuture.completedFuture(serverResponse)).when(client)
+        .get("server-host", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
+
+    InputStream result =
+        manager.get(TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE)
+            .toCompletableFuture()
+            .get(10, TimeUnit.SECONDS);
+
+    Assert.assertSame(result, serverResponse);
+    InOrder transferOrder = Mockito.inOrder(client);
+    transferOrder.verify(client)
+        .get("dvc-host", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
+    transferOrder.verify(client)
+        .get("server-host", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
+  }
+
   /**
    * The client is initialized with host freshness 30 sec, so when purgeStaleConnectivityRecords is called,
    * All hosts connectivity records older than 30s should be purged.
@@ -540,7 +575,9 @@ public class TestNettyP2PBlobTransferManager {
         blobTransferStats,
         sslFactory,
         aclHandler,
-        20);
+        20,
+        25,
+        true);
 
     NettyP2PBlobTransferManager newManager = new NettyP2PBlobTransferManager(
         newServer,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestP2PFileTransferServerHandler.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestP2PFileTransferServerHandler.java
@@ -2,15 +2,18 @@ package com.linkedin.davinci.blobtransfer;
 
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BLOB_TRANSFER_COMPLETED;
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BLOB_TRANSFER_PARTITION_STATE_SCHEMA_VERSION;
+import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BLOB_TRANSFER_REQUEST_ORIGIN;
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BLOB_TRANSFER_STATUS;
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BLOB_TRANSFER_STORE_VERSION_STATE_SCHEMA_VERSION;
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BLOB_TRANSFER_TYPE;
+import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferRequestOrigin;
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferType;
 import static com.linkedin.venice.response.VeniceReadResponseStatus.TOO_MANY_REQUESTS;
 import static com.linkedin.venice.utils.TestUtils.DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING;
 import static org.mockito.ArgumentMatchers.any;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.davinci.blobtransfer.server.BlobTransferAdmissionController;
 import com.linkedin.davinci.blobtransfer.server.P2PFileTransferServerHandler;
 import com.linkedin.davinci.stats.AggBlobTransferStats;
 import com.linkedin.davinci.storage.StorageEngineRepository;
@@ -74,7 +77,9 @@ public class TestP2PFileTransferServerHandler {
         blobTransferMaxTimeoutInMin,
         blobSnapshotManager,
         blobTransferStats,
-        maxAllowedConcurrentSnapshotUsers);
+        maxAllowedConcurrentSnapshotUsers,
+        new BlobTransferAdmissionController(maxAllowedConcurrentSnapshotUsers, 25),
+        true);
     ch = new EmbeddedChannel(serverHandler);
   }
 
@@ -88,6 +93,121 @@ public class TestP2PFileTransferServerHandler {
         e.printStackTrace();
       }
     });
+  }
+
+  @Test
+  public void testRejectClientOriginWhenClientReservationFull() {
+    // clientCap = 1 (25% of 4). Pre-occupy the only client slot so the incoming client-origin request is rejected at
+    // admission with 429, before any snapshot work -- independent of whether getTransferMetadata would succeed.
+    BlobTransferAdmissionController fullController = new BlobTransferAdmissionController(4, 25);
+    Assert.assertTrue(fullController.tryAdmitClient(), "Test setup: the single client slot should be claimable");
+    P2PFileTransferServerHandler clientHandler = new P2PFileTransferServerHandler(
+        baseDir.toString(),
+        blobTransferMaxTimeoutInMin,
+        blobSnapshotManager,
+        blobTransferStats,
+        4,
+        fullController,
+        true);
+    EmbeddedChannel clientChannel = new EmbeddedChannel(clientHandler);
+    clientChannel.attr(BLOB_TRANSFER_REQUEST_ORIGIN).set(BlobTransferRequestOrigin.CLIENT);
+
+    clientChannel.writeInbound(
+        new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/myStore/1/10/BLOCK_BASED_TABLE"));
+
+    boolean foundTooManyRequestsResponse = false;
+    Object outbound;
+    while ((outbound = clientChannel.readOutbound()) != null) {
+      if (outbound instanceof FullHttpResponse
+          && ((FullHttpResponse) outbound).status().code() == TOO_MANY_REQUESTS.getCode()) {
+        foundTooManyRequestsResponse = true;
+      }
+    }
+    Assert.assertTrue(
+        foundTooManyRequestsResponse,
+        "Client-origin request must be rejected once the client reservation is full");
+    clientChannel.close();
+  }
+
+  @Test
+  public void testClientSlotReleasedWhenMetadataFails() {
+    // A client-origin request that fails getTransferMetadata (no storage engine in this mock setup) must release its
+    // admission slot immediately rather than holding it until the channel closes.
+    BlobTransferAdmissionController controller = new BlobTransferAdmissionController(4, 25); // clientCap = 1
+    P2PFileTransferServerHandler clientHandler = new P2PFileTransferServerHandler(
+        baseDir.toString(),
+        blobTransferMaxTimeoutInMin,
+        blobSnapshotManager,
+        blobTransferStats,
+        4,
+        controller,
+        true);
+    EmbeddedChannel clientChannel = new EmbeddedChannel(clientHandler);
+    clientChannel.attr(BLOB_TRANSFER_REQUEST_ORIGIN).set(BlobTransferRequestOrigin.CLIENT);
+
+    clientChannel.writeInbound(
+        new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/myStore/1/10/BLOCK_BASED_TABLE"));
+
+    // The handler closes the channel on a failed client-origin metadata fetch, so channelInactive promptly releases
+    // the admission slot instead of pinning it on a kept-alive connection.
+    Assert.assertFalse(
+        clientChannel.isActive(),
+        "Channel must be closed after a failed client-origin metadata fetch so cleanup runs promptly");
+    Assert.assertEquals(
+        controller.getClientInFlight(),
+        0,
+        "A failed client-origin metadata fetch must release the admission slot immediately");
+    clientChannel.close();
+  }
+
+  @Test
+  public void testClientSlotReleasedWhenSnapshotMissing() throws Exception {
+    BlobTransferAdmissionController controller = new BlobTransferAdmissionController(4, 25); // clientCap = 1
+    P2PFileTransferServerHandler clientHandler = new P2PFileTransferServerHandler(
+        baseDir.toString(),
+        blobTransferMaxTimeoutInMin,
+        blobSnapshotManager,
+        blobTransferStats,
+        4,
+        controller,
+        true);
+    EmbeddedChannel clientChannel = new EmbeddedChannel(clientHandler);
+    clientChannel.attr(BLOB_TRANSFER_REQUEST_ORIGIN).set(BlobTransferRequestOrigin.CLIENT);
+
+    BlobTransferPartitionMetadata metadata = new BlobTransferPartitionMetadata();
+    Mockito.doReturn(metadata).when(blobSnapshotManager).getTransferMetadata(any(), any());
+    clientChannel.writeInbound(
+        new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/myStore/1/10/BLOCK_BASED_TABLE"));
+
+    Assert.assertFalse(
+        clientChannel.isActive(),
+        "Channel must be closed after a post-admission client-origin error so cleanup runs promptly");
+    Assert.assertEquals(controller.getClientInFlight(), 0, "The client admission slot must be released promptly");
+    clientChannel.close();
+  }
+
+  @Test
+  public void testAdmissionControllerNotRequiredWhenAcceptDisabled() {
+    new P2PFileTransferServerHandler(
+        baseDir.toString(),
+        blobTransferMaxTimeoutInMin,
+        blobSnapshotManager,
+        blobTransferStats,
+        maxAllowedConcurrentSnapshotUsers,
+        null,
+        false);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testAdmissionControllerRequiredWhenAcceptEnabled() {
+    new P2PFileTransferServerHandler(
+        baseDir.toString(),
+        blobTransferMaxTimeoutInMin,
+        blobSnapshotManager,
+        blobTransferStats,
+        maxAllowedConcurrentSnapshotUsers,
+        null,
+        true);
   }
 
   @Test
@@ -132,8 +252,8 @@ public class TestP2PFileTransferServerHandler {
     Files.write(file1.toAbsolutePath(), "hello".getBytes());
     Mockito.doNothing().when(blobSnapshotManager).createSnapshot(Mockito.anyString(), Mockito.anyInt());
 
-    // Send maxAllowedConcurrentSnapshotUsers + 1 requests
-    for (int requestCount = 0; requestCount < maxAllowedConcurrentSnapshotUsers; requestCount++) {
+    // Send maxAllowedConcurrentSnapshotUsers + 1 requests so the final one exceeds the host budget.
+    for (int requestCount = 0; requestCount <= maxAllowedConcurrentSnapshotUsers; requestCount++) {
       FullHttpRequest request =
           new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/myStore/1/10/BLOCK_BASED_TABLE");
       ch.writeInbound(request);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2313,6 +2313,25 @@ public class ConfigKeys {
   // Enable acl for the blob transfer between Da Vinci peers, or server peers
   public static final String BLOB_TRANSFER_ACL_ENABLED = "blob.transfer.acl.enabled";
 
+  /**
+   * This is the server host-level flag -- when true and the blob transfer service is enabled, the Venice
+   * server accepts blob transfer requests from (Da Vinci /
+   * Stateful CDC) clients. Defaults to false.
+   */
+  public static final String SERVER_BLOB_TRANSFER_ACCEPT_CLIENT_REQUEST_ENABLED =
+      "server.blob.transfer.accept.client.request.enabled";
+
+  // Client-side flag: when true, after peer-to-peer (client) blob discovery finds no usable peer, the
+  // Stateful CDC / Da Vinci client falls back to requesting the blob from a Venice server. Defaults to false.
+  public static final String DAVINCI_BLOB_TRANSFER_SERVER_FALLBACK_ENABLED =
+      "davinci.blob.transfer.server.fallback.enabled";
+
+  // Server-side hard cap, as a percentage of the host blob-transfer budget
+  // (BLOB_TRANSFER_MAX_CONCURRENT_SNAPSHOT_USER), that client-origin transfers may occupy. Server-origin
+  // (server-to-server) transfers are not capped and may use the full budget. Defaults to 25.
+  public static final String SERVER_BLOB_TRANSFER_CLIENT_CAPACITY_PERCENT =
+      "server.blob.transfer.client.capacity.percent";
+
   // Port used by peer-to-peer transfer service. It should be used by both server and client
   public static final String DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT = "davinci.p2p.blob.transfer.server.port";
   // Ideally this config should NOT be used but for testing purpose on a single host, we need to separate the ports.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/BlobFinder.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/BlobFinder.java
@@ -7,4 +7,8 @@ public interface BlobFinder extends AutoCloseable {
    */
   BlobPeersDiscoveryResponse discoverBlobPeers(String storeName, int version, int partitionId);
 
+  default boolean shouldPreservePeerOrder() {
+    return false;
+  }
+
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/MetadataBasedServerBlobFinder.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/MetadataBasedServerBlobFinder.java
@@ -1,0 +1,426 @@
+package com.linkedin.venice.blobtransfer;
+
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.venice.annotation.VisibleForTesting;
+import com.linkedin.venice.client.exceptions.VeniceClientException;
+import com.linkedin.venice.client.schema.RouterBackedSchemaReader;
+import com.linkedin.venice.client.store.AvroGenericStoreClientImpl;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.D2ServiceDiscovery;
+import com.linkedin.venice.client.store.InternalAvroStoreClient;
+import com.linkedin.venice.client.store.transport.D2TransportClient;
+import com.linkedin.venice.client.store.transport.TransportClientResponse;
+import com.linkedin.venice.controllerapi.D2ServiceDiscoveryResponse;
+import com.linkedin.venice.meta.QueryAction;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.metadata.response.MetadataResponseRecord;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordDeserializer;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.Schema;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+
+/**
+ * Discovers the Venice servers hosting a store partition so a Stateful CDC / Da Vinci client with no peer can fall back
+ * to fetching a blob from a server. Used only on the cold-start fallback path.
+ *
+ * <p>{@code metadata/<store>} is served by Venice servers, not the Router, so this finder uses D2 server-routing (like
+ * Fast Client's {@code RequestBasedMetadata}): it resolves the store's server D2 service, GETs {@code metadata/<store>}
+ * on a server, and reads the partition-to-replica map from {@link MetadataResponseRecord#getRoutingInfo()}, reusing the
+ * D2 client on the {@link ClientConfig}. The response is decoded against the writer schema the server advertises (via
+ * its schema id), so a server running a newer {@link MetadataResponseRecord} schema than the client is still readable.
+ * Any failure returns an empty/error response so the caller falls back to Version Topic replay -- it never returns a
+ * wrong host.
+ */
+public class MetadataBasedServerBlobFinder implements BlobFinder {
+  private static final Logger LOGGER = LogManager.getLogger(MetadataBasedServerBlobFinder.class);
+  /** Short timeout so a slow or unreachable server fails fast to Version Topic replay rather than stalling. */
+  private static final int METADATA_FETCH_TIMEOUT_SECONDS = 3;
+
+  /** Fallback deserializer using the client's compiled schema, for responses that carry no usable writer schema id. */
+  private static final RecordDeserializer<MetadataResponseRecord> COMPILED_METADATA_DESERIALIZER =
+      FastSerializerDeserializerFactory
+          .getFastAvroSpecificDeserializer(MetadataResponseRecord.SCHEMA$, MetadataResponseRecord.class);
+  private final ClientConfig clientConfig;
+  private final D2ServiceDiscovery d2ServiceDiscovery;
+
+  /**
+   * One transport per store, cached after discovery points it at the store's server D2 service: avoids re-resolving on
+   * each cold start and keeps {@code setServiceName} from racing across stores.
+   */
+  private final VeniceConcurrentHashMap<String, D2TransportClient> storeToServerTransportClientMap =
+      new VeniceConcurrentHashMap<>();
+
+  /** Lets concurrent partition lookups share the same metadata request. */
+  private final VeniceConcurrentHashMap<String, CompletableFuture<MetadataResponseRecord>> metadataRequests =
+      new VeniceConcurrentHashMap<>();
+
+  /** Prevents successful metadata fetches from logging once per partition. */
+  private final VeniceConcurrentHashMap<String, Boolean> metadataFetchLoggedStores = new VeniceConcurrentHashMap<>();
+
+  /**
+   * Resolves a {@link MetadataResponseRecord} writer schema from the server-advertised schema id; built lazily on first
+   * use (or injected for tests). Reuses the config's D2 client to read the metadata-response system store's schemas.
+   */
+  private volatile RouterBackedSchemaReader metadataResponseSchemaReader;
+
+  public MetadataBasedServerBlobFinder(ClientConfig clientConfig) {
+    this(clientConfig, new D2ServiceDiscovery(), null);
+  }
+
+  @VisibleForTesting
+  MetadataBasedServerBlobFinder(ClientConfig clientConfig, D2ServiceDiscovery d2ServiceDiscovery) {
+    this(clientConfig, d2ServiceDiscovery, null);
+  }
+
+  @VisibleForTesting
+  MetadataBasedServerBlobFinder(
+      ClientConfig clientConfig,
+      D2ServiceDiscovery d2ServiceDiscovery,
+      RouterBackedSchemaReader metadataResponseSchemaReader) {
+    this.clientConfig = clientConfig;
+    this.d2ServiceDiscovery = d2ServiceDiscovery;
+    this.metadataResponseSchemaReader = metadataResponseSchemaReader;
+  }
+
+  /**
+   * Lazily build and cache one transport per store, routed to that store's server D2 service via D2 discovery on the
+   * config's D2 client. Closed in {@link #close()}.
+   *
+   * @throws VeniceClientException if the config has no D2 client (caller falls back to Version Topic replay).
+   */
+  @VisibleForTesting
+  D2TransportClient getServerTransportClient(String storeName) {
+    return storeToServerTransportClientMap.computeIfAbsent(storeName, k -> {
+      D2TransportClient transportClient = getD2TransportClient(storeName);
+      try {
+        D2ServiceDiscoveryResponse discoveryResponse = d2ServiceDiscovery.find(transportClient, storeName, true);
+        String serverD2ServiceName = discoveryResponse == null ? null : discoveryResponse.getServerD2Service();
+        if (serverD2ServiceName == null || serverD2ServiceName.trim().isEmpty()) {
+          throw new VeniceClientException("No server D2 service discovered for store: " + storeName);
+        }
+        transportClient.setServiceName(serverD2ServiceName);
+        LOGGER.info(
+            "Resolved server D2 service {} for store {} using discovery D2 service {}.",
+            serverD2ServiceName,
+            storeName,
+            clientConfig.getD2ServiceName());
+        return transportClient;
+      } catch (RuntimeException e) {
+        transportClient.close();
+        throw e;
+      }
+    });
+  }
+
+  @VisibleForTesting
+  @NonNull
+  D2TransportClient getD2TransportClient(String storeName) {
+    D2Client d2Client = clientConfig.getD2Client();
+    if (d2Client == null) {
+      throw new VeniceClientException(
+          "Server blob discovery requires a D2 client on the client config, but none was configured for store: "
+              + storeName);
+    }
+
+    return new D2TransportClient(clientConfig.getD2ServiceName(), d2Client);
+  }
+
+  /** Return the server replicas hosting {@code partitionId} for the store's current serving version. */
+  @Override
+  public BlobPeersDiscoveryResponse discoverBlobPeers(String storeName, int version, int partitionId) {
+    BlobPeersDiscoveryResponse response = new BlobPeersDiscoveryResponse();
+    try {
+      MetadataResponseRecord metadata = getMetadata(storeName, version);
+      List<String> replicas = extractReplicas(metadata.getRoutingInfo(), partitionId);
+      LOGGER.info(
+          "Discovered {} server replica(s) for store {} partition {}: {}",
+          replicas.size(),
+          storeName,
+          partitionId,
+          replicas);
+      response.setDiscoveryResult(replicas);
+      return response;
+    } catch (Exception e) {
+      return errorResponse(storeName, version, partitionId, e);
+    }
+  }
+
+  /**
+   * Fetch metadata for a store version, or share the request already being performed by another partition lookup.
+   */
+  private MetadataResponseRecord getMetadata(String storeName, int version) {
+    String storeVersion = Version.composeKafkaTopic(storeName, version);
+    CompletableFuture<MetadataResponseRecord> newRequest = new CompletableFuture<>();
+    CompletableFuture<MetadataResponseRecord> existingRequest = metadataRequests.putIfAbsent(storeVersion, newRequest);
+    if (existingRequest != null) {
+      return waitForMetadata(existingRequest, storeVersion);
+    }
+
+    try {
+      MetadataResponseRecord metadata = fetchMetadata(storeName);
+      validateCurrentVersion(metadata, version);
+      logMetadataFetchSuccess(storeName, version, metadata);
+      newRequest.complete(metadata);
+      return metadata;
+    } catch (RuntimeException e) {
+      LOGGER.warn(
+          "Failed to fetch or validate server metadata for {}. Server blob discovery will fall back.",
+          storeVersion,
+          e);
+      newRequest.completeExceptionally(e);
+      throw e;
+    } finally {
+      metadataRequests.remove(storeVersion, newRequest);
+    }
+  }
+
+  /**
+   * Wait for another partition lookup's metadata request and preserve its original failure when it does not succeed.
+   */
+  private MetadataResponseRecord waitForMetadata(
+      CompletableFuture<MetadataResponseRecord> metadataFuture,
+      String storeVersion) {
+    try {
+      return metadataFuture.get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOGGER.warn("Interrupted while waiting for the shared server metadata request for {}.", storeVersion, e);
+      throw new VeniceClientException("Interrupted while waiting for metadata for: " + storeVersion, e);
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      throw new VeniceClientException("Failed to fetch metadata for: " + storeVersion, cause);
+    }
+  }
+
+  /** Request and deserialize the current routing metadata from the store's Venice server D2 service. */
+  private MetadataResponseRecord fetchMetadata(String storeName) {
+    String uri = QueryAction.METADATA.toString().toLowerCase() + "/" + storeName;
+    LOGGER.info("Fetching {} to discover servers hosting store {}.", uri, storeName);
+    D2TransportClient transportClient = getServerTransportClient(storeName);
+    String requestDescription = uri + " via D2 service " + transportClient.getServiceName();
+    TransportClientResponse metadataResponse;
+    try {
+      metadataResponse = transportClient.get(uri).get(METADATA_FETCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      invalidateServerTransportClient(storeName, transportClient);
+      throw new VeniceClientException("Interrupted while fetching " + requestDescription, e);
+    } catch (Exception e) {
+      invalidateServerTransportClient(storeName, transportClient);
+      throw new VeniceClientException("Failed to fetch " + requestDescription, e);
+    }
+    if (metadataResponse == null || metadataResponse.getBody() == null) {
+      invalidateServerTransportClient(storeName, transportClient);
+      throw new VeniceClientException("Metadata response body was null for " + requestDescription);
+    }
+    return deserializeMetadata(metadataResponse);
+  }
+
+  /** Remove a failed store transport so the next metadata request reruns D2 service discovery. */
+  private void invalidateServerTransportClient(String storeName, D2TransportClient transportClient) {
+    if (storeToServerTransportClientMap.remove(storeName, transportClient)) {
+      metadataFetchLoggedStores.remove(storeName);
+      LOGGER.info(
+          "Invalidated server D2 service {} for store {}; the next metadata lookup will rerun D2 discovery.",
+          transportClient.getServiceName(),
+          storeName);
+      transportClient.close();
+    }
+  }
+
+  /** Log the first successful metadata response for a store, and again only after its D2 transport is invalidated. */
+  private void logMetadataFetchSuccess(String storeName, int version, MetadataResponseRecord metadata) {
+    if (metadataFetchLoggedStores.putIfAbsent(storeName, Boolean.TRUE) != null) {
+      return;
+    }
+    D2TransportClient transportClient = storeToServerTransportClientMap.get(storeName);
+    LOGGER.info(
+        "Fetched and validated server metadata for store {} version {} via D2 service {}; routing contains {} partition(s).",
+        storeName,
+        version,
+        transportClient == null ? "unknown" : transportClient.getServiceName(),
+        metadata.getRoutingInfo() == null ? 0 : metadata.getRoutingInfo().size());
+  }
+
+  /** Ensure the routing metadata belongs to the exact store version requested for blob transfer. */
+  private void validateCurrentVersion(MetadataResponseRecord metadata, int version) {
+    if (metadata.getVersionMetadata() == null || metadata.getVersionMetadata().getCurrentVersion() != version) {
+      throw new VeniceClientException(
+          "Metadata current version was " + (metadata.getVersionMetadata() == null
+              ? "missing"
+              : String.valueOf(metadata.getVersionMetadata().getCurrentVersion())) + ", expected " + version);
+    }
+  }
+
+  /**
+   * Decode the metadata response against the writer schema the server advertises (its schema id), so a server running a
+   * newer {@link MetadataResponseRecord} schema than this client is still readable. Falls back to the client's compiled
+   * schema when the response carries no usable schema id or the writer schema cannot be resolved.
+   */
+  private MetadataResponseRecord deserializeMetadata(TransportClientResponse metadataResponse) {
+    byte[] body = metadataResponse.getBody();
+    if (metadataResponse.isSchemaIdValid()) {
+      try {
+        Schema writerSchema = getMetadataResponseSchemaReader().getValueSchema(metadataResponse.getSchemaId());
+        if (writerSchema != null) {
+          return FastSerializerDeserializerFactory
+              .getFastAvroSpecificDeserializer(writerSchema, MetadataResponseRecord.class)
+              .deserialize(body);
+        }
+      } catch (Exception e) {
+        LOGGER.warn(
+            "Could not resolve the metadata response writer schema for id {}; decoding with the compiled schema.",
+            metadataResponse.getSchemaId(),
+            e);
+      }
+    }
+    return COMPILED_METADATA_DESERIALIZER.deserialize(body);
+  }
+
+  private RouterBackedSchemaReader getMetadataResponseSchemaReader() {
+    RouterBackedSchemaReader reader = metadataResponseSchemaReader;
+    if (reader == null) {
+      synchronized (this) {
+        reader = metadataResponseSchemaReader;
+        if (reader == null) {
+          reader = buildMetadataResponseSchemaReader();
+          metadataResponseSchemaReader = reader;
+        }
+      }
+    }
+    return reader;
+  }
+
+  /**
+   * Build a schema reader for the metadata-response system store so a server-advertised writer-schema id can be
+   * resolved to its schema. Mirrors Fast Client's {@code RequestBasedMetadata}, reusing the config's D2 client and
+   * cluster-discovery service.
+   *
+   * @throws VeniceClientException if the config has no D2 client (the caller then decodes with the compiled schema).
+   */
+  private RouterBackedSchemaReader buildMetadataResponseSchemaReader() {
+    D2Client d2Client = clientConfig.getD2Client();
+    if (d2Client == null) {
+      throw new VeniceClientException("Server blob discovery requires a D2 client to resolve the metadata schema.");
+    }
+    InternalAvroStoreClient schemaStoreClient = new AvroGenericStoreClientImpl(
+        new D2TransportClient(clientConfig.getD2ServiceName(), d2Client),
+        false,
+        ClientConfig.defaultGenericClientConfig(AvroProtocolDefinition.SERVER_METADATA_RESPONSE.getSystemStoreName()));
+    return new RouterBackedSchemaReader(() -> schemaStoreClient, Optional.empty(), Optional.empty());
+  }
+
+  /**
+   * Extract the replica hosts for {@code partitionId} from the routing map (keyed by partition number as a string);
+   * empty if the partition is absent. Raw-{@link Map}-typed so it is unit-testable without Avro.
+   */
+  @VisibleForTesting
+  static List<String> extractReplicas(Map<?, ?> routingInfo, int partitionId) {
+    List<String> replicas = new ArrayList<>();
+    if (routingInfo == null) {
+      return replicas;
+    }
+    String targetKey = String.valueOf(partitionId);
+    for (Map.Entry<?, ?> entry: routingInfo.entrySet()) {
+      if (entry.getKey() != null && targetKey.equals(entry.getKey().toString()) && entry.getValue() instanceof List) {
+        for (Object replica: (List<?>) entry.getValue()) {
+          String host = normalizeHost(replica == null ? null : replica.toString());
+          if (host != null && !host.isEmpty()) {
+            replicas.add(host);
+          }
+        }
+        break;
+      }
+    }
+    return replicas;
+  }
+
+  /**
+   * Reduce a routing entry to its bare host: server metadata values are instance URLs ({@code https://host:port}), but
+   * the blob client connects by host on its own p2p port. Host-only entries pass through; IPv6 literals are unbracketed.
+   */
+  @VisibleForTesting
+  static String normalizeHost(String replica) {
+    if (replica == null) {
+      return null;
+    }
+    String value = replica.trim();
+    if (value.isEmpty()) {
+      return null;
+    }
+    if (value.contains("://")) {
+      try {
+        String parsedHost = URI.create(value).getHost();
+        if (parsedHost != null && !parsedHost.isEmpty()) {
+          value = parsedHost;
+        }
+      } catch (IllegalArgumentException e) {
+        LOGGER.warn("Could not parse host from metadata replica entry: {}", replica);
+      }
+    }
+    if (value.length() > 1 && value.startsWith("[") && value.endsWith("]")) {
+      value = value.substring(1, value.length() - 1);
+    }
+    return value;
+  }
+
+  private BlobPeersDiscoveryResponse errorResponse(String storeName, int version, int partitionId, Exception e) {
+    return buildErrorResponse(storeName, version, partitionId, e.getMessage() == null ? e.toString() : e.getMessage());
+  }
+
+  private BlobPeersDiscoveryResponse buildErrorResponse(
+      String storeName,
+      int version,
+      int partitionId,
+      String message) {
+    BlobPeersDiscoveryResponse response = new BlobPeersDiscoveryResponse();
+    response.setError(true);
+    response.setErrorMessage(
+        String.format(
+            "Error finding servers for blob transfer of store: %s, version: %d, partition: %d. Error: %s",
+            storeName,
+            version,
+            partitionId,
+            message));
+    return response;
+  }
+
+  /**
+   * Release finder-owned resources after the blob transfer manager has stopped issuing discovery requests.
+   */
+  @Override
+  public void close() {
+    metadataRequests.clear();
+    metadataFetchLoggedStores.clear();
+    for (D2TransportClient transportClient: storeToServerTransportClientMap.values()) {
+      // Releases this transport only; the shared D2 client (owned by the config) keeps running.
+      transportClient.close();
+    }
+    storeToServerTransportClientMap.clear();
+    RouterBackedSchemaReader reader = metadataResponseSchemaReader;
+    if (reader != null) {
+      try {
+        reader.close();
+      } catch (IOException e) {
+        LOGGER.warn("Error closing the metadata response schema reader.", e);
+      }
+    }
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/ServerAndDaVinciBlobFinder.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/ServerAndDaVinciBlobFinder.java
@@ -1,0 +1,92 @@
+package com.linkedin.venice.blobtransfer;
+
+import com.linkedin.venice.annotation.VisibleForTesting;
+import com.linkedin.venice.client.store.ClientConfig;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Discovers Da Vinci peers first and Venice servers second for client cold-start blob transfer.
+ */
+public class ServerAndDaVinciBlobFinder implements BlobFinder {
+  private static final Logger LOGGER = LogManager.getLogger(ServerAndDaVinciBlobFinder.class);
+
+  private final BlobFinder daVinciBlobFinder;
+  private final BlobFinder serverBlobFinder;
+
+  public ServerAndDaVinciBlobFinder(ClientConfig clientConfig) {
+    this(new DaVinciBlobFinder(clientConfig), new MetadataBasedServerBlobFinder(clientConfig));
+  }
+
+  @VisibleForTesting
+  ServerAndDaVinciBlobFinder(BlobFinder daVinciBlobFinder, BlobFinder serverBlobFinder) {
+    this.daVinciBlobFinder = daVinciBlobFinder;
+    this.serverBlobFinder = serverBlobFinder;
+  }
+
+  @Override
+  public BlobPeersDiscoveryResponse discoverBlobPeers(String storeName, int version, int partitionId) {
+    BlobPeersDiscoveryResponse daVinciResponse = daVinciBlobFinder.discoverBlobPeers(storeName, version, partitionId);
+    BlobPeersDiscoveryResponse serverResponse = serverBlobFinder.discoverBlobPeers(storeName, version, partitionId);
+
+    List<String> daVinciPeers = getDiscoveredPeers(daVinciResponse);
+    List<String> serverPeers = getDiscoveredPeers(serverResponse);
+    Collections.shuffle(daVinciPeers);
+    Collections.shuffle(serverPeers);
+
+    BlobPeersDiscoveryResponse response = new BlobPeersDiscoveryResponse();
+    List<String> discoveredPeers = new ArrayList<>(daVinciPeers.size() + serverPeers.size());
+    discoveredPeers.addAll(daVinciPeers);
+    discoveredPeers.addAll(serverPeers);
+    response.setDiscoveryResult(discoveredPeers);
+
+    if (discoveredPeers.isEmpty() && hasError(daVinciResponse) && hasError(serverResponse)) {
+      response.setError(true);
+      response.setErrorMessage(
+          "Failed to discover both Da Vinci peers and Venice servers. Da Vinci error: "
+              + getErrorMessage(daVinciResponse) + "; server error: " + getErrorMessage(serverResponse));
+    }
+    LOGGER.info(
+        "Discovered {} Da Vinci peer(s) and {} Venice server peer(s) for store {} version {} partition {}.",
+        daVinciPeers.size(),
+        serverPeers.size(),
+        storeName,
+        version,
+        partitionId);
+    return response;
+  }
+
+  @Override
+  public boolean shouldPreservePeerOrder() {
+    return true;
+  }
+
+  private static List<String> getDiscoveredPeers(BlobPeersDiscoveryResponse response) {
+    if (response == null || response.isError() || response.getDiscoveryResult() == null
+        || response.getDiscoveryResult().isEmpty()) {
+      return new ArrayList<>();
+    }
+    return new ArrayList<>(response.getDiscoveryResult());
+  }
+
+  private static boolean hasError(BlobPeersDiscoveryResponse response) {
+    return response == null || response.isError();
+  }
+
+  private static String getErrorMessage(BlobPeersDiscoveryResponse response) {
+    return response == null ? "null response" : response.getErrorMessage();
+  }
+
+  @Override
+  public void close() throws Exception {
+    try {
+      daVinciBlobFinder.close();
+    } finally {
+      serverBlobFinder.close();
+    }
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/MetadataBasedServerBlobFinderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/MetadataBasedServerBlobFinderTest.java
@@ -1,0 +1,429 @@
+package com.linkedin.venice.blobtransfer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.venice.client.schema.RouterBackedSchemaReader;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.D2ServiceDiscovery;
+import com.linkedin.venice.client.store.transport.D2TransportClient;
+import com.linkedin.venice.client.store.transport.TransportClientResponse;
+import com.linkedin.venice.controllerapi.D2ServiceDiscoveryResponse;
+import com.linkedin.venice.metadata.response.MetadataResponseRecord;
+import com.linkedin.venice.metadata.response.VersionProperties;
+import com.linkedin.venice.schema.SchemaData;
+import com.linkedin.venice.serializer.SerializerDeserializerFactory;
+import com.linkedin.venice.utils.TestUtils;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.mockito.ArgumentCaptor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class MetadataBasedServerBlobFinderTest {
+  private static final String STORE_NAME = "testStore";
+  private static final int VERSION = 1;
+  private static final String DISCOVERY_D2 = "venice-discovery";
+  private static final String SERVER_D2 = "venice-server-d2";
+
+  @Test
+  public void testExtractReplicasNormalizesUrlEntriesToHosts() {
+    // Server metadata populates routing values as instance URLs (https://host:port); the finder returns bare hosts.
+    Map<String, List<String>> routingInfo = new HashMap<>();
+    routingInfo.put("0", Arrays.asList("https://server-x:7778"));
+    routingInfo.put("1", Arrays.asList("https://server-a:7778", "https://server-b:7778"));
+    Assert.assertEquals(
+        MetadataBasedServerBlobFinder.extractReplicas(routingInfo, 1),
+        Arrays.asList("server-a", "server-b"));
+  }
+
+  @Test
+  public void testExtractReplicasEmptyWhenPartitionAbsent() {
+    Map<String, List<String>> routingInfo = new HashMap<>();
+    routingInfo.put("0", Arrays.asList("hostX"));
+    Assert.assertTrue(MetadataBasedServerBlobFinder.extractReplicas(routingInfo, 7).isEmpty());
+  }
+
+  @Test
+  public void testExtractReplicasEmptyWhenRoutingNull() {
+    Assert.assertTrue(MetadataBasedServerBlobFinder.extractReplicas(null, 0).isEmpty());
+  }
+
+  @Test
+  public void testNormalizeHost() {
+    Assert.assertEquals(MetadataBasedServerBlobFinder.normalizeHost("https://server-a:7778"), "server-a");
+    Assert.assertEquals(MetadataBasedServerBlobFinder.normalizeHost("http://server-b:1234"), "server-b");
+    // Host-only entries pass through unchanged.
+    Assert.assertEquals(MetadataBasedServerBlobFinder.normalizeHost("server-c"), "server-c");
+    // Bracketed IPv6 literals are unwrapped.
+    Assert.assertEquals(MetadataBasedServerBlobFinder.normalizeHost("[::1]"), "::1");
+    Assert.assertNull(MetadataBasedServerBlobFinder.normalizeHost(null));
+  }
+
+  /**
+   * The metadata endpoint is server-served, so the transport must be pointed at the store's SERVER D2 service (resolved
+   * via D2 service discovery) rather than the cluster-discovery/Router service. The per-store transport is cached, so
+   * discovery runs once.
+   */
+  @Test
+  public void testGetServerTransportClientResolvesAndCachesServerD2() {
+    ClientConfig clientConfig = mock(ClientConfig.class);
+    when(clientConfig.getD2Client()).thenReturn(mock(D2Client.class));
+    when(clientConfig.getD2ServiceName()).thenReturn(DISCOVERY_D2);
+
+    D2ServiceDiscovery d2ServiceDiscovery = mock(D2ServiceDiscovery.class);
+    D2ServiceDiscoveryResponse discoveryResponse = new D2ServiceDiscoveryResponse();
+    discoveryResponse.setServerD2Service(SERVER_D2);
+    when(d2ServiceDiscovery.find(any(D2TransportClient.class), eq(STORE_NAME), eq(true))).thenReturn(discoveryResponse);
+
+    MetadataBasedServerBlobFinder finder = new MetadataBasedServerBlobFinder(clientConfig, d2ServiceDiscovery);
+
+    D2TransportClient transportClient = finder.getServerTransportClient(STORE_NAME);
+    Assert.assertEquals(transportClient.getServiceName(), SERVER_D2);
+
+    // Cached: a second lookup returns the same instance and does not re-run discovery.
+    Assert.assertSame(finder.getServerTransportClient(STORE_NAME), transportClient);
+    verify(d2ServiceDiscovery, times(1)).find(any(D2TransportClient.class), eq(STORE_NAME), eq(true));
+  }
+
+  @Test(expectedExceptions = com.linkedin.venice.client.exceptions.VeniceClientException.class)
+  public void testGetServerTransportClientFailsWhenServerD2Missing() {
+    ClientConfig clientConfig = mock(ClientConfig.class);
+    when(clientConfig.getD2Client()).thenReturn(mock(D2Client.class));
+    when(clientConfig.getD2ServiceName()).thenReturn(DISCOVERY_D2);
+
+    D2ServiceDiscovery d2ServiceDiscovery = mock(D2ServiceDiscovery.class);
+    D2ServiceDiscoveryResponse discoveryResponse = new D2ServiceDiscoveryResponse();
+    when(d2ServiceDiscovery.find(any(D2TransportClient.class), eq(STORE_NAME), eq(true))).thenReturn(discoveryResponse);
+
+    new MetadataBasedServerBlobFinder(clientConfig, d2ServiceDiscovery).getServerTransportClient(STORE_NAME);
+  }
+
+  @Test
+  public void testDiscoverBlobPeersSuccess() {
+    RouterBackedSchemaReader schemaReader = mock(RouterBackedSchemaReader.class);
+    when(schemaReader.getValueSchema(1)).thenReturn(MetadataResponseRecord.SCHEMA$);
+    MetadataBasedServerBlobFinder finder =
+        spy(new MetadataBasedServerBlobFinder(mock(ClientConfig.class), mock(D2ServiceDiscovery.class), schemaReader));
+
+    Map<CharSequence, List<CharSequence>> routingInfo = new HashMap<>();
+    routingInfo.put("0", Arrays.asList("https://server-x:7778"));
+    routingInfo.put("1", Arrays.asList("https://server-a:7778", "https://server-b:7778"));
+
+    D2TransportClient transportClient = mock(D2TransportClient.class);
+    when(transportClient.get(anyString())).thenReturn(
+        CompletableFuture.completedFuture(new TransportClientResponse(1, null, serializeMetadata(routingInfo))));
+    doReturn(transportClient).when(finder).getServerTransportClient(STORE_NAME);
+
+    BlobPeersDiscoveryResponse response = finder.discoverBlobPeers(STORE_NAME, VERSION, 1);
+
+    Assert.assertFalse(response.isError());
+    Assert.assertEquals(response.getDiscoveryResult(), Arrays.asList("server-a", "server-b"));
+
+    // The writer schema was resolved from the response's advertised schema id, not assumed to be the compiled one.
+    verify(schemaReader).getValueSchema(1);
+
+    // The metadata endpoint is hit by store name (server returns routing for the current serving version).
+    ArgumentCaptor<String> uriCaptor = ArgumentCaptor.forClass(String.class);
+    verify(transportClient).get(uriCaptor.capture());
+    Assert.assertEquals(uriCaptor.getValue(), "metadata/" + STORE_NAME);
+  }
+
+  @Test
+  public void testConcurrentPartitionDiscoverySharesMetadataRequest() throws Exception {
+    RouterBackedSchemaReader schemaReader = mock(RouterBackedSchemaReader.class);
+    when(schemaReader.getValueSchema(1)).thenReturn(MetadataResponseRecord.SCHEMA$);
+    MetadataBasedServerBlobFinder finder =
+        spy(new MetadataBasedServerBlobFinder(mock(ClientConfig.class), mock(D2ServiceDiscovery.class), schemaReader));
+
+    Map<CharSequence, List<CharSequence>> routingInfo = new HashMap<>();
+    routingInfo.put("0", Arrays.asList("https://server-a:7778"));
+    routingInfo.put("1", Arrays.asList("https://server-b:7778"));
+
+    D2TransportClient transportClient = mock(D2TransportClient.class);
+    CompletableFuture<TransportClientResponse> metadataResponse = new CompletableFuture<>();
+    when(transportClient.get(anyString())).thenReturn(metadataResponse);
+    doReturn(transportClient).when(finder).getServerTransportClient(STORE_NAME);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    CountDownLatch start = new CountDownLatch(1);
+    try {
+      Future<BlobPeersDiscoveryResponse> partitionZero = executor.submit(() -> discoverAfterLatch(finder, start, 0));
+      Future<BlobPeersDiscoveryResponse> partitionOne = executor.submit(() -> discoverAfterLatch(finder, start, 1));
+      start.countDown();
+
+      verify(transportClient, timeout(1000).times(1)).get("metadata/" + STORE_NAME);
+      metadataResponse.complete(new TransportClientResponse(1, null, serializeMetadata(routingInfo)));
+
+      Assert.assertEquals(partitionZero.get().getDiscoveryResult(), Arrays.asList("server-a"));
+      Assert.assertEquals(partitionOne.get().getDiscoveryResult(), Arrays.asList("server-b"));
+
+      finder.discoverBlobPeers(STORE_NAME, VERSION, 0);
+      verify(transportClient, times(2)).get("metadata/" + STORE_NAME);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  public void testConcurrentMetadataRequestFailureIsSharedAndNextLookupRetries() throws Exception {
+    RouterBackedSchemaReader schemaReader = mock(RouterBackedSchemaReader.class);
+    when(schemaReader.getValueSchema(1)).thenReturn(MetadataResponseRecord.SCHEMA$);
+    MetadataBasedServerBlobFinder finder =
+        spy(new MetadataBasedServerBlobFinder(mock(ClientConfig.class), mock(D2ServiceDiscovery.class), schemaReader));
+
+    D2TransportClient transportClient = mock(D2TransportClient.class);
+    CompletableFuture<TransportClientResponse> failedMetadataResponse = new CompletableFuture<>();
+    Map<CharSequence, List<CharSequence>> routingInfo = new HashMap<>();
+    routingInfo.put("0", Arrays.asList("https://server-a:7778"));
+    when(transportClient.get(anyString())).thenReturn(
+        failedMetadataResponse,
+        CompletableFuture.completedFuture(new TransportClientResponse(1, null, serializeMetadata(routingInfo))));
+    doReturn(transportClient).when(finder).getServerTransportClient(STORE_NAME);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    AtomicReference<Thread> waitingThread = new AtomicReference<>();
+    try {
+      Future<BlobPeersDiscoveryResponse> requestOwner =
+          executor.submit(() -> finder.discoverBlobPeers(STORE_NAME, VERSION, 0));
+      verify(transportClient, timeout(1000)).get("metadata/" + STORE_NAME);
+
+      Future<BlobPeersDiscoveryResponse> sharedRequest = executor.submit(() -> {
+        waitingThread.set(Thread.currentThread());
+        return finder.discoverBlobPeers(STORE_NAME, VERSION, 0);
+      });
+      TestUtils.waitForNonDeterministicAssertion(
+          1,
+          TimeUnit.SECONDS,
+          () -> Assert.assertEquals(waitingThread.get().getState(), Thread.State.WAITING));
+
+      failedMetadataResponse.completeExceptionally(new RuntimeException("metadata unavailable"));
+
+      Assert.assertTrue(requestOwner.get().isError());
+      Assert.assertTrue(sharedRequest.get().isError());
+      verify(transportClient, times(1)).get("metadata/" + STORE_NAME);
+
+      BlobPeersDiscoveryResponse retryResponse = finder.discoverBlobPeers(STORE_NAME, VERSION, 0);
+      Assert.assertFalse(retryResponse.isError());
+      Assert.assertEquals(retryResponse.getDiscoveryResult(), Arrays.asList("server-a"));
+      verify(transportClient, times(2)).get("metadata/" + STORE_NAME);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  public void testDiscoverBlobPeersFallsBackToCompiledSchemaWhenSchemaIdInvalid() {
+    // No usable writer schema id on the response: the finder must not consult the schema reader and instead decode
+    // with the client's compiled schema.
+    RouterBackedSchemaReader schemaReader = mock(RouterBackedSchemaReader.class);
+    MetadataBasedServerBlobFinder finder =
+        spy(new MetadataBasedServerBlobFinder(mock(ClientConfig.class), mock(D2ServiceDiscovery.class), schemaReader));
+
+    Map<CharSequence, List<CharSequence>> routingInfo = new HashMap<>();
+    routingInfo.put("0", Arrays.asList("https://server-a:7778"));
+
+    D2TransportClient transportClient = mock(D2TransportClient.class);
+    when(transportClient.get(anyString())).thenReturn(
+        CompletableFuture.completedFuture(
+            new TransportClientResponse(SchemaData.INVALID_VALUE_SCHEMA_ID, null, serializeMetadata(routingInfo))));
+    doReturn(transportClient).when(finder).getServerTransportClient(STORE_NAME);
+
+    BlobPeersDiscoveryResponse response = finder.discoverBlobPeers(STORE_NAME, VERSION, 0);
+
+    Assert.assertFalse(response.isError());
+    Assert.assertEquals(response.getDiscoveryResult(), Arrays.asList("server-a"));
+    verify(schemaReader, never()).getValueSchema(anyInt());
+  }
+
+  @Test
+  public void testDiscoverBlobPeersFallsBackToCompiledSchemaWhenWriterSchemaUnresolved() {
+    // The writer schema id is valid but the reader cannot resolve it (e.g. a transient Router issue): fall back to the
+    // compiled schema rather than failing discovery.
+    RouterBackedSchemaReader schemaReader = mock(RouterBackedSchemaReader.class);
+    when(schemaReader.getValueSchema(9)).thenThrow(new RuntimeException("schema fetch failed"));
+    MetadataBasedServerBlobFinder finder =
+        spy(new MetadataBasedServerBlobFinder(mock(ClientConfig.class), mock(D2ServiceDiscovery.class), schemaReader));
+
+    Map<CharSequence, List<CharSequence>> routingInfo = new HashMap<>();
+    routingInfo.put("0", Arrays.asList("https://server-a:7778"));
+
+    D2TransportClient transportClient = mock(D2TransportClient.class);
+    when(transportClient.get(anyString())).thenReturn(
+        CompletableFuture.completedFuture(new TransportClientResponse(9, null, serializeMetadata(routingInfo))));
+    doReturn(transportClient).when(finder).getServerTransportClient(STORE_NAME);
+
+    BlobPeersDiscoveryResponse response = finder.discoverBlobPeers(STORE_NAME, VERSION, 0);
+
+    Assert.assertFalse(response.isError());
+    Assert.assertEquals(response.getDiscoveryResult(), Arrays.asList("server-a"));
+    verify(schemaReader).getValueSchema(9);
+  }
+
+  @Test
+  public void testDiscoverBlobPeersErrorsWhenNoD2Client() {
+    // No D2 client (non-D2 deployment) -> discovery cannot route to a server -> fail safe to VT replay.
+    ClientConfig clientConfig = ClientConfig.defaultGenericClientConfig(STORE_NAME);
+    Assert.assertNull(clientConfig.getD2Client());
+    MetadataBasedServerBlobFinder finder = new MetadataBasedServerBlobFinder(clientConfig);
+
+    BlobPeersDiscoveryResponse response = finder.discoverBlobPeers(STORE_NAME, VERSION, 0);
+
+    Assert.assertTrue(response.isError());
+    Assert.assertTrue(response.getDiscoveryResult() == null || response.getDiscoveryResult().isEmpty());
+  }
+
+  @Test
+  public void testDiscoverBlobPeersErrorsWhenDiscoveryFails() {
+    ClientConfig clientConfig = mock(ClientConfig.class);
+    when(clientConfig.getD2Client()).thenReturn(mock(D2Client.class));
+    when(clientConfig.getD2ServiceName()).thenReturn(DISCOVERY_D2);
+
+    D2ServiceDiscovery d2ServiceDiscovery = mock(D2ServiceDiscovery.class);
+    when(d2ServiceDiscovery.find(any(D2TransportClient.class), eq(STORE_NAME), eq(true)))
+        .thenThrow(new RuntimeException("d2 discovery unavailable"));
+
+    MetadataBasedServerBlobFinder finder = new MetadataBasedServerBlobFinder(clientConfig, d2ServiceDiscovery);
+
+    BlobPeersDiscoveryResponse response = finder.discoverBlobPeers(STORE_NAME, VERSION, 0);
+    Assert.assertTrue(response.isError());
+  }
+
+  @Test
+  public void testMetadataRequestFailureTriggersD2Rediscovery() {
+    ClientConfig clientConfig = mock(ClientConfig.class);
+    RouterBackedSchemaReader schemaReader = mock(RouterBackedSchemaReader.class);
+    when(schemaReader.getValueSchema(1)).thenReturn(MetadataResponseRecord.SCHEMA$);
+
+    D2ServiceDiscovery d2ServiceDiscovery = mock(D2ServiceDiscovery.class);
+    D2ServiceDiscoveryResponse discoveryResponse = new D2ServiceDiscoveryResponse();
+    discoveryResponse.setServerD2Service(SERVER_D2);
+    when(d2ServiceDiscovery.find(any(D2TransportClient.class), eq(STORE_NAME), eq(true))).thenReturn(discoveryResponse);
+
+    MetadataBasedServerBlobFinder finder =
+        spy(new MetadataBasedServerBlobFinder(clientConfig, d2ServiceDiscovery, schemaReader));
+    D2TransportClient failedTransport = mock(D2TransportClient.class);
+    D2TransportClient recoveredTransport = mock(D2TransportClient.class);
+    doReturn(failedTransport, recoveredTransport).when(finder).getD2TransportClient(STORE_NAME);
+
+    CompletableFuture<TransportClientResponse> failedResponse = new CompletableFuture<>();
+    failedResponse.completeExceptionally(new RuntimeException("old D2 service unavailable"));
+    when(failedTransport.get(anyString())).thenReturn(failedResponse);
+
+    Map<CharSequence, List<CharSequence>> routingInfo = new HashMap<>();
+    routingInfo.put("0", Arrays.asList("https://server-a:7778"));
+    when(recoveredTransport.get(anyString())).thenReturn(
+        CompletableFuture.completedFuture(new TransportClientResponse(1, null, serializeMetadata(routingInfo))));
+
+    Assert.assertTrue(finder.discoverBlobPeers(STORE_NAME, VERSION, 0).isError());
+    BlobPeersDiscoveryResponse recoveredResponse = finder.discoverBlobPeers(STORE_NAME, VERSION, 0);
+
+    Assert.assertFalse(recoveredResponse.isError());
+    Assert.assertEquals(recoveredResponse.getDiscoveryResult(), Arrays.asList("server-a"));
+    verify(failedTransport).close();
+    verify(d2ServiceDiscovery, times(2)).find(any(D2TransportClient.class), eq(STORE_NAME), eq(true));
+  }
+
+  @Test
+  public void testMetadataRequestPreservesInterruptedStatus() throws Exception {
+    MetadataBasedServerBlobFinder finder = spy(new MetadataBasedServerBlobFinder(mock(ClientConfig.class)));
+    D2TransportClient transportClient = mock(D2TransportClient.class);
+    when(transportClient.get(anyString())).thenReturn(new CompletableFuture<>());
+    doReturn(transportClient).when(finder).getServerTransportClient(STORE_NAME);
+
+    AtomicReference<BlobPeersDiscoveryResponse> response = new AtomicReference<>();
+    AtomicBoolean interrupted = new AtomicBoolean();
+    Thread discoveryThread = new Thread(() -> {
+      response.set(finder.discoverBlobPeers(STORE_NAME, VERSION, 0));
+      interrupted.set(Thread.currentThread().isInterrupted());
+    });
+
+    discoveryThread.start();
+    verify(transportClient, timeout(1000)).get("metadata/" + STORE_NAME);
+    discoveryThread.interrupt();
+    discoveryThread.join();
+
+    Assert.assertTrue(response.get().isError());
+    Assert.assertTrue(interrupted.get(), "Interrupted status should be restored before discovery returns");
+  }
+
+  @Test
+  public void testDiscoverBlobPeersErrorsWhenBodyNull() {
+    MetadataBasedServerBlobFinder finder = spy(new MetadataBasedServerBlobFinder(mock(ClientConfig.class)));
+    D2TransportClient transportClient = mock(D2TransportClient.class);
+    when(transportClient.get(anyString())).thenReturn(CompletableFuture.completedFuture(null));
+    doReturn(transportClient).when(finder).getServerTransportClient(STORE_NAME);
+
+    BlobPeersDiscoveryResponse response = finder.discoverBlobPeers(STORE_NAME, VERSION, 0);
+    Assert.assertTrue(response.isError());
+  }
+
+  @Test
+  public void testDiscoverBlobPeersErrorsWhenMetadataVersionDiffers() {
+    RouterBackedSchemaReader schemaReader = mock(RouterBackedSchemaReader.class);
+    when(schemaReader.getValueSchema(1)).thenReturn(MetadataResponseRecord.SCHEMA$);
+    MetadataBasedServerBlobFinder finder =
+        spy(new MetadataBasedServerBlobFinder(mock(ClientConfig.class), mock(D2ServiceDiscovery.class), schemaReader));
+
+    Map<CharSequence, List<CharSequence>> routingInfo = new HashMap<>();
+    routingInfo.put("0", Arrays.asList("https://server-a:7778"));
+
+    D2TransportClient transportClient = mock(D2TransportClient.class);
+    when(transportClient.get(anyString())).thenReturn(
+        CompletableFuture.completedFuture(new TransportClientResponse(1, null, serializeMetadata(routingInfo, 2))));
+    doReturn(transportClient).when(finder).getServerTransportClient(STORE_NAME);
+
+    BlobPeersDiscoveryResponse response = finder.discoverBlobPeers(STORE_NAME, VERSION, 0);
+    Assert.assertTrue(response.isError());
+    Assert.assertTrue(response.getDiscoveryResult() == null || response.getDiscoveryResult().isEmpty());
+  }
+
+  private static byte[] serializeMetadata(Map<CharSequence, List<CharSequence>> routingInfo) {
+    return serializeMetadata(routingInfo, VERSION);
+  }
+
+  private static byte[] serializeMetadata(Map<CharSequence, List<CharSequence>> routingInfo, int currentVersion) {
+    MetadataResponseRecord record = new MetadataResponseRecord(
+        new VersionProperties(currentVersion, 0, 1, "", Collections.emptyMap(), 1),
+        Collections.singletonList(currentVersion),
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        1,
+        routingInfo,
+        Collections.emptyMap(),
+        150,
+        0);
+    return SerializerDeserializerFactory.getAvroGenericSerializer(MetadataResponseRecord.SCHEMA$).serialize(record);
+  }
+
+  private static BlobPeersDiscoveryResponse discoverAfterLatch(
+      MetadataBasedServerBlobFinder finder,
+      CountDownLatch start,
+      int partitionId) throws InterruptedException {
+    start.await();
+    return finder.discoverBlobPeers(STORE_NAME, VERSION, partitionId);
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/ServerAndDaVinciBlobFinderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/ServerAndDaVinciBlobFinderTest.java
@@ -1,0 +1,92 @@
+package com.linkedin.venice.blobtransfer;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class ServerAndDaVinciBlobFinderTest {
+  private static final String STORE_NAME = "testStore";
+  private static final int VERSION = 1;
+  private static final int PARTITION = 0;
+
+  @Test
+  public void testDiscoverBlobPeersReturnsDaVinciPeersBeforeServerPeers() {
+    BlobFinder daVinciBlobFinder = mock(BlobFinder.class);
+    BlobPeersDiscoveryResponse daVinciResponse = new BlobPeersDiscoveryResponse();
+    daVinciResponse.setDiscoveryResult(Collections.singletonList("dvc-host"));
+    doReturn(daVinciResponse).when(daVinciBlobFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
+
+    BlobFinder serverBlobFinder = mock(BlobFinder.class);
+    BlobPeersDiscoveryResponse serverResponse = new BlobPeersDiscoveryResponse();
+    serverResponse.setDiscoveryResult(Collections.singletonList("server-host"));
+    doReturn(serverResponse).when(serverBlobFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
+
+    ServerAndDaVinciBlobFinder finder = new ServerAndDaVinciBlobFinder(daVinciBlobFinder, serverBlobFinder);
+
+    BlobPeersDiscoveryResponse response = finder.discoverBlobPeers(STORE_NAME, VERSION, PARTITION);
+
+    Assert.assertFalse(response.isError());
+    Assert.assertEquals(response.getDiscoveryResult(), Arrays.asList("dvc-host", "server-host"));
+    verify(daVinciBlobFinder).discoverBlobPeers(STORE_NAME, VERSION, PARTITION);
+    verify(serverBlobFinder).discoverBlobPeers(STORE_NAME, VERSION, PARTITION);
+  }
+
+  @Test
+  public void testDiscoverBlobPeersUsesServerPeersWhenDaVinciDiscoveryHasNoPeers() {
+    BlobFinder daVinciBlobFinder = mock(BlobFinder.class);
+    BlobPeersDiscoveryResponse daVinciResponse = new BlobPeersDiscoveryResponse();
+    daVinciResponse.setDiscoveryResult(Collections.emptyList());
+    doReturn(daVinciResponse).when(daVinciBlobFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
+
+    BlobFinder serverBlobFinder = mock(BlobFinder.class);
+    BlobPeersDiscoveryResponse serverResponse = new BlobPeersDiscoveryResponse();
+    serverResponse.setDiscoveryResult(Collections.singletonList("server-host"));
+    doReturn(serverResponse).when(serverBlobFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
+    ServerAndDaVinciBlobFinder finder = new ServerAndDaVinciBlobFinder(daVinciBlobFinder, serverBlobFinder);
+
+    BlobPeersDiscoveryResponse response = finder.discoverBlobPeers(STORE_NAME, VERSION, PARTITION);
+
+    Assert.assertFalse(response.isError());
+    Assert.assertEquals(response.getDiscoveryResult(), Collections.singletonList("server-host"));
+  }
+
+  @Test
+  public void testDiscoverBlobPeersUsesDaVinciPeersWhenServerDiscoveryErrors() {
+    BlobFinder daVinciBlobFinder = mock(BlobFinder.class);
+    BlobPeersDiscoveryResponse daVinciResponse = new BlobPeersDiscoveryResponse();
+    daVinciResponse.setDiscoveryResult(Collections.singletonList("dvc-host"));
+    doReturn(daVinciResponse).when(daVinciBlobFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
+
+    BlobFinder serverBlobFinder = mock(BlobFinder.class);
+    BlobPeersDiscoveryResponse serverResponse = new BlobPeersDiscoveryResponse();
+    serverResponse.setError(true);
+    serverResponse.setErrorMessage("server discovery failed");
+    doReturn(serverResponse).when(serverBlobFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
+
+    ServerAndDaVinciBlobFinder finder = new ServerAndDaVinciBlobFinder(daVinciBlobFinder, serverBlobFinder);
+
+    BlobPeersDiscoveryResponse response = finder.discoverBlobPeers(STORE_NAME, VERSION, PARTITION);
+
+    Assert.assertFalse(response.isError());
+    Assert.assertEquals(response.getDiscoveryResult(), Collections.singletonList("dvc-host"));
+  }
+
+  @Test
+  public void testCloseClosesBothFinders() throws Exception {
+    BlobFinder daVinciBlobFinder = mock(BlobFinder.class);
+    BlobFinder serverBlobFinder = mock(BlobFinder.class);
+
+    new ServerAndDaVinciBlobFinder(daVinciBlobFinder, serverBlobFinder).close();
+
+    verify(daVinciBlobFinder).close();
+    verify(serverBlobFinder).close();
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientServerFallbackBlobTransferTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientServerFallbackBlobTransferTest.java
@@ -1,0 +1,264 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_BLOCK_CACHE_SIZE_IN_BYTES;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYMANAGER_ALGORITHM;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_LOCATION;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_PASSWORD;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_TYPE;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEY_PASSWORD;
+import static com.linkedin.venice.CommonConfigKeys.SSL_SECURE_RANDOM_IMPLEMENTATION;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTMANAGER_ALGORITHM;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_LOCATION;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_PASSWORD;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_TYPE;
+import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_ACL_ENABLED;
+import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_DISABLED_OFFSET_LAG_THRESHOLD;
+import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_MANAGER_ENABLED;
+import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_SSL_ENABLED;
+import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_BLOB_TRANSFER_SERVER_FALLBACK_ENABLED;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
+import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
+import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_BLOB_TRANSFER_ACCEPT_CLIENT_REQUEST_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED;
+import static com.linkedin.venice.integration.utils.DaVinciTestContext.getCachingDaVinciClientFactory;
+import static com.linkedin.venice.integration.utils.VeniceClusterWrapper.DEFAULT_KEY_SCHEMA;
+import static com.linkedin.venice.meta.PersistenceType.ROCKS_DB;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
+import static com.linkedin.venice.utils.SslUtils.LOCAL_KEYSTORE_JKS;
+import static com.linkedin.venice.utils.SslUtils.LOCAL_PASSWORD;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithIntToStringSchema;
+
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.davinci.client.DaVinciClient;
+import com.linkedin.davinci.client.DaVinciConfig;
+import com.linkedin.davinci.client.factory.CachingDaVinciClientFactory;
+import com.linkedin.venice.D2.D2ClientUtils;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.integration.utils.D2TestUtils;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
+import com.linkedin.venice.integration.utils.VeniceServerWrapper;
+import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.PropertyBuilder;
+import com.linkedin.venice.utils.SslUtils;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import io.tehuti.metrics.MetricsRepository;
+import java.io.File;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * End-to-end mechanics test for the Stateful CDC / Da Vinci client falling back to a <b>Venice server</b> for blob
+ * transfer when no Da Vinci peer is available. A single blob-serving server hosts the store;
+ * a fresh Da Vinci client with the server-fallback flag and no peers should cold-start by pulling the snapshot
+ * directly from the server (instead of replaying the Version Topic, which is forced off below).
+ *
+ * <p><b>Scope / known limitations of this local test:</b>
+ * <ul>
+ *   <li><b>Origin is SERVER, not CLIENT.</b> The client and server share the same local keystore, so the server's
+ *       {@code determineRequestOrigin} (application-identity equality) classifies the client's request as
+ *       SERVER-origin. This validates the <i>fallback discovery + transfer mechanics</i>, but NOT the client-origin
+ *       gating (accept-flag, store ACL, client cap) — those are covered by unit tests and need distinct cert
+ *       identities to exercise end-to-end.</li>
+ *   <li><b>Single server, swapped p2p ports.</b> Blob transfer assumes a fleet-wide fixed p2p port; locally we fake
+ *       it by setting the client's {@code clientPort} to the server's blob {@code serverPort} so the client connects
+ *       to the server's blob endpoint.</li>
+ *   <li><b>Host-format probe.</b> The fallback feeds the server hosts from {@code MetadataResponseRecord.getRoutingInfo()}
+ *       into the same {@code getConnectableHosts} path the peer flow uses. This test is where a mismatch between the
+ *       metadata replica-host format and what the blob-transfer connect expects would surface.</li>
+ * </ul>
+ */
+public class DaVinciClientServerFallbackBlobTransferTest {
+  private static final int TEST_TIMEOUT = 180_000;
+  // Dedicated bound for the cold-start subscribe and the follow-up read. Kept well under the method-level
+  // TEST_TIMEOUT so a hung blob-transfer / subscription / read path fails promptly with a clear TimeoutException,
+  // instead of stalling until the suite-level timeout.
+  private static final int CLIENT_BOOTSTRAP_TIMEOUT_SECONDS = 60;
+
+  private VeniceClusterWrapper cluster;
+  private D2Client d2Client;
+  // The blob p2p port the single server serves on; the client's blob clientPort is set to this so it connects here.
+  private int serverBlobServerPort;
+  private int serverBlobClientPort;
+
+  @BeforeClass
+  public void setUp() {
+    Utils.thisIsLocalhost();
+    serverBlobServerPort = TestUtils.getFreePort();
+    serverBlobClientPort = TestUtils.getFreePort();
+    while (serverBlobClientPort == serverBlobServerPort) {
+      serverBlobClientPort = TestUtils.getFreePort();
+    }
+
+    Properties clusterConfig = new Properties();
+    clusterConfig.put(PUSH_STATUS_STORE_ENABLED, true);
+    clusterConfig.put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 3);
+    VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
+        .numberOfServers(0)
+        .numberOfRouters(1)
+        .replicationFactor(1)
+        .sslToStorageNodes(true)
+        .sslToKafka(false)
+        .extraProperties(clusterConfig)
+        .build();
+    cluster = ServiceFactory.getVeniceCluster(options);
+
+    // Add a single server configured to serve blobs. This full-cluster test uses the shared cluster SSL identity, so it
+    // exercises server fallback mechanics; CLIENT-origin gating is covered by TestClientOriginServerBlobTransfer.
+    Properties serverProperties = new Properties();
+    serverProperties.put(PERSISTENCE_TYPE, PersistenceType.ROCKS_DB);
+    serverProperties.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "false");
+    serverProperties.setProperty(DATA_BASE_PATH, Utils.getTempDataDirectory().getAbsolutePath());
+    serverProperties.setProperty(DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT, String.valueOf(serverBlobServerPort));
+    serverProperties.setProperty(DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT, String.valueOf(serverBlobClientPort));
+    serverProperties.setProperty(BLOB_TRANSFER_MANAGER_ENABLED, "true");
+    serverProperties.setProperty(BLOB_TRANSFER_SSL_ENABLED, "true");
+    serverProperties.setProperty(BLOB_TRANSFER_ACL_ENABLED, "true");
+    serverProperties.setProperty(SERVER_BLOB_TRANSFER_ACCEPT_CLIENT_REQUEST_ENABLED, "false");
+    // The server's metadata endpoint is reached over D2; enabling HTTP/2 inbound makes the server's D2 service
+    // prioritize the https scheme (see VeniceServerWrapper), so the HTTPS d2 client connects over TLS instead of
+    // hitting the SSL-only port in plaintext (which returns 403). Mirrors the Fast Client request-based-metadata tests.
+    serverProperties.setProperty(SERVER_HTTP2_INBOUND_ENABLED, "true");
+    serverProperties.setProperty(BLOB_TRANSFER_DISABLED_OFFSET_LAG_THRESHOLD, "-1000000");
+
+    Properties serverFeatureProperties = new Properties();
+    serverFeatureProperties.put(VeniceServerWrapper.SERVER_ENABLE_SSL, "true");
+    cluster.addVeniceServer(serverFeatureProperties, serverProperties);
+
+    // The server's metadata endpoint (used by server blob discovery) is SSL-only, so the D2 client the finder reuses
+    // must be HTTPS-enabled — same as Fast Client's RequestBasedMetadata reads from servers. (The peer path's
+    // DaVinciBlobFinder hits the Router's blob_discovery endpoint, which does not gate SSL, so it tolerated plaintext.)
+    d2Client = D2TestUtils.getAndStartHttpsD2Client(cluster.getZk().getAddress());
+  }
+
+  @AfterClass
+  public void cleanUp() {
+    if (d2Client != null) {
+      D2ClientUtils.shutdownClient(d2Client);
+    }
+    Utils.closeQuietlyWithErrorLogged(cluster);
+  }
+
+  /**
+   * Verifies that a Stateful CDC / Da Vinci client with no peers cold-starts by pulling the snapshot directly from a
+   * <b>Venice server</b> rather than replaying the Version Topic. The assertion requires a positive blob-transfer
+   * metric, so it cannot false-pass via VT replay.
+   *
+   * <p>Server discovery hits the server-served {@code metadata/<store>} endpoint, which is SSL-only and gated on the
+   * store's storage-node read quota. The harness therefore uses an HTTPS D2 client, sets
+   * {@code SERVER_HTTP2_INBOUND_ENABLED} so the server's D2 service advertises https, and enables
+   * {@code setStorageNodeReadQuotaEnabled(true)} on the store.
+   */
+  @Test(timeOut = TEST_TIMEOUT, enabled = true)
+  public void testClientColdStartsFromServerWhenNoPeers() throws Exception {
+    String storeName = Utils.getUniqueString("server-fallback-store");
+    setUpStore(storeName);
+
+    String keyStorePath = SslUtils.getPathForResource(LOCAL_KEYSTORE_JKS);
+    String dvcPath = Utils.getTempDataDirectory().getAbsolutePath();
+
+    // Consuming client: enable blob transfer + the server-fallback flag, force blob transfer over VT, and match the
+    // blob clientPort to the server's blob serverPort so the client connects to the server's blob endpoint. No peer
+    // Da Vinci client is started, so peer discovery returns empty and the client must fall back to the server.
+    VeniceProperties backendConfig = new PropertyBuilder().put(PERSISTENCE_TYPE, ROCKS_DB)
+        .put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "false")
+        .put(ROCKSDB_BLOCK_CACHE_SIZE_IN_BYTES, 2 * 1024 * 1024L)
+        .put(DATA_BASE_PATH, dvcPath)
+        .put(PUSH_STATUS_STORE_ENABLED, true)
+        .put(BLOB_TRANSFER_MANAGER_ENABLED, true)
+        .put(BLOB_TRANSFER_SSL_ENABLED, true)
+        .put(BLOB_TRANSFER_ACL_ENABLED, true)
+        .put(DAVINCI_BLOB_TRANSFER_SERVER_FALLBACK_ENABLED, true)
+        .put(BLOB_TRANSFER_DISABLED_OFFSET_LAG_THRESHOLD, -1000000)
+        .put(DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT, serverBlobClientPort)
+        .put(DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT, serverBlobServerPort)
+        .put(SSL_KEYSTORE_TYPE, "JKS")
+        .put(SSL_KEYSTORE_LOCATION, keyStorePath)
+        .put(SSL_KEYSTORE_PASSWORD, LOCAL_PASSWORD)
+        .put(SSL_TRUSTSTORE_TYPE, "JKS")
+        .put(SSL_TRUSTSTORE_LOCATION, keyStorePath)
+        .put(SSL_TRUSTSTORE_PASSWORD, LOCAL_PASSWORD)
+        .put(SSL_KEY_PASSWORD, LOCAL_PASSWORD)
+        .put(SSL_KEYMANAGER_ALGORITHM, "SunX509")
+        .put(SSL_TRUSTMANAGER_ALGORITHM, "SunX509")
+        .put(SSL_SECURE_RANDOM_IMPLEMENTATION, "SHA1PRNG")
+        .build();
+
+    // Non-isolated so blob transfer + its metrics run in this JVM, where the metric assertion below can observe them.
+    DaVinciConfig dvcConfig = new DaVinciConfig().setIsolated(false);
+    MetricsRepository metricsRepository = new MetricsRepository();
+    try (CachingDaVinciClientFactory factory = getCachingDaVinciClientFactory(
+        d2Client,
+        VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
+        metricsRepository,
+        backendConfig,
+        cluster)) {
+      DaVinciClient<Integer, Object> client = factory.getAndStartGenericAvroClient(storeName, dvcConfig);
+      // If the server fallback works, this completes by bootstrapping the snapshot from the server (VT is forced off).
+      client.subscribeAll().get(CLIENT_BOOTSTRAP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+      // The store was pushed with int -> string records keyed 1..N (writeSimpleAvroFileWithIntToStringSchema).
+      Object value = client.get(1).get(CLIENT_BOOTSTRAP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      Assert.assertNotNull(value, "Client should have bootstrapped the value for key 1 from the server snapshot");
+
+      // Prove the snapshot came from a server blob transfer (no DVC peers exist) rather than Version Topic replay:
+      // a positive blob-transfer time/throughput/received metric must have been recorded (without this the test can
+      // false-pass via VT replay). These metrics surface as AsyncGauges that sample asynchronously, so an immediate
+      // read can return a stale 0 before the first refresh; poll until the recorded value becomes visible.
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
+        boolean blobTransferOccurred = metricsRepository.metrics().entrySet().stream().anyMatch(metric -> {
+          String name = metric.getKey().toLowerCase();
+          return name.contains("blob_transfer")
+              && (name.contains("received") || name.contains("throughput") || name.contains("time"))
+              && metric.getValue().value() > 0d;
+        });
+        Assert.assertTrue(
+            blobTransferOccurred,
+            "Expected a positive blob-transfer metric (snapshot served by a Venice server), but found none — "
+                + "the client may have fallen back to Version Topic replay");
+      });
+    }
+  }
+
+  private void setUpStore(String storeName) {
+    File inputDir = getTempDataDirectory();
+    try {
+      writeSimpleAvroFileWithIntToStringSchema(inputDir);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    Properties vpjProperties = defaultVPJProps(cluster, inputDirPath, storeName);
+    // The server metadata endpoint (used by server blob discovery) is gated on storage-node read quota being enabled
+    // for the store (ServerReadMetadataRepository: "Fast client is not enabled for store ..."), so enable it here.
+    UpdateStoreQueryParams params = new UpdateStoreQueryParams().setPartitionCount(1)
+        .setBlobTransferEnabled(true)
+        .setStorageNodeReadQuotaEnabled(true);
+    try (ControllerClient controllerClient =
+        createStoreForJob(cluster, DEFAULT_KEY_SCHEMA, "\"string\"", vpjProperties)) {
+      cluster.createMetaSystemStore(storeName);
+      cluster.createPushStatusSystemStore(storeName);
+      TestUtils.assertCommand(controllerClient.updateStore(storeName, params));
+      IntegrationTestPushUtils.runVPJ(vpjProperties);
+      cluster.waitVersion(storeName, 1);
+    }
+  }
+}

--- a/internal/venice-test-common/test-shard-assignments.json
+++ b/internal/venice-test-common/test-shard-assignments.json
@@ -434,7 +434,8 @@
       "com.linkedin.venice.helix.ZkRoutersClusterManagerConfigChangeTest",
       "com.linkedin.venice.controller.migration.TestMigrationPushStrategyZKAccessor",
       "com.linkedin.venice.integration.utils.SystemExitPrevention",
-      "com.linkedin.venice.controller.server.TestAdminSparkServerWithMultiServers"
+      "com.linkedin.venice.controller.server.TestAdminSparkServerWithMultiServers",
+      "com.linkedin.venice.endToEnd.DaVinciClientServerFallbackBlobTransferTest"
     ]
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -533,7 +533,9 @@ public class VeniceServer {
           serverConfig.getBlobTransferServiceWriteLimitBytesPerSec(),
           serverConfig.getSnapshotCleanupIntervalInMins(),
           serverConfig.getMaxConcurrentBlobReceiveReplicas(),
-          serverConfig.getBlobTransferClientNettyWorkerThreadCount());
+          serverConfig.getBlobTransferClientNettyWorkerThreadCount(),
+          serverConfig.getBlobTransferClientCapacityPercent(),
+          serverConfig.isServerAcceptClientBlobRequestEnabled());
       VeniceAdaptiveBlobTransferTrafficThrottler writeThrottler = null;
       VeniceAdaptiveBlobTransferTrafficThrottler readThrottler = null;
       if (serverConfig.isAdaptiveThrottlerEnabled() && serverConfig.isBlobTransferAdaptiveThrottlerEnabled()) {
@@ -568,7 +570,11 @@ public class VeniceServer {
           .setStorageEngineRepository(storageService.getStorageEngineRepository())
           .setAggBlobTransferStats(aggBlobTransferStats)
           .setBlobTransferSSLFactory(sslFactory)
-          .setBlobTransferAclHandler(BlobTransferUtils.createAclHandler(veniceConfigLoader))
+          .setBlobTransferAclHandler(
+              BlobTransferUtils.createAclHandler(
+                  veniceConfigLoader,
+                  storeAccessController,
+                  serverConfig.isServerAcceptClientBlobRequestEnabled()))
           .setAdaptiveBlobTransferWriteTrafficThrottler(writeThrottler)
           .setAdaptiveBlobTransferReadTrafficThrottler(readThrottler)
           .setPushStatusNotifierSupplier(


### PR DESCRIPTION
## Problem Statement

When a Stateful CDC / Da Vinci client cold-starts with no local state, it loads the store by replaying the Version Topic (VT) or by pulling a RocksDB snapshot from a client peer. With the move to Northguard (no topic compaction), the VT can grow unbounded, so VT-replay cold-start scales from minutes to days and becomes impractical. Peer-to-peer blob transfer covers the steady state but breaks when there are no peers:

- **New-store onboarding:** a brand-new store has no peer clients yet to serve a blob.
- **Disaster (Sev 0-1):** all peers in a region are down for an extended period, so no peer can serve a blob.

Today there is no automated recovery path for these cases — a Venice operator must manually issue a repush.

## Solution

Allow Venice servers to serve blob-transfer requests from Stateful CDC clients when no client peer is available. The client falls back to a server only after peer discovery returns no usable peer. Everything is gated by independent, default-off flags, and the pre-existing server-to-server (s2s) and peer-to-peer blob-transfer paths are unchanged.

- **Server discovery:** `MetadataBasedServerBlobFinder` (venice-common) finds servers hosting the partition via request-based metadata over D2 server-routing (the Fast Client `RequestBasedMetadata` pattern) — no new client ZK fan-out. The Avro response is decoded against the server-advertised writer schema (`TransportClientResponse.getSchemaId()` → `RouterBackedSchemaReader`) to tolerate `MetadataResponseRecord` version skew; any failure fails safe to VT replay.
- **Client fallback:** `NettyP2PBlobTransferManager` escalates peers → one bounded server pass → VT.
- **Accept gate + access control:** `P2PFileTransferServerHandler` honors the accept flag; `BlobTransferAclHandler` classifies SERVER- vs CLIENT-origin by application identity (via `IdentityParser`) and enforces the per-store read ACL (`DynamicAccessController`) on client-origin requests.
- **Prioritization:** `BlobTransferAdmissionController` caps concurrent client-origin transfers so server-to-server traffic is never starved.
- **Format compatibility** reuses the existing `requestTableFormat` 404 rejection.

Out of scope (per design): RocksDB format conversion, cross-region client→server transfers, and automatic client→server overload recovery.

### Code changes
- [x] Added new code behind **a config**. Configs (all default off / conservative):
  - `server.blob.transfer.accept.client.request.enabled` — server accepts client-origin blob requests. Default `false`.
  - `davinci.blob.transfer.server.fallback.enabled` — client falls back to a server when no peer is found. Default `false`.
  - `server.blob.transfer.client.capacity.percent` — cap on the host blob-transfer budget that client-origin transfers may use (s2s uncapped). Default `25`.
- [x] Introduced new **log lines** (INFO milestones + DEBUG diagnostics on the cold-start path).
  - [x] Confirmed if logs need to be **rate limited** — they are on the rare cold-start/fallback path (not a hot path), so no rate limiting is needed.

### **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** are used where needed (double-checked locking for the lazy schema reader; `synchronized` admission accounting).
- [x] No **blocking calls** inside critical sections (schema/metadata fetches occur outside locks).
- [x] Verified **thread-safe collections** are used (`VeniceConcurrentHashMap`).
- [x] Validated proper exception handling in multi-threaded code (discovery and transfer fail safe to VT replay).

## How was this PR tested?

- [x] Local code review completed
- [x] New unit tests added (`TestBlobTransferAclHandler`, `TestBlobTransferAdmissionController`, `MetadataBasedServerBlobFinderTest`).
- [x] New integration tests added (`DaVinciClientServerFallbackBlobTransferTest` — server→client cold-start, asserts a positive blob-transfer metric so it cannot false-pass via VT; `TestClientOriginServerBlobTransfer` — real-mTLS CLIENT-origin accept/ACL gates).
- [x] Modified or extended existing tests (`TestNettyP2PBlobTransferManager`, `TestP2PFileTransferServerHandler`, `TestBlobTransferManagerBuilder`).
- [x] Verified backward compatibility — flags default off; the pre-existing s2s (`BlobP2PTransferAmongServersTest`) and DVC&lt;-&gt;DVC (`DaVinciClientP2PBlobTransferTest`) suites remain green.

Local run: da-vinci-client `*BlobTransfer*`/`*P2P*` (169) and venice-common `MetadataBasedServerBlobFinder` (11) unit tests pass; the integration tests above pass. Local code review completed. A complete e2e integration test could not be completed due to certification issues. 

## Does this PR introduce any user-facing or breaking changes?

- [x] No. All new behavior is behind default-off flags; with the flags off, server-to-server and DVC&lt;-&gt;DVC blob transfer behave exactly as before.
