### PR TITLE
[controller] Add multi-region topic-operation safety check (Admin API + verdict endpoint)

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -755,6 +755,15 @@ public class ControllerClient implements Closeable {
     return request(ControllerRoute.GET_KAFKA_TOPIC_CONFIGS, params, PubSubTopicConfigResponse.class);
   }
 
+  /**
+   * Read-only pre-flight check of whether a destructive PubSub operation on the given topic is safe to run. See
+   * {@link TopicOperationSafetyResponse} / the controller-side verdict for semantics.
+   */
+  public TopicOperationSafetyResponse checkTopicOperationSafety(String topicName) {
+    QueryParams params = newParams().add(TOPIC, topicName);
+    return request(ControllerRoute.CHECK_TOPIC_OPERATION_SAFETY, params, TopicOperationSafetyResponse.class);
+  }
+
   public ControllerResponse updateKafkaTopicLogCompaction(String kafkaTopicName, boolean logCompactionEnabled) {
     QueryParams params =
         newParams().add(TOPIC, kafkaTopicName).add(KAFKA_TOPIC_LOG_COMPACTION_ENABLED, logCompactionEnabled);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -291,6 +291,7 @@ public enum ControllerRoute implements VeniceDimensionInterface {
       "/get_region_push_details", HttpMethod.GET, Arrays.asList(CLUSTER, NAME, PARTITION_DETAIL_ENABLED)
   ), GET_PER_REGION_STORAGE_MODE("/get_per_region_storage_mode", HttpMethod.GET, Arrays.asList(CLUSTER, NAME)),
   GET_KAFKA_TOPIC_CONFIGS("/get_kafka_topic_configs", HttpMethod.GET, Collections.singletonList(TOPIC)),
+  CHECK_TOPIC_OPERATION_SAFETY("/check_topic_operation_safety", HttpMethod.GET, Collections.singletonList(TOPIC)),
   UPDATE_KAFKA_TOPIC_LOG_COMPACTION(
       "/update_kafka_topic_log_compaction", HttpMethod.POST, Arrays.asList(TOPIC, KAFKA_TOPIC_LOG_COMPACTION_ENABLED)
   ),

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/TopicOperationSafetyResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/TopicOperationSafetyResponse.java
@@ -1,0 +1,41 @@
+package com.linkedin.venice.controllerapi;
+
+import java.util.Collections;
+import java.util.Map;
+
+
+/**
+ * Response for {@link ControllerRoute#CHECK_TOPIC_OPERATION_SAFETY}: whether a destructive PubSub operation (topic
+ * truncation, retention update, or deletion) on a topic is safe to run without an operator override. The store name and
+ * resolved owning cluster are carried on the base {@link ControllerResponse} ({@code name} / {@code cluster}).
+ */
+public class TopicOperationSafetyResponse extends ControllerResponse {
+  private boolean allowed;
+  private String reason;
+  /** region -&gt; why that region blocks the operation; empty when {@link #allowed}. */
+  private Map<String, String> blockingRegions = Collections.emptyMap();
+
+  public boolean isAllowed() {
+    return allowed;
+  }
+
+  public void setAllowed(boolean allowed) {
+    this.allowed = allowed;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public void setReason(String reason) {
+    this.reason = reason;
+  }
+
+  public Map<String, String> getBlockingRegions() {
+    return blockingRegions;
+  }
+
+  public void setBlockingRegions(Map<String, String> blockingRegions) {
+    this.blockingRegions = blockingRegions == null ? Collections.emptyMap() : blockingRegions;
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -326,6 +326,14 @@ public interface Admin extends AutoCloseable, Closeable {
 
   Map<String, String> getBackupVersionsForMultiColos(String clusterName, String storeName);
 
+  /**
+   * Determine whether a destructive PubSub operation (topic truncation, retention update, or deletion) on the given
+   * topic is safe to execute, by checking whether the topic still backs a non-deprecated version (current, future, or
+   * backup) of its store in any region. See {@link TopicOperationSafetyVerdict} for the semantics of the result, in
+   * particular the additive nature of the check and how orphaned/unverifiable topics are handled.
+   */
+  TopicOperationSafetyVerdict checkTopicOperationSafety(String topicName);
+
   int getBackupVersion(String clusterName, String storeName);
 
   int getFutureVersion(String clusterName, String storeName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ParentVersionOrchestrator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ParentVersionOrchestrator.java
@@ -13,9 +13,11 @@ import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.VersionResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
+import com.linkedin.venice.meta.StoreConfig;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -116,6 +118,89 @@ class ParentVersionOrchestrator {
             controllerClient -> controllerClient.getFutureVersions(clusterName, storeName),
             response -> response.getStoreStatusMap().get(storeName),
             String.valueOf(IGNORED_CURRENT_VERSION));
+  }
+
+  /**
+   * Multi-region safety check for a destructive PubSub operation on {@code topicName}. Resolves the owning cluster from
+   * store config, then fans out to every region to gather the current, future, and backup versions. The operation is
+   * blocked when the topic backs a non-deprecated version (current/future/backup) in any region, or when a region's
+   * current version cannot be read (unreachable, {@link #IGNORED_CURRENT_VERSION}) — in which case it cannot be proven
+   * safe. Orphaned topics (no resolvable store/cluster) are allowed, preserving legacy behavior.
+   */
+  TopicOperationSafetyVerdict checkTopicOperationSafety(String topicName) {
+    String storeName = Version.parseStoreFromKafkaTopicName(topicName);
+    StoreConfig storeConfig = (storeName == null || storeName.isEmpty())
+        ? null
+        : parent.getVeniceHelixAdmin().getStoreConfigRepo().getStoreConfig(storeName).orElse(null);
+    if (storeConfig == null || storeConfig.getCluster() == null || storeConfig.getCluster().isEmpty()) {
+      return TopicOperationSafetyVerdict
+          .allowed(topicName, storeName, null, "No owning store/cluster resolved for topic; operation allowed.");
+    }
+    String clusterName = storeConfig.getCluster();
+
+    Map<String, Integer> currentVersions = getCurrentVersionsForMultiColos(clusterName, storeName);
+    // region -> human-readable reason the operation is blocked there.
+    Map<String, String> blockingRegions = new HashMap<>();
+
+    // Regions we could not reach cannot be proven safe -> fail safe and block.
+    for (Map.Entry<String, Integer> entry: currentVersions.entrySet()) {
+      if (entry.getValue() == IGNORED_CURRENT_VERSION) {
+        blockingRegions.put(entry.getKey(), "current version could not be read (region unreachable)");
+      }
+    }
+
+    if (Version.isRealTimeTopic(topicName)) {
+      // A real-time topic is shared across versions; it is unsafe to operate on while the store has any serving version
+      // in any region.
+      for (Map.Entry<String, Integer> entry: currentVersions.entrySet()) {
+        int current = entry.getValue();
+        if (current != IGNORED_CURRENT_VERSION && current != NON_EXISTING_VERSION) {
+          blockingRegions.putIfAbsent(entry.getKey(), "store has current version " + current);
+        }
+      }
+    } else {
+      int targetVersion = Version.parseVersionFromKafkaTopicName(topicName);
+      Map<String, String> futureVersions = getFutureVersionsForMultiColos(clusterName, storeName);
+      Map<String, String> backupVersions = getBackupVersionsForMultiColos(clusterName, storeName);
+      for (String region: currentVersions.keySet()) {
+        if (blockingRegions.containsKey(region)) {
+          continue; // already blocked (unreachable)
+        }
+        if (currentVersions.get(region) == targetVersion) {
+          blockingRegions.put(region, "version " + targetVersion + " is the current version");
+        } else if (parseVersionOrIgnored(futureVersions.get(region)) == targetVersion) {
+          blockingRegions.put(region, "version " + targetVersion + " is a future version");
+        } else if (parseVersionOrIgnored(backupVersions.get(region)) == targetVersion) {
+          blockingRegions.put(region, "version " + targetVersion + " is a backup version");
+        }
+      }
+    }
+
+    if (blockingRegions.isEmpty()) {
+      return TopicOperationSafetyVerdict
+          .allowed(topicName, storeName, clusterName, "Topic does not back any non-deprecated version in any region.");
+    }
+    return TopicOperationSafetyVerdict.blocked(
+        topicName,
+        storeName,
+        clusterName,
+        "Topic backs a non-deprecated version (or could not be verified) in region(s): " + blockingRegions.keySet(),
+        blockingRegions);
+  }
+
+  /**
+   * Parse a version number from a multi-colo version string, returning {@link #IGNORED_CURRENT_VERSION} when the value
+   * is absent/non-numeric (e.g. the error sentinel, or no future/backup version exists).
+   */
+  private static int parseVersionOrIgnored(String versionStr) {
+    if (versionStr == null || versionStr.isEmpty()) {
+      return IGNORED_CURRENT_VERSION;
+    }
+    try {
+      return Integer.parseInt(versionStr.trim());
+    } catch (NumberFormatException e) {
+      return IGNORED_CURRENT_VERSION;
+    }
   }
 
   Map<String, String> getBackupVersionsForMultiColos(String clusterName, String storeName) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/TopicOperationSafetyVerdict.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/TopicOperationSafetyVerdict.java
@@ -1,0 +1,84 @@
+package com.linkedin.venice.controller;
+
+import java.util.Collections;
+import java.util.Map;
+
+
+/**
+ * Result of {@link Admin#checkTopicOperationSafety(String)}: whether a destructive PubSub operation (topic truncation,
+ * retention update, or deletion) on a given topic is safe to execute without an operator override.
+ *
+ * <p>The check is <em>additive</em>: it only reports {@code allowed == false} when it can positively determine that the
+ * topic still backs a non-deprecated version (current, future, or backup) of its store in at least one region, or when
+ * it cannot verify the per-region current versions (a region is unreachable, or the check is running on a controller
+ * that cannot observe every region). When the owning store/cluster cannot be resolved (an orphaned topic) the operation
+ * is {@code allowed}, preserving legacy behavior. A blocked operation can still be forced via the admin tool's
+ * {@code --force} flag.</p>
+ */
+public class TopicOperationSafetyVerdict {
+  private final boolean allowed;
+  private final String topicName;
+  private final String storeName;
+  private final String cluster;
+  private final String reason;
+  /** region -&gt; why that region blocks the operation; empty when {@link #allowed}. */
+  private final Map<String, String> blockingRegions;
+
+  private TopicOperationSafetyVerdict(
+      boolean allowed,
+      String topicName,
+      String storeName,
+      String cluster,
+      String reason,
+      Map<String, String> blockingRegions) {
+    this.allowed = allowed;
+    this.topicName = topicName;
+    this.storeName = storeName;
+    this.cluster = cluster;
+    this.reason = reason;
+    this.blockingRegions = blockingRegions == null ? Collections.emptyMap() : blockingRegions;
+  }
+
+  public static TopicOperationSafetyVerdict allowed(String topicName, String storeName, String cluster, String reason) {
+    return new TopicOperationSafetyVerdict(true, topicName, storeName, cluster, reason, Collections.emptyMap());
+  }
+
+  public static TopicOperationSafetyVerdict blocked(
+      String topicName,
+      String storeName,
+      String cluster,
+      String reason,
+      Map<String, String> blockingRegions) {
+    return new TopicOperationSafetyVerdict(false, topicName, storeName, cluster, reason, blockingRegions);
+  }
+
+  public boolean isAllowed() {
+    return allowed;
+  }
+
+  public String getTopicName() {
+    return topicName;
+  }
+
+  public String getStoreName() {
+    return storeName;
+  }
+
+  public String getCluster() {
+    return cluster;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public Map<String, String> getBlockingRegions() {
+    return blockingRegions;
+  }
+
+  @Override
+  public String toString() {
+    return "TopicOperationSafetyVerdict{allowed=" + allowed + ", topicName=" + topicName + ", storeName=" + storeName
+        + ", cluster=" + cluster + ", reason=" + reason + ", blockingRegions=" + blockingRegions + "}";
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4078,6 +4078,30 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
+   * A non-parent controller cannot observe the per-region current versions across all fabrics, so it cannot prove a
+   * topic is safe to operate on. Orphaned topics (no resolvable owning store/cluster) preserve legacy behavior and are
+   * allowed; everything else is reported as blocked so the caller reruns against the parent controller or overrides
+   * with --force.
+   */
+  @Override
+  public TopicOperationSafetyVerdict checkTopicOperationSafety(String topicName) {
+    String storeName = Version.parseStoreFromKafkaTopicName(topicName);
+    StoreConfig storeConfig =
+        StringUtils.isEmpty(storeName) ? null : getStoreConfigRepo().getStoreConfig(storeName).orElse(null);
+    if (storeConfig == null || StringUtils.isEmpty(storeConfig.getCluster())) {
+      return TopicOperationSafetyVerdict
+          .allowed(topicName, storeName, null, "No owning store/cluster resolved for topic; operation allowed.");
+    }
+    return TopicOperationSafetyVerdict.blocked(
+        topicName,
+        storeName,
+        storeConfig.getCluster(),
+        "Topic safety cannot be verified on a non-parent controller (per-region current versions are not visible). "
+            + "Rerun against the parent controller or override with --force.",
+        Collections.emptyMap());
+  }
+
+  /**
    * @see Admin#deleteAllVersionsInStore(String, String)
    */
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2206,6 +2206,14 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   /**
+   * @see Admin#checkTopicOperationSafety(String)
+   */
+  @Override
+  public TopicOperationSafetyVerdict checkTopicOperationSafety(String topicName) {
+    return parentVersionOrchestrator.checkTopicOperationSafety(topicName);
+  }
+
+  /**
    * @return a RepushInfo object with store information retrieved from the specified cluster and fabric.
    */
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -11,6 +11,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.ALLOW_LIST_REMOV
 import static com.linkedin.venice.controllerapi.ControllerRoute.AUTO_MIGRATE_STORE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.BACKUP_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.CHECK_RESOURCE_CLEANUP_FOR_STORE_CREATION;
+import static com.linkedin.venice.controllerapi.ControllerRoute.CHECK_TOPIC_OPERATION_SAFETY;
 import static com.linkedin.venice.controllerapi.ControllerRoute.CLEANUP_INSTANCE_CUSTOMIZED_STATES;
 import static com.linkedin.venice.controllerapi.ControllerRoute.CLEAN_EXECUTION_IDS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.CLUSTER_DISCOVERY;
@@ -665,6 +666,9 @@ public class AdminSparkServer extends AbstractVeniceService {
     httpService.get(
         GET_KAFKA_TOPIC_CONFIGS.getPath(),
         new VeniceParentControllerRegionStateHandler(admin, controllerRoutes.getKafkaTopicConfigs(admin)));
+    httpService.get(
+        CHECK_TOPIC_OPERATION_SAFETY.getPath(),
+        new VeniceParentControllerRegionStateHandler(admin, controllerRoutes.checkTopicOperationSafety(admin)));
     httpService.post(
         UPDATE_KAFKA_TOPIC_LOG_COMPACTION.getPath(),
         new VeniceParentControllerRegionStateHandler(admin, controllerRoutes.updateKafkaTopicLogCompaction(admin)));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -19,6 +19,7 @@ import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.InstanceRemovableStatuses;
+import com.linkedin.venice.controller.TopicOperationSafetyVerdict;
 import com.linkedin.venice.controllerapi.AdminOperationProtocolVersionControllerResponse;
 import com.linkedin.venice.controllerapi.AggregatedHealthStatusRequest;
 import com.linkedin.venice.controllerapi.ChildAwareResponse;
@@ -26,6 +27,7 @@ import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.LeaderControllerResponse;
 import com.linkedin.venice.controllerapi.PubSubTopicConfigResponse;
 import com.linkedin.venice.controllerapi.StoppableNodeStatusResponse;
+import com.linkedin.venice.controllerapi.TopicOperationSafetyResponse;
 import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.protocols.controller.LeaderControllerGrpcRequest;
 import com.linkedin.venice.protocols.controller.LeaderControllerGrpcResponse;
@@ -153,6 +155,33 @@ public class ControllerRoutes extends AbstractRoute {
         AdminSparkServer.handleError(e, request, response);
       }
       response.type(HttpConstants.JSON);
+      return AdminSparkServer.OBJECT_MAPPER.writeValueAsString(responseObject);
+    };
+  }
+
+  /**
+   * No ACL check; read-only pre-flight that reports whether a destructive PubSub operation on a topic is safe to run.
+   * @see Admin#checkTopicOperationSafety(String)
+   */
+  public Route checkTopicOperationSafety(Admin admin) {
+    return (request, response) -> {
+      TopicOperationSafetyResponse responseObject = new TopicOperationSafetyResponse();
+      response.type(HttpConstants.JSON);
+      try {
+        String topicName = request.queryParams(TOPIC);
+        if (StringUtils.isEmpty(topicName)) {
+          throw new IllegalArgumentException("Param '" + TOPIC + "' is required");
+        }
+        TopicOperationSafetyVerdict verdict = admin.checkTopicOperationSafety(topicName);
+        responseObject.setCluster(verdict.getCluster() == null ? "" : verdict.getCluster());
+        responseObject.setName(verdict.getStoreName());
+        responseObject.setAllowed(verdict.isAllowed());
+        responseObject.setReason(verdict.getReason());
+        responseObject.setBlockingRegions(verdict.getBlockingRegions());
+      } catch (Throwable e) {
+        responseObject.setError(e);
+        AdminSparkServer.handleError(e, request, response);
+      }
       return AdminSparkServer.OBJECT_MAPPER.writeValueAsString(responseObject);
     };
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestTopicOperationSafetyCheck.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestTopicOperationSafetyCheck.java
@@ -1,0 +1,222 @@
+package com.linkedin.venice.controller;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.helix.HelixReadOnlyStoreConfigRepository;
+import com.linkedin.venice.meta.StoreConfig;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for the multi-region topic-operation safety check ({@link Admin#checkTopicOperationSafety(String)}).
+ *
+ * <p>The parent-controller decision logic lives in {@link ParentVersionOrchestrator}; these tests spy the orchestrator
+ * and stub the per-region version fan-outs ({@code getCurrentVersionsForMultiColos} / {@code ...Future...} /
+ * {@code ...Backup...}) so they exercise the block/allow branches in isolation. The cross-fabric fan-out plumbing and
+ * end-to-end behavior are covered by integration tests.</p>
+ */
+public class TestTopicOperationSafetyCheck {
+  private static final String STORE = "testStore";
+  private static final String CLUSTER = "test-cluster";
+  private static final String VT_V2 = STORE + "_v2"; // version topic for version 2
+  private static final String RT = STORE + "_rt"; // real-time topic
+
+  /**
+   * Build a spied orchestrator whose store-config resolution returns {@code cluster} (or no owning store when
+   * {@code cluster == null}) and whose per-region version fan-outs return the supplied maps.
+   */
+  private ParentVersionOrchestrator orchestrator(
+      String cluster,
+      Map<String, Integer> current,
+      Map<String, String> future,
+      Map<String, String> backup) {
+    VeniceParentHelixAdmin parent = mock(VeniceParentHelixAdmin.class);
+    VeniceHelixAdmin internal = mock(VeniceHelixAdmin.class);
+    when(parent.getVeniceHelixAdmin()).thenReturn(internal);
+    HelixReadOnlyStoreConfigRepository repo = mock(HelixReadOnlyStoreConfigRepository.class);
+    when(internal.getStoreConfigRepo()).thenReturn(repo);
+    if (cluster == null) {
+      when(repo.getStoreConfig(STORE)).thenReturn(Optional.empty());
+    } else {
+      StoreConfig storeConfig = mock(StoreConfig.class);
+      when(storeConfig.getCluster()).thenReturn(cluster);
+      when(repo.getStoreConfig(STORE)).thenReturn(Optional.of(storeConfig));
+    }
+
+    ParentVersionOrchestrator orchestrator = spy(new ParentVersionOrchestrator(parent));
+    if (cluster != null) {
+      doReturn(current).when(orchestrator).getCurrentVersionsForMultiColos(cluster, STORE);
+      doReturn(future).when(orchestrator).getFutureVersionsForMultiColos(cluster, STORE);
+      doReturn(backup).when(orchestrator).getBackupVersionsForMultiColos(cluster, STORE);
+    }
+    return orchestrator;
+  }
+
+  private static Map<String, Integer> currentVersions(Object... regionVersionPairs) {
+    Map<String, Integer> map = new HashMap<>();
+    for (int i = 0; i < regionVersionPairs.length; i += 2) {
+      map.put((String) regionVersionPairs[i], (Integer) regionVersionPairs[i + 1]);
+    }
+    return map;
+  }
+
+  private static Map<String, String> versionStrings(String... regionVersionPairs) {
+    Map<String, String> map = new HashMap<>();
+    for (int i = 0; i < regionVersionPairs.length; i += 2) {
+      map.put(regionVersionPairs[i], regionVersionPairs[i + 1]);
+    }
+    return map;
+  }
+
+  @Test
+  public void testBlocksWhenTargetIsCurrentVersionInOneRegion() {
+    // region1 still serves v2 while region2 has moved to v3 -> deleting _v2 must be blocked, citing region1 only.
+    ParentVersionOrchestrator orchestrator =
+        orchestrator(CLUSTER, currentVersions("region1", 2, "region2", 3), versionStrings(), versionStrings());
+
+    TopicOperationSafetyVerdict verdict = orchestrator.checkTopicOperationSafety(VT_V2);
+
+    assertFalse(verdict.isAllowed());
+    assertTrue(verdict.getBlockingRegions().containsKey("region1"));
+    assertFalse(verdict.getBlockingRegions().containsKey("region2"));
+    assertEquals(verdict.getCluster(), CLUSTER);
+    assertEquals(verdict.getStoreName(), STORE);
+  }
+
+  @Test
+  public void testAllowsWhenTargetIsDeprecatedInAllRegions() {
+    // v2 is neither current (5), future (6), nor backup (4) anywhere -> safe.
+    ParentVersionOrchestrator orchestrator = orchestrator(
+        CLUSTER,
+        currentVersions("region1", 5, "region2", 5),
+        versionStrings("region1", "6", "region2", "6"),
+        versionStrings("region1", "4", "region2", "4"));
+
+    TopicOperationSafetyVerdict verdict = orchestrator.checkTopicOperationSafety(VT_V2);
+
+    assertTrue(verdict.isAllowed());
+    assertTrue(verdict.getBlockingRegions().isEmpty());
+  }
+
+  @Test
+  public void testBlocksWhenTargetIsFutureVersion() {
+    ParentVersionOrchestrator orchestrator =
+        orchestrator(CLUSTER, currentVersions("region1", 5), versionStrings("region1", "2"), versionStrings());
+
+    TopicOperationSafetyVerdict verdict = orchestrator.checkTopicOperationSafety(VT_V2);
+
+    assertFalse(verdict.isAllowed());
+    assertTrue(verdict.getBlockingRegions().containsKey("region1"));
+  }
+
+  @Test
+  public void testBlocksWhenTargetIsBackupVersion() {
+    ParentVersionOrchestrator orchestrator =
+        orchestrator(CLUSTER, currentVersions("region1", 5), versionStrings(), versionStrings("region1", "2"));
+
+    TopicOperationSafetyVerdict verdict = orchestrator.checkTopicOperationSafety(VT_V2);
+
+    assertFalse(verdict.isAllowed());
+    assertTrue(verdict.getBlockingRegions().containsKey("region1"));
+  }
+
+  @Test
+  public void testBlocksWhenAnyRegionIsUnreachable() {
+    // region2 returned the IGNORED_CURRENT_VERSION (-1) sentinel -> cannot prove safety -> fail safe and block,
+    // even though v2 is not the current version anywhere reachable.
+    ParentVersionOrchestrator orchestrator =
+        orchestrator(CLUSTER, currentVersions("region1", 5, "region2", -1), versionStrings(), versionStrings());
+
+    TopicOperationSafetyVerdict verdict = orchestrator.checkTopicOperationSafety(VT_V2);
+
+    assertFalse(verdict.isAllowed());
+    assertTrue(verdict.getBlockingRegions().containsKey("region2"));
+    assertFalse(verdict.getBlockingRegions().containsKey("region1"));
+  }
+
+  @Test
+  public void testAllowsOrphanedTopicWithNoOwningStore() {
+    // No store config resolves for the topic -> additive check allows it (legacy behavior preserved).
+    ParentVersionOrchestrator orchestrator = orchestrator(null, null, null, null);
+
+    TopicOperationSafetyVerdict verdict = orchestrator.checkTopicOperationSafety(STORE + "_v9");
+
+    assertTrue(verdict.isAllowed());
+  }
+
+  @Test
+  public void testBlocksRealTimeTopicWhenStoreHasCurrentVersion() {
+    // A real-time topic is shared across versions; any serving version in any region makes it unsafe.
+    ParentVersionOrchestrator orchestrator =
+        orchestrator(CLUSTER, currentVersions("region1", 3), versionStrings(), versionStrings());
+
+    TopicOperationSafetyVerdict verdict = orchestrator.checkTopicOperationSafety(RT);
+
+    assertFalse(verdict.isAllowed());
+    assertTrue(verdict.getBlockingRegions().containsKey("region1"));
+  }
+
+  @Test
+  public void testAllowsRealTimeTopicWhenStoreHasNoCurrentVersion() {
+    // NON_EXISTING_VERSION (0) in every region -> no serving version -> RT topic is safe.
+    ParentVersionOrchestrator orchestrator =
+        orchestrator(CLUSTER, currentVersions("region1", 0, "region2", 0), versionStrings(), versionStrings());
+
+    TopicOperationSafetyVerdict verdict = orchestrator.checkTopicOperationSafety(RT);
+
+    assertTrue(verdict.isAllowed());
+  }
+
+  @Test
+  public void testChildControllerBlocksBecauseItCannotVerifyAllRegions() {
+    VeniceHelixAdmin childAdmin = mock(VeniceHelixAdmin.class);
+    when(childAdmin.checkTopicOperationSafety(VT_V2)).thenCallRealMethod();
+    HelixReadOnlyStoreConfigRepository repo = mock(HelixReadOnlyStoreConfigRepository.class);
+    when(childAdmin.getStoreConfigRepo()).thenReturn(repo);
+    StoreConfig storeConfig = mock(StoreConfig.class);
+    when(storeConfig.getCluster()).thenReturn(CLUSTER);
+    when(repo.getStoreConfig(STORE)).thenReturn(Optional.of(storeConfig));
+
+    TopicOperationSafetyVerdict verdict = childAdmin.checkTopicOperationSafety(VT_V2);
+
+    assertFalse(verdict.isAllowed());
+    assertEquals(verdict.getCluster(), CLUSTER);
+  }
+
+  @Test
+  public void testChildControllerAllowsOrphanedTopic() {
+    VeniceHelixAdmin childAdmin = mock(VeniceHelixAdmin.class);
+    when(childAdmin.checkTopicOperationSafety(STORE + "_v9")).thenCallRealMethod();
+    HelixReadOnlyStoreConfigRepository repo = mock(HelixReadOnlyStoreConfigRepository.class);
+    when(childAdmin.getStoreConfigRepo()).thenReturn(repo);
+    when(repo.getStoreConfig(STORE)).thenReturn(Optional.empty());
+
+    TopicOperationSafetyVerdict verdict = childAdmin.checkTopicOperationSafety(STORE + "_v9");
+
+    assertTrue(verdict.isAllowed());
+  }
+
+  @Test
+  public void testVerdictFactoryMethods() {
+    TopicOperationSafetyVerdict allowed = TopicOperationSafetyVerdict.allowed(VT_V2, STORE, CLUSTER, "ok");
+    assertTrue(allowed.isAllowed());
+    assertTrue(allowed.getBlockingRegions().isEmpty());
+    assertEquals(allowed.getReason(), "ok");
+
+    Map<String, String> blocking = Collections.singletonMap("region1", "current version");
+    TopicOperationSafetyVerdict blocked = TopicOperationSafetyVerdict.blocked(VT_V2, STORE, CLUSTER, "nope", blocking);
+    assertFalse(blocked.isAllowed());
+    assertEquals(blocked.getBlockingRegions(), blocking);
+    assertEquals(blocked.getStoreName(), STORE);
+  }
+}


### PR DESCRIPTION
## Summary

Centralize destructive PubSub operations (topic truncation, retention update, deletion) behind the controller with a current-version safeguard.

This change adds a shared, **multi-region** safety check that determines whether a destructive operation on a topic is safe: it blocks when the topic still backs a non-deprecated version (current, future, or backup) of its store **in any region**. During targeted-region or staggered `DeferredVersionSwapService` rollouts the current version differs by region, so a single-region view is insufficient.

### What's included
- `Admin#checkTopicOperationSafety(String topicName)` → `TopicOperationSafetyVerdict`.
- Parent controller (`ParentVersionOrchestrator`): resolves the owning cluster via `StoreConfig`, fans out current/future/backup versions across all regions, and blocks if the target version is live in any region.
  - Unreachable regions (`IGNORED_CURRENT_VERSION`) fail safe and block.
  - Orphaned topics (no resolvable store/cluster) are allowed (legacy behavior preserved).
  - Real-time topics block when the store has any current version in any region.
- Child controller: blocks (cannot observe all regions) unless the topic is orphaned.
- Read-only verdict endpoint `CHECK_TOPIC_OPERATION_SAFETY` + `ControllerClient#checkTopicOperationSafety` for the upcoming admin-tool pre-flight.

### Behavior impact
This PR only **adds** the capability — it is not yet enforced on any route, so it is behavior-preserving on its own. Route enforcement (truncate/retention) and the admin-tool `delete-kafka-topic` pre-flight + `--force` override follow in subsequent PRs.


### Testing
New `TestTopicOperationSafetyCheck` (11 unit tests): multi-region current-version skew, future/backup version match, unreachable-region fail-safe, orphan allow, RT vs VT, and child-controller behavior. All passing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
