### PR TITLE
[log] add more log to check transfer error

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/P2PFileTransferClientHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/P2PFileTransferClientHandler.java
@@ -104,6 +104,18 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
           throw new VeniceBlobTransferFileNotFoundException(
               "Requested files from remote peer are not found. Response: " + response.status());
         } else {
+          // Unusual / non-standard status (e.g. "999 Unknown") that the blob server never deliberately emits
+          // (it only returns 200/400/403/404/405/408/429/500). A 999 typically means the response was malformed
+          // or the connection was torn down mid-transfer by a peer that was shutting down / draining. Log rich
+          // context here because the propagated exception message keeps only the status and loses the peer host,
+          // decoder result, and headers that are needed to tell a torn response apart from a real server error.
+          LOGGER.warn(
+              "Unexpected non-OK response while fetching blob for replica: {} from peer: {}. Status: {}, decoderResult: {}, headers: {}",
+              replicaId,
+              ctx.channel().remoteAddress(),
+              response.status(),
+              response.decoderResult(),
+              response.headers());
           throw new VeniceException("Failed to fetch file from remote peer. Response: " + response.status());
         }
       }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestP2PFileTransferClientHandler.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestP2PFileTransferClientHandler.java
@@ -143,6 +143,23 @@ public class TestP2PFileTransferClientHandler {
   }
 
   @Test
+  public void testFailToGetResponseForUnusualStatus() {
+    // Non-standard status such as "999 Unknown" is never deliberately emitted by the blob server; it typically
+    // means a malformed/torn response from a peer shutting down mid-transfer. It must still surface as a
+    // VeniceException carrying the status, and exercises the diagnostic logging path added for this case.
+    DefaultHttpResponse response =
+        new DefaultHttpResponse(HttpVersion.HTTP_1_1, new HttpResponseStatus(999, "Unknown"));
+    ch.writeInbound(response);
+    try {
+      inputStreamFuture.toCompletableFuture().get(1, TimeUnit.MINUTES);
+      Assert.fail("Expected exception not thrown");
+    } catch (Exception e) {
+      Assert.assertTrue(e.getCause() instanceof VeniceException);
+      Assert.assertEquals(e.getCause().getMessage(), "Failed to fetch file from remote peer. Response: 999 Unknown");
+    }
+  }
+
+  @Test
   public void testInvalidResponseHeader() {
     DefaultHttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
     response.headers().add(BLOB_TRANSFER_TYPE, BlobTransferType.FILE);


### PR DESCRIPTION
## Problem Statement
During the blob transfer production rollout, we observed several types of transfer errors:

- No peer found – This occurs when the target peer is not present in Helix, which is expected behavior, especially for future-version peers. This is considered a normal case.
- Transfer interrupted midway due to rebalancing – During a rebalance, the sender node may transition from STANDBY to OFFLINE because the partition being transferred is being dropped from the sender. As a result, the blob transfer can be terminated before completion.
- Error code 999 – This is a new error that we have not encountered before. Based on the logs, it appears that Netty returns this error when the sender is hosted on a node that has been swapped out. However, we would like to add additional logging to validate this assumption and better understand the root cause.

<img width="1235" height="213" alt="Screenshot 2026-06-17 at 10 49 29 AM" src="https://github.com/user-attachments/assets/d8e86ced-b2c5-4cbd-8af7-40aa2cd2d1d5" />


## Solution
Add log for investigation. 


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.