### PR TITLE
[da-vinci][server] Right-size and de-prioritize blob transfer threads

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -318,7 +318,8 @@ public class DaVinciBackend implements Closeable {
             backendConfig.getBlobTransferClientReadLimitBytesPerSec(),
             backendConfig.getBlobTransferServiceWriteLimitBytesPerSec(),
             backendConfig.getSnapshotCleanupIntervalInMins(),
-            backendConfig.getMaxConcurrentBlobReceiveReplicas());
+            backendConfig.getMaxConcurrentBlobReceiveReplicas(),
+            backendConfig.getBlobTransferClientNettyWorkerThreadCount());
 
         blobTransferManager = new BlobTransferManagerBuilder().setBlobTransferConfig(p2PBlobTransferConfig)
             .setClientConfig(clientConfig)

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferManagerBuilder.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferManagerBuilder.java
@@ -172,6 +172,7 @@ public class BlobTransferManagerBuilder {
               blobTransferConfig.getPeersConnectivityFreshnessInSeconds(),
               blobTransferConfig.getBlobReceiveTimeoutInMin(),
               blobTransferConfig.getBlobReceiveReaderIdleTimeInSeconds(),
+              blobTransferConfig.getP2pTransferClientNettyWorkerThreadCount(),
               globalTrafficHandler,
               getAggBlobTransferStats(),
               sslFactory,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/P2PBlobTransferConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/P2PBlobTransferConfig.java
@@ -32,6 +32,8 @@ public class P2PBlobTransferConfig {
   private final int snapshotCleanupIntervalInMins;
   // Max concurrent replicas that is allowed to receive blob data simultaneously
   private final int maxConcurrentBlobReceiveReplicas;
+  // Number of Netty worker (event-loop) threads for the blob transfer client.
+  private final int p2pTransferClientNettyWorkerThreadCount;
 
   public P2PBlobTransferConfig(
       int p2pTransferServerPort,
@@ -47,7 +49,8 @@ public class P2PBlobTransferConfig {
       long blobTransferClientReadLimitBytesPerSec,
       long blobTransferServiceWriteLimitBytesPerSec,
       int snapshotCleanupIntervalInMins,
-      int maxConcurrentBlobReceiveReplicas) {
+      int maxConcurrentBlobReceiveReplicas,
+      int p2pTransferClientNettyWorkerThreadCount) {
     this.p2pTransferServerPort = p2pTransferServerPort;
     this.p2pTransferClientPort = p2pTransferClientPort;
     this.baseDir = baseDir;
@@ -62,6 +65,7 @@ public class P2PBlobTransferConfig {
     this.blobTransferServiceWriteLimitBytesPerSec = blobTransferServiceWriteLimitBytesPerSec;
     this.snapshotCleanupIntervalInMins = snapshotCleanupIntervalInMins;
     this.maxConcurrentBlobReceiveReplicas = maxConcurrentBlobReceiveReplicas;
+    this.p2pTransferClientNettyWorkerThreadCount = p2pTransferClientNettyWorkerThreadCount;
   }
 
   public int getP2pTransferServerPort() {
@@ -118,5 +122,9 @@ public class P2PBlobTransferConfig {
 
   public int getMaxConcurrentBlobReceiveReplicas() {
     return maxConcurrentBlobReceiveReplicas;
+  }
+
+  public int getP2pTransferClientNettyWorkerThreadCount() {
+    return p2pTransferClientNettyWorkerThreadCount;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/client/NettyFileTransferClient.java
@@ -33,6 +33,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.handler.traffic.GlobalChannelTrafficShapingHandler;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -60,8 +61,17 @@ public class NettyFileTransferClient {
   private static final int PER_HOST_CONNECTION_TIMEOUT_MS = 50 * 1000;
   // Maximum time that Netty will wait to establish the initial connection before failing. (TCP connection)
   private static final int CONNECTION_ESTABLISHMENT_TIMEOUT_MS = 30 * 1000;
-  // The default checksum threadpool size is the number of available processors.
-  private static final int DEFAULT_CHECKSUM_VALIDATION_THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors();
+  // Blob transfer is not latency sensitive, so the checksum validation pool is capped at 20% of available cores (min 4)
+  // rather than one thread per core.
+  private static final int DEFAULT_CHECKSUM_VALIDATION_THREAD_POOL_SIZE =
+      Math.max(4, Runtime.getRuntime().availableProcessors() / 5);
+  // Blob transfer is not latency sensitive, so all of its client thread pools (Netty event loops, checksum validation,
+  // host connect, and timeout checker) run below normal priority so they yield to the read/write hot path under CPU
+  // contention.
+  private static final int BLOB_TRANSFER_CLIENT_THREAD_PRIORITY = 4;
+  // Floor for the event-loop pool size: any configured worker thread count at or below this clamps up to it. Also the
+  // minimum used by VeniceServerConfig when computing the unset default, so the floor is defined in exactly one place.
+  public static final int MIN_NETTY_WORKER_THREADS = 4;
   EventLoopGroup workerGroup;
   Bootstrap clientBootstrap;
   private final String baseDir;
@@ -95,6 +105,7 @@ public class NettyFileTransferClient {
       int peersConnectivityFreshnessInSeconds,
       int blobReceiveTimeoutInMin,
       int blobReceiveReaderIdleTimeInSeconds,
+      int nettyWorkerThreadCount,
       GlobalChannelTrafficShapingHandler globalChannelTrafficShapingHandler,
       AggBlobTransferStats aggBlobTransferStats,
       Optional<SSLFactory> sslFactory,
@@ -110,7 +121,15 @@ public class NettyFileTransferClient {
     this.aggBlobTransferStats = aggBlobTransferStats;
 
     clientBootstrap = new Bootstrap();
-    workerGroup = new NioEventLoopGroup();
+    // Explicitly size the event-loop pool (Netty defaults to 2 * available processors, which is far more than a P2P
+    // file-transfer client needs) and run the threads below normal priority since blob transfer is not latency
+    // sensitive. VeniceServerConfig already clamps configured values up to MIN_NETTY_WORKER_THREADS (and warns); this
+    // floor is a defensive net for any other caller so a count of 0 can't make Netty fall back to its 2 * cores default
+    // and a negative count can't throw.
+    int resolvedWorkerThreadCount = Math.max(MIN_NETTY_WORKER_THREADS, nettyWorkerThreadCount);
+    workerGroup = new NioEventLoopGroup(
+        resolvedWorkerThreadCount,
+        new DefaultThreadFactory("Venice-BlobTransfer-Client-Netty", true, BLOB_TRANSFER_CLIENT_THREAD_PRIORITY));
     clientBootstrap.group(workerGroup);
     clientBootstrap.channel(NioSocketChannel.class);
     clientBootstrap.option(ChannelOption.SO_KEEPALIVE, true);
@@ -135,17 +154,26 @@ public class NettyFileTransferClient {
         }
       }
     });
-    this.hostConnectExecutorService = Executors
-        .newCachedThreadPool(new DaemonThreadFactory("Venice-BlobTransfer-Host-Connect-Executor-Service", logContext));
+    this.hostConnectExecutorService = Executors.newCachedThreadPool(
+        new DaemonThreadFactory(
+            "Venice-BlobTransfer-Host-Connect-Executor-Service",
+            BLOB_TRANSFER_CLIENT_THREAD_PRIORITY,
+            logContext));
     this.connectTimeoutScheduler = Executors.newSingleThreadScheduledExecutor(
-        new DaemonThreadFactory("Venice-BlobTransfer-Client-Timeout-Checker", logContext));
+        new DaemonThreadFactory(
+            "Venice-BlobTransfer-Client-Timeout-Checker",
+            BLOB_TRANSFER_CLIENT_THREAD_PRIORITY,
+            logContext));
     this.checksumValidationExecutorService = new ThreadPoolExecutor(
         DEFAULT_CHECKSUM_VALIDATION_THREAD_POOL_SIZE,
         DEFAULT_CHECKSUM_VALIDATION_THREAD_POOL_SIZE,
         60L,
         TimeUnit.SECONDS,
         new LinkedBlockingQueue<>(),
-        new DaemonThreadFactory("Venice-BlobTransfer-Checksum-Validation-Executor-Service", logContext));
+        new DaemonThreadFactory(
+            "Venice-BlobTransfer-Checksum-Validation-Executor-Service",
+            BLOB_TRANSFER_CLIENT_THREAD_PRIORITY,
+            logContext));
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PBlobTransferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PBlobTransferService.java
@@ -16,6 +16,7 @@ import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.traffic.GlobalChannelTrafficShapingHandler;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -23,6 +24,13 @@ import org.apache.logging.log4j.Logger;
 
 public class P2PBlobTransferService extends AbstractVeniceService {
   private static final Logger LOGGER = LogManager.getLogger(P2PBlobTransferService.class);
+  // Blob transfer is not latency sensitive, so its Netty event-loop threads run below normal priority so they yield to
+  // the read/write hot path under CPU contention.
+  private static final int BLOB_TRANSFER_SERVER_NETTY_THREAD_PRIORITY = 4;
+  // Size the worker event-loop pool at 20% of available cores (min 4) instead of a hardcoded count, since blob transfer
+  // is not latency sensitive and does not need a large dedicated I/O pool.
+  private static final int BLOB_TRANSFER_SERVER_NETTY_WORKER_THREAD_COUNT =
+      Math.max(4, Runtime.getRuntime().availableProcessors() / 5);
 
   private final ServerBootstrap serverBootstrap;
   private EventLoopGroup bossGroup;
@@ -51,13 +59,22 @@ public class P2PBlobTransferService extends AbstractVeniceService {
 
     Class<? extends ServerChannel> socketChannelClass = NioServerSocketChannel.class;
 
+    // Name the event-loop threads and run them below normal priority since blob transfer is not latency sensitive.
+    // daemon=false preserves the behavior of Netty's default thread factory for these groups.
+    DefaultThreadFactory bossThreadFactory =
+        new DefaultThreadFactory("Venice-BlobTransfer-Server-Boss", false, BLOB_TRANSFER_SERVER_NETTY_THREAD_PRIORITY);
+    DefaultThreadFactory workerThreadFactory = new DefaultThreadFactory(
+        "Venice-BlobTransfer-Server-Worker",
+        false,
+        BLOB_TRANSFER_SERVER_NETTY_THREAD_PRIORITY);
+
     if (Epoll.isAvailable()) {
-      bossGroup = new EpollEventLoopGroup(1);
-      workerGroup = new EpollEventLoopGroup(32);
+      bossGroup = new EpollEventLoopGroup(1, bossThreadFactory);
+      workerGroup = new EpollEventLoopGroup(BLOB_TRANSFER_SERVER_NETTY_WORKER_THREAD_COUNT, workerThreadFactory);
       socketChannelClass = EpollServerSocketChannel.class;
     } else {
-      bossGroup = new NioEventLoopGroup(1);
-      workerGroup = new NioEventLoopGroup(32);
+      bossGroup = new NioEventLoopGroup(1, bossThreadFactory);
+      workerGroup = new NioEventLoopGroup(BLOB_TRANSFER_SERVER_NETTY_WORKER_THREAD_COUNT, workerThreadFactory);
     }
 
     serverBootstrap.group(bossGroup, workerGroup)

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -7,6 +7,7 @@ import static com.linkedin.venice.ConfigKeys.AUTOCREATE_DATA_PATH;
 import static com.linkedin.venice.ConfigKeys.BLOB_RECEIVE_MAX_TIMEOUT_IN_MIN;
 import static com.linkedin.venice.ConfigKeys.BLOB_RECEIVE_READER_IDLE_TIME_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_ACL_ENABLED;
+import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_CLIENT_NETTY_WORKER_THREADS;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_CLIENT_READ_LIMIT_BYTES_PER_SEC;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_DISABLED_OFFSET_LAG_THRESHOLD;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_DISABLED_TIME_LAG_THRESHOLD_IN_MINUTES;
@@ -255,6 +256,7 @@ import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 import static com.linkedin.venice.utils.ByteUtils.generateHumanReadableByteCountString;
 
 import com.github.luben.zstd.Zstd;
+import com.linkedin.davinci.blobtransfer.client.NettyFileTransferClient;
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModelFactory;
 import com.linkedin.davinci.ingestion.utils.IngestionTaskReusableObjects;
 import com.linkedin.davinci.kafka.consumer.KafkaConsumerService;
@@ -667,6 +669,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final int blobReceiveMaxTimeoutInMin;
   private final int blobReceiveReaderIdleTimeInSeconds;
   private final int blobTransferPeersConnectivityFreshnessInSeconds;
+  private final int blobTransferClientNettyWorkerThreadCount;
   private final long blobTransferClientReadLimitBytesPerSec;
   private final long blobTransferServiceWriteLimitBytesPerSec;
   private final long blobTransferDisabledOffsetLagThreshold;
@@ -803,6 +806,28 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     blobReceiveReaderIdleTimeInSeconds = serverProperties.getInt(BLOB_RECEIVE_READER_IDLE_TIME_IN_SECONDS, 60);
     blobTransferPeersConnectivityFreshnessInSeconds =
         serverProperties.getInt(BLOB_TRANSFER_PEERS_CONNECTIVITY_FRESHNESS_IN_SECONDS, 30);
+    // Runtime.availableProcessors() returns the processor count available to the JVM. On Java 17, this is
+    // container/cgroup-aware by default unless overridden by JVM flags such as -XX:ActiveProcessorCount or
+    // -XX:-UseContainerSupport.
+    int availableProcessorCount = Runtime.getRuntime().availableProcessors();
+    // Blob transfer is not latency sensitive, so when unset the client event-loop pool defaults to 20% of available
+    // cores (min 4) instead of Netty's default of 2 * cores. The unset default is already >= 4, so an explicitly
+    // configured value below 4 is the only case that gets clamped; warn so the operator knows their setting was
+    // overridden (a value of 0 would otherwise make Netty fall back to its 2 * cores default, and a negative value
+    // would throw).
+    int configuredBlobTransferClientNettyWorkerThreadCount = serverProperties.getInt(
+        BLOB_TRANSFER_CLIENT_NETTY_WORKER_THREADS,
+        Math.max(NettyFileTransferClient.MIN_NETTY_WORKER_THREADS, availableProcessorCount / 5));
+    if (configuredBlobTransferClientNettyWorkerThreadCount < NettyFileTransferClient.MIN_NETTY_WORKER_THREADS) {
+      LOGGER.warn(
+          "Configured {}={} is below the minimum of {}; using {} instead.",
+          BLOB_TRANSFER_CLIENT_NETTY_WORKER_THREADS,
+          configuredBlobTransferClientNettyWorkerThreadCount,
+          NettyFileTransferClient.MIN_NETTY_WORKER_THREADS,
+          NettyFileTransferClient.MIN_NETTY_WORKER_THREADS);
+      configuredBlobTransferClientNettyWorkerThreadCount = NettyFileTransferClient.MIN_NETTY_WORKER_THREADS;
+    }
+    blobTransferClientNettyWorkerThreadCount = configuredBlobTransferClientNettyWorkerThreadCount;
     blobTransferClientReadLimitBytesPerSec =
         serverProperties.getSizeInBytes(BLOB_TRANSFER_CLIENT_READ_LIMIT_BYTES_PER_SEC, 157286400L); // default 150 MB/s
     blobTransferServiceWriteLimitBytesPerSec =
@@ -864,8 +889,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     nettyGracefulShutdownPeriodSeconds = serverProperties.getInt(SERVER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS, 30);
     nettyWorkerThreadCount = serverProperties.getInt(SERVER_NETTY_WORKER_THREADS, 0);
     helixJoinAsUnknown = serverProperties.getBoolean(SERVER_HELIX_JOIN_AS_UNKNOWN, false);
-    grpcWorkerThreadCount =
-        serverProperties.getInt(GRPC_SERVER_WORKER_THREAD_COUNT, Runtime.getRuntime().availableProcessors());
+    grpcWorkerThreadCount = serverProperties.getInt(GRPC_SERVER_WORKER_THREAD_COUNT, availableProcessorCount);
 
     remoteIngestionRepairSleepInterval = serverProperties.getInt(
         SERVER_REMOTE_INGESTION_REPAIR_SLEEP_INTERVAL_SECONDS,
@@ -1251,8 +1275,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getInt(SERVER_LOAD_CONTROLLER_COMPUTE_LATENCY_ACCEPT_THRESHOLD_IN_MS, 100);
     consumerPollTrackerStaleThresholdInSeconds = serverProperties
         .getLong(SERVER_CONSUMER_POLL_TRACKER_STALE_THRESHOLD_IN_SECONDS, TimeUnit.MINUTES.toSeconds(15));
-    daVinciRecordTransformerOnRecoveryThreadPoolSize = serverProperties
-        .getInt(DAVINCI_RECORD_TRANSFORMER_ON_RECOVERY_THREAD_POOL_SIZE, Runtime.getRuntime().availableProcessors());
+    daVinciRecordTransformerOnRecoveryThreadPoolSize =
+        serverProperties.getInt(DAVINCI_RECORD_TRANSFORMER_ON_RECOVERY_THREAD_POOL_SIZE, availableProcessorCount);
     storeChangeNotifierThreadPoolSize = serverProperties.getInt(STORE_CHANGE_NOTIFIER_THREAD_POOL_SIZE, 1);
     this.ingestionTaskReusableObjectsStrategy = IngestionTaskReusableObjects.Strategy.valueOf(
         serverProperties.getString(
@@ -1383,6 +1407,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getBlobTransferPeersConnectivityFreshnessInSeconds() {
     return blobTransferPeersConnectivityFreshnessInSeconds;
+  }
+
+  public int getBlobTransferClientNettyWorkerThreadCount() {
+    return blobTransferClientNettyWorkerThreadCount;
   }
 
   public long getBlobTransferClientReadLimitBytesPerSec() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestBlobTransferManagerBuilder.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestBlobTransferManagerBuilder.java
@@ -50,7 +50,8 @@ public class TestBlobTransferManagerBuilder {
         2000000,
         2000000,
         2,
-        5);
+        5,
+        Math.max(4, Runtime.getRuntime().availableProcessors() / 5));
 
     BlobTransferManager blobTransferManager = new BlobTransferManagerBuilder().setBlobTransferConfig(blobTransferConfig)
         .setClientConfig(clientConfig)
@@ -93,7 +94,8 @@ public class TestBlobTransferManagerBuilder {
         2000000,
         2000000,
         2,
-        5);
+        5,
+        Math.max(4, Runtime.getRuntime().availableProcessors() / 5));
 
     // Case 1: expect exception is thrown due to both clientConfig and customizedViewFuture are not null
     try {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
@@ -149,6 +149,7 @@ public class TestNettyP2PBlobTransferManager {
             30,
             60,
             blobTransferMaxTimeoutInMin,
+            Math.max(4, Runtime.getRuntime().availableProcessors() / 5),
             globalChannelTrafficShapingHandler,
             blobTransferStats,
             sslFactory,
@@ -520,6 +521,7 @@ public class TestNettyP2PBlobTransferManager {
             30,
             0, // general transfer timeout immediately
             10,
+            Math.max(4, Runtime.getRuntime().availableProcessors() / 5),
             newGlobalChannelTrafficShapingHandler,
             blobTransferStats,
             sslFactory,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/client/TestNettyFileTransferClient.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/client/TestNettyFileTransferClient.java
@@ -1,0 +1,98 @@
+package com.linkedin.davinci.blobtransfer.client;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.davinci.stats.AggBlobTransferStats;
+import com.linkedin.davinci.storage.StorageMetadataService;
+import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.utils.LogContext;
+import com.linkedin.venice.utils.Utils;
+import io.netty.util.concurrent.EventExecutor;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.StreamSupport;
+import org.testng.annotations.Test;
+
+
+/**
+ * Targeted tests for the Netty event-loop pool sizing and thread priority configured in
+ * {@link NettyFileTransferClient}. Lives in the same package as the client so it can read the
+ * package-private {@code workerGroup}.
+ */
+public class TestNettyFileTransferClient {
+  // Reuse the production floor so this test tracks it instead of hard-coding a second copy.
+  private static final int MIN_NETTY_WORKER_THREADS = NettyFileTransferClient.MIN_NETTY_WORKER_THREADS;
+  // Mirrors NettyFileTransferClient#BLOB_TRANSFER_CLIENT_THREAD_PRIORITY.
+  private static final int EXPECTED_THREAD_PRIORITY = 4;
+
+  private NettyFileTransferClient createClient(int nettyWorkerThreadCount) throws Exception {
+    return new NettyFileTransferClient(
+        0, // serverPort
+        Utils.getTempDataDirectory().getAbsolutePath(), // baseDir (auto-registered for deletion on JVM exit)
+        mock(StorageMetadataService.class),
+        30, // peersConnectivityFreshnessInSeconds
+        30, // blobReceiveTimeoutInMin
+        60, // blobReceiveReaderIdleTimeInSeconds
+        nettyWorkerThreadCount,
+        null, // globalChannelTrafficShapingHandler: only referenced when a channel is initialized, never in this test
+        mock(AggBlobTransferStats.class),
+        Optional.<SSLFactory>empty(),
+        () -> null, // notifierSupplier
+        LogContext.forTests("test"));
+  }
+
+  private static int countWorkerThreads(NettyFileTransferClient client) {
+    return (int) StreamSupport.stream(client.workerGroup.spliterator(), false).count();
+  }
+
+  @Test
+  public void testWorkerThreadCountAboveFloorIsHonored() throws Exception {
+    int requested = MIN_NETTY_WORKER_THREADS + 6;
+    NettyFileTransferClient client = createClient(requested);
+    try {
+      assertEquals(countWorkerThreads(client), requested, "A worker thread count above the floor should be used as-is");
+    } finally {
+      client.close();
+    }
+  }
+
+  @Test
+  public void testWorkerThreadCountIsFlooredAtMinimum() throws Exception {
+    // Any value at or below the floor (including a non-positive value that would otherwise make Netty fall back to its
+    // 2 * cores default) clamps up to MIN_NETTY_WORKER_THREADS.
+    for (int requested: new int[] { 1, MIN_NETTY_WORKER_THREADS, 0, -1 }) {
+      NettyFileTransferClient client = createClient(requested);
+      try {
+        assertEquals(
+            countWorkerThreads(client),
+            MIN_NETTY_WORKER_THREADS,
+            "A worker thread count of " + requested + " should be floored at " + MIN_NETTY_WORKER_THREADS);
+      } finally {
+        client.close();
+      }
+    }
+  }
+
+  @Test
+  public void testWorkerThreadsRunBelowNormalPriorityAsNamedDaemons() throws Exception {
+    NettyFileTransferClient client = createClient(MIN_NETTY_WORKER_THREADS);
+    try {
+      for (EventExecutor executor: client.workerGroup) {
+        // Submitting a task forces the event-loop thread to be created, then we inspect that thread.
+        Thread thread = executor.submit(Thread::currentThread).get(5, TimeUnit.SECONDS);
+        assertEquals(
+            thread.getPriority(),
+            EXPECTED_THREAD_PRIORITY,
+            "Blob transfer event-loop threads should run below normal priority");
+        assertTrue(
+            thread.getName().startsWith("Venice-BlobTransfer-Client-Netty"),
+            "Unexpected event-loop thread name: " + thread.getName());
+        assertTrue(thread.isDaemon(), "Blob transfer event-loop threads should be daemon threads");
+      }
+    } finally {
+      client.close();
+    }
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.config;
 
+import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_CLIENT_NETTY_WORKER_THREADS;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.INGESTION_USE_DA_VINCI_CLIENT;
@@ -24,6 +25,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import com.linkedin.davinci.blobtransfer.client.NettyFileTransferClient;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -98,6 +100,33 @@ public class VeniceServerConfigTest {
       assertEquals(consumerPoolRecordsLimitFactors.size(), 4);
       assertEquals(consumerPoolRecordsLimitFactors.toArray(), factors);
     }
+  }
+
+  @Test
+  public void testBlobTransferClientNettyWorkerThreadCount() {
+    int availableProcessors = Runtime.getRuntime().availableProcessors();
+    // When unset, the client event-loop pool defaults to max(MIN_NETTY_WORKER_THREADS, 20% of available processors).
+    int expectedDefault = Math.max(NettyFileTransferClient.MIN_NETTY_WORKER_THREADS, availableProcessors / 5);
+
+    Properties props = populatedBasicProperties();
+    VeniceServerConfig defaultConfig = new VeniceServerConfig(new VeniceProperties(props));
+    assertEquals(defaultConfig.getBlobTransferClientNettyWorkerThreadCount(), expectedDefault);
+
+    // An explicitly configured value above the floor is read back verbatim.
+    int explicit = expectedDefault + 13;
+    props.setProperty(BLOB_TRANSFER_CLIENT_NETTY_WORKER_THREADS, String.valueOf(explicit));
+    VeniceServerConfig overriddenConfig = new VeniceServerConfig(new VeniceProperties(props));
+    assertEquals(overriddenConfig.getBlobTransferClientNettyWorkerThreadCount(), explicit);
+
+    // An explicitly configured value below the floor (including 0, which would otherwise make Netty fall back to its
+    // 2 * cores default) is clamped up to the minimum.
+    props.setProperty(
+        BLOB_TRANSFER_CLIENT_NETTY_WORKER_THREADS,
+        String.valueOf(NettyFileTransferClient.MIN_NETTY_WORKER_THREADS - 1));
+    VeniceServerConfig clampedConfig = new VeniceServerConfig(new VeniceProperties(props));
+    assertEquals(
+        clampedConfig.getBlobTransferClientNettyWorkerThreadCount(),
+        NettyFileTransferClient.MIN_NETTY_WORKER_THREADS);
   }
 
   @Test

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/DaemonThreadFactory.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/DaemonThreadFactory.java
@@ -10,18 +10,30 @@ import javax.annotation.Nullable;
  * that embed the threadpool can't shut themselves down).
  */
 public class DaemonThreadFactory implements ThreadFactory {
+  // Sentinel meaning "leave the thread's priority at the JVM default (inherited from the creating thread)".
+  public static final int UNSPECIFIED_PRIORITY = -1;
   protected final AtomicInteger threadNumber;
   private final String namePrefix;
   private final LogContext logContext;
+  private final int priority;
 
   public DaemonThreadFactory(String threadNamePrefix, @Nullable LogContext logContext) {
-    this.threadNumber = new AtomicInteger(0);
-    this.namePrefix = threadNamePrefix;
-    this.logContext = logContext;
+    this(threadNamePrefix, UNSPECIFIED_PRIORITY, logContext);
   }
 
   public DaemonThreadFactory(String threadNamePrefix) {
     this(threadNamePrefix, null);
+  }
+
+  /**
+   * @param priority the {@link Thread#setPriority(int) priority} for created threads, or {@link #UNSPECIFIED_PRIORITY}
+   *                 to leave it at the JVM default.
+   */
+  public DaemonThreadFactory(String threadNamePrefix, int priority, @Nullable LogContext logContext) {
+    this.threadNumber = new AtomicInteger(0);
+    this.namePrefix = threadNamePrefix;
+    this.logContext = logContext;
+    this.priority = priority;
   }
 
   @Override
@@ -37,6 +49,9 @@ public class DaemonThreadFactory implements ThreadFactory {
 
     Thread t = new Thread(wrapped, namePrefix + "-t" + threadNumber.getAndIncrement());
     t.setDaemon(true);
+    if (priority != UNSPECIFIED_PRIORITY) {
+      t.setPriority(priority);
+    }
     return t;
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/DaemonThreadFactoryTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/DaemonThreadFactoryTest.java
@@ -1,0 +1,35 @@
+package com.linkedin.venice.utils;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class DaemonThreadFactoryTest {
+  @Test
+  public void testCreatesNamedDaemonThreads() {
+    DaemonThreadFactory factory = new DaemonThreadFactory("TestPool");
+    Thread first = factory.newThread(() -> {});
+    Thread second = factory.newThread(() -> {});
+    Assert.assertTrue(first.isDaemon(), "Threads should be daemons");
+    Assert.assertEquals(first.getName(), "TestPool-t0");
+    Assert.assertEquals(second.getName(), "TestPool-t1");
+  }
+
+  @Test
+  public void testPriorityIsSetWhenSpecified() {
+    int priority = Thread.NORM_PRIORITY - 1;
+    DaemonThreadFactory factory = new DaemonThreadFactory("TestPool", priority, null);
+    Thread t = factory.newThread(() -> {});
+    Assert.assertEquals(t.getPriority(), priority, "Configured priority should be applied");
+    Assert.assertTrue(t.isDaemon());
+  }
+
+  @Test
+  public void testUnspecifiedPriorityInheritsFromCreatingThread() {
+    DaemonThreadFactory factory = new DaemonThreadFactory("TestPool");
+    Thread t = factory.newThread(() -> {});
+    // With UNSPECIFIED_PRIORITY the factory does not call setPriority, so the thread inherits the creating thread's
+    // priority (the JVM default behavior).
+    Assert.assertEquals(t.getPriority(), Thread.currentThread().getPriority());
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2289,6 +2289,10 @@ public class ConfigKeys {
   // if the connectivity is not fresh, then retry the connection.
   public static final String BLOB_TRANSFER_PEERS_CONNECTIVITY_FRESHNESS_IN_SECONDS =
       "blob.transfer.peers.connectivity.freshness.in.seconds";
+  // Number of Netty worker (event-loop) threads for the blob transfer client. Blob transfer is not latency sensitive,
+  // so when unset this defaults to max(4, 20% of available processors) rather than Netty's default of 2 * available
+  // processors. Any explicitly configured value of 4 or below is clamped up to 4; values above 4 are used as-is.
+  public static final String BLOB_TRANSFER_CLIENT_NETTY_WORKER_THREADS = "blob.transfer.client.netty.worker.threads";
   // This is the maximum allowed read speed (in bytes per sec) for the Netty client when receiving data from the remote
   // peer.
   public static final String BLOB_TRANSFER_CLIENT_READ_LIMIT_BYTES_PER_SEC =

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -532,7 +532,8 @@ public class VeniceServer {
           serverConfig.getBlobTransferClientReadLimitBytesPerSec(),
           serverConfig.getBlobTransferServiceWriteLimitBytesPerSec(),
           serverConfig.getSnapshotCleanupIntervalInMins(),
-          serverConfig.getMaxConcurrentBlobReceiveReplicas());
+          serverConfig.getMaxConcurrentBlobReceiveReplicas(),
+          serverConfig.getBlobTransferClientNettyWorkerThreadCount());
       VeniceAdaptiveBlobTransferTrafficThrottler writeThrottler = null;
       VeniceAdaptiveBlobTransferTrafficThrottler readThrottler = null;
       if (serverConfig.isAdaptiveThrottlerEnabled() && serverConfig.isBlobTransferAdaptiveThrottlerEnabled()) {


### PR DESCRIPTION
  ## Problem Statement                                                                                                                                                                                                                              
  In preparation for thread priority enforcement, an analysis was performed on a thread dump from a staging Venice server (`venice-server`, ~58 cores, 2,345 threads). It showed the blob-transfer subsystem dominating the thread population: ~150+ threads running at `MAX_PRIORITY` (prio=10). Specifically, the client's Netty event-loop pool used Netty's default of `2 × availableProcessors` (~116 threads), the server worker pool was hardcoded at 32, and the checksum-validation pool ran one thread per    
  core (58).                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
  Blob transfer is bursty, infrequent, and not latency-sensitive, yet these pools are oversized, run at a higher priority than the read/write hot path they compete with for CPU, and are hard to attribute in thread dumps because they inherit    
  Netty's anonymous `nioEventLoopGroup-*` / `epollEventLoopGroup-*` names. The dump's single hottest threads were in fact these blob-transfer event loops.                                                                                          
                                                                                                                                                                                                                                                    
  ## Solution                                                                                                                                                                                                                                       
  Right-size the blob-transfer thread pools, drop them below normal priority, and give them descriptive names. 

  **Client (`NettyFileTransferClient`)**                                                                                                                                                                                                            
  - The Netty event-loop pool is now configurable via `blob.transfer.client.netty.worker.threads`. When unset it defaults to `max(4, 20% of available processors)` instead of `2 × cores`. `VeniceServerConfig` warns and clamps any explicitly     
  configured value below 4 (a value of 0 would otherwise make Netty silently fall back to its `2 × cores` default, and a negative value would throw); the client floors again as a defensive net for any direct caller.                             
  - The checksum-validation pool is sized at `max(4, 20% of available processors)` instead of one thread per core.                                                                                                                                  
  - All four client pools (Netty event loops, checksum validation, host-connect, timeout-checker) now run at priority 4.                                                                                                                            
                                                                                                                                                                                                                                                    
  **Server (`P2PBlobTransferService`)**                                                                                                                                                                                                             
  - The worker pool is sized at `max(4, 20% of available processors)` instead of a hardcoded 32; the boss group stays at 1. Both run at priority 4.                                                                                                 
                                                                                                                                                                                                                                                    
  **Supporting**                                                                                                                                                                                                                                    
  - `DaemonThreadFactory` gains an optional thread priority (backward compatible — existing constructors leave the JVM default via an `UNSPECIFIED_PRIORITY` sentinel).                                                                             
  - All event-loop and executor threads keep the `Venice-BlobTransfer-*` naming convention already used by the sibling pools.                                                                                                                       
                                                                                                                                                                                                                                                    
  **Trade-offs.** `20%-of-cores` is a deliberate, blunt reduction since blob transfer tolerates lower parallelism. Checksum validation is CPU-bound, so this does cap how fast a snapshot's checksums verify during bootstrap, but that's a one-shot
  per-transfer cost, not steady-state. Java thread priority is largely advisory on Linux (`os_prio` stays 0), so the priority change primarily removes the inappropriate `MAX_PRIORITY` signal; the thread-count reductions are what materially     
  shrink the footprint. Net effect on the dumped 58-core host: ~150+ threads at prio 10 → ~40 threads at prio 4, all clearly named.                                                                                                                 
                                                                                                                                                                                                                                                    
  ###  Code changes                                                                                                                                                                                                                                 
  - [x] Added new code behind **a config**. Config: `blob.transfer.client.netty.worker.threads`, default `max(4, 20% of available processors)`.                                                                                                     
  - [x] Introduced new **log lines**. One WARN in `VeniceServerConfig` when an explicit value below 4 is clamped.                                                                                                                                   
    - [x] Confirmed if logs need to be **rate limited** — not needed; it fires at most once per process at config construction.                                                                                                                     
                                                                                                                                                                                                                                                    
  ###  **Concurrency-Specific Checks**                                                                                                                                                                                                              
  - [x] Code has **no race conditions** or **thread safety issues** — only pool sizing/priority/naming changed; no new shared mutable state.                                                                                                        
  - [x] Proper **synchronization mechanisms** are used where needed — `DaemonThreadFactory` keeps its existing per-instance `AtomicInteger` counter.                                                                                                
  - [x] No **blocking calls** inside critical sections.                                                                                                                                                                                             
  - [x] Verified **thread-safe collections** are used — unchanged.                                                                                                                                                                                  
  - [x] Validated proper exception handling in multi-threaded code.     

  ## How was this PR tested?                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
  - [x] New unit tests added — `TestNettyFileTransferClient` (pool sizing, floor at 4, priority/naming/daemon) and `DaemonThreadFactoryTest` (priority applied when specified, default left untouched otherwise).                                   
  - [ ] New integration tests added.                                                                                                                                                                                                                
  - [x] Modified or extended existing tests — `VeniceServerConfigTest` covers the default, an explicit override, and the sub-4 clamp; existing `TestNettyP2PBlobTransferManager` / `TestBlobTransferManagerBuilder` pass against the new            
  constructors.                                                                                                                                                                                                                                     
  - [x] Verified backward compatibility — `DaemonThreadFactory`'s new constructor is additive; all existing callers are unchanged.                                                                                                                  
                                                                                                                                                                                                                                                    
  ## Does this PR introduce any user-facing or breaking changes?                                                                                                                                                                                    
                                                                                                                                                                                                                                                    
  - [ ] No. You can skip the rest of this section.                                                                                                                                                                                                  
  - [x] Yes. Clearly explain the behavior change and its impact.                                                                                                                                                                                    
                                                                                                                                                                                                                                                    
  Operationally observable but non-breaking: no API or protocol changes. Blob-transfer thread pools are smaller by default (e.g. on a 58-core host the client Netty pool drops ~116 → 11, checksum ~58 → 11, server worker 32 → 11), run at priority
  4 instead of 10, and appear in thread dumps as `Venice-BlobTransfer-*` instead of anonymous Netty pool names. Operators who want the previous parallelism can raise `blob.transfer.client.netty.worker.threads`.                                  
 