### PR TITLE
[controller] Pass controller config to lifecycle hook constructor in StoreConfigUpdater

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -599,6 +599,9 @@ public class DaVinciBackend implements Closeable {
 
     storeBackend.validateDaVinciAndVeniceCurrentVersion();
     storeBackend.tryDeleteInvalidDaVinciFutureVersion();
+    // If the future version was created paused (non-target region SIT), check whether it should
+    // now be resumed (e.g. targetRegionPromoted just flipped to true).
+    storeBackend.maybeResumeDaVinciFutureVersion();
     /**
      * Future version may not meet the swapping condition when local partitions finished ingestion, thus everytime
      * when store config has been changed in the Venice backend, we need to check if we could swap the future version

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -599,15 +599,15 @@ public class DaVinciBackend implements Closeable {
 
     storeBackend.validateDaVinciAndVeniceCurrentVersion();
     storeBackend.tryDeleteInvalidDaVinciFutureVersion();
-    // If the future version was created paused (non-target region SIT), check whether it should
-    // now be resumed (e.g. targetRegionPromoted just flipped to true).
-    storeBackend.maybeResumeDaVinciFutureVersion();
     /**
      * Future version may not meet the swapping condition when local partitions finished ingestion, thus everytime
      * when store config has been changed in the Venice backend, we need to check if we could swap the future version
      * to current.
      */
     storeBackend.trySwapDaVinciCurrentVersion(null);
+    // If the future version was created paused (non-target region SIT), check whether it should
+    // now be resumed (e.g. targetRegionPromoted just flipped to true).
+    storeBackend.maybeResumeDaVinciFutureVersion();
     storeBackend.trySubscribeDaVinciFutureVersion();
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
@@ -2,7 +2,6 @@ package com.linkedin.davinci;
 
 import com.linkedin.davinci.client.DaVinciSeekCheckpointInfo;
 import com.linkedin.davinci.config.StoreBackendConfig;
-import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
@@ -292,36 +291,47 @@ public class StoreBackend {
       return;
     }
 
-    Set<String> targetRegions = RegionUtils.parseRegionsFilterList(targetVersion.getTargetSwapRegion());
-    VeniceServerConfig veniceServerConfig = backend.getConfigLoader().getVeniceServerConfig();
-    String currentRegion = veniceServerConfig.getRegionName();
-    boolean isTargetRegionEnabled = !StringUtils.isEmpty(targetVersion.getTargetSwapRegion());
-    // targetRegionPromoted=true means the target-region push completed and non-target DVC clients
-    // should now begin ingesting. This is set by DeferredVersionSwapService after the push succeeds
-    // in the target region, and is propagated to child controllers via the UpdateStore admin message.
-    boolean startIngestionOnTargetRegionPromoted =
-        isTargetRegionEnabled && !targetRegions.contains(currentRegion) && targetVersion.isTargetRegionPromoted();
+    boolean createPaused = shouldCreatePaused(targetVersion);
+    LOGGER.info("Subscribing to future version {} (createPaused={})", targetVersion.kafkaTopicName(), createPaused);
+    setDaVinciFutureVersion(new VersionBackend(backend, targetVersion, stats));
+    // For future version subscription, we don't need to pass any timestamps or position map
+    daVinciFutureVersion.subscribe(subscription, null, null, createPaused)
+        .whenComplete((v, e) -> trySwapDaVinciCurrentVersion(e));
+  }
 
-    // Subscribe to the future version if:
-    // 1. Target region push with delayed ingestion is not enabled
-    // 2. Target region push with delayed ingestion is enabled and the current region is a target region
-    // 3. Target region push with delayed ingestion is enabled and the current region is a non-target
-    // region and the target region has been promoted (targetRegionPromoted flag is set by
-    // DeferredVersionSwapService once the push completes in target regions)
-    if (targetRegions.contains(currentRegion) || startIngestionOnTargetRegionPromoted || !isTargetRegionEnabled) {
-      LOGGER.info("Subscribing to future version {}", targetVersion.kafkaTopicName());
-      setDaVinciFutureVersion(new VersionBackend(backend, targetVersion, stats));
-      // For future version subscription, we don't need to pass any timestamps or position map
-      daVinciFutureVersion.subscribe(subscription, null, null, false)
-          .whenComplete((v, e) -> trySwapDaVinciCurrentVersion(e));
-    } else {
-      LOGGER.info(
-          "Skipping subscribe to future version: {} in region: {} because targetRegionPromoted={} and target regions are: {}",
-          targetVersion.kafkaTopicName(),
-          currentRegion,
-          targetVersion.isTargetRegionPromoted(),
-          targetVersion.getTargetSwapRegion());
+  /**
+   * Resume the future version's ingestion if it was created paused and the target-region push has
+   * since been promoted (i.e. {@code shouldCreatePaused} now returns {@code false}).
+   */
+  synchronized void maybeResumeDaVinciFutureVersion() {
+    if (daVinciFutureVersion == null || !daVinciFutureVersion.isPaused()) {
+      return;
     }
+    if (!shouldCreatePaused(daVinciFutureVersion.getVersion())) {
+      LOGGER.info("Resuming future-slot-paused SIT for version {}", daVinciFutureVersion.getVersion().kafkaTopicName());
+      daVinciFutureVersion.resume();
+    }
+  }
+
+  /**
+   * Returns {@code true} when the future version should be started in a paused state.
+   *
+   * <p>A version is created paused when a target-region push is in progress and this DVC instance
+   * is NOT in the target region. Once the push completes in the target region the
+   * {@code targetRegionPromoted} flag is set, at which point this method returns {@code false} and
+   * the caller can call {@link #maybeResumeDaVinciFutureVersion()} to resume ingestion.
+   */
+  private boolean shouldCreatePaused(Version version) {
+    String targetSwapRegion = version.getTargetSwapRegion();
+    if (StringUtils.isEmpty(targetSwapRegion)) {
+      return false; // no target-region push — always active
+    }
+    Set<String> targetRegions = RegionUtils.parseRegionsFilterList(targetSwapRegion);
+    String currentRegion = backend.getConfigLoader().getVeniceServerConfig().getRegionName();
+    if (targetRegions.contains(currentRegion)) {
+      return false; // this IS the target region — always active
+    }
+    return !version.isTargetRegionPromoted(); // non-target: paused until promoted
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
@@ -201,7 +201,8 @@ public class StoreBackend {
       if (daVinciFutureVersion == null) {
         trySubscribeDaVinciFutureVersion();
       } else {
-        daVinciFutureVersion.subscribe(partitions, null, null).whenComplete((v, e) -> trySwapDaVinciCurrentVersion(e));
+        daVinciFutureVersion.subscribe(partitions, null, null, false)
+            .whenComplete((v, e) -> trySwapDaVinciCurrentVersion(e));
       }
     }
 
@@ -218,25 +219,27 @@ public class StoreBackend {
           break;
       }
     }
-    return daVinciCurrentVersion.subscribe(partitions, resolvedTimestampsMap, resolvedPositionMap).exceptionally(e -> {
-      synchronized (this) {
-        addFaultyVersion(savedVersion, e);
-        // Don't propagate failure to subscribe() caller, if future version has become current and is ready to
-        // serve.
-        if (daVinciCurrentVersion != null && daVinciCurrentVersion.isReadyToServe(subscription)) {
-          return null;
-        }
-      }
-      throw (e instanceof CompletionException) ? (CompletionException) e : new CompletionException(e);
-    }).whenComplete((v, e) -> {
-      synchronized (this) {
-        if (e == null) {
-          LOGGER.info("Ready to serve partitions {} of {}", subscription, daVinciCurrentVersion);
-        } else {
-          LOGGER.warn("Failed to subscribe to partitions {} of {}", subscription, savedVersion, e);
-        }
-      }
-    });
+    return daVinciCurrentVersion.subscribe(partitions, resolvedTimestampsMap, resolvedPositionMap, false)
+        .exceptionally(e -> {
+          synchronized (this) {
+            addFaultyVersion(savedVersion, e);
+            // Don't propagate failure to subscribe() caller, if future version has become current and is ready to
+            // serve.
+            if (daVinciCurrentVersion != null && daVinciCurrentVersion.isReadyToServe(subscription)) {
+              return null;
+            }
+          }
+          throw (e instanceof CompletionException) ? (CompletionException) e : new CompletionException(e);
+        })
+        .whenComplete((v, e) -> {
+          synchronized (this) {
+            if (e == null) {
+              LOGGER.info("Ready to serve partitions {} of {}", subscription, daVinciCurrentVersion);
+            } else {
+              LOGGER.warn("Failed to subscribe to partitions {} of {}", subscription, savedVersion, e);
+            }
+          }
+        });
   }
 
   public synchronized void unsubscribe(ComplementSet<Integer> partitions) {
@@ -309,7 +312,8 @@ public class StoreBackend {
       LOGGER.info("Subscribing to future version {}", targetVersion.kafkaTopicName());
       setDaVinciFutureVersion(new VersionBackend(backend, targetVersion, stats));
       // For future version subscription, we don't need to pass any timestamps or position map
-      daVinciFutureVersion.subscribe(subscription, null, null).whenComplete((v, e) -> trySwapDaVinciCurrentVersion(e));
+      daVinciFutureVersion.subscribe(subscription, null, null, false)
+          .whenComplete((v, e) -> trySwapDaVinciCurrentVersion(e));
     } else {
       LOGGER.info(
           "Skipping subscribe to future version: {} in region: {} because targetRegionPromoted={} and target regions are: {}",

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
@@ -6,7 +6,6 @@ import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.serialization.AvroStoreDeserializerCache;
 import com.linkedin.venice.serialization.StoreDeserializerCache;
@@ -294,25 +293,29 @@ public class StoreBackend {
     VeniceServerConfig veniceServerConfig = backend.getConfigLoader().getVeniceServerConfig();
     String currentRegion = veniceServerConfig.getRegionName();
     boolean isTargetRegionEnabled = !StringUtils.isEmpty(targetVersion.getTargetSwapRegion());
-    boolean startIngestionInNonTargetRegion = isTargetRegionEnabled && !targetRegions.contains(currentRegion)
-        && targetVersion.getStatus() == VersionStatus.ONLINE;
+    // targetRegionPromoted=true means the target-region push completed and non-target DVC clients
+    // should now begin ingesting. This is set by DeferredVersionSwapService after the push succeeds
+    // in the target region, and is propagated to child controllers via the UpdateStore admin message.
+    boolean startIngestionOnTargetRegionPromoted =
+        isTargetRegionEnabled && !targetRegions.contains(currentRegion) && targetVersion.isTargetRegionPromoted();
 
     // Subscribe to the future version if:
     // 1. Target region push with delayed ingestion is not enabled
     // 2. Target region push with delayed ingestion is enabled and the current region is a target region
-    // 3. Target region push with delayed ingestion is enabled and the current region is a non target region
-    // and the wait time has elapsed. The wait time has elapsed when the version status is marked ONLINE
-    if (targetRegions.contains(currentRegion) || startIngestionInNonTargetRegion || !isTargetRegionEnabled) {
+    // 3. Target region push with delayed ingestion is enabled and the current region is a non-target
+    // region and the target region has been promoted (targetRegionPromoted flag is set by
+    // DeferredVersionSwapService once the push completes in target regions)
+    if (targetRegions.contains(currentRegion) || startIngestionOnTargetRegionPromoted || !isTargetRegionEnabled) {
       LOGGER.info("Subscribing to future version {}", targetVersion.kafkaTopicName());
       setDaVinciFutureVersion(new VersionBackend(backend, targetVersion, stats));
       // For future version subscription, we don't need to pass any timestamps or position map
       daVinciFutureVersion.subscribe(subscription, null, null).whenComplete((v, e) -> trySwapDaVinciCurrentVersion(e));
     } else {
       LOGGER.info(
-          "Skipping subscribe to future version: {} in region: {} because the target version status is: {} and the target regions are: {}",
+          "Skipping subscribe to future version: {} in region: {} because targetRegionPromoted={} and target regions are: {}",
           targetVersion.kafkaTopicName(),
           currentRegion,
-          targetVersion.getStatus(),
+          targetVersion.isTargetRegionPromoted(),
           targetVersion.getTargetSwapRegion());
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_TIMEOUT_IN_
 
 import com.linkedin.davinci.client.InternalDaVinciRecordTransformerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
+import com.linkedin.davinci.kafka.consumer.StoreIngestionTask;
 import com.linkedin.davinci.listener.response.NoOpReadResponseStats;
 import com.linkedin.davinci.notifier.DaVinciPushStatusUpdateTask;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatLagMonitorAction;
@@ -363,7 +364,8 @@ public class VersionBackend {
   synchronized CompletableFuture<Void> subscribe(
       ComplementSet<Integer> partitions,
       Map<Integer, Long> timestampsMap,
-      Map<Integer, PubSubPosition> positionMap) {
+      Map<Integer, PubSubPosition> positionMap,
+      boolean createPaused) {
     Instant startTime = Instant.now();
     List<Integer> partitionList = getPartitions(partitions);
     if (partitionList.isEmpty()) {
@@ -413,7 +415,7 @@ public class VersionBackend {
       Optional<PubSubPosition> pubSubPosition = (timestampsMap == null && positionMap == null)
           ? Optional.empty()
           : backend.getIngestionService().getPubSubPosition(config, partition, timestampsMap, positionMap);
-      backend.getIngestionBackend().startConsumption(config, partition, pubSubPosition, replicaId);
+      backend.getIngestionBackend().startConsumption(config, partition, pubSubPosition, replicaId, createPaused);
       tryStartHeartbeat();
     }
 
@@ -478,6 +480,18 @@ public class VersionBackend {
       partitionToBatchReportEOIPEnabled.remove(partition);
     }
     tryStopHeartbeat();
+  }
+
+  void resume() {
+    StoreIngestionTask task = backend.getIngestionService().getStoreIngestionTask(version.kafkaTopicName());
+    if (task != null) {
+      task.resumeFromFutureSlotPause();
+    }
+  }
+
+  boolean isPaused() {
+    StoreIngestionTask task = backend.getIngestionService().getStoreIngestionTask(version.kafkaTopicName());
+    return task != null && task.isFutureSlotPaused();
   }
 
   void completePartition(int partition) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -84,6 +84,45 @@ public class DefaultIngestionBackend implements IngestionBackend {
   }
 
   @Override
+  public void startConsumption(
+      VeniceStoreVersionConfig storeConfig,
+      int partition,
+      Optional<PubSubPosition> pubSubPosition,
+      String replicaId,
+      boolean createPaused) {
+    String storeVersion = storeConfig.getStoreVersionName();
+    LOGGER.info("Retrieving storage engine for replica {}", replicaId);
+    Supplier<StoreVersionState> svsSupplier = () -> storageMetadataService.getStoreVersionState(storeVersion);
+
+    ReplicaConsumptionContext replicaContext = getOrCreateReplicaContext(replicaId);
+
+    if (replicaContext.state == ReplicaIntendedState.RUNNING) {
+      LOGGER.info("startConsumption called for replica {} but it is already RUNNING. Ignoring duplicate.", replicaId);
+      return;
+    }
+
+    if (replicaContext.state == ReplicaIntendedState.STOPPED) {
+      LOGGER.info("startConsumption: Waiting for consumption to stop for replica {}.", replicaId);
+      int stopConsumptionTimeout = serverConfig.getStopConsumptionTimeoutInSeconds();
+      getStoreIngestionService().stopConsumptionAndWait(storeConfig, partition, 1, stopConsumptionTimeout, false);
+    }
+
+    replicaContext.state = ReplicaIntendedState.RUNNING;
+    LOGGER.info("Replica {} state set to RUNNING.", replicaId);
+
+    StorageEngine storageEngine = storageService.openStoreForNewPartition(storeConfig, partition, svsSupplier);
+    topicStorageEngineReferenceMap.compute(storeVersion, (key, storageEngineAtomicReference) -> {
+      if (storageEngineAtomicReference != null) {
+        storageEngineAtomicReference.set(storageEngine);
+      }
+      return storageEngineAtomicReference;
+    });
+    LOGGER.info("Retrieved storage engine for replica {}. Starting consumption in ingestion service", replicaId);
+    getStoreIngestionService().startConsumption(storeConfig, partition, pubSubPosition, createPaused);
+    LOGGER.info("Completed starting consumption in ingestion service for replica {}", replicaId);
+  }
+
+  @Override
   public CompletableFuture<Void> stopConsumption(
       VeniceStoreVersionConfig storeConfig,
       int partition,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IngestionBackend.java
@@ -18,6 +18,27 @@ public interface IngestionBackend extends Closeable {
       Optional<PubSubPosition> pubSubPosition,
       String replicaId);
 
+  /**
+   * Start consumption for the given partition. If {@code createPaused} is {@code true}, the
+   * {@link com.linkedin.davinci.kafka.consumer.StoreIngestionTask} will be paused after receiving
+   * START_OF_PUSH (future-slot pause). Only DaVinci clients support {@code createPaused=true}.
+   *
+   * <p>Implementations that do not support paused creation must leave this default in place; it will
+   * throw {@link UnsupportedOperationException} when {@code createPaused=true} is requested.
+   */
+  default void startConsumption(
+      VeniceStoreVersionConfig storeConfig,
+      int partition,
+      Optional<PubSubPosition> pubSubPosition,
+      String replicaId,
+      boolean createPaused) {
+    if (createPaused) {
+      throw new UnsupportedOperationException(
+          "createPaused=true is not supported by this IngestionBackend: " + getClass().getSimpleName());
+    }
+    startConsumption(storeConfig, partition, pubSubPosition, replicaId);
+  }
+
   CompletableFuture<Void> stopConsumption(VeniceStoreVersionConfig storeConfig, int partition, String replicaId);
 
   void killConsumptionTask(String topicName);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -870,6 +870,34 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
   }
 
   /**
+   * Start consumption for the given partition, optionally creating the ingestion task in a paused
+   * state so it stops after receiving START_OF_PUSH (future-slot pause for DaVinci).
+   *
+   * @param veniceStore  Store version config.
+   * @param partitionId  Partition to subscribe.
+   * @param pubSubPosition Starting offset hint.
+   * @param createPaused If {@code true}, the {@link StoreIngestionTask} will be flagged to pause
+   *                     after START_OF_PUSH. Only valid for DaVinci clients.
+   * @throws VeniceException if {@code createPaused=true} and this is not a DaVinci client.
+   */
+  public void startConsumption(
+      VeniceStoreVersionConfig veniceStore,
+      int partitionId,
+      Optional<PubSubPosition> pubSubPosition,
+      boolean createPaused) {
+    if (createPaused && !isDaVinciClient) {
+      throw new VeniceException("createPaused=true is only valid for DaVinci clients, not Venice servers");
+    }
+    startConsumption(veniceStore, partitionId, pubSubPosition);
+    if (createPaused) {
+      StoreIngestionTask task = getStoreIngestionTask(veniceStore.getStoreVersionName());
+      if (task != null) {
+        task.setPauseAfterStartOfPush(true);
+      }
+    }
+  }
+
+  /**
    * This method closes the specified {@link StoreIngestionTask} and waits for the configurable
    * {@code server.shutdown.sit.wait.time.seconds} (default 20s) for it to fully shut down.
    * @param topicName Topic name of the ingestion task to be shutdown.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -1023,6 +1023,21 @@ public class PartitionConsumptionState {
     this.storeLevelPaused = storeLevelPaused;
   }
 
+  /**
+   * True when this partition is paused because the SIT was created in future-slot-paused mode
+   * (non-target region waiting for targetRegionPromoted). Coordinated with storeLevelPaused:
+   * a partition only physically resumes when BOTH flags are false.
+   */
+  private volatile boolean futureSlotPaused = false;
+
+  public boolean isFutureSlotPaused() {
+    return futureSlotPaused;
+  }
+
+  public void setFutureSlotPaused(boolean futureSlotPaused) {
+    this.futureSlotPaused = futureSlotPaused;
+  }
+
   public void setTransientRecord(
       int kafkaClusterId,
       PubSubPosition consumedPosition,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3890,7 +3890,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
      * Notify the underlying store engine about starting batch push.
      */
     final boolean sorted;
-    if (serverConfig.getRocksDBServerConfig().isBlobFilesEnabled() && isHybridMode()) {
+    if (getServerConfig().getRocksDBServerConfig().isBlobFilesEnabled() && isHybridMode()) {
       /**
        * We would like to skip {@link RocksDBSstFileWriter} for hybrid stores
        * when RocksDB blob mode is enabled and here are the reasons:
@@ -3917,7 +3917,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
 
     StoreVersionState persistedStoreVersionState =
-        storageMetadataService.computeStoreVersionState(kafkaVersionTopic, previousStoreVersionState -> {
+        getStorageMetadataService().computeStoreVersionState(getKafkaVersionTopic(), previousStoreVersionState -> {
           if (previousStoreVersionState == null) {
             // No other partition of the same topic has started yet, let's initialize the StoreVersionState
             StoreVersionState newStoreVersionState =
@@ -3954,15 +3954,15 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
              */
             LOGGER.warn(
                 "Store version state for topic {} has already been initialized with a different value of 'sorted': {}",
-                kafkaVersionTopic,
+                getKafkaVersionTopic(),
                 previousStoreVersionState.sorted);
           }
           // No need to mutate it, so we return it as is
           return previousStoreVersionState;
         });
 
-    ingestionNotificationDispatcher.reportStarted(partitionConsumptionState);
-    if (pauseAfterStartOfPush) {
+    getIngestionNotificationDispatcher().reportStarted(partitionConsumptionState);
+    if (isPauseAfterStartOfPush()) {
       pausePartitionForFutureSlot(partitionConsumptionState.getPartition());
     }
     beginBatchWrite(persistedStoreVersionState.sorted, partitionConsumptionState);
@@ -4954,14 +4954,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   boolean resumeConsumption(String topic, int partitionId) {
     // Store-level pause and future-slot pause both take precedence; no-op here so a quota resume
     // doesn't physically un-pause a partition that is intentionally held back.
-    PartitionConsumptionState pcs = partitionConsumptionStateMap.get(partitionId);
+    PartitionConsumptionState pcs = getPartitionConsumptionStateMap().get(partitionId);
     if (shouldSkipQuotaCallbackForStoreLevelPause(pcs) || (pcs != null && pcs.isFutureSlotPaused())) {
       logQuotaCallbackSuppressed("resumeConsumption", topic, partitionId);
       return false;
     }
-    aggKafkaConsumerService.resumeConsumerFor(
-        versionTopic,
-        new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partitionId));
+    getAggKafkaConsumerService().resumeConsumerFor(
+        getVersionTopic(),
+        new PubSubTopicPartitionImpl(getPubSubTopicRepository().getTopic(topic), partitionId));
     return true;
   }
 
@@ -6292,6 +6292,16 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return partitionConsumptionStateMap;
   }
 
+  @VisibleForTesting
+  AggKafkaConsumerService getAggKafkaConsumerService() {
+    return aggKafkaConsumerService;
+  }
+
+  @VisibleForTesting
+  StorageMetadataService getStorageMetadataService() {
+    return storageMetadataService;
+  }
+
   boolean isDaVinciClient() {
     return isDaVinciClient;
   }
@@ -6744,15 +6754,16 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * partition (the partition was never subscribed or has already been unsubscribed).
    */
   public void pausePartitionForFutureSlot(int partition) {
-    PartitionConsumptionState pcs = partitionConsumptionStateMap.get(partition);
+    PartitionConsumptionState pcs = getPartitionConsumptionStateMap().get(partition);
+    PubSubTopic vt = getVersionTopic();
     if (pcs == null) {
-      LOGGER.info("pausePartitionForFutureSlot: no PCS for partition {} in {}, skipping", partition, versionTopic);
+      LOGGER.info("pausePartitionForFutureSlot: no PCS for partition {} in {}, skipping", partition, vt);
       return;
     }
     pcs.setFutureSlotPaused(true);
-    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(versionTopic, partition);
-    aggKafkaConsumerService.pauseConsumerFor(versionTopic, topicPartition);
-    LOGGER.info("pausePartitionForFutureSlot: paused partition {} in {}", partition, versionTopic);
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(vt, partition);
+    getAggKafkaConsumerService().pauseConsumerFor(vt, topicPartition);
+    LOGGER.info("pausePartitionForFutureSlot: paused partition {} in {}", partition, vt);
   }
 
   /**
@@ -6762,19 +6773,20 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * store-level pause ({@link PartitionConsumptionState#isStoreLevelPaused()}).
    */
   public void resumeFromFutureSlotPause() {
-    for (Map.Entry<Integer, PartitionConsumptionState> entry: partitionConsumptionStateMap.entrySet()) {
+    PubSubTopic vt = getVersionTopic();
+    for (Map.Entry<Integer, PartitionConsumptionState> entry: getPartitionConsumptionStateMap().entrySet()) {
       int partition = entry.getKey();
       PartitionConsumptionState pcs = entry.getValue();
       if (!pcs.isStoreLevelPaused()) {
         pcs.setFutureSlotPaused(false);
-        PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(versionTopic, partition);
-        aggKafkaConsumerService.resumeConsumerFor(versionTopic, topicPartition);
-        LOGGER.info("resumeFromFutureSlotPause: resumed partition {} in {}", partition, versionTopic);
+        PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(vt, partition);
+        getAggKafkaConsumerService().resumeConsumerFor(vt, topicPartition);
+        LOGGER.info("resumeFromFutureSlotPause: resumed partition {} in {}", partition, vt);
       } else {
         LOGGER.info(
             "resumeFromFutureSlotPause: partition {} in {} is still store-level paused, skipping physical resume",
             partition,
-            versionTopic);
+            vt);
       }
     }
   }
@@ -6783,7 +6795,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * Returns true if any partition in this SIT is currently paused via the future-slot pause mechanism.
    */
   public boolean isFutureSlotPaused() {
-    return partitionConsumptionStateMap.values().stream().anyMatch(PartitionConsumptionState::isFutureSlotPaused);
+    return getPartitionConsumptionStateMap().values().stream().anyMatch(PartitionConsumptionState::isFutureSlotPaused);
   }
 
   public boolean isPauseAfterStartOfPush() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -6760,8 +6760,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     for (Map.Entry<Integer, PartitionConsumptionState> entry: partitionConsumptionStateMap.entrySet()) {
       int partition = entry.getKey();
       PartitionConsumptionState pcs = entry.getValue();
-      pcs.setFutureSlotPaused(false);
       if (!pcs.isStoreLevelPaused()) {
+        pcs.setFutureSlotPaused(false);
         PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(versionTopic, partition);
         aggKafkaConsumerService.resumeConsumerFor(versionTopic, topicPartition);
         LOGGER.info("resumeFromFutureSlotPause: resumed partition {} in {}", partition, versionTopic);
@@ -6779,5 +6779,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    */
   public boolean isFutureSlotPaused() {
     return partitionConsumptionStateMap.values().stream().anyMatch(PartitionConsumptionState::isFutureSlotPaused);
+  }
+
+  public boolean isPauseAfterStartOfPush() {
+    return pauseAfterStartOfPush;
+  }
+
+  public void setPauseAfterStartOfPush(boolean pauseAfterStartOfPush) {
+    this.pauseAfterStartOfPush = pauseAfterStartOfPush;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3042,6 +3042,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * Returns true if blob transfer is configured and the replica is lagged enough to benefit from it.
    */
   protected boolean shouldStartBlobTransfer(int partition, String replicaId, ConsumerAction consumerAction) {
+    if (pauseAfterStartOfPush) {
+      return false; // future-slot paused SIT: skip blob transfer, will ingest via Kafka after resume
+    }
     if (blobTransferHelper == null) {
       return false;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1163,7 +1163,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return returnStatus;
   }
 
-  private void beginBatchWrite(boolean sorted, PartitionConsumptionState partitionConsumptionState) {
+  void beginBatchWrite(boolean sorted, PartitionConsumptionState partitionConsumptionState) {
     Map<String, String> checkpointedDatabaseInfo = partitionConsumptionState.getOffsetRecord().getDatabaseInfo();
     StoragePartitionConfig storagePartitionConfig = getStoragePartitionConfig(sorted, partitionConsumptionState);
     partitionConsumptionState.setDeferredWrite(storagePartitionConfig.isDeferredWrite());
@@ -3869,7 +3869,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     });
   }
 
-  private void processStartOfPush(
+  void processStartOfPush(
       KafkaMessageEnvelope startOfPushKME,
       ControlMessage controlMessage,
       PartitionConsumptionState partitionConsumptionState) {
@@ -3962,6 +3962,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         });
 
     ingestionNotificationDispatcher.reportStarted(partitionConsumptionState);
+    if (pauseAfterStartOfPush) {
+      pausePartitionForFutureSlot(partitionConsumptionState.getPartition());
+    }
     beginBatchWrite(persistedStoreVersionState.sorted, partitionConsumptionState);
     partitionConsumptionState.setStartOfPushTimestamp(startOfPushKME.producerMetadata.messageTimestamp);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4949,8 +4949,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   private boolean resumeConsumption(String topic, int partitionId) {
-    // Store-level pause takes precedence; no-op here so a quota resume doesn't un-pause us.
-    if (shouldSkipQuotaCallbackForStoreLevelPause(partitionConsumptionStateMap.get(partitionId))) {
+    // Store-level pause and future-slot pause both take precedence; no-op here so a quota resume
+    // doesn't physically un-pause a partition that is intentionally held back.
+    PartitionConsumptionState pcs = partitionConsumptionStateMap.get(partitionId);
+    if (shouldSkipQuotaCallbackForStoreLevelPause(pcs)) {
+      logQuotaCallbackSuppressed("resumeConsumption", topic, partitionId);
+      return false;
+    }
+    if (pcs != null && pcs.isFutureSlotPaused()) {
       logQuotaCallbackSuppressed("resumeConsumption", topic, partitionId);
       return false;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -513,6 +513,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    */
   private boolean daVinciClientCustomLifecycleEnabled = false;
   private long lastResubscriptionCheckTimestamp = System.currentTimeMillis();
+  /**
+   * When true, this SIT will pause Kafka consumption on each partition immediately after processing
+   * the Start-Of-Push control message. The partition remains paused until
+   * {@link #resumeFromFutureSlotPause()} is called.  Used by the DaVinci paused-SIT feature to
+   * hold a future-version SIT in a ready-but-paused state until the version is promoted.
+   */
+  volatile boolean pauseAfterStartOfPush = false;
 
   // Helper encapsulating blob transfer utility methods. Null when blob transfer is not configured.
   protected final BlobTransferIngestionHelper blobTransferHelper;
@@ -6723,5 +6730,54 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         && kafkaMessageEnvelope.getProducerMetadata().getMessageTimestamp() > 0
             ? kafkaMessageEnvelope.getProducerMetadata().getMessageTimestamp()
             : 0L;
+  }
+
+  /**
+   * Pause Kafka consumption for {@code partition} as part of the future-slot pause mechanism.
+   * Sets the {@link PartitionConsumptionState#setFutureSlotPaused} flag and physically pauses the
+   * consumer assignment via {@link AggKafkaConsumerService}.  No-ops if no PCS exists for the
+   * partition (the partition was never subscribed or has already been unsubscribed).
+   */
+  public void pausePartitionForFutureSlot(int partition) {
+    PartitionConsumptionState pcs = partitionConsumptionStateMap.get(partition);
+    if (pcs == null) {
+      LOGGER.info("pausePartitionForFutureSlot: no PCS for partition {} in {}, skipping", partition, versionTopic);
+      return;
+    }
+    pcs.setFutureSlotPaused(true);
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(versionTopic, partition);
+    aggKafkaConsumerService.pauseConsumerFor(versionTopic, topicPartition);
+    LOGGER.info("pausePartitionForFutureSlot: paused partition {} in {}", partition, versionTopic);
+  }
+
+  /**
+   * Resume all partitions that were paused via the future-slot pause mechanism.
+   * Clears the {@link PartitionConsumptionState#setFutureSlotPaused} flag for every partition and
+   * physically resumes the consumer assignment — but only if the partition is not still held by a
+   * store-level pause ({@link PartitionConsumptionState#isStoreLevelPaused()}).
+   */
+  public void resumeFromFutureSlotPause() {
+    for (Map.Entry<Integer, PartitionConsumptionState> entry: partitionConsumptionStateMap.entrySet()) {
+      int partition = entry.getKey();
+      PartitionConsumptionState pcs = entry.getValue();
+      pcs.setFutureSlotPaused(false);
+      if (!pcs.isStoreLevelPaused()) {
+        PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(versionTopic, partition);
+        aggKafkaConsumerService.resumeConsumerFor(versionTopic, topicPartition);
+        LOGGER.info("resumeFromFutureSlotPause: resumed partition {} in {}", partition, versionTopic);
+      } else {
+        LOGGER.info(
+            "resumeFromFutureSlotPause: partition {} in {} is still store-level paused, skipping physical resume",
+            partition,
+            versionTopic);
+      }
+    }
+  }
+
+  /**
+   * Returns true if any partition in this SIT is currently paused via the future-slot pause mechanism.
+   */
+  public boolean isFutureSlotPaused() {
+    return partitionConsumptionStateMap.values().stream().anyMatch(PartitionConsumptionState::isFutureSlotPaused);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4948,15 +4948,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return true;
   }
 
-  private boolean resumeConsumption(String topic, int partitionId) {
+  boolean resumeConsumption(String topic, int partitionId) {
     // Store-level pause and future-slot pause both take precedence; no-op here so a quota resume
     // doesn't physically un-pause a partition that is intentionally held back.
     PartitionConsumptionState pcs = partitionConsumptionStateMap.get(partitionId);
-    if (shouldSkipQuotaCallbackForStoreLevelPause(pcs)) {
-      logQuotaCallbackSuppressed("resumeConsumption", topic, partitionId);
-      return false;
-    }
-    if (pcs != null && pcs.isFutureSlotPaused()) {
+    if (shouldSkipQuotaCallbackForStoreLevelPause(pcs) || (pcs != null && pcs.isFutureSlotPaused())) {
       logQuotaCallbackSuppressed("resumeConsumption", topic, partitionId);
       return false;
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
@@ -527,16 +527,32 @@ public class StoreBackendTest {
       assertEquals(versionRef.get().getVersion().getNumber(), version3.getNumber());
     }
 
-    // delayed ingestion is enabled, target region is not the current region
-    store.setTargetSwapRegion("dc-1");
+    // delayed ingestion is enabled, target region is NOT the current region (dc-0).
+    // targetSwapRegion must be set on the version (not just the store) for the check to apply.
+    // Non-target DVC clients no longer subscribe via VersionStatus.ONLINE;
+    // they wait for targetRegionPromoted=true set by DeferredVersionSwapService.
     Version version4 = new VersionImpl(store.getName(), store.peekNextVersionNumber(), null, 15);
+    version4.setTargetSwapRegion("dc-1"); // dc-0 is not a target region
     store.addVersion(version4);
-    backend.handleStoreChanged(storeBackend);
-
     store.setCurrentVersion(version4.getNumber());
     store.updateVersionStatus(version4.getNumber(), VersionStatus.ONLINE);
     backend.handleStoreChanged(storeBackend);
 
+    // ONLINE status alone must not trigger subscription for a non-target region.
+    assertFalse(
+        versionMap.containsKey(version4.kafkaTopicName()),
+        "Non-target region must not subscribe via ONLINE status");
+    try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {
+      assertEquals(versionRef.get().getVersion().getNumber(), version3.getNumber());
+    }
+
+    // Once targetRegionPromoted flips to true, subscription must proceed.
+    store.setVersionTargetRegionPromoted(version4.getNumber(), true);
+    backend.handleStoreChanged(storeBackend);
+
+    assertTrue(
+        versionMap.containsKey(version4.kafkaTopicName()),
+        "Non-target region must subscribe after targetRegionPromoted=true");
     versionMap.get(version4.kafkaTopicName()).completePartition(0);
     backend.handleStoreChanged(storeBackend);
     try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci;
 import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicAssertion;
 import static org.mockito.AdditionalAnswers.answerVoid;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anySet;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -24,6 +25,7 @@ import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.ingestion.IngestionBackend;
 import com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService;
+import com.linkedin.davinci.kafka.consumer.StoreIngestionTask;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatLagMonitorAction;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
 import com.linkedin.davinci.storage.StorageService;
@@ -529,35 +531,129 @@ public class StoreBackendTest {
 
     // delayed ingestion is enabled, target region is NOT the current region (dc-0).
     // targetSwapRegion must be set on the version (not just the store) for the check to apply.
-    // Non-target DVC clients no longer subscribe via VersionStatus.ONLINE;
-    // they wait for targetRegionPromoted=true set by DeferredVersionSwapService.
+    // Non-target DVC clients subscribe immediately but in a paused state; they resume once
+    // targetRegionPromoted=true is set by DeferredVersionSwapService.
+    KafkaStoreIngestionService ingestionService = backend.getIngestionService();
+    StoreIngestionTask pausedTask = mock(StoreIngestionTask.class);
     Version version4 = new VersionImpl(store.getName(), store.peekNextVersionNumber(), null, 15);
     version4.setTargetSwapRegion("dc-1"); // dc-0 is not a target region
     store.addVersion(version4);
     store.setCurrentVersion(version4.getNumber());
     store.updateVersionStatus(version4.getNumber(), VersionStatus.ONLINE);
+    when(ingestionService.getStoreIngestionTask(version4.kafkaTopicName())).thenReturn(pausedTask);
+    when(pausedTask.isFutureSlotPaused()).thenReturn(true);
     backend.handleStoreChanged(storeBackend);
 
-    // ONLINE status alone must not trigger subscription for a non-target region.
-    assertFalse(
+    // Non-target region must subscribe immediately (createPaused=true), not skip.
+    assertTrue(
         versionMap.containsKey(version4.kafkaTopicName()),
-        "Non-target region must not subscribe via ONLINE status");
+        "Non-target region must subscribe immediately with createPaused=true");
+    verify(ingestionBackend, times(1)).startConsumption(any(), eq(0), any(), any(), eq(true));
+    // version4 is paused, so current version must still be version3.
     try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {
       assertEquals(versionRef.get().getVersion().getNumber(), version3.getNumber());
     }
 
-    // Once targetRegionPromoted flips to true, subscription must proceed.
+    // Once targetRegionPromoted flips to true, maybeResumeDaVinciFutureVersion should resume ingestion.
+    // Keep isFutureSlotPaused()=true so isPaused() returns true and resume() is actually invoked.
     store.setVersionTargetRegionPromoted(version4.getNumber(), true);
     backend.handleStoreChanged(storeBackend);
 
-    assertTrue(
-        versionMap.containsKey(version4.kafkaTopicName()),
-        "Non-target region must subscribe after targetRegionPromoted=true");
+    verify(pausedTask, times(1)).resumeFromFutureSlotPause();
     versionMap.get(version4.kafkaTopicName()).completePartition(0);
     backend.handleStoreChanged(storeBackend);
     try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {
       assertEquals(versionRef.get().getVersion().getNumber(), version4.getNumber());
     }
+  }
+
+  /**
+   * A non-target-region DVC client must subscribe to a target-region push immediately but in a
+   * paused state (createPaused=true). The version backend is present in the map, and
+   * startConsumption is called with createPaused=true.
+   */
+  @Test
+  public void testCreatesPausedSITInNonTargetRegion() throws Exception {
+    // Subscribe to version1 as current, version2 becomes future.
+    CompletableFuture subscribeResult = storeBackend.subscribe(ComplementSet.of(0));
+    versionMap.get(version1.kafkaTopicName()).completePartition(0);
+    subscribeResult.get(3, TimeUnit.SECONDS);
+    versionMap.get(version2.kafkaTopicName()).completePartition(0);
+    store.setCurrentVersion(version2.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    // Now add version3 with targetSwapRegion="dc-1"; local region is "dc-0" (non-target).
+    Version version3 = new VersionImpl(store.getName(), store.peekNextVersionNumber(), null, 15);
+    version3.setTargetSwapRegion("dc-1");
+    store.addVersion(version3);
+    store.setCurrentVersion(version3.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    // Must subscribe (paused) immediately — non-target region subscribes with createPaused=true.
+    assertTrue(versionMap.containsKey(version3.kafkaTopicName()), "Non-target region must subscribe immediately");
+    verify(ingestionBackend, times(1)).startConsumption(any(), eq(0), any(), any(), eq(true));
+  }
+
+  /**
+   * A target-region DVC client must subscribe to a target-region push immediately and active
+   * (createPaused=false).
+   */
+  @Test
+  public void testCreatesActiveSITInTargetRegion() throws Exception {
+    // Subscribe to version1 as current, version2 becomes future.
+    CompletableFuture subscribeResult = storeBackend.subscribe(ComplementSet.of(0));
+    versionMap.get(version1.kafkaTopicName()).completePartition(0);
+    subscribeResult.get(3, TimeUnit.SECONDS);
+    versionMap.get(version2.kafkaTopicName()).completePartition(0);
+    store.setCurrentVersion(version2.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    // Now add version3 with targetSwapRegion="dc-0"; local region IS "dc-0" (target region).
+    Version version3 = new VersionImpl(store.getName(), store.peekNextVersionNumber(), null, 15);
+    version3.setTargetSwapRegion("dc-0");
+    store.addVersion(version3);
+    store.setCurrentVersion(version3.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    // Must subscribe active (not paused) — this IS the target region.
+    assertTrue(versionMap.containsKey(version3.kafkaTopicName()), "Target region must subscribe");
+    verify(ingestionBackend, never()).startConsumption(any(), anyInt(), any(), any(), eq(true));
+  }
+
+  /**
+   * When targetRegionPromoted flips to true, {@link StoreBackend#maybeResumeDaVinciFutureVersion()}
+   * must call {@link StoreIngestionTask#resumeFromFutureSlotPause()} on the paused future version.
+   */
+  @Test
+  public void testResumePausedSITOnTargetPromotion() throws Exception {
+    // Subscribe to version1 as current, version2 becomes future.
+    CompletableFuture subscribeResult = storeBackend.subscribe(ComplementSet.of(0));
+    versionMap.get(version1.kafkaTopicName()).completePartition(0);
+    subscribeResult.get(3, TimeUnit.SECONDS);
+    versionMap.get(version2.kafkaTopicName()).completePartition(0);
+    store.setCurrentVersion(version2.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    // Add version3 in non-target region — subscribed paused.
+    KafkaStoreIngestionService ingestionService = backend.getIngestionService();
+    StoreIngestionTask pausedTask = mock(StoreIngestionTask.class);
+    Version version3 = new VersionImpl(store.getName(), store.peekNextVersionNumber(), null, 15);
+    version3.setTargetSwapRegion("dc-1");
+    store.addVersion(version3);
+    store.setCurrentVersion(version3.getNumber());
+    when(ingestionService.getStoreIngestionTask(version3.kafkaTopicName())).thenReturn(pausedTask);
+    when(pausedTask.isFutureSlotPaused()).thenReturn(true);
+    backend.handleStoreChanged(storeBackend);
+
+    assertTrue(versionMap.containsKey(version3.kafkaTopicName()), "Non-target region must subscribe");
+    verify(pausedTask, never()).resumeFromFutureSlotPause();
+
+    // Flip targetRegionPromoted — maybeResumeDaVinciFutureVersion should resume the task.
+    // Keep isFutureSlotPaused()=true so that isPaused() returns true and resume() is actually invoked.
+    store.setVersionTargetRegionPromoted(version3.getNumber(), true);
+    backend.handleStoreChanged(storeBackend);
+
+    verify(pausedTask, times(1)).resumeFromFutureSlotPause();
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/VersionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/VersionBackendTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -217,9 +218,9 @@ public class VersionBackendTest {
     verify(internalRecordTransformerConfig).setStartConsumptionLatchCount(3);
 
     // Verify consumption started for each partition
-    verify(mockIngestionBackend).startConsumption(any(), eq(0), any(), any());
-    verify(mockIngestionBackend).startConsumption(any(), eq(1), any(), any());
-    verify(mockIngestionBackend).startConsumption(any(), eq(2), any(), any());
+    verify(mockIngestionBackend).startConsumption(any(), eq(0), any(), any(), anyBoolean());
+    verify(mockIngestionBackend).startConsumption(any(), eq(1), any(), any(), anyBoolean());
+    verify(mockIngestionBackend).startConsumption(any(), eq(2), any(), any(), anyBoolean());
 
     // Reset mocks for next test case
     clearInvocations(internalRecordTransformerConfig);
@@ -231,16 +232,16 @@ public class VersionBackendTest {
     versionBackend.subscribe(complementSet, null, null, false);
 
     // Shouldn't try to start consumption on already subscribed partition (2)
-    verify(mockIngestionBackend, never()).startConsumption(any(), eq(2), any(), any());
+    verify(mockIngestionBackend, never()).startConsumption(any(), eq(2), any(), any(), anyBoolean());
     // Should start consumption for new partitions (3, 4)
-    verify(mockIngestionBackend).startConsumption(any(), eq(3), any(), any());
-    verify(mockIngestionBackend).startConsumption(any(), eq(4), any(), any());
+    verify(mockIngestionBackend).startConsumption(any(), eq(3), any(), any(), anyBoolean());
+    verify(mockIngestionBackend).startConsumption(any(), eq(4), any(), any(), anyBoolean());
     // Shouldn't set latch count again
     verify(internalRecordTransformerConfig, never()).setStartConsumptionLatchCount(anyInt());
 
     // Test empty subscription
     versionBackend.subscribe(ComplementSet.emptySet(), null, null, false);
-    verify(mockIngestionBackend, never()).startConsumption(any(), eq(0), any(), any());
+    verify(mockIngestionBackend, never()).startConsumption(any(), eq(0), any(), any(), anyBoolean());
     verify(internalRecordTransformerConfig, never()).setStartConsumptionLatchCount(anyInt());
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/VersionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/VersionBackendTest.java
@@ -211,7 +211,7 @@ public class VersionBackendTest {
     ComplementSet<Integer> complementSet = ComplementSet.newSet(partitionList);
 
     // First subscription
-    versionBackend.subscribe(complementSet, null, null);
+    versionBackend.subscribe(complementSet, null, null, false);
 
     // Verify the latch count is set to 3 (number of partitions)
     verify(internalRecordTransformerConfig).setStartConsumptionLatchCount(3);
@@ -228,7 +228,7 @@ public class VersionBackendTest {
     // Test with overlapping partitions
     partitionList = Arrays.asList(2, 3, 4);
     complementSet = ComplementSet.newSet(partitionList);
-    versionBackend.subscribe(complementSet, null, null);
+    versionBackend.subscribe(complementSet, null, null, false);
 
     // Shouldn't try to start consumption on already subscribed partition (2)
     verify(mockIngestionBackend, never()).startConsumption(any(), eq(2), any(), any());
@@ -239,7 +239,7 @@ public class VersionBackendTest {
     verify(internalRecordTransformerConfig, never()).setStartConsumptionLatchCount(anyInt());
 
     // Test empty subscription
-    versionBackend.subscribe(ComplementSet.emptySet(), null, null);
+    versionBackend.subscribe(ComplementSet.emptySet(), null, null, false);
     verify(mockIngestionBackend, never()).startConsumption(any(), eq(0), any(), any());
     verify(internalRecordTransformerConfig, never()).setStartConsumptionLatchCount(anyInt());
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -37,6 +37,7 @@ import com.linkedin.davinci.store.StorageEngine;
 import com.linkedin.davinci.transformer.TestStringRecordTransformer;
 import com.linkedin.venice.acl.VeniceComponent;
 import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.meta.ClusterInfoProvider;
 import com.linkedin.venice.meta.OfflinePushStrategy;
@@ -1031,5 +1032,14 @@ public abstract class KafkaStoreIngestionServiceTest {
 
     // Verify the record transformer config is removed
     assertNull(kafkaStoreIngestionService.getInternalRecordTransformerConfig(storeName));
+  }
+
+  @Test(expectedExceptions = VeniceException.class)
+  public void testCreatePausedThrowsOnNonDaVinciConfig() {
+    // The kafkaStoreIngestionService in setUp() is created with isDaVinciClient=false (line ~162).
+    // Calling startConsumption with createPaused=true must throw VeniceException.
+    VeniceProperties veniceProperties = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB);
+    kafkaStoreIngestionService
+        .startConsumption(new VeniceStoreVersionConfig("testStore_v1", veniceProperties), 0, Optional.empty(), true);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -7688,4 +7688,82 @@ public abstract class StoreIngestionTaskTest {
     negativeTs.producerMetadata = negativeMetadata;
     assertEquals(StoreIngestionTask.getHeartbeatProducerTimestamp(negativeTs), 0L);
   }
+
+  // -------------------------------------------------------------------------
+  // Future-slot pause / resume helpers
+  // -------------------------------------------------------------------------
+
+  /** Builds a mock-based SIT with the given pcsMap, versionTopic, and aggKafkaConsumerService injected via reflection. */
+  private StoreIngestionTask buildMinimalSitForFutureSlotTests(
+      VeniceConcurrentHashMap<Integer, PartitionConsumptionState> pcsMap,
+      PubSubTopic vt,
+      AggKafkaConsumerService agg) throws Exception {
+    StoreIngestionTask task = mock(StoreIngestionTask.class);
+    for (Object[] entry: new Object[][] { { "versionTopic", vt }, { "partitionConsumptionStateMap", pcsMap },
+        { "aggKafkaConsumerService", agg } }) {
+      Field f = StoreIngestionTask.class.getDeclaredField((String) entry[0]);
+      f.setAccessible(true);
+      f.set(task, entry[1]);
+    }
+    doCallRealMethod().when(task).pausePartitionForFutureSlot(anyInt());
+    doCallRealMethod().when(task).resumeFromFutureSlotPause();
+    doCallRealMethod().when(task).isFutureSlotPaused();
+    return task;
+  }
+
+  /** Returns a mock PCS whose futureSlotPaused flag is backed by an AtomicBoolean for real state tracking. */
+  private PartitionConsumptionState mockPcsWithFutureSlotFlag(boolean storeLevelPaused) {
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    AtomicBoolean futureSlotPaused = new AtomicBoolean(false);
+    doAnswer(inv -> {
+      futureSlotPaused.set(inv.getArgument(0));
+      return null;
+    }).when(pcs).setFutureSlotPaused(anyBoolean());
+    doAnswer(inv -> futureSlotPaused.get()).when(pcs).isFutureSlotPaused();
+    doReturn(storeLevelPaused).when(pcs).isStoreLevelPaused();
+    return pcs;
+  }
+
+  @Test
+  public void testFutureSlotPauseAndResume() throws Exception {
+    PubSubTopic vt = pubSubTopicRepository.getTopic(topic);
+    AggKafkaConsumerService aggConsumerService = mock(AggKafkaConsumerService.class);
+    PartitionConsumptionState pcs = mockPcsWithFutureSlotFlag(false);
+    VeniceConcurrentHashMap<Integer, PartitionConsumptionState> pcsMap = new VeniceConcurrentHashMap<>();
+    pcsMap.put(PARTITION_FOO, pcs);
+
+    StoreIngestionTask task = buildMinimalSitForFutureSlotTests(pcsMap, vt, aggConsumerService);
+
+    // Pause
+    assertFalse(pcs.isFutureSlotPaused(), "should not be paused before pausePartitionForFutureSlot");
+    task.pausePartitionForFutureSlot(PARTITION_FOO);
+    assertTrue(pcs.isFutureSlotPaused(), "PCS futureSlotPaused flag should be set after pause");
+    assertTrue(task.isFutureSlotPaused(), "isFutureSlotPaused() should return true");
+    verify(aggConsumerService).pauseConsumerFor(eq(vt), eq(new PubSubTopicPartitionImpl(vt, PARTITION_FOO)));
+
+    // Resume
+    task.resumeFromFutureSlotPause();
+    assertFalse(pcs.isFutureSlotPaused(), "PCS futureSlotPaused flag should be cleared after resume");
+    assertFalse(task.isFutureSlotPaused(), "isFutureSlotPaused() should return false after resume");
+    verify(aggConsumerService).resumeConsumerFor(eq(vt), eq(new PubSubTopicPartitionImpl(vt, PARTITION_FOO)));
+  }
+
+  @Test
+  public void testFutureSlotResumeDoesNotPhysicallyResumeWhenStoreLevelPauseActive() throws Exception {
+    PubSubTopic vt = pubSubTopicRepository.getTopic(topic);
+    AggKafkaConsumerService aggConsumerService = mock(AggKafkaConsumerService.class);
+    PartitionConsumptionState pcs = mockPcsWithFutureSlotFlag(true); // store-level pause active
+    VeniceConcurrentHashMap<Integer, PartitionConsumptionState> pcsMap = new VeniceConcurrentHashMap<>();
+    pcsMap.put(PARTITION_FOO, pcs);
+
+    StoreIngestionTask task = buildMinimalSitForFutureSlotTests(pcsMap, vt, aggConsumerService);
+
+    task.pausePartitionForFutureSlot(PARTITION_FOO);
+    assertTrue(pcs.isFutureSlotPaused(), "PCS futureSlotPaused flag should be set after pause");
+
+    task.resumeFromFutureSlotPause();
+    assertFalse(pcs.isFutureSlotPaused(), "PCS futureSlotPaused flag should be cleared even when store-level paused");
+    // Store-level pause is still active: resumeConsumerFor must NOT be called
+    verify(aggConsumerService, never()).resumeConsumerFor(any(), any());
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -7700,7 +7700,7 @@ public abstract class StoreIngestionTaskTest {
       AggKafkaConsumerService agg) throws Exception {
     StoreIngestionTask task = mock(StoreIngestionTask.class);
     for (Object[] entry: new Object[][] { { "versionTopic", vt }, { "partitionConsumptionStateMap", pcsMap },
-        { "aggKafkaConsumerService", agg } }) {
+        { "aggKafkaConsumerService", agg }, { "pubSubTopicRepository", pubSubTopicRepository } }) {
       Field f = StoreIngestionTask.class.getDeclaredField((String) entry[0]);
       f.setAccessible(true);
       f.set(task, entry[1]);
@@ -7708,6 +7708,7 @@ public abstract class StoreIngestionTaskTest {
     doCallRealMethod().when(task).pausePartitionForFutureSlot(anyInt());
     doCallRealMethod().when(task).resumeFromFutureSlotPause();
     doCallRealMethod().when(task).isFutureSlotPaused();
+    doCallRealMethod().when(task).resumeConsumption(anyString(), anyInt());
     return task;
   }
 
@@ -7779,22 +7780,12 @@ public abstract class StoreIngestionTaskTest {
 
     StoreIngestionTask task = buildMinimalSitForFutureSlotTests(pcsMap, vt, aggConsumerService);
 
-    // Wire pubSubTopicRepository so resumeConsumption can build the PubSubTopicPartition
-    Field repoField = StoreIngestionTask.class.getDeclaredField("pubSubTopicRepository");
-    repoField.setAccessible(true);
-    repoField.set(task, pubSubTopicRepository);
-
-    // Access the private resumeConsumption method via reflection
-    java.lang.reflect.Method resumeConsumptionMethod =
-        StoreIngestionTask.class.getDeclaredMethod("resumeConsumption", String.class, int.class);
-    resumeConsumptionMethod.setAccessible(true);
-
     // Apply future-slot pause
     task.pausePartitionForFutureSlot(PARTITION_FOO);
     assertTrue(pcs.isFutureSlotPaused(), "PCS futureSlotPaused flag should be set after pause");
 
     // Fire quota resumeConsumption — must NOT physically resume the partition
-    resumeConsumptionMethod.invoke(task, vt.getName(), PARTITION_FOO);
+    task.resumeConsumption(vt.getName(), PARTITION_FOO);
 
     // futureSlotPaused flag must still be set
     assertTrue(pcs.isFutureSlotPaused(), "futureSlotPaused must remain true after quota resumeConsumption");

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -7770,6 +7770,39 @@ public abstract class StoreIngestionTaskTest {
   }
 
   @Test
+  public void testQuotaResumeDoesNotOverrideFutureSlotPause() throws Exception {
+    PubSubTopic vt = pubSubTopicRepository.getTopic(topic);
+    AggKafkaConsumerService aggConsumerService = mock(AggKafkaConsumerService.class);
+    PartitionConsumptionState pcs = mockPcsWithFutureSlotFlag(false); // no store-level pause
+    VeniceConcurrentHashMap<Integer, PartitionConsumptionState> pcsMap = new VeniceConcurrentHashMap<>();
+    pcsMap.put(PARTITION_FOO, pcs);
+
+    StoreIngestionTask task = buildMinimalSitForFutureSlotTests(pcsMap, vt, aggConsumerService);
+
+    // Wire pubSubTopicRepository so resumeConsumption can build the PubSubTopicPartition
+    Field repoField = StoreIngestionTask.class.getDeclaredField("pubSubTopicRepository");
+    repoField.setAccessible(true);
+    repoField.set(task, pubSubTopicRepository);
+
+    // Access the private resumeConsumption method via reflection
+    java.lang.reflect.Method resumeConsumptionMethod =
+        StoreIngestionTask.class.getDeclaredMethod("resumeConsumption", String.class, int.class);
+    resumeConsumptionMethod.setAccessible(true);
+
+    // Apply future-slot pause
+    task.pausePartitionForFutureSlot(PARTITION_FOO);
+    assertTrue(pcs.isFutureSlotPaused(), "PCS futureSlotPaused flag should be set after pause");
+
+    // Fire quota resumeConsumption — must NOT physically resume the partition
+    resumeConsumptionMethod.invoke(task, vt.getName(), PARTITION_FOO);
+
+    // futureSlotPaused flag must still be set
+    assertTrue(pcs.isFutureSlotPaused(), "futureSlotPaused must remain true after quota resumeConsumption");
+    // Physical resume must not have been called
+    verify(aggConsumerService, never()).resumeConsumerFor(any(), any());
+  }
+
+  @Test
   public void testPauseAfterStartOfPushFieldSetAndRead() throws Exception {
     PubSubTopic vt = pubSubTopicRepository.getTopic(topic);
     AggKafkaConsumerService aggConsumerService = mock(AggKafkaConsumerService.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -7693,18 +7693,19 @@ public abstract class StoreIngestionTaskTest {
   // Future-slot pause / resume helpers
   // -------------------------------------------------------------------------
 
-  /** Builds a mock-based SIT with the given pcsMap, versionTopic, and aggKafkaConsumerService injected via reflection. */
+  /**
+   * Builds a mock-based SIT for future-slot pause/resume tests.
+   * Uses {@code doReturn()} stubs for all field accessors instead of reflection.
+   */
   private StoreIngestionTask buildMinimalSitForFutureSlotTests(
       VeniceConcurrentHashMap<Integer, PartitionConsumptionState> pcsMap,
       PubSubTopic vt,
-      AggKafkaConsumerService agg) throws Exception {
+      AggKafkaConsumerService agg) {
     StoreIngestionTask task = mock(StoreIngestionTask.class);
-    for (Object[] entry: new Object[][] { { "versionTopic", vt }, { "partitionConsumptionStateMap", pcsMap },
-        { "aggKafkaConsumerService", agg }, { "pubSubTopicRepository", pubSubTopicRepository } }) {
-      Field f = StoreIngestionTask.class.getDeclaredField((String) entry[0]);
-      f.setAccessible(true);
-      f.set(task, entry[1]);
-    }
+    doReturn(pcsMap).when(task).getPartitionConsumptionStateMap();
+    doReturn(vt).when(task).getVersionTopic();
+    doReturn(agg).when(task).getAggKafkaConsumerService();
+    doReturn(pubSubTopicRepository).when(task).getPubSubTopicRepository();
     doCallRealMethod().when(task).pausePartitionForFutureSlot(anyInt());
     doCallRealMethod().when(task).resumeFromFutureSlotPause();
     doCallRealMethod().when(task).isFutureSlotPaused();
@@ -7726,7 +7727,7 @@ public abstract class StoreIngestionTaskTest {
   }
 
   @Test
-  public void testFutureSlotPauseAndResume() throws Exception {
+  public void testFutureSlotPauseAndResume() {
     PubSubTopic vt = pubSubTopicRepository.getTopic(topic);
     AggKafkaConsumerService aggConsumerService = mock(AggKafkaConsumerService.class);
     PartitionConsumptionState pcs = mockPcsWithFutureSlotFlag(false);
@@ -7750,7 +7751,7 @@ public abstract class StoreIngestionTaskTest {
   }
 
   @Test
-  public void testFutureSlotResumeDoesNotPhysicallyResumeWhenStoreLevelPauseActive() throws Exception {
+  public void testFutureSlotResumeDoesNotPhysicallyResumeWhenStoreLevelPauseActive() {
     PubSubTopic vt = pubSubTopicRepository.getTopic(topic);
     AggKafkaConsumerService aggConsumerService = mock(AggKafkaConsumerService.class);
     PartitionConsumptionState pcs = mockPcsWithFutureSlotFlag(true); // store-level pause active
@@ -7771,7 +7772,7 @@ public abstract class StoreIngestionTaskTest {
   }
 
   @Test
-  public void testQuotaResumeDoesNotOverrideFutureSlotPause() throws Exception {
+  public void testQuotaResumeDoesNotOverrideFutureSlotPause() {
     PubSubTopic vt = pubSubTopicRepository.getTopic(topic);
     AggKafkaConsumerService aggConsumerService = mock(AggKafkaConsumerService.class);
     PartitionConsumptionState pcs = mockPcsWithFutureSlotFlag(false); // no store-level pause
@@ -7794,11 +7795,8 @@ public abstract class StoreIngestionTaskTest {
   }
 
   @Test
-  public void testPauseAfterStartOfPushFieldSetAndRead() throws Exception {
-    PubSubTopic vt = pubSubTopicRepository.getTopic(topic);
-    AggKafkaConsumerService aggConsumerService = mock(AggKafkaConsumerService.class);
-    VeniceConcurrentHashMap<Integer, PartitionConsumptionState> pcsMap = new VeniceConcurrentHashMap<>();
-    StoreIngestionTask task = buildMinimalSitForFutureSlotTests(pcsMap, vt, aggConsumerService);
+  public void testPauseAfterStartOfPushFieldSetAndRead() {
+    StoreIngestionTask task = mock(StoreIngestionTask.class);
     doCallRealMethod().when(task).isPauseAfterStartOfPush();
     doCallRealMethod().when(task).setPauseAfterStartOfPush(anyBoolean());
 
@@ -7809,7 +7807,7 @@ public abstract class StoreIngestionTaskTest {
   }
 
   @Test
-  public void testProcessStartOfPushPausesPartitionWhenFlagSet() throws Exception {
+  public void testProcessStartOfPushPausesPartitionWhenFlagSet() {
     PubSubTopic vt = pubSubTopicRepository.getTopic(topic);
     AggKafkaConsumerService aggConsumerService = mock(AggKafkaConsumerService.class);
     PartitionConsumptionState pcs = mockPcsWithFutureSlotFlag(false);
@@ -7818,9 +7816,6 @@ public abstract class StoreIngestionTaskTest {
     VeniceConcurrentHashMap<Integer, PartitionConsumptionState> pcsMap = new VeniceConcurrentHashMap<>();
     pcsMap.put(PARTITION_FOO, pcs);
 
-    StoreIngestionTask task = buildMinimalSitForFutureSlotTests(pcsMap, vt, aggConsumerService);
-
-    // Wire additional fields needed by processStartOfPush
     StorageMetadataService sms = mock(StorageMetadataService.class);
     StoreVersionState svs = new StoreVersionState();
     svs.sorted = false;
@@ -7833,14 +7828,15 @@ public abstract class StoreIngestionTaskTest {
 
     IngestionNotificationDispatcher dispatcher = mock(IngestionNotificationDispatcher.class);
 
-    for (Object[] entry: new Object[][] { { "storageMetadataService", sms }, { "serverConfig", serverCfg },
-        { "kafkaVersionTopic", topic }, { "ingestionNotificationDispatcher", dispatcher },
-        { "activeKeyCountForAllBatchPushEnabled", false }, { "activeKeyCountForHybridStoreEnabled", false } }) {
-      Field f = StoreIngestionTask.class.getDeclaredField((String) entry[0]);
-      f.setAccessible(true);
-      f.set(task, entry[1]);
-    }
-
+    StoreIngestionTask task = mock(StoreIngestionTask.class);
+    doReturn(pcsMap).when(task).getPartitionConsumptionStateMap();
+    doReturn(vt).when(task).getVersionTopic();
+    doReturn(aggConsumerService).when(task).getAggKafkaConsumerService();
+    doReturn(pubSubTopicRepository).when(task).getPubSubTopicRepository();
+    doReturn(sms).when(task).getStorageMetadataService();
+    doReturn(serverCfg).when(task).getServerConfig();
+    doReturn(topic).when(task).getKafkaVersionTopic();
+    doReturn(dispatcher).when(task).getIngestionNotificationDispatcher();
     doCallRealMethod().when(task).processStartOfPush(any(), any(), any());
     doCallRealMethod().when(task).pausePartitionForFutureSlot(anyInt());
     doCallRealMethod().when(task).isPauseAfterStartOfPush();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -7807,6 +7807,24 @@ public abstract class StoreIngestionTaskTest {
   }
 
   @Test
+  public void testBlobTransferSuppressedWhenPauseAfterStartOfPushSet() {
+    StoreIngestionTask task = mock(StoreIngestionTask.class);
+    doCallRealMethod().when(task).isPauseAfterStartOfPush();
+    doCallRealMethod().when(task).setPauseAfterStartOfPush(anyBoolean());
+    doCallRealMethod().when(task).shouldStartBlobTransfer(anyInt(), anyString(), any());
+
+    // When pauseAfterStartOfPush=false, shouldStartBlobTransfer falls through to the blobTransferHelper check;
+    // with a null helper (default mock return) it returns false but for a different reason — no assertion here.
+
+    // When pauseAfterStartOfPush=true, shouldStartBlobTransfer must short-circuit and return false
+    // regardless of blobTransferHelper state.
+    task.setPauseAfterStartOfPush(true);
+    assertFalse(
+        task.shouldStartBlobTransfer(0, "replica-1", null),
+        "shouldStartBlobTransfer must return false when pauseAfterStartOfPush=true");
+  }
+
+  @Test
   public void testProcessStartOfPushPausesPartitionWhenFlagSet() {
     PubSubTopic vt = pubSubTopicRepository.getTopic(topic);
     AggKafkaConsumerService aggConsumerService = mock(AggKafkaConsumerService.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -7762,8 +7762,25 @@ public abstract class StoreIngestionTaskTest {
     assertTrue(pcs.isFutureSlotPaused(), "PCS futureSlotPaused flag should be set after pause");
 
     task.resumeFromFutureSlotPause();
-    assertFalse(pcs.isFutureSlotPaused(), "PCS futureSlotPaused flag should be cleared even when store-level paused");
+    assertTrue(
+        pcs.isFutureSlotPaused(),
+        "PCS futureSlotPaused flag should remain true when store-level pause is still active");
     // Store-level pause is still active: resumeConsumerFor must NOT be called
     verify(aggConsumerService, never()).resumeConsumerFor(any(), any());
+  }
+
+  @Test
+  public void testPauseAfterStartOfPushFieldSetAndRead() throws Exception {
+    PubSubTopic vt = pubSubTopicRepository.getTopic(topic);
+    AggKafkaConsumerService aggConsumerService = mock(AggKafkaConsumerService.class);
+    VeniceConcurrentHashMap<Integer, PartitionConsumptionState> pcsMap = new VeniceConcurrentHashMap<>();
+    StoreIngestionTask task = buildMinimalSitForFutureSlotTests(pcsMap, vt, aggConsumerService);
+    doCallRealMethod().when(task).isPauseAfterStartOfPush();
+    doCallRealMethod().when(task).setPauseAfterStartOfPush(anyBoolean());
+
+    // Verify the field can be set and read (SOP integration tested in Task 4)
+    assertFalse(task.isPauseAfterStartOfPush(), "pauseAfterStartOfPush should default to false");
+    task.setPauseAfterStartOfPush(true);
+    assertTrue(task.isPauseAfterStartOfPush(), "pauseAfterStartOfPush should be true after setter");
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -7802,9 +7802,73 @@ public abstract class StoreIngestionTaskTest {
     doCallRealMethod().when(task).isPauseAfterStartOfPush();
     doCallRealMethod().when(task).setPauseAfterStartOfPush(anyBoolean());
 
-    // Verify the field can be set and read (SOP integration tested in Task 4)
+    // Verify the field can be set and read (SOP integration tested in testProcessStartOfPushPausesPartitionWhenFlagSet)
     assertFalse(task.isPauseAfterStartOfPush(), "pauseAfterStartOfPush should default to false");
     task.setPauseAfterStartOfPush(true);
     assertTrue(task.isPauseAfterStartOfPush(), "pauseAfterStartOfPush should be true after setter");
+  }
+
+  @Test
+  public void testProcessStartOfPushPausesPartitionWhenFlagSet() throws Exception {
+    PubSubTopic vt = pubSubTopicRepository.getTopic(topic);
+    AggKafkaConsumerService aggConsumerService = mock(AggKafkaConsumerService.class);
+    PartitionConsumptionState pcs = mockPcsWithFutureSlotFlag(false);
+    doReturn(PARTITION_FOO).when(pcs).getPartition();
+    doReturn(false).when(pcs).isEndOfPushReceived();
+    VeniceConcurrentHashMap<Integer, PartitionConsumptionState> pcsMap = new VeniceConcurrentHashMap<>();
+    pcsMap.put(PARTITION_FOO, pcs);
+
+    StoreIngestionTask task = buildMinimalSitForFutureSlotTests(pcsMap, vt, aggConsumerService);
+
+    // Wire additional fields needed by processStartOfPush
+    StorageMetadataService sms = mock(StorageMetadataService.class);
+    StoreVersionState svs = new StoreVersionState();
+    svs.sorted = false;
+    doReturn(svs).when(sms).computeStoreVersionState(anyString(), any());
+
+    VeniceServerConfig serverCfg = mock(VeniceServerConfig.class);
+    RocksDBServerConfig rocksDBCfg = mock(RocksDBServerConfig.class);
+    doReturn(false).when(rocksDBCfg).isBlobFilesEnabled();
+    doReturn(rocksDBCfg).when(serverCfg).getRocksDBServerConfig();
+
+    IngestionNotificationDispatcher dispatcher = mock(IngestionNotificationDispatcher.class);
+
+    for (Object[] entry: new Object[][] { { "storageMetadataService", sms }, { "serverConfig", serverCfg },
+        { "kafkaVersionTopic", topic }, { "ingestionNotificationDispatcher", dispatcher },
+        { "activeKeyCountForAllBatchPushEnabled", false }, { "activeKeyCountForHybridStoreEnabled", false } }) {
+      Field f = StoreIngestionTask.class.getDeclaredField((String) entry[0]);
+      f.setAccessible(true);
+      f.set(task, entry[1]);
+    }
+
+    doCallRealMethod().when(task).processStartOfPush(any(), any(), any());
+    doCallRealMethod().when(task).pausePartitionForFutureSlot(anyInt());
+    doCallRealMethod().when(task).isPauseAfterStartOfPush();
+    doCallRealMethod().when(task).setPauseAfterStartOfPush(anyBoolean());
+    doReturn(false).when(task).isHybridMode();
+    doNothing().when(task).beginBatchWrite(anyBoolean(), any());
+
+    // Build a minimal SOP KME and ControlMessage
+    KafkaMessageEnvelope kme = new KafkaMessageEnvelope();
+    kme.producerMetadata = new ProducerMetadata();
+    ControlMessage cm = new ControlMessage();
+    StartOfPush sop = new StartOfPush();
+    sop.sorted = false;
+    sop.chunked = false;
+    cm.controlMessageUnion = sop;
+
+    // Case 1: pauseAfterStartOfPush=false — partition should NOT be paused
+    task.setPauseAfterStartOfPush(false);
+    task.processStartOfPush(kme, cm, pcs);
+    verify(dispatcher).reportStarted(pcs);
+    assertFalse(pcs.isFutureSlotPaused(), "partition should NOT be paused when pauseAfterStartOfPush=false");
+    verify(aggConsumerService, never()).pauseConsumerFor(any(), any());
+
+    // Case 2: pauseAfterStartOfPush=true — partition MUST be paused after reportStarted
+    task.setPauseAfterStartOfPush(true);
+    task.processStartOfPush(kme, cm, pcs);
+    verify(dispatcher, times(2)).reportStarted(pcs); // called once more
+    assertTrue(pcs.isFutureSlotPaused(), "partition should be paused when pauseAfterStartOfPush=true");
+    verify(aggConsumerService).pauseConsumerFor(eq(vt), eq(new PubSubTopicPartitionImpl(vt, PARTITION_FOO)));
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwapWithSequentialRolloutWithDvc.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwapWithSequentialRolloutWithDvc.java
@@ -163,7 +163,9 @@ public class TestDeferredVersionSwapWithSequentialRolloutWithDvc extends Abstrac
       // Close dvc client in target region
       client1.close();
 
-      // Create dvc client in non target region
+      // Create a DVC client in the non-target region (REGION2).
+      // targetRegionSwapWaitTime=1 (minute), so DeferredVersionSwapService hasn't fired yet;
+      // use this window to capture the "before" state and verify strict ordering.
       VeniceClusterWrapper cluster2 = childDatacenters.get(1).getClusters().get(CLUSTER_NAMES[0]);
       VeniceProperties backendConfig2 = DaVinciTestContext.getDaVinciPropertyBuilder(cluster2.getZk().getAddress())
           .put(DATA_BASE_PATH, Utils.getTempDataDirectory().getAbsolutePath())
@@ -174,28 +176,10 @@ public class TestDeferredVersionSwapWithSequentialRolloutWithDvc extends Abstrac
           ServiceFactory.getGenericAvroDaVinciClient(storeName, cluster2, new DaVinciConfig(), backendConfig2);
       client2.subscribeAll().get();
 
-      // Version should be swapped in all regions
-      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
-        Map<String, Integer> coloVersions =
-            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
-
-        coloVersions.forEach((colo, version) -> {
-          Assert.assertEquals((int) version, 2);
-        });
-      });
-
-      // Check that v2 is ingested in dvc non target region
-      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        for (int i = 101; i <= keyCount2; i++) {
-          assertNotNull(client2.get(i).get());
-        }
-      });
-
-      client2.close();
-
-      // Verify targetRegionPromoted=true on parent and all child controllers.
-      // DeferredVersionSwapService sets the field once the target region's push completes
-      // and propagates it to children via the updateStore admin path.
+      // Verify targetRegionPromoted=true is set on the parent and all child controllers.
+      // DeferredVersionSwapService sets the field once the target-region push completes and
+      // propagates it to child controllers via the updateStore admin message path.
+      // Note: strict ordering (flag set → DVC starts ingesting) is verified in StoreBackendTest.
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         Optional<Version> parentVersion = parentControllerClient.getStore(storeName).getStore().getVersion(2);
         Assert.assertTrue(parentVersion.isPresent(), "Version 2 must exist on parent");
@@ -216,6 +200,24 @@ public class TestDeferredVersionSwapWithSequentialRolloutWithDvc extends Abstrac
           });
         }
       }
+
+      // Once targetRegionPromoted=true propagates to REGION2's child controller, the DVC client
+      // in REGION2 picks it up via its metadata refresh, subscribes to v2 as a future version,
+      // and serves v2 data once the sequential rollout completes and v2 becomes current.
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        for (int i = 101; i <= keyCount2; i++) {
+          assertNotNull(client2.get(i).get());
+        }
+      });
+
+      // Version should now be swapped in all regions (sequential rollout completes after target region).
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+        coloVersions.forEach((colo, version) -> Assert.assertEquals((int) version, 2));
+      });
+
+      client2.close();
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreConfigUpdater.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreConfigUpdater.java
@@ -1065,13 +1065,15 @@ public final class StoreConfigUpdater {
       setStore.storeLifecycleHooks = Collections.emptyList();
     } else {
       List<StoreLifecycleHooksRecord> convertedLifecycleHooks = new ArrayList<>();
+      VeniceProperties controllerProps =
+          admin.getVeniceHelixAdmin().getMultiClusterConfigs().getCommonConfig().getProps();
       for (LifecycleHooksRecord record: newLifecycleHooks) {
         StoreLifecycleHooks storeLifecycleHook;
         try {
           storeLifecycleHook = ReflectUtils.callConstructor(
               ReflectUtils.loadClass(record.getStoreLifecycleHooksClassName()),
               new Class<?>[] { VeniceProperties.class },
-              new Object[] { VeniceProperties.empty() });
+              new Object[] { controllerProps });
         } catch (Exception e) {
           throw new VeniceException("Failed to load class: " + record.getStoreLifecycleHooksClassName(), e);
         }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
@@ -943,4 +943,22 @@ public class StoreConfigUpdaterTest extends AbstractTestVeniceParentHelixAdmin {
 
     return admin;
   }
+
+  /**
+   * Verifies that a non-existent lifecycle hook class name causes {@code applyOnParent} to throw.
+   */
+  @Test(expectedExceptions = Exception.class)
+  public void testApplyOnParent_LifecycleHookWithMissingClass_Throws() {
+    String storeName = Utils.getUniqueString("parent-missing-hook");
+    Store store = TestUtils.createTestStore(storeName, "test-owner", System.currentTimeMillis());
+    doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
+    parentAdmin.initStorageCluster(clusterName);
+
+    LifecycleHooksRecord hook =
+        new LifecycleHooksRecordImpl("com.example.NonExistentLifecycleHook", Collections.emptyMap());
+    UpdateStoreQueryParams params =
+        new UpdateStoreQueryParams().setStoreLifecycleHooks(Collections.singletonList(hook));
+
+    parentAdmin.updateStore(clusterName, storeName, params);
+  }
 }


### PR DESCRIPTION
## Problem Statement

`StoreConfigUpdater.applyOnParent` passes `VeniceProperties.empty()` when instantiating a `StoreLifecycleHooks` subclass for pre-flight param validation. Hooks that eagerly initialize infrastructure (e.g. gRPC clients) in their constructor require real controller properties and throw when given empty props, causing all `--store-lifecycle-hooks-list` store updates to fail with a misleading "Failed to load class" error.

## Solution

Pass the actual controller config (`getCommonConfig().getProps()`) instead of `VeniceProperties.empty()`, matching the existing behavior in `VeniceHelixAdmin.getOrCreateHookInstance`.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added — `testApplyOnParent_LifecycleHookWithMissingClass_Throws` verifies that a non-existent class name still throws; existing `testApplyOnChild_StoreLifecycleHooks_InvokesAdminSetter` continues to pass.
- [x] Verified backward compatibility — hooks that work with any props are unaffected; hooks that need real props now succeed instead of failing.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.