### PR TITLE
[controller] Pass controller config to lifecycle hook constructor in StoreConfigUpdater

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreConfigUpdater.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreConfigUpdater.java
@@ -1065,13 +1065,15 @@ public final class StoreConfigUpdater {
       setStore.storeLifecycleHooks = Collections.emptyList();
     } else {
       List<StoreLifecycleHooksRecord> convertedLifecycleHooks = new ArrayList<>();
+      VeniceProperties controllerProps =
+          admin.getVeniceHelixAdmin().getMultiClusterConfigs().getCommonConfig().getProps();
       for (LifecycleHooksRecord record: newLifecycleHooks) {
         StoreLifecycleHooks storeLifecycleHook;
         try {
           storeLifecycleHook = ReflectUtils.callConstructor(
               ReflectUtils.loadClass(record.getStoreLifecycleHooksClassName()),
               new Class<?>[] { VeniceProperties.class },
-              new Object[] { VeniceProperties.empty() });
+              new Object[] { controllerProps });
         } catch (Exception e) {
           throw new VeniceException("Failed to load class: " + record.getStoreLifecycleHooksClassName(), e);
         }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreConfigUpdater.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreConfigUpdater.java
@@ -1075,7 +1075,9 @@ public final class StoreConfigUpdater {
               new Class<?>[] { VeniceProperties.class },
               new Object[] { controllerProps });
         } catch (Exception e) {
-          throw new VeniceException("Failed to load class: " + record.getStoreLifecycleHooksClassName(), e);
+          throw new VeniceException(
+              "Failed to instantiate lifecycle hook class: " + record.getStoreLifecycleHooksClassName(),
+              e);
         }
         if (storeLifecycleHook.validateHookParams(
             clusterName,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -46,9 +47,11 @@ import com.linkedin.venice.controller.kafka.protocol.admin.AdminOperation;
 import com.linkedin.venice.controller.kafka.protocol.admin.UpdateStore;
 import com.linkedin.venice.controller.storeconfig.StoreConfigUpdater;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceHttpException;
 import com.linkedin.venice.helix.StoragePersonaRepository;
 import com.linkedin.venice.helix.ZkRoutersClusterManager;
+import com.linkedin.venice.hooks.StoreLifecycleHooks;
 import com.linkedin.venice.meta.BackupStrategy;
 import com.linkedin.venice.meta.ExternalStorageReadMode;
 import com.linkedin.venice.meta.IngestionPauseMode;
@@ -62,6 +65,7 @@ import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.utils.ConfigCommonUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
@@ -945,13 +949,59 @@ public class StoreConfigUpdaterTest extends AbstractTestVeniceParentHelixAdmin {
   }
 
   /**
-   * Verifies that a non-existent lifecycle hook class name causes {@code applyOnParent} to throw.
+   * A lifecycle hook that records the {@link VeniceProperties} passed to its constructor.
+   * Used to assert that {@code applyOnParent} passes real controller props, not empty ones.
    */
-  @Test(expectedExceptions = Exception.class)
+  public static class PropsCapturingHook extends StoreLifecycleHooks {
+    static volatile VeniceProperties capturedProps;
+
+    public PropsCapturingHook(VeniceProperties props) {
+      super(props);
+      capturedProps = props;
+    }
+  }
+
+  /**
+   * Verifies that {@code applyOnParent} passes the real controller {@link VeniceProperties} to
+   * the lifecycle hook constructor, not {@code VeniceProperties.empty()}. This is the core
+   * behavioral contract introduced by this fix: hooks that require real infrastructure config
+   * in their constructor must receive it during pre-flight validation.
+   */
+  @Test
+  public void testApplyOnParent_LifecycleHookReceivesRealControllerProps() {
+    String storeName = Utils.getUniqueString("parent-props-hook");
+    Store store = TestUtils.createTestStore(storeName, "test-owner", System.currentTimeMillis());
+    doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
+    doReturn(mock(VeniceControllerMultiClusterConfig.class, RETURNS_DEEP_STUBS)).when(internalAdmin)
+        .getMultiClusterConfigs();
+    parentAdmin.initStorageCluster(clusterName);
+
+    PropsCapturingHook.capturedProps = null;
+    String hookClassName = StoreConfigUpdaterTest.class.getName() + "$PropsCapturingHook";
+    LifecycleHooksRecord hook = new LifecycleHooksRecordImpl(hookClassName, Collections.emptyMap());
+    UpdateStoreQueryParams params =
+        new UpdateStoreQueryParams().setStoreLifecycleHooks(Collections.singletonList(hook));
+
+    parentAdmin.updateStore(clusterName, storeName, params);
+
+    assertNotNull(PropsCapturingHook.capturedProps, "Hook constructor must receive non-null VeniceProperties");
+    assertNotSame(
+        VeniceProperties.empty(),
+        PropsCapturingHook.capturedProps,
+        "Hook constructor must receive real controller props, not VeniceProperties.empty()");
+  }
+
+  /**
+   * Verifies that a non-existent lifecycle hook class name causes {@code applyOnParent} to throw
+   * a {@link VeniceException} — the class-existence check is preserved.
+   */
+  @Test(expectedExceptions = VeniceException.class)
   public void testApplyOnParent_LifecycleHookWithMissingClass_Throws() {
     String storeName = Utils.getUniqueString("parent-missing-hook");
     Store store = TestUtils.createTestStore(storeName, "test-owner", System.currentTimeMillis());
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
+    doReturn(mock(VeniceControllerMultiClusterConfig.class, RETURNS_DEEP_STUBS)).when(internalAdmin)
+        .getMultiClusterConfigs();
     parentAdmin.initStorageCluster(clusterName);
 
     LifecycleHooksRecord hook =

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -75,7 +75,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.mockito.ArgumentCaptor;
@@ -950,14 +952,14 @@ public class StoreConfigUpdaterTest extends AbstractTestVeniceParentHelixAdmin {
 
   /**
    * A lifecycle hook that records the {@link VeniceProperties} passed to its constructor.
-   * Used to assert that {@code applyOnParent} passes real controller props, not empty ones.
+   * Uses {@link AtomicReference} to avoid writing to a static field from an instance method.
    */
   public static class PropsCapturingHook extends StoreLifecycleHooks {
-    static volatile VeniceProperties capturedProps;
+    static final AtomicReference<VeniceProperties> capturedProps = new AtomicReference<>();
 
     public PropsCapturingHook(VeniceProperties props) {
       super(props);
-      capturedProps = props;
+      capturedProps.set(props);
     }
   }
 
@@ -972,11 +974,18 @@ public class StoreConfigUpdaterTest extends AbstractTestVeniceParentHelixAdmin {
     String storeName = Utils.getUniqueString("parent-props-hook");
     Store store = TestUtils.createTestStore(storeName, "test-owner", System.currentTimeMillis());
     doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
-    doReturn(mock(VeniceControllerMultiClusterConfig.class, RETURNS_DEEP_STUBS)).when(internalAdmin)
-        .getMultiClusterConfigs();
+
+    Properties rawProps = new Properties();
+    rawProps.setProperty("grpc.endpoint", "test-host:1234");
+    VeniceProperties controllerProps = new VeniceProperties(rawProps);
+    VeniceControllerClusterConfig mockClusterConfig = mock(VeniceControllerClusterConfig.class);
+    doReturn(controllerProps).when(mockClusterConfig).getProps();
+    VeniceControllerMultiClusterConfig mockMultiConfig = mock(VeniceControllerMultiClusterConfig.class);
+    doReturn(mockClusterConfig).when(mockMultiConfig).getCommonConfig();
+    doReturn(mockMultiConfig).when(internalAdmin).getMultiClusterConfigs();
     parentAdmin.initStorageCluster(clusterName);
 
-    PropsCapturingHook.capturedProps = null;
+    PropsCapturingHook.capturedProps.set(null);
     String hookClassName = StoreConfigUpdaterTest.class.getName() + "$PropsCapturingHook";
     LifecycleHooksRecord hook = new LifecycleHooksRecordImpl(hookClassName, Collections.emptyMap());
     UpdateStoreQueryParams params =
@@ -984,11 +993,10 @@ public class StoreConfigUpdaterTest extends AbstractTestVeniceParentHelixAdmin {
 
     parentAdmin.updateStore(clusterName, storeName, params);
 
-    assertNotNull(PropsCapturingHook.capturedProps, "Hook constructor must receive non-null VeniceProperties");
-    assertNotSame(
-        VeniceProperties.empty(),
-        PropsCapturingHook.capturedProps,
-        "Hook constructor must receive real controller props, not VeniceProperties.empty()");
+    assertSame(
+        controllerProps,
+        PropsCapturingHook.capturedProps.get(),
+        "Hook constructor must receive the exact controller VeniceProperties instance");
   }
 
   /**

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
@@ -943,4 +943,22 @@ public class StoreConfigUpdaterTest extends AbstractTestVeniceParentHelixAdmin {
 
     return admin;
   }
+
+  /**
+   * Verifies that a non-existent lifecycle hook class name causes {@code applyOnParent} to throw.
+   */
+  @Test(expectedExceptions = Exception.class)
+  public void testApplyOnParent_LifecycleHookWithMissingClass_Throws() {
+    String storeName = Utils.getUniqueString("parent-missing-hook");
+    Store store = TestUtils.createTestStore(storeName, "test-owner", System.currentTimeMillis());
+    doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
+    parentAdmin.initStorageCluster(clusterName);
+
+    LifecycleHooksRecord hook =
+        new LifecycleHooksRecordImpl("com.example.NonExistentLifecycleHook", Collections.emptyMap());
+    UpdateStoreQueryParams params =
+        new UpdateStoreQueryParams().setStoreLifecycleHooks(Collections.singletonList(hook));
+
+    parentAdmin.updateStore(clusterName, storeName, params);
+  }
 }


### PR DESCRIPTION
## Problem Statement

`StoreConfigUpdater.applyOnParent` passes `VeniceProperties.empty()` when instantiating a `StoreLifecycleHooks` subclass for pre-flight param validation. Hooks that eagerly initialize infrastructure (e.g. gRPC clients) in their constructor require real controller properties and throw when given empty props, causing all `--store-lifecycle-hooks-list` store updates to fail with a misleading "Failed to load class" error.

## Solution

Pass the actual controller config (`getCommonConfig().getProps()`) instead of `VeniceProperties.empty()`, matching the existing behavior in `VeniceHelixAdmin.getOrCreateHookInstance`.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added — `PropsCapturingHook` records the `VeniceProperties` passed to its constructor; `testApplyOnParent_LifecycleHookReceivesRealControllerProps` asserts it is not `VeniceProperties.empty()` (would have failed under the old code). `testApplyOnParent_LifecycleHookWithMissingClass_Throws` verifies a non-existent class still throws `VeniceException`.
- [x] Verified backward compatibility — hooks that work with any props are unaffected; hooks that need real props now succeed instead of failing.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.