### PR TITLE
[fast-client] Reconcile InstanceHealthMonitor state with the live server set

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/InstanceHealthMonitor.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/InstanceHealthMonitor.java
@@ -16,6 +16,7 @@ import com.linkedin.venice.utils.concurrent.ChainedCompletableFuture;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -49,6 +50,12 @@ public class InstanceHealthMonitor implements Closeable {
   private final Map<String, Integer> pendingRequestCounterMap = new VeniceConcurrentHashMap<>();
   private final Set<String> unhealthyInstanceSet = new ConcurrentSkipListSet<>();
   private final Set<String> suspiciousInstanceSet = new ConcurrentSkipListSet<>();
+
+  /**
+   * Instances currently serving this store, refreshed via {@link #updateLiveInstanceSet(Set)}. Empty means "not yet
+   * known", so liveness filtering fails open.
+   */
+  private volatile Set<String> liveInstanceSet = Collections.emptySet();
 
   private final TimeoutProcessor timeoutProcessor;
 
@@ -116,7 +123,8 @@ public class InstanceHealthMonitor implements Closeable {
             finalTimeoutFuture.cancel();
           }
           if (throwable != null) {
-            if (!unhealthyInstanceSet.contains(instance)) {
+            // Skip hosts removed since the last refresh, so a heartbeat in flight during a prune does not re-add them.
+            if (isInstanceLive(instance) && !unhealthyInstanceSet.contains(instance)) {
               LOGGER.warn(
                   "Heartbeat to instance: {} failed with exception: {}, will add it to unhealthy instance set",
                   instance,
@@ -171,14 +179,17 @@ public class InstanceHealthMonitor implements Closeable {
           /** Using a special http status to indicate the timed out request */
           () -> {
             transportFuture.completeExceptionally(new VeniceClientHttpException("Request timed out", SC_GONE));
-            String logMessage = String.format(
-                "Request to instance: %s timed out after %d ms, will start sending heart-beat to this instance to check whether it is healthy or not",
-                instance,
-                config.getRoutingRequestDefaultTimeoutMS());
-            if (!REDUNDANT_EXCEPTION_FILTER.isRedundantException(logMessage)) {
-              LOGGER.warn(logMessage);
+            // Only track a host still in the fleet, so a timeout to a removed host does not resurrect heartbeats.
+            if (isInstanceLive(instance)) {
+              String logMessage = String.format(
+                  "Request to instance: %s timed out after %d ms, will start sending heart-beat to this instance to check whether it is healthy or not",
+                  instance,
+                  config.getRoutingRequestDefaultTimeoutMS());
+              if (!REDUNDANT_EXCEPTION_FILTER.isRedundantException(logMessage)) {
+                LOGGER.warn(logMessage);
+              }
+              suspiciousInstanceSet.add(instance);
             }
-            suspiciousInstanceSet.add(instance);
           },
           config.getRoutingRequestDefaultTimeoutMS(),
           TimeUnit.MILLISECONDS);
@@ -265,9 +276,44 @@ public class InstanceHealthMonitor implements Closeable {
     return unhealthyInstanceSet.size();
   }
 
+  /**
+   * Reconcile all per-instance state (suspicious/unhealthy sets, pending-request counters, load controllers) with the
+   * store's current serving set on every metadata refresh, dropping hosts that left the fleet — otherwise they would
+   * be tracked and sent heart-beat indefinitely. A null or empty set means "not yet known" and is ignored, so a
+   * transient empty refresh cannot wipe accumulated state.
+   */
+  void updateLiveInstanceSet(Set<String> liveInstances) {
+    if (liveInstances == null || liveInstances.isEmpty()) {
+      return;
+    }
+    // Own a private snapshot so a caller mutating its set can't affect the hb flow
+    Set<String> liveSnapshot = Collections.unmodifiableSet(new HashSet<>(liveInstances));
+    liveInstanceSet = liveSnapshot;
+    unhealthyInstanceSet.retainAll(liveSnapshot);
+    suspiciousInstanceSet.retainAll(liveSnapshot);
+    // Drop counters for departed hosts, but keep in-flight (non-zero) ones so their completion reset stays correct.
+    for (String instance: pendingRequestCounterMap.keySet()) {
+      if (!liveSnapshot.contains(instance)) {
+        pendingRequestCounterMap.computeIfPresent(instance, (k, count) -> count == 0 ? null : count);
+      }
+    }
+    loadController.retainInstances(liveSnapshot);
+  }
+
+  /** True if the instance still serves this store, or the serving set is unknown (fail open before first refresh). */
+  private boolean isInstanceLive(String instance) {
+    Set<String> liveInstances = liveInstanceSet;
+    return liveInstances.isEmpty() || liveInstances.contains(instance);
+  }
+
   public int getPendingRequestCounter(String instance) {
     Integer pendingRequestCounter = pendingRequestCounterMap.get(instance);
     return pendingRequestCounter == null ? 0 : pendingRequestCounter;
+  }
+
+  /** Visible for testing: whether a pending-request counter entry currently exists for the instance. */
+  boolean hasPendingRequestCounter(String instance) {
+    return pendingRequestCounterMap.containsKey(instance);
   }
 
   @Override

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/InstanceHealthMonitor.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/InstanceHealthMonitor.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.fastclient.meta;
 import static org.apache.hc.core5.http.HttpStatus.SC_GONE;
 import static org.apache.hc.core5.http.HttpStatus.SC_SERVICE_UNAVAILABLE;
 
+import com.google.common.collect.ImmutableSet;
 import com.linkedin.alpini.base.concurrency.Executors;
 import com.linkedin.alpini.base.concurrency.ScheduledExecutorService;
 import com.linkedin.alpini.base.concurrency.TimeoutProcessor;
@@ -16,7 +17,6 @@ import com.linkedin.venice.utils.concurrent.ChainedCompletableFuture;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -52,10 +52,14 @@ public class InstanceHealthMonitor implements Closeable {
   private final Set<String> suspiciousInstanceSet = new ConcurrentSkipListSet<>();
 
   /**
-   * Instances currently serving this store, refreshed via {@link #updateLiveInstanceSet(Set)}. Empty means "not yet
-   * known", so liveness filtering fails open.
+   * The store's ready-to-serve instances from the metadata routing table, replaced on each metadata refresh via
+   * {@link #updateLiveInstanceSet(Set)}; empty before the first refresh (see {@link #isInstanceLive(String)}).
+   *
+   * <p>The {@link ImmutableSet} type plus a volatile reference is the whole thread-safety story (no lock needed): the
+   * value can never be mutated in place, so the metadata thread may swap the reference at any time and concurrent
+   * reads in {@link #isInstanceLive(String)} stay safe.
    */
-  private volatile Set<String> liveInstanceSet = Collections.emptySet();
+  private volatile ImmutableSet<String> liveInstanceSet = ImmutableSet.of();
 
   private final TimeoutProcessor timeoutProcessor;
 
@@ -286,8 +290,8 @@ public class InstanceHealthMonitor implements Closeable {
     if (liveInstances == null || liveInstances.isEmpty()) {
       return;
     }
-    // Own a private snapshot so a caller mutating its set can't affect the hb flow
-    Set<String> liveSnapshot = Collections.unmodifiableSet(new HashSet<>(liveInstances));
+    // Own a private immutable snapshot so a caller mutating its set can't affect the hb flow.
+    ImmutableSet<String> liveSnapshot = ImmutableSet.copyOf(liveInstances);
     liveInstanceSet = liveSnapshot;
     unhealthyInstanceSet.retainAll(liveSnapshot);
     suspiciousInstanceSet.retainAll(liveSnapshot);
@@ -300,7 +304,10 @@ public class InstanceHealthMonitor implements Closeable {
     loadController.retainInstances(liveSnapshot);
   }
 
-  /** True if the instance still serves this store, or the serving set is unknown (fail open before first refresh). */
+  /**
+   * Whether {@code instance} still serves this store. Returns {@code true} when the serving set is empty (before the
+   * first metadata refresh): a defensive check so a host is never excluded before the serving set is known;
+   */
   private boolean isInstanceLive(String instance) {
     Set<String> liveInstances = liveInstanceSet;
     return liveInstances.isEmpty() || liveInstances.contains(instance);

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/InstanceLoadController.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/InstanceLoadController.java
@@ -5,6 +5,7 @@ import com.linkedin.venice.reliability.LoadController;
 import com.linkedin.venice.utils.RedundantExceptionFilter;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Map;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -91,4 +92,8 @@ public class InstanceLoadController {
     return getLoadController(instanceId).getRejectionRatio();
   }
 
+  /** Drop {@link LoadController} state for hosts no longer serving the store, so the map does not grow unbounded. */
+  void retainInstances(Set<String> liveInstances) {
+    instanceLoadControllerMap.keySet().retainAll(liveInstances);
+  }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
@@ -529,6 +529,17 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
       versionPartitionCountMap.entrySet().removeIf(entry -> !activeVersions.contains(entry.getKey()));
       versionZstdDictionaryMap.entrySet().removeIf(entry -> !activeVersions.contains(entry.getKey()));
       versionCompressionStrategyMap.entrySet().removeIf(entry -> !activeVersions.contains(entry.getKey()));
+
+      /*
+       * Reconcile instance-health tracking with the live serving set (all active versions' replicas) so departed
+       * hosts stop being tracked. See InstanceHealthMonitor#updateLiveInstanceSet.
+       */
+      Set<String> liveInstances = new HashSet<>();
+      for (List<String> replicas: readyToServeInstancesMap.values()) {
+        liveInstances.addAll(replicas);
+      }
+      getInstanceHealthMonitor().updateLiveInstanceSet(liveInstances);
+
       if (whetherToSwitchToFetchedCurrentVersion(
           storeName,
           activeVersions,

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/InstanceHealthMonitorTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/InstanceHealthMonitorTest.java
@@ -22,6 +22,7 @@ import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.concurrent.ChainedCompletableFuture;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -188,6 +189,106 @@ public class InstanceHealthMonitorTest {
           TimeUnit.SECONDS,
           true,
           () -> assertEquals(monitor.getPendingRequestCounter(instance), 0));
+    }
+  }
+
+  /**
+   * A host left in the unhealthy set but removed from the fleet must be evicted by updateLiveInstanceSet and not
+   * re-added by the still-failing heartbeat.
+   */
+  @Test
+  public void testUpdateLiveInstanceSetEvictsHostRemovedFromFleet() throws Exception {
+    Map<String, Long> requestPathToResponseDelayMap = new VeniceConcurrentHashMap<>();
+    Map<String, CompletableFuture<RestResponse>> requestPathToResponseFutureMap = new VeniceConcurrentHashMap<>();
+    CompletableFuture<RestResponse> hbResponseFuture =
+        CompletableFuture.completedFuture(new RestResponseBuilder().setStatus(SC_OK).build());
+    String hbPath = instance + "/" + QueryAction.HEALTH.toString().toLowerCase();
+    requestPathToResponseFutureMap.put(hbPath, hbResponseFuture);
+    // a large delay forces every heartbeat to this instance to time out, so it keeps failing
+    requestPathToResponseDelayMap.put(hbPath, 10000L);
+    MockClient client = new MockClient(requestPathToResponseDelayMap, requestPathToResponseFutureMap);
+
+    InstanceHealthMonitorConfig config = InstanceHealthMonitorConfig.builder()
+        .setRoutingRequestDefaultTimeoutMS(1000L)
+        .setRoutingPendingRequestCounterInstanceBlockThreshold(10)
+        .setHeartBeatIntervalSeconds(1)
+        .setHeartBeatRequestTimeoutMS(100L)
+        .setRoutingTimedOutRequestCounterResetDelayMS(2000)
+        .setClient(client)
+        .build();
+
+    try (InstanceHealthMonitor monitor = new InstanceHealthMonitor(config)) {
+      // Drive the instance into the unhealthy set via a timed-out user request + a failing heartbeat.
+      CompletableFuture<TransportClientResponse> requestFuture = new CompletableFuture<>();
+      ChainedCompletableFuture<Integer, Integer> chainedRequestFuture =
+          monitor.trackHealthBasedOnRequestToInstance(instance, requestFuture);
+      Thread.sleep(1500); // must exceed routingRequestDefaultTimeoutMS (1000ms) to trigger unhealthy detection
+      requestFuture.complete(null);
+      chainedRequestFuture.getOriginalFuture().complete(SC_GONE);
+      TestUtils.waitForNonDeterministicAssertion(
+          5,
+          TimeUnit.SECONDS,
+          true,
+          () -> assertFalse(monitor.isInstanceHealthy(instance), "instance should be marked unhealthy"));
+      assertEquals(monitor.getUnhealthyInstanceCount(), 1);
+
+      // A refresh whose serving set still contains the host keeps it tracked (a live-but-unhealthy host).
+      monitor.updateLiveInstanceSet(Collections.singleton(instance));
+      assertFalse(monitor.isInstanceHealthy(instance));
+      assertEquals(monitor.getUnhealthyInstanceCount(), 1);
+
+      // An empty or null serving set is treated as "unknown" and must NOT wipe accumulated health state.
+      monitor.updateLiveInstanceSet(Collections.emptySet());
+      assertEquals(monitor.getUnhealthyInstanceCount(), 1);
+      monitor.updateLiveInstanceSet(null);
+      assertEquals(monitor.getUnhealthyInstanceCount(), 1);
+
+      // A refresh whose serving set no longer contains the host evicts it, and the still-failing heartbeat must not
+      // bring it back.
+      monitor.updateLiveInstanceSet(Collections.singleton("https://other.host:4321"));
+      TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, true, () -> {
+        assertTrue(
+            monitor.isInstanceHealthy(instance),
+            "host removed from the fleet should no longer be tracked as unhealthy");
+        assertEquals(monitor.getUnhealthyInstanceCount(), 0);
+      });
+    }
+  }
+
+  /**
+   * A drained (zero) pending-request counter for a departed host is evicted; a counter for a live host or one with an
+   * in-flight request is kept so accounting stays correct.
+   */
+  @Test
+  public void testUpdateLiveInstanceSetEvictsDrainedPendingRequestCounters() throws Exception {
+    InstanceHealthMonitorConfig config =
+        InstanceHealthMonitorConfig.builder().setRoutingRequestDefaultTimeoutMS(10000L).build();
+
+    try (InstanceHealthMonitor monitor = new InstanceHealthMonitor(config)) {
+      // Complete a request so the pending-request counter drains to 0 but the entry remains.
+      ChainedCompletableFuture<Integer, Integer> chainedFuture = monitor.trackHealthBasedOnRequestToInstance(instance);
+      chainedFuture.getOriginalFuture().complete(SC_OK);
+      waitQuietly(chainedFuture.getResultFuture());
+      assertEquals(monitor.getPendingRequestCounter(instance), 0);
+      assertTrue(monitor.hasPendingRequestCounter(instance));
+
+      // A refresh that still lists the host keeps its drained counter.
+      monitor.updateLiveInstanceSet(Collections.singleton(instance));
+      assertTrue(monitor.hasPendingRequestCounter(instance));
+
+      // A refresh that drops the host evicts the drained counter.
+      monitor.updateLiveInstanceSet(Collections.singleton("https://other.host:4321"));
+      assertFalse(monitor.hasPendingRequestCounter(instance));
+
+      // An in-flight request (non-zero counter) is preserved even when the host is not in the serving set, so the
+      // accounting and its completion-time reset stay correct.
+      ChainedCompletableFuture<Integer, Integer> inFlightFuture = monitor.trackHealthBasedOnRequestToInstance(instance);
+      assertEquals(monitor.getPendingRequestCounter(instance), 1);
+      monitor.updateLiveInstanceSet(Collections.singleton("https://other.host:4321"));
+      assertTrue(monitor.hasPendingRequestCounter(instance));
+      assertEquals(monitor.getPendingRequestCounter(instance), 1);
+      inFlightFuture.getOriginalFuture().complete(SC_OK);
+      waitQuietly(inFlightFuture.getResultFuture());
     }
   }
 

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/InstanceHealthMonitorTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/InstanceHealthMonitorTest.java
@@ -160,7 +160,13 @@ public class InstanceHealthMonitorTest {
       CompletableFuture<TransportClientResponse> requestFuture = new CompletableFuture<>();
       ChainedCompletableFuture<Integer, Integer> chainedRequestFuture =
           monitor.trackHealthBasedOnRequestToInstance(instance, requestFuture);
-      Thread.sleep(1500); // must exceed routingRequestDefaultTimeoutMS (1000ms) to trigger unhealthy detection
+      // Wait for the routing request to time out (it completes the request future) before completing the request,
+      // so the timeout is not cancelled and the instance is marked suspicious.
+      TestUtils.waitForNonDeterministicAssertion(
+          5,
+          TimeUnit.SECONDS,
+          true,
+          () -> assertTrue(requestFuture.isCompletedExceptionally(), "routing request should have timed out"));
       requestFuture.complete(null);
       chainedRequestFuture.getOriginalFuture().complete(SC_GONE);
       // Pending request counter will be reset with a delay
@@ -198,38 +204,14 @@ public class InstanceHealthMonitorTest {
    */
   @Test
   public void testUpdateLiveInstanceSetEvictsHostRemovedFromFleet() throws Exception {
-    Map<String, Long> requestPathToResponseDelayMap = new VeniceConcurrentHashMap<>();
-    Map<String, CompletableFuture<RestResponse>> requestPathToResponseFutureMap = new VeniceConcurrentHashMap<>();
-    CompletableFuture<RestResponse> hbResponseFuture =
-        CompletableFuture.completedFuture(new RestResponseBuilder().setStatus(SC_OK).build());
-    String hbPath = instance + "/" + QueryAction.HEALTH.toString().toLowerCase();
-    requestPathToResponseFutureMap.put(hbPath, hbResponseFuture);
-    // a large delay forces every heartbeat to this instance to time out, so it keeps failing
-    requestPathToResponseDelayMap.put(hbPath, 10000L);
-    MockClient client = new MockClient(requestPathToResponseDelayMap, requestPathToResponseFutureMap);
-
-    InstanceHealthMonitorConfig config = InstanceHealthMonitorConfig.builder()
-        .setRoutingRequestDefaultTimeoutMS(1000L)
-        .setRoutingPendingRequestCounterInstanceBlockThreshold(10)
-        .setHeartBeatIntervalSeconds(1)
-        .setHeartBeatRequestTimeoutMS(100L)
-        .setRoutingTimedOutRequestCounterResetDelayMS(2000)
-        .setClient(client)
-        .build();
-
-    try (InstanceHealthMonitor monitor = new InstanceHealthMonitor(config)) {
-      // Drive the instance into the unhealthy set via a timed-out user request + a failing heartbeat.
-      CompletableFuture<TransportClientResponse> requestFuture = new CompletableFuture<>();
-      ChainedCompletableFuture<Integer, Integer> chainedRequestFuture =
-          monitor.trackHealthBasedOnRequestToInstance(instance, requestFuture);
-      Thread.sleep(1500); // must exceed routingRequestDefaultTimeoutMS (1000ms) to trigger unhealthy detection
-      requestFuture.complete(null);
-      chainedRequestFuture.getOriginalFuture().complete(SC_GONE);
+    try (InstanceHealthMonitor monitor = new InstanceHealthMonitor(failingHeartbeatConfig())) {
+      // A request to the host hangs, so the routing timeout + failing heartbeat mark it unhealthy.
+      monitor.trackHealthBasedOnRequestToInstance(instance, new CompletableFuture<>());
       TestUtils.waitForNonDeterministicAssertion(
           5,
           TimeUnit.SECONDS,
           true,
-          () -> assertFalse(monitor.isInstanceHealthy(instance), "instance should be marked unhealthy"));
+          () -> assertFalse(monitor.isInstanceHealthy(instance), "slow host should be marked unhealthy"));
       assertEquals(monitor.getUnhealthyInstanceCount(), 1);
 
       // A refresh whose serving set still contains the host keeps it tracked (a live-but-unhealthy host).
@@ -252,6 +234,64 @@ public class InstanceHealthMonitorTest {
             "host removed from the fleet should no longer be tracked as unhealthy");
         assertEquals(monitor.getUnhealthyInstanceCount(), 0);
       });
+    }
+  }
+
+  /**
+   * Unhealthy-host lifecycle: a slow host is marked unhealthy by the monitor, evicted when it leaves the serving set,
+   * then rejoins clean.
+   */
+  @Test
+  public void testUnhealthyHostEvictedThenRejoinsClean() throws Exception {
+    try (InstanceHealthMonitor monitor = new InstanceHealthMonitor(failingHeartbeatConfig())) {
+      // Host is in the cluster; a request to it hangs, so the routing timeout + failing heartbeat mark it unhealthy.
+      monitor.updateLiveInstanceSet(Collections.singleton(instance));
+      monitor.trackHealthBasedOnRequestToInstance(instance, new CompletableFuture<>());
+      TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, true, () -> {
+        assertFalse(monitor.isInstanceHealthy(instance), "slow host should be marked unhealthy");
+        assertEquals(monitor.getUnhealthyInstanceCount(), 1);
+      });
+
+      // Host leaves the cluster: the next serving set drops it, so the monitor evicts it.
+      monitor.updateLiveInstanceSet(Collections.singleton("https://other.host:4321"));
+      TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, true, () -> {
+        assertTrue(monitor.isInstanceHealthy(instance), "departed host should no longer be tracked");
+        assertEquals(monitor.getUnhealthyInstanceCount(), 0);
+      });
+
+      // The same host returns and starts clean.
+      monitor.updateLiveInstanceSet(Collections.singleton(instance));
+      assertTrue(monitor.isInstanceHealthy(instance), "rejoined host should start clean");
+      assertEquals(monitor.getUnhealthyInstanceCount(), 0);
+    }
+  }
+
+  /**
+   * Healthy-host lifecycle: even a host that never went unhealthy has its tracking state evicted when it leaves the
+   * serving set, and rejoins clean.
+   */
+  @Test
+  public void testHealthyHostEvictedThenRejoinsClean() throws Exception {
+    InstanceHealthMonitorConfig config =
+        InstanceHealthMonitorConfig.builder().setRoutingRequestDefaultTimeoutMS(10000L).build();
+    try (InstanceHealthMonitor monitor = new InstanceHealthMonitor(config)) {
+      // Host is in the cluster and serves a successful request, so it is tracked (a drained counter) and healthy.
+      monitor.updateLiveInstanceSet(Collections.singleton(instance));
+      ChainedCompletableFuture<Integer, Integer> chainedFuture = monitor.trackHealthBasedOnRequestToInstance(instance);
+      chainedFuture.getOriginalFuture().complete(SC_OK);
+      waitQuietly(chainedFuture.getResultFuture());
+      assertTrue(monitor.isInstanceHealthy(instance));
+      assertTrue(monitor.hasPendingRequestCounter(instance));
+
+      // Host leaves the cluster: even though it is healthy, its tracking state is evicted.
+      monitor.updateLiveInstanceSet(Collections.singleton("https://other.host:4321"));
+      assertTrue(monitor.isInstanceHealthy(instance));
+      assertFalse(monitor.hasPendingRequestCounter(instance));
+
+      // The same host returns clean.
+      monitor.updateLiveInstanceSet(Collections.singleton(instance));
+      assertTrue(monitor.isInstanceHealthy(instance));
+      assertFalse(monitor.hasPendingRequestCounter(instance));
     }
   }
 
@@ -290,6 +330,24 @@ public class InstanceHealthMonitorTest {
       inFlightFuture.getOriginalFuture().complete(SC_OK);
       waitQuietly(inFlightFuture.getResultFuture());
     }
+  }
+
+  /** Config whose heartbeat to {@link #instance} always times out, so the instance stays unhealthy once tracked. */
+  private static InstanceHealthMonitorConfig failingHeartbeatConfig() {
+    Map<String, CompletableFuture<RestResponse>> futureMap = new VeniceConcurrentHashMap<>();
+    Map<String, Long> delayMap = new VeniceConcurrentHashMap<>();
+    String hbPath = instance + "/" + QueryAction.HEALTH.toString().toLowerCase();
+    futureMap.put(hbPath, CompletableFuture.completedFuture(new RestResponseBuilder().setStatus(SC_OK).build()));
+    // a large delay forces every heartbeat to this instance to time out, so it keeps failing
+    delayMap.put(hbPath, 10000L);
+    return InstanceHealthMonitorConfig.builder()
+        .setRoutingRequestDefaultTimeoutMS(1000L)
+        .setRoutingPendingRequestCounterInstanceBlockThreshold(10)
+        .setHeartBeatIntervalSeconds(1)
+        .setHeartBeatRequestTimeoutMS(100L)
+        .setRoutingTimedOutRequestCounterResetDelayMS(2000)
+        .setClient(new MockClient(delayMap, futureMap))
+        .build();
   }
 
   private void waitQuietly(CompletableFuture future) throws InterruptedException {

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/InstanceLoadControllerTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/InstanceLoadControllerTest.java
@@ -3,9 +3,11 @@ package com.linkedin.venice.fastclient.meta;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.utils.TestUtils;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.testng.annotations.Test;
 
@@ -53,5 +55,35 @@ public class InstanceLoadControllerTest {
     }
     assertEquals(requestRejectedByInstance1, true);
     assertEquals(requestRejectedByInstance2, true);
+  }
+
+  /** A host removed from the serving set has its LoadController evicted by retainInstances, so it stops being counted. */
+  @Test
+  public void testRetainInstancesEvictsRemovedHosts() {
+    InstanceHealthMonitorConfig config = mock(InstanceHealthMonitorConfig.class);
+    doReturn(true).when(config).isLoadControllerEnabled();
+    doReturn(5).when(config).getLoadControllerWindowSizeInSec();
+    doReturn(1.5d).when(config).getLoadControllerAcceptMultiplier();
+    doReturn(0.9).when(config).getLoadControllerMaxRejectionRatio();
+    doReturn(1).when(config).getLoadControllerRejectionRatioUpdateIntervalInSec();
+
+    InstanceLoadController instanceLoadController = new InstanceLoadController(config);
+    String instanceId1 = "instance1";
+    String instanceId2 = "instance2";
+    for (int i = 0; i < 10; ++i) {
+      instanceLoadController.recordResponse(instanceId1, HttpConstants.SC_SERVICE_OVERLOADED);
+      instanceLoadController.recordResponse(instanceId2, HttpConstants.SC_SERVICE_OVERLOADED);
+    }
+    TestUtils.waitForNonDeterministicAssertion(
+        10,
+        TimeUnit.SECONDS,
+        () -> assertEquals(instanceLoadController.getTotalNumberOfOverLoadedInstances(), 2));
+
+    // Dropping instance2 from the serving set evicts its LoadController, so only instance1 remains overloaded.
+    instanceLoadController.retainInstances(Collections.singleton(instanceId1));
+    assertEquals(instanceLoadController.getTotalNumberOfOverLoadedInstances(), 1);
+    // instance1 specifically is the survivor — its accumulated rejection state is retained (a wrong removeAll would
+    // have evicted instance1 and a fresh LoadController would report a 0 rejection ratio).
+    assertTrue(instanceLoadController.getRejectionRatio(instanceId1) > 0);
   }
 }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTest.java
@@ -13,7 +13,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -118,6 +120,36 @@ public class RequestBasedMetadataTest {
       e.printStackTrace();
     } finally {
       scheduler.shutdownNow();
+      if (requestBasedMetadata != null) {
+        requestBasedMetadata.close();
+      }
+    }
+  }
+
+  /**
+   * Each metadata refresh pushes the serving set (all active versions' replicas) to the monitor; after the
+   * REPLICA1_NAME to NEW_REPLICA_NAME swap, the reconciliation must be invoked with a set that no longer has
+   * REPLICA1_NAME.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testUpdateCacheReconcilesHealthMonitorWithServingSet() throws IOException, InterruptedException {
+    String storeName = "testStore";
+    ClientConfig clientConfig = RequestBasedMetadataTestUtils.getMockClientConfig(storeName, false, false);
+    InstanceHealthMonitor healthMonitor = clientConfig.getInstanceHealthMonitor();
+    RequestBasedMetadata requestBasedMetadata = null;
+    try {
+      requestBasedMetadata = getMockMetaData(clientConfig, storeName, true /* metadataChange */);
+      requestBasedMetadata.start();
+
+      // First refresh serves REPLICA1_NAME (partition 0) and REPLICA2_NAME (partition 1).
+      verify(healthMonitor, atLeastOnce())
+          .updateLiveInstanceSet(argThat(s -> s.contains(REPLICA1_NAME) && s.contains(REPLICA2_NAME)));
+
+      // After the metadata change, partition 0 is served by NEW_REPLICA_NAME instead of REPLICA1_NAME, so a later
+      // refresh must reconcile with a serving set that drops REPLICA1_NAME.
+      verify(healthMonitor, timeout(10 * Time.MS_PER_SECOND).atLeastOnce()).updateLiveInstanceSet(
+          argThat(s -> s.contains(NEW_REPLICA_NAME) && s.contains(REPLICA2_NAME) && !s.contains(REPLICA1_NAME)));
+    } finally {
       if (requestBasedMetadata != null) {
         requestBasedMetadata.close();
       }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTest.java
@@ -15,7 +15,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -141,8 +140,10 @@ public class RequestBasedMetadataTest {
       requestBasedMetadata = getMockMetaData(clientConfig, storeName, true /* metadataChange */);
       requestBasedMetadata.start();
 
-      // First refresh serves REPLICA1_NAME (partition 0) and REPLICA2_NAME (partition 1).
-      verify(healthMonitor, atLeastOnce())
+      // First refresh serves REPLICA1_NAME (partition 0) and REPLICA2_NAME (partition 1). start() runs the first
+      // refresh synchronously, so this invocation has already happened; the timeout just keeps it consistent with the
+      // async second verify below.
+      verify(healthMonitor, timeout(10 * Time.MS_PER_SECOND).atLeastOnce())
           .updateLiveInstanceSet(argThat(s -> s.contains(REPLICA1_NAME) && s.contains(REPLICA2_NAME)));
 
       // After the metadata change, partition 0 is served by NEW_REPLICA_NAME instead of REPLICA1_NAME, so a later

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTest.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
+import com.linkedin.r2.transport.common.Client;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.exceptions.VeniceClientHttpException;
 import com.linkedin.venice.client.schema.RouterBackedSchemaReader;
@@ -150,6 +151,69 @@ public class RequestBasedMetadataTest {
       // refresh must reconcile with a serving set that drops REPLICA1_NAME.
       verify(healthMonitor, timeout(10 * Time.MS_PER_SECOND).atLeastOnce()).updateLiveInstanceSet(
           argThat(s -> s.contains(NEW_REPLICA_NAME) && s.contains(REPLICA2_NAME) && !s.contains(REPLICA1_NAME)));
+    } finally {
+      if (requestBasedMetadata != null) {
+        requestBasedMetadata.close();
+      }
+    }
+  }
+
+  /**
+   * Host lifecycle exercised through the real {@link RequestBasedMetadata} refresh + reconciliation and a real
+   * {@link InstanceHealthMonitor} (transport and metadata responses are mocked): a hung request marks a host
+   * unhealthy, a refresh that drops the host evicts it, and a refresh that re-adds it leaves it clean.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testHostLifecycleThroughMetadataRefreshAndRequestPath() throws IOException, InterruptedException {
+    String storeName = "testStore";
+    // No-op refresh executor so only this test drives refreshes (via updateCache) and the metadata sequence is
+    // consumed in order.
+    ScheduledExecutorService noOpRefreshExecutor = mock(ScheduledExecutorService.class);
+    ClientConfig clientConfig =
+        RequestBasedMetadataTestUtils.getMockClientConfig(storeName, false, false, noOpRefreshExecutor);
+
+    // Real monitor whose heartbeat client never responds, so a suspicious instance becomes unhealthy on the next beat.
+    InstanceHealthMonitor realMonitor = new InstanceHealthMonitor(
+        InstanceHealthMonitorConfig.builder()
+            .setRoutingRequestDefaultTimeoutMS(1000L)
+            .setHeartBeatIntervalSeconds(1)
+            .setHeartBeatRequestTimeoutMS(100L)
+            .setRoutingTimedOutRequestCounterResetDelayMS(2000)
+            .setClient(mock(Client.class))
+            .build());
+    doReturn(realMonitor).when(clientConfig).getInstanceHealthMonitor();
+
+    RequestBasedMetadata requestBasedMetadata = null;
+    try {
+      D2TransportClient d2TransportClient = RequestBasedMetadataTestUtils.getMockD2TransportClientCycling(storeName);
+      requestBasedMetadata = new RequestBasedMetadata(clientConfig, d2TransportClient);
+      requestBasedMetadata
+          .setMetadataResponseSchemaReader(RequestBasedMetadataTestUtils.getMockRouterBackedSchemaReader());
+      requestBasedMetadata.setD2ServiceDiscovery(getMockD2ServiceDiscovery(d2TransportClient, storeName));
+
+      // State 1: REPLICA1_NAME and REPLICA2_NAME serving (the first refresh runs synchronously in start()).
+      requestBasedMetadata.start();
+
+      // A hung request to REPLICA1_NAME: the routing timeout marks it suspicious and the failing heartbeat then marks
+      // it unhealthy.
+      requestBasedMetadata
+          .trackHealthBasedOnRequestToInstance(REPLICA1_NAME, CURRENT_VERSION, 0, new CompletableFuture<>());
+      waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, true, () -> {
+        assertFalse(realMonitor.isInstanceHealthy(REPLICA1_NAME));
+        assertEquals(realMonitor.getUnhealthyInstanceCount(), 1);
+      });
+
+      // State 2: a refresh drops REPLICA1_NAME, so reconciliation evicts it and it is healthy again.
+      requestBasedMetadata.updateCache(false);
+      waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, true, () -> {
+        assertTrue(realMonitor.isInstanceHealthy(REPLICA1_NAME));
+        assertEquals(realMonitor.getUnhealthyInstanceCount(), 0);
+      });
+
+      // State 3: a refresh re-adds REPLICA1_NAME; it returns clean.
+      requestBasedMetadata.updateCache(false);
+      assertTrue(realMonitor.isInstanceHealthy(REPLICA1_NAME));
+      assertEquals(realMonitor.getUnhealthyInstanceCount(), 0);
     } finally {
       if (requestBasedMetadata != null) {
         requestBasedMetadata.close();

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTestUtils.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTestUtils.java
@@ -83,6 +83,7 @@ public class RequestBasedMetadataTestUtils {
     doReturn(clusterStats).when(clientConfig).getClusterStats();
     doReturn(ClientRoutingStrategyType.LEAST_LOADED).when(clientConfig).getClientRoutingStrategyType();
     doReturn(mock(FastClientStats.class)).when(clientConfig).getStats(RequestType.SINGLE_GET);
+    doReturn(mock(InstanceHealthMonitor.class)).when(clientConfig).getInstanceHealthMonitor();
     return clientConfig;
   }
 

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTestUtils.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTestUtils.java
@@ -201,6 +201,75 @@ public class RequestBasedMetadataTestUtils {
     return d2TransportClient;
   }
 
+  /**
+   * A {@link D2TransportClient} whose METADATA endpoint returns three responses in sequence, driving REPLICA1_NAME
+   * through present -> absent (replaced by NEW_REPLICA_NAME) -> present across three refreshes.
+   */
+  public static D2TransportClient getMockD2TransportClientCycling(String storeName) {
+    D2TransportClient d2TransportClient = mock(D2TransportClient.class);
+
+    Map<CharSequence, List<CharSequence>> withReplica1 = new HashMap<>();
+    withReplica1.put("0", Collections.singletonList(REPLICA1_NAME));
+    withReplica1.put("1", Collections.singletonList(REPLICA2_NAME));
+    Map<CharSequence, List<CharSequence>> withoutReplica1 = new HashMap<>();
+    withoutReplica1.put("0", Collections.singletonList(NEW_REPLICA_NAME));
+    withoutReplica1.put("1", Collections.singletonList(REPLICA2_NAME));
+
+    int metadataResponseSchemaId = AvroProtocolDefinition.SERVER_METADATA_RESPONSE.getCurrentProtocolVersion();
+    CompletableFuture<TransportClientResponse> state1 = CompletableFuture.completedFuture(
+        new TransportClientResponse(
+            metadataResponseSchemaId,
+            CompressionStrategy.NO_OP,
+            buildCyclingMetadataBody(withReplica1)));
+    CompletableFuture<TransportClientResponse> state2 = CompletableFuture.completedFuture(
+        new TransportClientResponse(
+            metadataResponseSchemaId + 1,
+            CompressionStrategy.NO_OP,
+            buildCyclingMetadataBody(withoutReplica1)));
+    CompletableFuture<TransportClientResponse> state3 = CompletableFuture.completedFuture(
+        new TransportClientResponse(
+            metadataResponseSchemaId,
+            CompressionStrategy.NO_OP,
+            buildCyclingMetadataBody(withReplica1)));
+
+    when(d2TransportClient.get(eq(QueryAction.METADATA.toString().toLowerCase() + "/" + storeName)))
+        .thenReturn(state1, state2, state3);
+
+    TransportClientResponse dictionaryResponse = new TransportClientResponse(0, CompressionStrategy.NO_OP, DICTIONARY);
+    doReturn(CompletableFuture.completedFuture(dictionaryResponse)).when(d2TransportClient)
+        .get(eq(QueryAction.DICTIONARY.toString().toLowerCase() + "/" + storeName + "/" + CURRENT_VERSION));
+
+    return d2TransportClient;
+  }
+
+  private static byte[] buildCyclingMetadataBody(Map<CharSequence, List<CharSequence>> routeMap) {
+    Map<String, String> partitionerParams = new HashMap<>();
+    partitionerParams.put("testKey", "testValue");
+    VersionProperties versionProperties = new VersionProperties(
+        CURRENT_VERSION,
+        CompressionStrategy.ZSTD_WITH_DICT.getValue(),
+        2,
+        "com.linkedin.venice.partitioner.DefaultVenicePartitioner",
+        Collections.unmodifiableMap(partitionerParams),
+        1);
+    Map<CharSequence, Integer> helixGroupMap = new HashMap<>();
+    helixGroupMap.put(REPLICA1_NAME, 0);
+    helixGroupMap.put(REPLICA2_NAME, 1);
+    helixGroupMap.put(NEW_REPLICA_NAME, 0);
+    MetadataResponseRecord metadataResponse = new MetadataResponseRecord(
+        versionProperties,
+        Collections.singletonList(CURRENT_VERSION),
+        Collections.singletonMap("1", KEY_SCHEMA),
+        Collections.singletonMap("1", VALUE_SCHEMA),
+        1,
+        routeMap,
+        helixGroupMap,
+        150,
+        ExternalStorageReadMode.VENICE_ONLY.getValue());
+    return SerializerDeserializerFactory.getAvroGenericSerializer(MetadataResponseRecord.SCHEMA$)
+        .serialize(metadataResponse);
+  }
+
   public static D2ServiceDiscovery getMockD2ServiceDiscovery(D2TransportClient d2TransportClient, String storeName) {
     D2ServiceDiscovery d2ServiceDiscovery = mock(D2ServiceDiscovery.class);
     D2ServiceDiscoveryResponse d2ServiceDiscoveryResponse = new D2ServiceDiscoveryResponse();


### PR DESCRIPTION
## Problem Statement

The Fast Client's `InstanceHealthMonitor` tracks per-instance state — the suspicious/unhealthy instance sets, the pending-request counters, and the per-instance `LoadController`s — but never reconciled that state against the periodically refreshed server metadata. When a server host is removed from the fleet (decommissioned, replaced), it disappears from the metadata routing table but stays in the monitor forever:

- It remains in `unhealthyInstanceSet`/`suspiciousInstanceSet`. An entry only leaves on a **successful** heartbeat, which never comes for a host that is gone, so the heartbeat task keeps pinging the dead host every cycle indefinitely — wasted requests and recurring WARN lines (e.g. `Heartbeat to instance: ... failed with exception: http status: 410, Heartbeat request timed out`).
- `pendingRequestCounterMap` and the per-instance `LoadController` map grow unbounded as hosts are replaced over the lifetime of a long-running client.
- The `unhealthy`/`blocked`/`overloaded` instance-error gauges (recorded via `ClusterStats`) stay inflated by hosts that no longer exist.

## Solution

Add `InstanceHealthMonitor.updateLiveInstanceSet(Set<String>)`, invoked from `RequestBasedMetadata.updateCache()` on every metadata refresh with the union of replicas across all active versions of the store. It:

- retains the unhealthy/suspicious sets against the live serving set;
- drops drained (zero) pending-request counters for departed hosts, while keeping in-flight (non-zero) ones so their completion-time reset stays correct (atomic via `computeIfPresent`);
- evicts per-instance `LoadController`s via `InstanceLoadController.retainInstances`.

An `isInstanceLive()` guard on the heartbeat-failure and request-timeout paths prevents an in-flight callback from re-adding a just-pruned host. The live set is stored as an immutable snapshot, published before pruning, and read once into a local in `isInstanceLive`. A null or empty serving set is treated as "not yet known" and ignored, so a transient empty refresh cannot wipe accumulated state. A host that rejoins the fleet is re-discovered via metadata and re-tracked lazily by the normal request/heartbeat paths.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**. The volatile live-set snapshot is published before pruning; the residual prune/heartbeat re-add race is bounded and self-heals on the next refresh. The counter prune is atomic per key.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed. `updateCache()` is `synchronized`; reconciliation runs within it. `isInstanceLive` reads the volatile once into a local.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation. Reconciliation is non-blocking set/map work on a per-refresh (cold) path.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`). `ConcurrentSkipListSet` for the sets, `VeniceConcurrentHashMap` for the maps; the snapshot is an immutable `unmodifiableSet`.
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination. No new exception paths; reconciliation cannot throw on the (always non-null) replica lists.

## How was this PR tested?

All `clients:venice-client` unit tests pass on JDK 17.

- [x] New unit tests added. `InstanceHealthMonitorTest` (eviction despite a still-failing heartbeat; drained-vs-in-flight counter; empty/null guard) and `InstanceLoadControllerTest` (`retainInstances` eviction).
- [ ] New integration tests added.
- [x] Modified or extended existing tests. `RequestBasedMetadataTest` (reconciliation pushed on each refresh; host-swap drops the old host) and `RequestBasedMetadataTestUtils` (mock health-monitor stub).
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.

This is a correctness/efficiency fix with observable effects, though no API, config, protocol, or wire changes:

1. The Fast Client now stops sending heartbeats to server hosts that have been removed from the fleet; previously it heart-beated them indefinitely.
2. The `unhealthy`/`blocked`/`overloaded` instance-error metrics (Tehuti and OTel, via `ClusterStats`) now reflect only hosts currently in the serving set, so they drop for departed hosts instead of staying inflated.

Which replicas receive user requests is unchanged — a departed host is already absent from the routing table, so this only affects heartbeat traffic, bounded memory, and the emitted metric values.
