### PR TITLE
[controller] Pass controller config to lifecycle hook constructor in StoreConfigUpdater

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwapWithSequentialRolloutWithDvc.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestDeferredVersionSwapWithSequentialRolloutWithDvc.java
@@ -52,7 +52,7 @@ public class TestDeferredVersionSwapWithSequentialRolloutWithDvc extends Abstrac
   private static final String REGION3 = "dc-2";
   private static final String[] CLUSTER_NAMES =
       IntStream.range(0, 1).mapToObj(i -> "venice-cluster" + i).toArray(String[]::new);
-  private static final int TEST_TIMEOUT = 180_000;
+  private static final int TEST_TIMEOUT = 600_000;
 
   @Override
   protected int getNumberOfRegions() {
@@ -83,7 +83,9 @@ public class TestDeferredVersionSwapWithSequentialRolloutWithDvc extends Abstrac
   public void testDvcDelayedIngestionWithTargetRegionSequentialRollout() throws Exception {
     // Setup job properties
     UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setUnusedSchemaDeletionEnabled(true);
-    storeParms.setTargetRegionSwapWaitTime(1);
+    // Use a large wait time so DeferredVersionSwapService does not fire automatically.
+    // Promotion is triggered programmatically after verifying the paused-SIT state.
+    storeParms.setTargetRegionSwapWaitTime(10);
     String parentControllerURLs = multiRegionMultiClusterWrapper.getControllerConnectString();
     String keySchemaStr = "\"int\"";
     String valueSchemaStr = "\"int\"";
@@ -163,7 +165,9 @@ public class TestDeferredVersionSwapWithSequentialRolloutWithDvc extends Abstrac
       // Close dvc client in target region
       client1.close();
 
-      // Create dvc client in non target region
+      // Create client2 in the non-target region (REGION2) while targetRegionPromoted is still false.
+      // subscribeAll() is called without .get() because the returned future includes the paused v2
+      // future-version subscription, which never completes while paused. Instead we poll for v1.
       VeniceClusterWrapper cluster2 = childDatacenters.get(1).getClusters().get(CLUSTER_NAMES[0]);
       VeniceProperties backendConfig2 = DaVinciTestContext.getDaVinciPropertyBuilder(cluster2.getZk().getAddress())
           .put(DATA_BASE_PATH, Utils.getTempDataDirectory().getAbsolutePath())
@@ -172,30 +176,32 @@ public class TestDeferredVersionSwapWithSequentialRolloutWithDvc extends Abstrac
           .build();
       DaVinciClient<Object, Object> client2 =
           ServiceFactory.getGenericAvroDaVinciClient(storeName, cluster2, new DaVinciConfig(), backendConfig2);
-      client2.subscribeAll().get();
+      client2.subscribeAll();
 
-      // Version should be swapped in all regions
-      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
-        Map<String, Integer> coloVersions =
-            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
-
-        coloVersions.forEach((colo, version) -> {
-          Assert.assertEquals((int) version, 2);
-        });
-      });
-
-      // Check that v2 is ingested in dvc non target region
+      // Paused-SIT: wait until v1 (the current version in REGION2) is bootstrapped and readable.
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-        for (int i = 101; i <= keyCount2; i++) {
-          assertNotNull(client2.get(i).get());
-        }
+        assertNotNull(client2.get(1).get(), "v1 key 1 must be readable in REGION2 before promotion");
       });
+      for (int i = 1; i <= keyCount; i++) {
+        assertNotNull(client2.get(i).get(), "v1 key " + i + " must be readable in REGION2 before promotion");
+      }
+      // Paused-SIT: v2-only data must NOT be readable yet — the v2 SIT in REGION2 consumed
+      // Start-Of-Push (registering this DVC as a push reporter) but is paused before data records.
+      for (int i = keyCount + 1; i <= keyCount2; i++) {
+        Assert.assertNull(
+            client2.get(i).get(),
+            "v2-only key " + i + " must NOT be readable before targetRegionPromoted — v2 SIT is paused");
+      }
 
-      client2.close();
+      // Programmatically trigger promotion: set targetRegionSwapWaitTime=0 so
+      // DeferredVersionSwapService fires on its next check (every 100ms).
+      ControllerResponse updateResp =
+          parentControllerClient.updateStore(storeName, new UpdateStoreQueryParams().setTargetRegionSwapWaitTime(0));
+      Assert.assertFalse(updateResp.isError(), "Failed to trigger promotion: " + updateResp.getError());
 
-      // Verify targetRegionPromoted=true on parent and all child controllers.
-      // DeferredVersionSwapService sets the field once the target region's push completes
-      // and propagates it to children via the updateStore admin path.
+      // Verify targetRegionPromoted=true is set on the parent and all child controllers.
+      // DeferredVersionSwapService sets the field once the target-region push completes
+      // and propagates it to children via the updateStore admin message path.
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
         Optional<Version> parentVersion = parentControllerClient.getStore(storeName).getStore().getVersion(2);
         Assert.assertTrue(parentVersion.isPresent(), "Version 2 must exist on parent");
@@ -216,6 +222,23 @@ public class TestDeferredVersionSwapWithSequentialRolloutWithDvc extends Abstrac
           });
         }
       }
+
+      // Once targetRegionPromoted=true propagates to REGION2's child controller, the DVC picks it
+      // up via metadata refresh, the paused v2 SIT resumes ingestion, and v2 data becomes readable.
+      TestUtils.waitForNonDeterministicAssertion(2, TimeUnit.MINUTES, () -> {
+        for (int i = 101; i <= keyCount2; i++) {
+          assertNotNull(client2.get(i).get(), "v2 key " + i + " must be readable after targetRegionPromoted");
+        }
+      });
+
+      // Version should now be swapped in all regions (sequential rollout completes after target region).
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
+        Map<String, Integer> coloVersions =
+            parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+        coloVersions.forEach((colo, version) -> Assert.assertEquals((int) version, 2));
+      });
+
+      client2.close();
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreConfigUpdater.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreConfigUpdater.java
@@ -1065,13 +1065,15 @@ public final class StoreConfigUpdater {
       setStore.storeLifecycleHooks = Collections.emptyList();
     } else {
       List<StoreLifecycleHooksRecord> convertedLifecycleHooks = new ArrayList<>();
+      VeniceProperties controllerProps =
+          admin.getVeniceHelixAdmin().getMultiClusterConfigs().getCommonConfig().getProps();
       for (LifecycleHooksRecord record: newLifecycleHooks) {
         StoreLifecycleHooks storeLifecycleHook;
         try {
           storeLifecycleHook = ReflectUtils.callConstructor(
               ReflectUtils.loadClass(record.getStoreLifecycleHooksClassName()),
               new Class<?>[] { VeniceProperties.class },
-              new Object[] { VeniceProperties.empty() });
+              new Object[] { controllerProps });
         } catch (Exception e) {
           throw new VeniceException("Failed to load class: " + record.getStoreLifecycleHooksClassName(), e);
         }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -46,9 +47,11 @@ import com.linkedin.venice.controller.kafka.protocol.admin.AdminOperation;
 import com.linkedin.venice.controller.kafka.protocol.admin.UpdateStore;
 import com.linkedin.venice.controller.storeconfig.StoreConfigUpdater;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceHttpException;
 import com.linkedin.venice.helix.StoragePersonaRepository;
 import com.linkedin.venice.helix.ZkRoutersClusterManager;
+import com.linkedin.venice.hooks.StoreLifecycleHooks;
 import com.linkedin.venice.meta.BackupStrategy;
 import com.linkedin.venice.meta.ExternalStorageReadMode;
 import com.linkedin.venice.meta.IngestionPauseMode;
@@ -62,6 +65,7 @@ import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.utils.ConfigCommonUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
@@ -945,13 +949,59 @@ public class StoreConfigUpdaterTest extends AbstractTestVeniceParentHelixAdmin {
   }
 
   /**
-   * Verifies that a non-existent lifecycle hook class name causes {@code applyOnParent} to throw.
+   * A lifecycle hook that records the {@link VeniceProperties} passed to its constructor.
+   * Used to assert that {@code applyOnParent} passes real controller props, not empty ones.
    */
-  @Test(expectedExceptions = Exception.class)
+  public static class PropsCapturingHook extends StoreLifecycleHooks {
+    static volatile VeniceProperties capturedProps;
+
+    public PropsCapturingHook(VeniceProperties props) {
+      super(props);
+      capturedProps = props;
+    }
+  }
+
+  /**
+   * Verifies that {@code applyOnParent} passes the real controller {@link VeniceProperties} to
+   * the lifecycle hook constructor, not {@code VeniceProperties.empty()}. This is the core
+   * behavioral contract introduced by this fix: hooks that require real infrastructure config
+   * in their constructor must receive it during pre-flight validation.
+   */
+  @Test
+  public void testApplyOnParent_LifecycleHookReceivesRealControllerProps() {
+    String storeName = Utils.getUniqueString("parent-props-hook");
+    Store store = TestUtils.createTestStore(storeName, "test-owner", System.currentTimeMillis());
+    doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
+    doReturn(mock(VeniceControllerMultiClusterConfig.class, RETURNS_DEEP_STUBS)).when(internalAdmin)
+        .getMultiClusterConfigs();
+    parentAdmin.initStorageCluster(clusterName);
+
+    PropsCapturingHook.capturedProps = null;
+    String hookClassName = StoreConfigUpdaterTest.class.getName() + "$PropsCapturingHook";
+    LifecycleHooksRecord hook = new LifecycleHooksRecordImpl(hookClassName, Collections.emptyMap());
+    UpdateStoreQueryParams params =
+        new UpdateStoreQueryParams().setStoreLifecycleHooks(Collections.singletonList(hook));
+
+    parentAdmin.updateStore(clusterName, storeName, params);
+
+    assertNotNull(PropsCapturingHook.capturedProps, "Hook constructor must receive non-null VeniceProperties");
+    assertNotSame(
+        VeniceProperties.empty(),
+        PropsCapturingHook.capturedProps,
+        "Hook constructor must receive real controller props, not VeniceProperties.empty()");
+  }
+
+  /**
+   * Verifies that a non-existent lifecycle hook class name causes {@code applyOnParent} to throw
+   * a {@link VeniceException} — the class-existence check is preserved.
+   */
+  @Test(expectedExceptions = VeniceException.class)
   public void testApplyOnParent_LifecycleHookWithMissingClass_Throws() {
     String storeName = Utils.getUniqueString("parent-missing-hook");
     Store store = TestUtils.createTestStore(storeName, "test-owner", System.currentTimeMillis());
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
+    doReturn(mock(VeniceControllerMultiClusterConfig.class, RETURNS_DEEP_STUBS)).when(internalAdmin)
+        .getMultiClusterConfigs();
     parentAdmin.initStorageCluster(clusterName);
 
     LifecycleHooksRecord hook =

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
@@ -943,4 +943,22 @@ public class StoreConfigUpdaterTest extends AbstractTestVeniceParentHelixAdmin {
 
     return admin;
   }
+
+  /**
+   * Verifies that a non-existent lifecycle hook class name causes {@code applyOnParent} to throw.
+   */
+  @Test(expectedExceptions = Exception.class)
+  public void testApplyOnParent_LifecycleHookWithMissingClass_Throws() {
+    String storeName = Utils.getUniqueString("parent-missing-hook");
+    Store store = TestUtils.createTestStore(storeName, "test-owner", System.currentTimeMillis());
+    doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
+    parentAdmin.initStorageCluster(clusterName);
+
+    LifecycleHooksRecord hook =
+        new LifecycleHooksRecordImpl("com.example.NonExistentLifecycleHook", Collections.emptyMap());
+    UpdateStoreQueryParams params =
+        new UpdateStoreQueryParams().setStoreLifecycleHooks(Collections.singletonList(hook));
+
+    parentAdmin.updateStore(clusterName, storeName, params);
+  }
 }


### PR DESCRIPTION
## Problem Statement

`StoreConfigUpdater.applyOnParent` passes `VeniceProperties.empty()` when instantiating a `StoreLifecycleHooks` subclass for pre-flight param validation. Hooks that eagerly initialize infrastructure (e.g. gRPC clients) in their constructor require real controller properties and throw when given empty props, causing all `--store-lifecycle-hooks-list` store updates to fail with a misleading "Failed to load class" error.

## Solution

Pass the actual controller config (`getCommonConfig().getProps()`) instead of `VeniceProperties.empty()`, matching the existing behavior in `VeniceHelixAdmin.getOrCreateHookInstance`.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added — `testApplyOnParent_LifecycleHookWithMissingClass_Throws` verifies that a non-existent class name still throws; existing `testApplyOnChild_StoreLifecycleHooks_InvokesAdminSetter` continues to pass.
- [x] Verified backward compatibility — hooks that work with any props are unaffected; hooks that need real props now succeed instead of failing.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.