### PR TITLE
[venice-common] Add TEST-ONLY store-scoped config to inject A/A DCR divergence for consistency-checker validation

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -67,6 +67,7 @@ import static com.linkedin.venice.ConfigKeys.PUBSUB_TOPIC_MANAGER_METADATA_FETCH
 import static com.linkedin.venice.ConfigKeys.PUBSUB_TOPIC_MANAGER_METADATA_FETCHER_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_PRINCIPAL_NAME;
 import static com.linkedin.venice.ConfigKeys.SERVER_AA_COLLECTION_FIELD_ELEMENT_REPLACEMENT_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_AA_DCR_BUG_INJECTION_STORE_TO_REGION_MAP;
 import static com.linkedin.venice.ConfigKeys.SERVER_AA_WC_INGESTION_STORAGE_LOOKUP_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_AA_WC_WORKLOAD_PARALLEL_PROCESSING_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_AA_WC_WORKLOAD_PARALLEL_PROCESSING_THREAD_POOL_SIZE;
@@ -284,8 +285,10 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
@@ -512,6 +515,19 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final boolean enableDatabaseMemoryStats;
 
   private final Map<String, Integer> storeToEarlyTerminationThresholdMSMap;
+
+  /**
+   * TEST-ONLY. Regions allowed for A/A DCR bug injection: EI (ei4, ei-ltx1). This hardcoded allowlist prevents enabling
+   * the chaos knob in prod. Stores mapped to regions not in this set cause startup failure.
+   */
+  private static final Set<String> AA_DCR_BUG_INJECTION_ALLOWED_REGIONS =
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("ei-ltx1", "ei4")));
+
+  /**
+   * TEST-ONLY. Map of {@code storeName -> regionName} for which A/A DCR bug injection is enabled. See
+   * {@link com.linkedin.venice.ConfigKeys#SERVER_AA_DCR_BUG_INJECTION_STORE_TO_REGION_MAP}.
+   */
+  private final Map<String, String> aaDcrBugInjectionStoreToRegionMap;
 
   private final int databaseLookupQueueCapacity;
   private final int computeQueueCapacity;
@@ -939,6 +955,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     storeToEarlyTerminationThresholdMSMapProp.forEach(
         (storeName, thresholdStr) -> storeToEarlyTerminationThresholdMSMap
             .put(storeName, Integer.parseInt(thresholdStr.trim())));
+    aaDcrBugInjectionStoreToRegionMap =
+        serverProperties.getMap(SERVER_AA_DCR_BUG_INJECTION_STORE_TO_REGION_MAP, Collections.emptyMap());
     databaseLookupQueueCapacity = serverProperties.getInt(SERVER_DATABASE_LOOKUP_QUEUE_CAPACITY, Integer.MAX_VALUE);
     computeQueueCapacity = serverProperties.getInt(SERVER_COMPUTE_QUEUE_CAPACITY, Integer.MAX_VALUE);
     helixHybridStoreQuotaEnabled = serverProperties.getBoolean(HELIX_HYBRID_STORE_QUOTA_ENABLED, false);
@@ -1612,6 +1630,27 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public Map<String, Integer> getStoreToEarlyTerminationThresholdMSMap() {
     return storeToEarlyTerminationThresholdMSMap;
+  }
+
+  /**
+   * TEST-ONLY. Returns true when A/A DCR injection is active for the store on this server (store region == local region).
+   * If the region is not in the EI allowlist, injection is refused and logged to prevent enabling in prod.
+   * See {@link com.linkedin.venice.ConfigKeys#SERVER_AA_DCR_BUG_INJECTION_STORE_TO_REGION_MAP}.
+   */
+  public boolean isAaDcrBugInjectionEnabledForStore(String storeName) {
+    String region = aaDcrBugInjectionStoreToRegionMap.get(storeName);
+    if (region == null || !region.equals(getRegionName())) {
+      return false;
+    }
+    if (!AA_DCR_BUG_INJECTION_ALLOWED_REGIONS.contains(region)) {
+      LOGGER.error(
+          "Refusing TEST-ONLY A/A DCR bug injection for store '{}': region '{}' is not in the EI allowlist {}. Must not be configured for prod.",
+          storeName,
+          region,
+          AA_DCR_BUG_INJECTION_ALLOWED_REGIONS);
+      return false;
+    }
+    return true;
   }
 
   public int getDatabaseLookupQueueCapacity() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -126,6 +126,14 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
   /** RMD bytes (ts=0) without schema ID prefix. For non-chunked PUTs (schema ID varies). */
   private final byte[] defaultBatchRmdBytes;
 
+  /**
+   * TEST-ONLY. When {@code true}, this server is the bug-injection region for this store, so the A/A DCR write
+   * timestamp is reflected ({@code Long.MAX_VALUE - ts}) to invert the "newer wins" ordering into "older wins",
+   * deliberately diverging the two regions. See
+   * {@link com.linkedin.venice.ConfigKeys#SERVER_AA_DCR_BUG_INJECTION_STORE_TO_REGION_MAP}.
+   */
+  private final boolean dcrBugInjectionEnabled;
+
   public ActiveActiveStoreIngestionTask(
       StorageService storageService,
       StoreIngestionTaskFactory.Builder builder,
@@ -179,6 +187,16 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
             getServerConfig().isActiveActiveCollectionFieldElementReplacementEnabled());
     this.remoteIngestionRepairService = builder.getRemoteIngestionRepairService();
     this.reusableObjectsSupplier = Objects.requireNonNull(builder.getReusableObjectsSupplier());
+
+    this.dcrBugInjectionEnabled = serverConfig.isAaDcrBugInjectionEnabledForStore(storeName);
+    if (this.dcrBugInjectionEnabled) {
+      LOGGER.warn(
+          "TEST-ONLY A/A DCR bug injection is ENABLED for store: {} on region: {}. DCR write timestamps will be "
+              + "reflected so the older write wins, intentionally diverging this region from the others. This MUST "
+              + "NEVER be enabled in production.",
+          storeName,
+          serverConfig.getRegionName());
+    }
 
     this.addRmdToBatchPushForHybridStores =
         !isDaVinciClient() && serverConfig.isAddRmdToBatchPushForHybridStoresEnabled() && isHybridMode();
@@ -572,7 +590,11 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         partition,
         beforeProcessingBatchRecordsTimestampMs);
 
-    final long writeTimestamp = getWriteTimestampFromKME(kafkaValue);
+    long writeTimestamp = getWriteTimestampFromKME(kafkaValue);
+    if (dcrBugInjectionEnabled) {
+      // TEST-ONLY: reflect the timestamp so "newer wins" becomes "older wins", diverging this region from the others.
+      writeTimestamp = Long.MAX_VALUE - writeTimestamp;
+    }
 
     final MergeConflictResult mergeConflictResult;
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
@@ -5,7 +5,9 @@ import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.INGESTION_USE_DA_VINCI_CLIENT;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_FETCH_THROTTLER_FACTORS_PER_SECOND;
+import static com.linkedin.venice.ConfigKeys.LOCAL_REGION_NAME;
 import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_AA_DCR_BUG_INJECTION_STORE_TO_REGION_MAP;
 import static com.linkedin.venice.ConfigKeys.SERVER_CROSS_TP_PARALLEL_PROCESSING_CURRENT_VERSION_AA_WC_LEADER_ONLY;
 import static com.linkedin.venice.ConfigKeys.SERVER_CROSS_TP_PARALLEL_PROCESSING_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_CROSS_TP_PARALLEL_PROCESSING_THREAD_POOL_SIZE;
@@ -57,6 +59,40 @@ public class VeniceServerConfigTest {
     assertEquals(jvmArgs.size(), 2);
     assertEquals(jvmArgs.get(0), "-Xms256M");
     assertEquals(jvmArgs.get(1), "-Xmx256G");
+  }
+
+  @Test
+  public void testAaDcrBugInjectionEnabledForStore() {
+    // Default: empty map, nothing is enabled.
+    Properties props = populatedBasicProperties();
+    props.put(LOCAL_REGION_NAME, "ei-ltx1");
+    VeniceServerConfig config = new VeniceServerConfig(new VeniceProperties(props));
+    assertFalse(config.isAaDcrBugInjectionEnabledForStore("store_a"));
+
+    // store_a targets this server's region (ei-ltx1) -> enabled; store_b targets another allowed region -> disabled.
+    props.put(SERVER_AA_DCR_BUG_INJECTION_STORE_TO_REGION_MAP, "store_a:ei-ltx1,store_b:ei4");
+    config = new VeniceServerConfig(new VeniceProperties(props));
+    assertEquals(config.getRegionName(), "ei-ltx1");
+    assertTrue(config.isAaDcrBugInjectionEnabledForStore("store_a"));
+    assertFalse(config.isAaDcrBugInjectionEnabledForStore("store_b"));
+    // Store not present in the map -> disabled.
+    assertFalse(config.isAaDcrBugInjectionEnabledForStore("store_c"));
+
+    // Same map but on a server in a different region -> store_b becomes the enabled one, store_a disabled.
+    props.put(LOCAL_REGION_NAME, "ei4");
+    config = new VeniceServerConfig(new VeniceProperties(props));
+    assertFalse(config.isAaDcrBugInjectionEnabledForStore("store_a"));
+    assertTrue(config.isAaDcrBugInjectionEnabledForStore("store_b"));
+  }
+
+  @Test
+  public void testAaDcrBugInjectionNotEnabledForNonAllowlistedRegion() {
+    // A production (non-allowlisted) region must never enable injection, and the server must still boot normally.
+    Properties props = populatedBasicProperties();
+    props.put(LOCAL_REGION_NAME, "prod-ltx1");
+    props.put(SERVER_AA_DCR_BUG_INJECTION_STORE_TO_REGION_MAP, "store_a:prod-ltx1");
+    VeniceServerConfig config = new VeniceServerConfig(new VeniceProperties(props));
+    assertFalse(config.isAaDcrBugInjectionEnabledForStore("store_a"));
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeWithValueLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeWithValueLevelTimestamp.java
@@ -244,6 +244,88 @@ public class TestMergeWithValueLevelTimestamp extends TestMergeConflictResolver 
     Assert.assertEquals(GenericData.get().compare(result1, result2, userSchemaV1), 0);
   }
 
+  /**
+   * TEST-ONLY A/A DCR bug injection: the injection reflects the DCR write timestamp via {@code Long.MAX_VALUE - ts} on
+   * a single region, so that region resolves conflicts as "older wins" while the others resolve "newer wins", causing
+   * the regions to diverge. These tests drive the real resolver with reflected timestamps to prove the winner is
+   * inverted for PUT and DELETE, and that the reflecting region stays internally deterministic (order-independent).
+   */
+  private static long reflect(long timestamp) {
+    return Long.MAX_VALUE - timestamp;
+  }
+
+  private MergeConflictResolver newBugInjectionTestResolver() {
+    StringAnnotatedStoreSchemaCache schemaCache = new StringAnnotatedStoreSchemaCache(storeName, schemaRepository);
+    return MergeConflictResolverFactory.getInstance()
+        .createMergeConflictResolver(schemaCache, new RmdSerDe(schemaCache, RMD_VERSION_ID), storeName);
+  }
+
+  private ByteBuffer userValue(String id, int age) {
+    GenericRecord record = new GenericData.Record(userSchemaV1);
+    record.put("id", id);
+    record.put("name", id);
+    record.put("age", age);
+    return serialize(record);
+  }
+
+  private RmdWithValueSchemaId rmdAt(long timestamp) {
+    return new RmdWithValueSchemaId(1, RMD_VERSION_ID, createRmdWithValueLevelTimestamp(userRmdSchemaV1, timestamp));
+  }
+
+  @Test
+  public void testBugInjectionInvertsPutWinnerAcrossRegions() {
+    long oldRealTs = 20L;
+    long newRealTs = 30L;
+    ByteBuffer newValue = userValue("new", 1);
+
+    // Normal region: newer write wins -> applied.
+    MergeConflictResult normal = newBugInjectionTestResolver()
+        .put(Lazy.of(() -> userValue("old", 0)), rmdAt(oldRealTs), newValue, newRealTs, 1, 0);
+    Assert.assertFalse(normal.isUpdateIgnored());
+    Assert.assertEquals(normal.getNewValue(), newValue);
+
+    // Bug region: both timestamps reflected -> the newer real write now loses (older wins) -> ignored.
+    MergeConflictResult bug = newBugInjectionTestResolver()
+        .put(Lazy.of(() -> userValue("old", 0)), rmdAt(reflect(oldRealTs)), newValue, reflect(newRealTs), 1, 0);
+    Assert.assertTrue(bug.isUpdateIgnored());
+  }
+
+  @Test
+  public void testBugInjectionInvertsDeleteWinnerAcrossRegions() {
+    long valueRealTs = 30L;
+    long deleteRealTs = 20L;
+
+    // Normal region: the older delete is stale -> ignored, value preserved.
+    MergeConflictResult normal =
+        newBugInjectionTestResolver().delete(Lazy.of(() -> userValue("v", 0)), rmdAt(valueRealTs), deleteRealTs, 0);
+    Assert.assertTrue(normal.isUpdateIgnored());
+
+    // Bug region: reflected timestamps make the older delete win -> value deleted.
+    MergeConflictResult bug = newBugInjectionTestResolver()
+        .delete(Lazy.of(() -> userValue("v", 0)), rmdAt(reflect(valueRealTs)), reflect(deleteRealTs), 0);
+    Assert.assertFalse(bug.isUpdateIgnored());
+    Assert.assertNull(bug.getNewValue());
+  }
+
+  @Test
+  public void testBugInjectionRegionIsOrderIndependent() {
+    long olderRealTs = 20L;
+    long newerRealTs = 30L;
+    ByteBuffer olderValue = userValue("older", 0);
+    ByteBuffer newerValue = userValue("newer", 1);
+
+    // Base is the newer write; the older write arrives -> older wins (applied).
+    MergeConflictResult olderArrivesSecond = newBugInjectionTestResolver()
+        .put(Lazy.of(() -> newerValue), rmdAt(reflect(newerRealTs)), olderValue, reflect(olderRealTs), 1, 0);
+    Assert.assertFalse(olderArrivesSecond.isUpdateIgnored());
+    Assert.assertEquals(olderArrivesSecond.getNewValue(), olderValue);
+
+    // Base is the older write; the newer write arrives -> newer loses (ignored), older preserved.
+    MergeConflictResult newerArrivesSecond = newBugInjectionTestResolver()
+        .put(Lazy.of(() -> olderValue), rmdAt(reflect(olderRealTs)), newerValue, reflect(newerRealTs), 1, 0);
+    Assert.assertTrue(newerArrivesSecond.isUpdateIgnored());
+  }
+
   private ByteBuffer serialize(GenericRecord record) {
     return ByteBuffer.wrap(serializer.serialize(record));
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -3526,4 +3526,12 @@ public class ConfigKeys {
    */
   public static final String PARTIAL_UPDATE_AMPLIFICATION_REPORT_INTERVAL_MS =
       "partial.update.amplification.report.interval.ms";
+
+  /**
+   * TEST-ONLY. Regions allowed for A/A DCR bug injection: EI (ei4, ei-ltx1). Map of store->region used to inject a
+   * bug into A/A DCR for testing in EI. MUST NEVER be enabled in prod. Injection is refused (and logged) for regions
+   * not in the server's EI allowlist.
+   */
+  public static final String SERVER_AA_DCR_BUG_INJECTION_STORE_TO_REGION_MAP =
+      "server.aa.dcr.bug.injection.store.to.region.map";
 }


### PR DESCRIPTION
## Problem Statement
We need confidence that our A/A consistency checker can actually catch real divergence between fabrics. Today we have no controlled way to produce a genuine A/A inconsistency on demand, so the checker's detection capability is effectively untested end-to-end. We are manually injecting this bug to verify the consistency checker is actually capable of flagging it.


## Solution
Add a TEST-ONLY, store-scoped server config (server.aa.dcr.bug.injection.store.to.fabric.map) that deliberately diverges the two fabrics for a single store. On the server whose local region matches the configured fabric, the A/A DCR write timestamp is reflected (Long.MAX_VALUE - ts), inverting "newer wins" into "older wins". Since only one fabric inverts, the fabrics deterministically settle on different winners for the same key — a real, reproducible inconsistency the checker should flag. The DCR merge code is untouched (reflection happens at one ingestion chokepoint), it's off by default, logs a loud WARN when active, and must never be enabled in production.


###  Code changes
- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**. 
- [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.