### PR TITLE
[vpj] Throttle external-storage dual-write by global record and byte rate

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -62,6 +62,8 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.PERMISSION_777;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.POLL_JOB_STATUS_INTERVAL_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.POLL_STATUS_RETRY_ATTEMPTS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_TIMEOUT_OVERRIDE_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_TO_SEPARATE_REALTIME_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
@@ -123,6 +125,7 @@ import com.linkedin.venice.hadoop.mapreduce.datawriter.jobs.DataWriterMRJob;
 import com.linkedin.venice.hadoop.mapreduce.engine.DefaultJobClientWrapper;
 import com.linkedin.venice.hadoop.schema.HDFSSchemaSource;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import com.linkedin.venice.hadoop.task.datawriter.ExternalStorageWriteThrottler;
 import com.linkedin.venice.hadoop.utils.HadoopUtils;
 import com.linkedin.venice.hadoop.utils.VPJSSLUtils;
 import com.linkedin.venice.hadoop.validation.NoOpValidator;
@@ -883,6 +886,9 @@ public class VenicePushJob implements AutoCloseable {
           props,
           optionalCompressionDictionary);
       updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.NEW_VERSION_CREATED);
+      // Fail fast here (driver-side, before the data-writer job launches) if external-storage dual-write
+      // throttling is misconfigured for the partition count just assigned to this version.
+      validateExternalStorageDualWriteQuota(pushJobSetting);
 
       // Fetch the version config for separateRealTimeTopicEnabled after version creation,
       Version createdVersion = getStoreVersion(pushJobSetting.storeName, pushJobSetting.version);
@@ -2643,6 +2649,22 @@ public class VenicePushJob implements AutoCloseable {
 
   private Version.PushType getPushType(PushJobSetting pushJobSetting) {
     return pushJobSetting.isIncrementalPush ? Version.PushType.INCREMENTAL : Version.PushType.BATCH;
+  }
+
+  /**
+   * Fail fast on the driver — before launching the data-writer job and allocating its cluster resources — when
+   * external-storage dual-write throttling is misconfigured for the partition count assigned to this version.
+   * Partition count is only known after {@link #createNewStoreVersion}, so this is the earliest it can run (not
+   * before topic creation). The executor-side throttler re-validates as a backstop.
+   */
+  private void validateExternalStorageDualWriteQuota(PushJobSetting setting) {
+    if (setting.dualWriteTargetRegions.isEmpty()) {
+      return;
+    }
+    ExternalStorageWriteThrottler.validateQuota(
+        props.getLong(PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND, -1),
+        props.getLong(PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND, -1),
+        setting.partitionCount);
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -642,19 +642,32 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
         externalWriters
             .add(ExternalStorageWriteUtils.loadAndConfigure(writerClassName, props, topicName, partitionId, region));
       }
+      // Optional per-region rate limiting. The configured global record/byte rate is the budget for one
+      // region; it is split evenly across this region's partitionCount partition-writer tasks, so each task
+      // (including this one) gets its own throttler sized to globalRate/partitionCount. Separate instances per
+      // region keep each region at its full per-region budget rather than sharing one bucket. The quota source
+      // sits behind ExternalStorageWriteQuotaProvider so it can later derive from something other than config.
+      ExternalStorageWriteQuotaProvider quota = new ConfigBackedExternalStorageWriteQuotaProvider(props);
+      long externalRecordRate = quota.getRecordRatePerSecond();
+      long externalByteRate = quota.getByteRatePerSecond();
+      List<ExternalStorageWriteThrottler> throttlers =
+          buildExternalStorageThrottlers(externalRecordRate, externalByteRate, dualWriteRegions.size());
       LOGGER.info(
           "Dual-write to external storage enabled for replica {} via impl {} for regions {} "
-              + "(batchSize={}, batchPutRetries={}, batchPutRetryBackoffMs={})",
+              + "(batchSize={}, batchPutRetries={}, batchPutRetryBackoffMs={}, recordThrottle={}, byteThrottle={})",
           Utils.getReplicaId(topicName, partitionId),
           writerClassName,
           dualWriteRegions,
           batchSize,
           batchPutRetries,
-          batchPutRetryBackoffMs);
+          batchPutRetryBackoffMs,
+          describeThrottle(externalRecordRate, "records/sec"),
+          describeThrottle(externalByteRate, "bytes/sec"));
       return new DualWriteVeniceWriter(
           topicName,
           baseWriter,
           externalWriters,
+          throttlers,
           batchSize,
           batchPutRetries,
           batchPutRetryBackoffMs);
@@ -673,6 +686,33 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
       }
       throw t;
     }
+  }
+
+  /**
+   * Build the per-region throttler list for the dual-write fan-out, or {@code null} when neither a record nor
+   * a byte quota is configured (throttling off). Each region gets an independent throttler instance so the
+   * per-region budgets are enforced separately; the configured global rate is split evenly across the
+   * {@link #getPartitionCount()} partition-writer tasks.
+   */
+  @VisibleForTesting
+  List<ExternalStorageWriteThrottler> buildExternalStorageThrottlers(
+      long globalRecordRate,
+      long globalByteRate,
+      int regionCount) {
+    List<ExternalStorageWriteThrottler> throttlers = new ArrayList<>(regionCount);
+    boolean anyEnabled = false;
+    for (int i = 0; i < regionCount; i++) {
+      ExternalStorageWriteThrottler throttler =
+          ExternalStorageWriteThrottler.create(globalRecordRate, globalByteRate, getPartitionCount());
+      throttlers.add(throttler);
+      anyEnabled |= throttler != null;
+    }
+    return anyEnabled ? throttlers : null;
+  }
+
+  /** Render one throttle dimension for logs: {@code "off"} when disabled ({@code <= 0}), else its per-region rate. */
+  private static String describeThrottle(long globalRatePerSecond, String unit) {
+    return globalRatePerSecond <= 0 ? "off" : globalRatePerSecond + " " + unit + " per region";
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/ConfigBackedExternalStorageWriteQuotaProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/ConfigBackedExternalStorageWriteQuotaProvider.java
@@ -1,0 +1,31 @@
+package com.linkedin.venice.hadoop.task.datawriter;
+
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND;
+
+import com.linkedin.venice.utils.VeniceProperties;
+
+
+/**
+ * {@link ExternalStorageWriteQuotaProvider} backed by static VPJ config: it reads the per-region record and
+ * byte quotas from the job properties once at construction. Absent keys default to {@code -1} (unthrottled).
+ */
+class ConfigBackedExternalStorageWriteQuotaProvider implements ExternalStorageWriteQuotaProvider {
+  private final long recordRatePerSecond;
+  private final long byteRatePerSecond;
+
+  ConfigBackedExternalStorageWriteQuotaProvider(VeniceProperties props) {
+    this.recordRatePerSecond = props.getLong(PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND, -1);
+    this.byteRatePerSecond = props.getLong(PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND, -1);
+  }
+
+  @Override
+  public long getRecordRatePerSecond() {
+    return recordRatePerSecond;
+  }
+
+  @Override
+  public long getByteRatePerSecond() {
+    return byteRatePerSecond;
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriter.java
@@ -55,6 +55,13 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
 
   private final AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter;
   private final List<ExternalStorageWriter> externalWriters;
+  /**
+   * Per-region rate limiters, index-aligned with {@link #externalWriters}. {@code null} when throttling is off
+   * for the whole task; individual entries may be {@code null} to leave a single region unthrottled.
+   */
+  private final List<ExternalStorageWriteThrottler> throttlers;
+  /** True iff at least one region enforces the byte dimension; gates the per-batch byte sum in {@link #drainBuffer}. */
+  private final boolean anyByteThrottling;
   private final int batchSize;
   private final int batchPutRetries;
   private final long batchPutRetryBackoffMs;
@@ -97,9 +104,29 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
       int batchSize,
       int batchPutRetries,
       long batchPutRetryBackoffMs) {
+    this(topicName, kafkaWriter, externalWriters, null, batchSize, batchPutRetries, batchPutRetryBackoffMs);
+  }
+
+  /**
+   * @param throttlers per-region rate limiters, index-aligned with {@code externalWriters}. {@code null}
+   *        disables throttling for every region; otherwise it must have the same size as
+   *        {@code externalWriters} and individual {@code null} entries leave that region unthrottled.
+   */
+  public DualWriteVeniceWriter(
+      String topicName,
+      AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter,
+      List<ExternalStorageWriter> externalWriters,
+      List<ExternalStorageWriteThrottler> throttlers,
+      int batchSize,
+      int batchPutRetries,
+      long batchPutRetryBackoffMs) {
     super(topicName);
     if (externalWriters == null || externalWriters.isEmpty()) {
       throw new IllegalArgumentException("externalWriters must be non-empty");
+    }
+    if (throttlers != null && throttlers.size() != externalWriters.size()) {
+      throw new IllegalArgumentException(
+          "throttlers size " + throttlers.size() + " must match externalWriters size " + externalWriters.size());
     }
     if (batchSize < 1) {
       throw new IllegalArgumentException("batchSize must be >= 1, got " + batchSize);
@@ -112,6 +139,8 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
     }
     this.kafkaWriter = kafkaWriter;
     this.externalWriters = new ArrayList<>(externalWriters);
+    this.throttlers = throttlers == null ? null : new ArrayList<>(throttlers);
+    this.anyByteThrottling = anyByteThrottling(this.throttlers);
     this.batchSize = batchSize;
     this.batchPutRetries = batchPutRetries;
     this.batchPutRetryBackoffMs = batchPutRetryBackoffMs;
@@ -297,14 +326,28 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
     for (BufferedPut buffered: putBuffer) {
       externalRecords.add(new ExternalStorageRecord(buffered.key, toRocksDbFormattedValue(buffered)));
     }
+    int recordCount = externalRecords.size();
+    // Only pay the O(batch) byte sum when at least one region actually enforces the byte dimension.
+    long byteCount = anyByteThrottling ? totalBytes(externalRecords) : 0L;
     CompletableFuture<PubSubProduceResult> last = null;
     try {
       // Fan out the same batch to every regional external sink before any Kafka produce. A failure on any
       // region (after its bounded retry) propagates before any produce and fails the push. Earlier regions in
       // the fan-out may already hold the batch when a later one fails; that partial state is reconciled by the
       // idempotent whole-partition retry (see the class-level contract), not prevented here.
-      for (ExternalStorageWriter externalWriter: externalWriters) {
-        batchPutWithRetry(externalWriter, externalRecords);
+      //
+      // Each region is rate limited (when a throttler is configured) immediately before its own write: the
+      // blocking limiter waits until the per-region budget admits the batch, enforcing independent per-region
+      // budgets without reordering the external-first writes. (If a limiter threw instead of blocking it would
+      // propagate before the write; the GuavaRateLimiter used here blocks rather than rejecting.)
+      for (int i = 0; i < externalWriters.size(); i++) {
+        if (throttlers != null) {
+          ExternalStorageWriteThrottler throttler = throttlers.get(i);
+          if (throttler != null) {
+            throttler.throttle(recordCount, byteCount);
+          }
+        }
+        batchPutWithRetry(externalWriters.get(i), externalRecords);
       }
       for (BufferedPut buffered: putBuffer) {
         CompletableFuture<PubSubProduceResult> kafkaFuture = invokeKafkaPut(buffered);
@@ -390,6 +433,27 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
     ByteUtils.writeInt(formatted, bp.valueSchemaId, 0);
     System.arraycopy(bp.value, 0, formatted, ExternalStorageRecord.SCHEMA_ID_PREFIX_LENGTH, bp.value.length);
     return formatted;
+  }
+
+  /** Total on-the-wire bytes of a batch: key bytes plus the RocksDB-formatted value bytes for every record. */
+  private static long totalBytes(List<ExternalStorageRecord> records) {
+    long total = 0;
+    for (ExternalStorageRecord record: records) {
+      total += record.getKey().length + record.getValue().length;
+    }
+    return total;
+  }
+
+  private static boolean anyByteThrottling(List<ExternalStorageWriteThrottler> throttlers) {
+    if (throttlers == null) {
+      return false;
+    }
+    for (ExternalStorageWriteThrottler throttler: throttlers) {
+      if (throttler != null && throttler.enforcesByteRate()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private CompletableFuture<PubSubProduceResult> invokeKafkaPut(BufferedPut bp) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/ExternalStorageWriteQuotaProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/ExternalStorageWriteQuotaProvider.java
@@ -1,0 +1,18 @@
+package com.linkedin.venice.hadoop.task.datawriter;
+
+/**
+ * Supplies the per-region external-storage write quota — a records/sec and a bytes/sec budget — for a push.
+ * This isolates <em>where the quota comes from</em> from <em>how the throttler enforces it</em>
+ * ({@link ExternalStorageWriteThrottler}), so the source can evolve (e.g. derived from a store's VU quota, or
+ * looked up from a service) without touching the enforcement path. Today the only implementation reads static
+ * VPJ config ({@link ConfigBackedExternalStorageWriteQuotaProvider}).
+ *
+ * <p>Both dimensions are independent and {@code <= 0} means that dimension is unthrottled.
+ */
+interface ExternalStorageWriteQuotaProvider {
+  /** Per-region record-write quota in records/sec; {@code <= 0} disables record-rate throttling. */
+  long getRecordRatePerSecond();
+
+  /** Per-region byte-write quota in bytes/sec; {@code <= 0} disables byte-rate throttling. */
+  long getByteRatePerSecond();
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/ExternalStorageWriteThrottler.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/ExternalStorageWriteThrottler.java
@@ -1,0 +1,141 @@
+package com.linkedin.venice.hadoop.task.datawriter;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.throttle.GuavaRateLimiter;
+import com.linkedin.venice.throttle.VeniceRateLimiter;
+
+
+/**
+ * Per-(partition-writer task, region) rate limiter for the VPJ external-storage dual-write path. A single
+ * configured <em>global</em> record rate and/or byte rate is the budget for writing to one external region;
+ * because partition-writer tasks run in separate distributed executors with no shared memory, the budget is
+ * enforced by static even split: every task gets a local throttler sized to {@code globalRate / partitionCount}
+ * so the aggregate across all {@code partitionCount} tasks for that region does not exceed the global rate.
+ *
+ * <p>Each region gets its own {@code ExternalStorageWriteThrottler} instance (independent buckets): the
+ * dual-write fan-out writes the same batch to every region sequentially, so a shared bucket would let two
+ * regions drain one budget and halve each region's effective rate. Per-region instances keep each region at
+ * its full per-region budget.
+ *
+ * <p>The two dimensions are independent: either can be configured alone (the other limiter is {@code null} and
+ * that dimension is unthrottled). Both use a blocking {@link VeniceRateLimiter} — a push must slow down to fit
+ * the budget, never drop records.
+ */
+public class ExternalStorageWriteThrottler {
+  private final VeniceRateLimiter recordRateLimiter;
+  private final VeniceRateLimiter byteRateLimiter;
+
+  ExternalStorageWriteThrottler(VeniceRateLimiter recordRateLimiter, VeniceRateLimiter byteRateLimiter) {
+    if (recordRateLimiter == null && byteRateLimiter == null) {
+      throw new IllegalArgumentException(
+          "ExternalStorageWriteThrottler requires at least one of the record/byte rate limiters to be non-null");
+    }
+    this.recordRateLimiter = recordRateLimiter;
+    this.byteRateLimiter = byteRateLimiter;
+  }
+
+  /**
+   * Block until both configured budgets admit a batch of {@code recordCount} records totalling
+   * {@code byteCount} bytes. A dimension whose limiter is {@code null} is not enforced. Called once per region
+   * per batch, immediately before that region's {@code batchPut}.
+   */
+  void throttle(int recordCount, long byteCount) {
+    if (recordRateLimiter != null) {
+      recordRateLimiter.acquirePermit(recordCount);
+    }
+    if (byteRateLimiter != null) {
+      acquire(byteRateLimiter, byteCount);
+    }
+  }
+
+  /**
+   * Charge {@code permits} to {@code limiter}. {@link VeniceRateLimiter#acquirePermit(int)} takes an int, so a
+   * batch whose byte count exceeds {@link Integer#MAX_VALUE} is charged in {@code Integer.MAX_VALUE} chunks
+   * rather than silently clamped — the byte budget is honored exactly even for very large batches.
+   */
+  private static void acquire(VeniceRateLimiter limiter, long permits) {
+    while (permits > Integer.MAX_VALUE) {
+      limiter.acquirePermit(Integer.MAX_VALUE);
+      permits -= Integer.MAX_VALUE;
+    }
+    if (permits > 0) {
+      limiter.acquirePermit((int) permits);
+    }
+  }
+
+  /**
+   * Build a throttler giving this one partition-writer task an even {@code 1/partitionCount} slice of each
+   * configured global rate, or {@code null} when neither dimension is configured (throttling off for this
+   * region). A dimension with rate {@code <= 0} is disabled.
+   */
+  static ExternalStorageWriteThrottler create(
+      long globalRecordRatePerSecond,
+      long globalByteRatePerSecond,
+      int partitionCount) {
+    VeniceRateLimiter recordRateLimiter = perTaskRateLimiter(globalRecordRatePerSecond, partitionCount, "records");
+    VeniceRateLimiter byteRateLimiter = perTaskRateLimiter(globalByteRatePerSecond, partitionCount, "bytes");
+    if (recordRateLimiter == null && byteRateLimiter == null) {
+      return null;
+    }
+    return new ExternalStorageWriteThrottler(recordRateLimiter, byteRateLimiter);
+  }
+
+  /**
+   * Validate that every configured ({@code > 0}) dimension can be split into at least 1/sec per task for
+   * {@code partitionCount} tasks, throwing {@link VeniceException} otherwise. Allocates nothing, so the VPJ
+   * driver can call it to fail a misconfigured push <em>before</em> launching the data-writer job (and its
+   * cluster resources). Partition count is only known after version creation, so the earliest the driver can
+   * call this is right after the version is created, not before topic creation.
+   */
+  public static void validateQuota(long globalRecordRatePerSecond, long globalByteRatePerSecond, int partitionCount) {
+    requireSplittable(globalRecordRatePerSecond, partitionCount, "records");
+    requireSplittable(globalByteRatePerSecond, partitionCount, "bytes");
+  }
+
+  /**
+   * The per-task slice of one global dimension, or {@code null} when that dimension is disabled
+   * ({@code globalRatePerSecond <= 0}).
+   */
+  private static VeniceRateLimiter perTaskRateLimiter(long globalRatePerSecond, int partitionCount, String dimension) {
+    if (globalRatePerSecond <= 0) {
+      return null;
+    }
+    requireSplittable(globalRatePerSecond, partitionCount, dimension);
+    return new GuavaRateLimiter(globalRatePerSecond / partitionCount);
+  }
+
+  /**
+   * @throws VeniceException if a configured ({@code > 0}) global rate cannot give each of {@code partitionCount}
+   *         tasks at least 1/sec — failing fast on a misconfiguration beats a 0/sec limiter that deadlocks the push.
+   */
+  private static void requireSplittable(long globalRatePerSecond, int partitionCount, String dimension) {
+    if (globalRatePerSecond <= 0) {
+      return;
+    }
+    if (partitionCount <= 0) {
+      throw new VeniceException(
+          "Cannot split the external-storage write " + dimension + " quota across a non-positive partition count "
+              + partitionCount);
+    }
+    if (globalRatePerSecond / partitionCount <= 0) {
+      throw new VeniceException(
+          "External-storage write " + dimension + " quota " + globalRatePerSecond + "/sec is smaller than the "
+              + partitionCount + " partition writers sharing it; each task would get 0/sec. Raise the quota to at "
+              + "least the partition count.");
+    }
+  }
+
+  /** True if this throttler enforces a byte-rate budget. Lets callers skip the byte sum when only records are limited. */
+  boolean enforcesByteRate() {
+    return byteRateLimiter != null;
+  }
+
+  // Visible for testing.
+  VeniceRateLimiter getRecordRateLimiter() {
+    return recordRateLimiter;
+  }
+
+  VeniceRateLimiter getByteRateLimiter() {
+    return byteRateLimiter;
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -516,6 +516,8 @@ public final class VenicePushJobConstants {
    *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE} — buffer threshold for the dual-write wrapper</li>
    *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES} — bounded retry count for {@code batchPut}</li>
    *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS} — sleep between retry attempts</li>
+   *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND} — per-region global record-rate cap</li>
+   *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND} — per-region global byte-rate cap</li>
    * </ul>
    * Any other key under this prefix is opaque pass-through and is the responsibility of the impl to
    * interpret. Operators should not assume new OSS-owned keys will appear here without a release note.
@@ -557,6 +559,29 @@ public final class VenicePushJobConstants {
   public static final String PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS =
       "push.job.external.storage.batchput.retry.backoff.ms";
   public static final long DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS = 1000L;
+
+  /**
+   * Global write quota in records per second for the external-storage dual-write path, applied <em>per target
+   * region</em>. Any value {@code <= 0} disables record-rate throttling ({@code -1} is the recommended
+   * "unlimited" sentinel). Because partition-writer tasks run in separate executors with no shared throttler,
+   * the budget is enforced by static even split: each task limits its external writes to
+   * {@code value / partition.count} records/sec, so the aggregate across all tasks writing to one region stays
+   * at or below {@code value}. The split requires {@code value >= partition.count} (else a task would get
+   * 0/sec); a smaller value fails the task fast. Independent of
+   * {@link #PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND} — either dimension may be set alone.
+   */
+  public static final String PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND =
+      "push.job.external.storage.write.quota.records.per.region.per.second";
+
+  /**
+   * Global write quota in bytes per second for the external-storage dual-write path, applied <em>per target
+   * region</em>. Bytes counted per record are the external key bytes plus the RocksDB-formatted value bytes
+   * (4-byte schema-id prefix + value payload). Any value {@code <= 0} disables byte-rate throttling
+   * ({@code -1} = unlimited). Split evenly across {@code partition.count} tasks exactly like
+   * {@link #PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND}.
+   */
+  public static final String PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND =
+      "push.job.external.storage.write.quota.bytes.per.region.per.second";
 
   /**
    * Comma-separated list of region names whose store-level {@link com.linkedin.venice.meta.StorageMode} is

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriterThrottlingTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriterThrottlingTest.java
@@ -15,14 +15,17 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.engine.EngineTaskConfigProvider;
 import com.linkedin.venice.throttle.EventThrottler;
 import com.linkedin.venice.throttle.GuavaRateLimiter;
 import com.linkedin.venice.throttle.TokenBucket;
 import com.linkedin.venice.throttle.VeniceRateLimiter;
 import com.linkedin.venice.writer.AbstractVeniceWriter;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.testng.annotations.BeforeMethod;
@@ -31,7 +34,8 @@ import org.testng.annotations.Test;
 
 
 /**
- * Unit tests for incremental push throttling functionality in AbstractPartitionWriter.
+ * Unit tests for throttling functionality in AbstractPartitionWriter: incremental-push write-quota
+ * throttling and external-storage dual-write per-region throttler wiring.
  */
 public class AbstractPartitionWriterThrottlingTest {
   private TestablePartitionWriter partitionWriter;
@@ -287,6 +291,74 @@ public class AbstractPartitionWriterThrottlingTest {
     VeniceRateLimiter throttler = partitionWriter.getRecordsThrottler();
     assertNotNull(throttler, "Throttler should be created despite invalid time window");
     assertTrue(throttler instanceof TokenBucket, "Should still be TokenBucket with fallback time window");
+  }
+
+  // --- External-storage dual-write throttler wiring -----------------------------------------------
+
+  @Test
+  public void testExternalStorageThrottlersDisabledWhenNoQuotaConfigured() {
+    Properties props = createBaseProperties();
+    setupMockConfigProvider(props);
+    partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
+    partitionWriter.configure(mockConfigProvider);
+
+    assertNull(
+        partitionWriter.buildExternalStorageThrottlers(-1, -1, 2),
+        "No external-storage throttlers when neither record nor byte quota is configured");
+  }
+
+  @Test
+  public void testExternalStorageThrottlersOnePerRegionSplitAcrossPartitions() {
+    Properties props = createBaseProperties();
+    props.setProperty(PARTITION_COUNT, "4");
+    setupMockConfigProvider(props);
+    partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
+    partitionWriter.configure(mockConfigProvider);
+
+    List<ExternalStorageWriteThrottler> throttlers = partitionWriter.buildExternalStorageThrottlers(1000, 8000, 3);
+    assertNotNull(throttlers, "Throttlers should be built when a quota is configured");
+    assertEquals(throttlers.size(), 3, "One throttler per region");
+    for (int i = 0; i < throttlers.size(); i++) {
+      assertNotNull(throttlers.get(i), "Region " + i + " should have a throttler");
+      assertEquals(
+          throttlers.get(i).getRecordRateLimiter().getQuota(),
+          250L,
+          "1000 records/sec split across 4 partition-writer tasks -> 250/sec each");
+      assertEquals(
+          throttlers.get(i).getByteRateLimiter().getQuota(),
+          2000L,
+          "8000 bytes/sec split across 4 partition-writer tasks -> 2000/sec each");
+    }
+    // Independent instances per region so each region keeps its full per-region budget (separate buckets).
+    assertTrue(throttlers.get(0) != throttlers.get(1), "Per-region throttler instances must be independent");
+    assertTrue(throttlers.get(1) != throttlers.get(2), "Per-region throttler instances must be independent");
+  }
+
+  @Test
+  public void testExternalStorageThrottlersWithOnlyByteQuotaConfigured() {
+    Properties props = createBaseProperties();
+    props.setProperty(PARTITION_COUNT, "2");
+    setupMockConfigProvider(props);
+    partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
+    partitionWriter.configure(mockConfigProvider);
+
+    List<ExternalStorageWriteThrottler> throttlers = partitionWriter.buildExternalStorageThrottlers(-1, 8000, 2);
+    assertNotNull(throttlers);
+    assertEquals(throttlers.size(), 2);
+    assertNull(throttlers.get(0).getRecordRateLimiter(), "Record dimension disabled");
+    assertEquals(throttlers.get(0).getByteRateLimiter().getQuota(), 4000L, "8000/sec across 2 tasks -> 4000/sec");
+  }
+
+  @Test
+  public void testExternalStorageThrottlersFailFastWhenQuotaBelowPartitionCount() {
+    Properties props = createBaseProperties();
+    props.setProperty(PARTITION_COUNT, "4");
+    setupMockConfigProvider(props);
+    partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
+    partitionWriter.configure(mockConfigProvider);
+
+    // 2 records/sec cannot be split across 4 tasks without giving someone 0/sec -> fail fast.
+    assertThrows(VeniceException.class, () -> partitionWriter.buildExternalStorageThrottlers(2, -1, 3));
   }
 
   private void setupMockConfigProvider(Properties props) {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/ConfigBackedExternalStorageWriteQuotaProviderTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/ConfigBackedExternalStorageWriteQuotaProviderTest.java
@@ -1,0 +1,41 @@
+package com.linkedin.venice.hadoop.task.datawriter;
+
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Properties;
+import org.testng.annotations.Test;
+
+
+public class ConfigBackedExternalStorageWriteQuotaProviderTest {
+  @Test
+  public void readsBothQuotasFromConfig() {
+    Properties props = new Properties();
+    props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND, "1000");
+    props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND, "8000");
+    ConfigBackedExternalStorageWriteQuotaProvider provider =
+        new ConfigBackedExternalStorageWriteQuotaProvider(new VeniceProperties(props));
+    assertEquals(provider.getRecordRatePerSecond(), 1000L);
+    assertEquals(provider.getByteRatePerSecond(), 8000L);
+  }
+
+  @Test
+  public void defaultsToDisabledWhenKeysAbsent() {
+    ConfigBackedExternalStorageWriteQuotaProvider provider =
+        new ConfigBackedExternalStorageWriteQuotaProvider(new VeniceProperties(new Properties()));
+    assertEquals(provider.getRecordRatePerSecond(), -1L, "absent record quota defaults to -1 (disabled)");
+    assertEquals(provider.getByteRatePerSecond(), -1L, "absent byte quota defaults to -1 (disabled)");
+  }
+
+  @Test
+  public void readsSingleConfiguredDimension() {
+    Properties props = new Properties();
+    props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND, "5000");
+    ConfigBackedExternalStorageWriteQuotaProvider provider =
+        new ConfigBackedExternalStorageWriteQuotaProvider(new VeniceProperties(props));
+    assertEquals(provider.getRecordRatePerSecond(), -1L, "unset record dimension stays disabled");
+    assertEquals(provider.getByteRatePerSecond(), 5000L);
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriterTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriterTest.java
@@ -16,6 +16,7 @@ import static org.testng.Assert.expectThrows;
 import static org.testng.Assert.fail;
 
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
+import com.linkedin.venice.throttle.VeniceRateLimiter;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.AbstractVeniceWriter;
 import java.io.IOException;
@@ -405,6 +406,144 @@ public class DualWriteVeniceWriterTest {
     }
   }
 
+  // --- Throttling tests ----------------------------------------------------------------------------
+
+  @Test
+  public void throttlesEachRegionWithRecordAndByteCountsBeforeBatchPut() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter dc0 = new RecordingExternalStorageWriter();
+    RecordingExternalStorageWriter dc1 = new RecordingExternalStorageWriter();
+    RecordingRateLimiter dc0Records = new RecordingRateLimiter();
+    RecordingRateLimiter dc0Bytes = new RecordingRateLimiter();
+    RecordingRateLimiter dc1Records = new RecordingRateLimiter();
+    RecordingRateLimiter dc1Bytes = new RecordingRateLimiter();
+    List<ExternalStorageWriteThrottler> throttlers = Arrays.asList(
+        new ExternalStorageWriteThrottler(dc0Records, dc0Bytes),
+        new ExternalStorageWriteThrottler(dc1Records, dc1Bytes));
+    try (DualWriteVeniceWriter writer =
+        new DualWriteVeniceWriter(TOPIC, kafkaWriter, Arrays.asList(dc0, dc1), throttlers, 1, 0, 0L)) {
+      writer.put(key(1), value(1), SCHEMA_ID, null);
+      writer.put(key(2), value(2), SCHEMA_ID, null);
+    }
+    // batchSize=1 -> one record per batch -> one throttle charge per region per put.
+    assertEquals(dc0Records.acquired, Arrays.asList(1, 1), "dc0 record limiter charged the per-batch record count");
+    assertEquals(dc1Records.acquired, Arrays.asList(1, 1), "dc1 record limiter charged the per-batch record count");
+    assertEquals(
+        dc0Bytes.acquired,
+        Arrays.asList(expectedBytes(1), expectedBytes(2)),
+        "dc0 byte limiter charged key + schema-id-prefix + value bytes");
+    assertEquals(dc1Bytes.acquired, Arrays.asList(expectedBytes(1), expectedBytes(2)));
+  }
+
+  @Test
+  public void throttleChargesWholeBatchOnceWhenBuffered() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    RecordingRateLimiter records = new RecordingRateLimiter();
+    RecordingRateLimiter bytes = new RecordingRateLimiter();
+    List<ExternalStorageWriteThrottler> throttlers = Arrays.asList(new ExternalStorageWriteThrottler(records, bytes));
+    try (DualWriteVeniceWriter writer =
+        new DualWriteVeniceWriter(TOPIC, kafkaWriter, Arrays.asList(external), throttlers, 3, 0, 0L)) {
+      writer.put(key(1), value(1), SCHEMA_ID, null);
+      writer.put(key(2), value(2), SCHEMA_ID, null);
+      writer.put(key(3), value(3), SCHEMA_ID, null);
+    }
+    // A single 3-record batch -> one charge of 3 records and the summed byte count.
+    assertEquals(records.acquired, Arrays.asList(3), "buffered batch charges the record limiter once for the batch");
+    assertEquals(bytes.acquired, Arrays.asList(expectedBytes(1) + expectedBytes(2) + expectedBytes(3)));
+  }
+
+  @Test
+  public void throttlerRejectionBlocksBatchPutAndKafkaProduce() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    RecordingRateLimiter records = new RecordingRateLimiter();
+    records.throwOnAcquire = new RuntimeException("quota exceeded boom");
+    List<ExternalStorageWriteThrottler> throttlers = Arrays.asList(new ExternalStorageWriteThrottler(records, null));
+    DualWriteVeniceWriter writer =
+        new DualWriteVeniceWriter(TOPIC, kafkaWriter, Arrays.asList(external), throttlers, 1, 0, 0L);
+    try {
+      RuntimeException raised =
+          expectThrows(RuntimeException.class, () -> writer.put(key(1), value(1), SCHEMA_ID, null));
+      assertTrue(
+          raised.getMessage().contains("quota exceeded boom"),
+          "throttle failure should propagate to the caller; got: " + raised.getMessage());
+      assertEquals(
+          external.batchPutAttempts,
+          0,
+          "throttle runs before batchPut, so a throttle failure must skip the external write entirely");
+      verify(kafkaWriter, never()).put(any(), any(), anyInt(), any());
+    } finally {
+      // The throttle rejection cleared the buffer, so close()'s flush/drain is a no-op that won't throw.
+      writer.close();
+    }
+  }
+
+  @Test
+  public void throttlesOnlyRegionsWithAThrottlerWhenAnEntryIsNull() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter dc0 = new RecordingExternalStorageWriter();
+    RecordingExternalStorageWriter dc1 = new RecordingExternalStorageWriter();
+    RecordingRateLimiter dc0Records = new RecordingRateLimiter();
+    // dc1's entry is null -> that region is unthrottled, but must still be written.
+    List<ExternalStorageWriteThrottler> throttlers =
+        Arrays.asList(new ExternalStorageWriteThrottler(dc0Records, null), null);
+    try (DualWriteVeniceWriter writer =
+        new DualWriteVeniceWriter(TOPIC, kafkaWriter, Arrays.asList(dc0, dc1), throttlers, 1, 0, 0L)) {
+      writer.put(key(1), value(1), SCHEMA_ID, null);
+    }
+    assertEquals(dc0Records.acquired, Arrays.asList(1), "dc0 is throttled");
+    assertEquals(dc0.batchPutInvocations.size(), 1, "dc0 still written");
+    assertEquals(dc1.batchPutInvocations.size(), 1, "dc1 has a null throttler entry but is still written");
+  }
+
+  @Test
+  public void emptyFlushDoesNotInvokeThrottler() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    RecordingRateLimiter records = new RecordingRateLimiter();
+    List<ExternalStorageWriteThrottler> throttlers = Arrays.asList(new ExternalStorageWriteThrottler(records, null));
+    try (DualWriteVeniceWriter writer =
+        new DualWriteVeniceWriter(TOPIC, kafkaWriter, Arrays.asList(external), throttlers, 1, 0, 0L)) {
+      writer.flush(); // nothing buffered
+    }
+    assertTrue(records.acquired.isEmpty(), "An empty drain must not charge the throttler (avoids acquiring 0 permits)");
+    assertEquals(external.batchPutInvocations.size(), 0, "No batchPut for an empty buffer");
+  }
+
+  @Test
+  public void recordOnlyThrottlingChargesRecordsAndSkipsByteSum() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    RecordingRateLimiter records = new RecordingRateLimiter();
+    // Record-only throttler (no byte limiter) -> the anyByteThrottling=false branch; the byte sum is skipped.
+    List<ExternalStorageWriteThrottler> throttlers = Arrays.asList(new ExternalStorageWriteThrottler(records, null));
+    try (DualWriteVeniceWriter writer =
+        new DualWriteVeniceWriter(TOPIC, kafkaWriter, Arrays.asList(external), throttlers, 2, 0, 0L)) {
+      writer.put(key(1), value(1), SCHEMA_ID, null);
+      writer.put(key(2), value(2), SCHEMA_ID, null);
+    }
+    // One 2-record batch -> record limiter charged once with the batch record count; no byte charge happens.
+    assertEquals(records.acquired, Arrays.asList(2), "record-only throttler charges the record count");
+    assertEquals(external.batchPutInvocations.size(), 1);
+  }
+
+  @Test
+  public void rejectsThrottlerListSizeMismatch() {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mock(AbstractVeniceWriter.class);
+    RecordingExternalStorageWriter dc0 = new RecordingExternalStorageWriter();
+    RecordingExternalStorageWriter dc1 = new RecordingExternalStorageWriter();
+    List<ExternalStorageWriteThrottler> oneThrottler =
+        Arrays.asList(new ExternalStorageWriteThrottler(new RecordingRateLimiter(), null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new DualWriteVeniceWriter(TOPIC, kafkaWriter, Arrays.asList(dc0, dc1), oneThrottler, 1, 0, 0L));
+  }
+
+  private static int expectedBytes(int i) {
+    return key(i).length + ExternalStorageRecord.SCHEMA_ID_PREFIX_LENGTH + value(i).length;
+  }
+
   private static AbstractVeniceWriter<byte[], byte[], byte[]> mockKafkaWriter() {
     @SuppressWarnings("unchecked")
     AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mock(AbstractVeniceWriter.class);
@@ -471,6 +610,42 @@ public class DualWriteVeniceWriterTest {
       if (throwOnClose != null) {
         throw throwOnClose;
       }
+    }
+  }
+
+  /**
+   * Records the units charged to each dimension so throttling tests can assert what the wrapper passed,
+   * without depending on real (timing-based) rate limiting. {@code throwOnAcquire} simulates a limiter that
+   * rejects, to prove throttling runs before the external write.
+   */
+  private static final class RecordingRateLimiter implements VeniceRateLimiter {
+    final List<Integer> acquired = new ArrayList<>();
+    RuntimeException throwOnAcquire = null;
+
+    @Override
+    public boolean tryAcquirePermit(int units) {
+      if (throwOnAcquire != null) {
+        throw throwOnAcquire;
+      }
+      acquired.add(units);
+      return true;
+    }
+
+    @Override
+    public void acquirePermit(int units) {
+      if (throwOnAcquire != null) {
+        throw throwOnAcquire;
+      }
+      acquired.add(units);
+    }
+
+    @Override
+    public void setQuota(long quota) {
+    }
+
+    @Override
+    public long getQuota() {
+      return 0;
     }
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/ExternalStorageWriteThrottlerTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/ExternalStorageWriteThrottlerTest.java
@@ -1,0 +1,182 @@
+package com.linkedin.venice.hadoop.task.datawriter;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.throttle.VeniceRateLimiter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.testng.annotations.Test;
+
+
+public class ExternalStorageWriteThrottlerTest {
+  @Test
+  public void throttleAcquiresBothLimitersWithRecordAndByteUnits() {
+    RecordingRateLimiter records = new RecordingRateLimiter();
+    RecordingRateLimiter bytes = new RecordingRateLimiter();
+    ExternalStorageWriteThrottler throttler = new ExternalStorageWriteThrottler(records, bytes);
+
+    throttler.throttle(3, 4096L);
+
+    assertEquals(records.acquired, Arrays.asList(3), "record limiter should be charged the record count");
+    assertEquals(bytes.acquired, Arrays.asList(4096), "byte limiter should be charged the byte count");
+  }
+
+  @Test
+  public void throttleChargesOnlyRecordLimiterWhenByteDimensionDisabled() {
+    RecordingRateLimiter records = new RecordingRateLimiter();
+    ExternalStorageWriteThrottler throttler = new ExternalStorageWriteThrottler(records, null);
+
+    throttler.throttle(5, 9999L);
+
+    assertEquals(records.acquired, Arrays.asList(5));
+  }
+
+  @Test
+  public void throttleChargesOnlyByteLimiterWhenRecordDimensionDisabled() {
+    RecordingRateLimiter bytes = new RecordingRateLimiter();
+    ExternalStorageWriteThrottler throttler = new ExternalStorageWriteThrottler(null, bytes);
+
+    throttler.throttle(5, 256L);
+
+    assertEquals(bytes.acquired, Arrays.asList(256));
+  }
+
+  @Test
+  public void throttleChargesByteCountAboveIntMaxInChunks() {
+    RecordingRateLimiter bytes = new RecordingRateLimiter();
+    ExternalStorageWriteThrottler throttler = new ExternalStorageWriteThrottler(null, bytes);
+
+    long byteCount = (long) Integer.MAX_VALUE + 100L;
+    throttler.throttle(1, byteCount);
+
+    // Charged in full, split into Integer.MAX_VALUE-sized chunks (no silent clamp / under-charge).
+    assertEquals(bytes.acquired, Arrays.asList(Integer.MAX_VALUE, 100), "large byte count charged across chunks");
+    long total = 0;
+    for (int units: bytes.acquired) {
+      total += units;
+    }
+    assertEquals(total, byteCount, "total permits charged must equal the batch byte count");
+  }
+
+  @Test
+  public void constructorRejectsBothLimitersNull() {
+    assertThrows(IllegalArgumentException.class, () -> new ExternalStorageWriteThrottler(null, null));
+  }
+
+  @Test
+  public void createReturnsNullWhenBothRatesDisabled() {
+    assertNull(ExternalStorageWriteThrottler.create(-1, -1, 4), "both dimensions disabled -> no throttler");
+    assertNull(ExternalStorageWriteThrottler.create(0, 0, 4), "zero is also disabled");
+  }
+
+  @Test
+  public void createSplitsGlobalRecordRateEvenlyAcrossPartitions() {
+    ExternalStorageWriteThrottler throttler = ExternalStorageWriteThrottler.create(1000, -1, 4);
+    assertNotNull(throttler);
+    assertEquals(throttler.getRecordRateLimiter().getQuota(), 250L, "1000/sec across 4 tasks -> 250/sec each");
+    assertNull(throttler.getByteRateLimiter(), "byte dimension disabled");
+  }
+
+  @Test
+  public void createSplitsGlobalByteRateEvenlyAcrossPartitions() {
+    ExternalStorageWriteThrottler throttler = ExternalStorageWriteThrottler.create(-1, 8000, 4);
+    assertNotNull(throttler);
+    assertNull(throttler.getRecordRateLimiter(), "record dimension disabled");
+    assertEquals(throttler.getByteRateLimiter().getQuota(), 2000L, "8000/sec across 4 tasks -> 2000/sec each");
+  }
+
+  @Test
+  public void createSplitsBothDimensionsWhenBothConfigured() {
+    ExternalStorageWriteThrottler throttler = ExternalStorageWriteThrottler.create(1000, 8000, 4);
+    assertNotNull(throttler);
+    assertEquals(throttler.getRecordRateLimiter().getQuota(), 250L);
+    assertEquals(throttler.getByteRateLimiter().getQuota(), 2000L);
+  }
+
+  @Test
+  public void createWithSinglePartitionGivesTaskFullGlobalRate() {
+    ExternalStorageWriteThrottler throttler = ExternalStorageWriteThrottler.create(1000, -1, 1);
+    assertNotNull(throttler);
+    assertEquals(throttler.getRecordRateLimiter().getQuota(), 1000L);
+  }
+
+  @Test
+  public void createFloorsTheEvenSplitOfTheGlobalRate() {
+    // Integer division floors, keeping the aggregate at or below the global budget.
+    ExternalStorageWriteThrottler throttler = ExternalStorageWriteThrottler.create(1000, 2000, 3);
+    assertNotNull(throttler);
+    assertEquals(throttler.getRecordRateLimiter().getQuota(), 333L, "1000/sec across 3 tasks floors to 333/sec each");
+    assertEquals(throttler.getByteRateLimiter().getQuota(), 666L, "2000/sec across 3 tasks floors to 666/sec each");
+  }
+
+  @Test
+  public void validateQuotaPassesWhenSplittable() {
+    ExternalStorageWriteThrottler.validateQuota(1000, 8000, 4); // both dimensions split cleanly -> no throw
+  }
+
+  @Test
+  public void validateQuotaIsNoOpWhenDimensionsDisabled() {
+    ExternalStorageWriteThrottler.validateQuota(-1, 0, 4); // nothing configured -> no throw
+  }
+
+  @Test
+  public void validateQuotaThrowsWhenRecordRateBelowPartitionCount() {
+    assertThrows(VeniceException.class, () -> ExternalStorageWriteThrottler.validateQuota(2, -1, 4));
+  }
+
+  @Test
+  public void validateQuotaThrowsWhenByteRateBelowPartitionCount() {
+    assertThrows(VeniceException.class, () -> ExternalStorageWriteThrottler.validateQuota(-1, 3, 4));
+  }
+
+  @Test
+  public void createRejectsGlobalRecordRateBelowPartitionCount() {
+    // 2 records/sec cannot be split across 4 tasks without giving someone 0/sec.
+    assertThrows(VeniceException.class, () -> ExternalStorageWriteThrottler.create(2, -1, 4));
+  }
+
+  @Test
+  public void createRejectsGlobalByteRateBelowPartitionCount() {
+    assertThrows(VeniceException.class, () -> ExternalStorageWriteThrottler.create(-1, 3, 4));
+  }
+
+  @Test
+  public void createRejectsNonPositivePartitionCountWhenADimensionIsEnabled() {
+    assertThrows(VeniceException.class, () -> ExternalStorageWriteThrottler.create(1000, -1, 0));
+  }
+
+  /**
+   * Records the units passed to {@code acquirePermit}/{@code tryAcquirePermit} so tests can assert the
+   * throttler charges each dimension the right amount, without depending on real (timing-based) rate limiting.
+   */
+  private static final class RecordingRateLimiter implements VeniceRateLimiter {
+    final List<Integer> acquired = new ArrayList<>();
+    private long quota;
+
+    @Override
+    public boolean tryAcquirePermit(int units) {
+      acquired.add(units);
+      return true;
+    }
+
+    @Override
+    public void acquirePermit(int units) {
+      acquired.add(units);
+    }
+
+    @Override
+    public void setQuota(long quota) {
+      this.quota = quota;
+    }
+
+    @Override
+    public long getQuota() {
+      return quota;
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVPJDualWriteExternalStorageMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVPJDualWriteExternalStorageMultiRegion.java
@@ -7,6 +7,8 @@ import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithSt
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DATA_WRITER_COMPUTE_JOB_CLASS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SPARK_NATIVE_INPUT_FORMAT_ENABLED;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -64,6 +66,9 @@ import org.testng.annotations.Test;
  *       reaches {@code configure()} on the executor.</li>
  *   <li><b>Batching:</b> {@code batchSize=1} flushes one record per {@code batchPut}; {@code batchSize=25}
  *       flushes a full 25-record batch (the store is pinned to a single partition for determinism).</li>
+ *   <li><b>Throttling:</b> a generous per-region record/byte write quota is configured so the dual-write
+ *       throttler is constructed and exercised on the write path end-to-end, without slowing the push or
+ *       dropping records.</li>
  *   <li><b>Ingestion unaffected:</b> Venice still serves every record in the {@code DUAL_WRITE} region.</li>
  * </ul>
  */
@@ -96,6 +101,11 @@ public class TestVPJDualWriteExternalStorageMultiRegion extends AbstractMultiReg
     props.setProperty(SPARK_NATIVE_INPUT_FORMAT_ENABLED, "true");
     props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS, InMemoryExternalStorageWriter.class.getName());
     props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE, String.valueOf(batchSize));
+    // Enable per-region external-write throttling end-to-end. The store is pinned to a single partition, so the
+    // per-task rate equals the global rate; both quotas are deliberately generous so the throttler is built and
+    // exercised on the write path without measurably slowing the push or ever dropping a record.
+    props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND, "100000");
+    props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND, "100000000");
     // Probe an arbitrary push.job.external.storage.* key to verify driver->executor prefix forwarding reaches
     // configure(). Read back via forwardedConfigObservedFor().
     String expectedProbeValue = "probe-value-for-b" + batchSize;


### PR DESCRIPTION
## Problem Statement

The VPJ external-storage dual-write path writes every pushed record to an external sink in addition to Venice. There is currently no way to cap the write rate to that external system, so a large push can overwhelm the downstream external-storage cluster.

## Solution

Add optional **per-region** rate limiting to the dual-write path. A configured **global** record rate and/or byte rate is the budget for writing to **one** external region. Because partition-writer tasks run in separate executors with no shared throttler, the budget is enforced by static even split: each task throttles its external writes to `globalRate / partition.count`, so the aggregate across all tasks writing to one region stays at or below the global rate.

- `ExternalStorageWriteThrottler` holds an optional record-rate limiter and an optional byte-rate limiter (`GuavaRateLimiter`, blocking — a push slows down rather than dropping records). Either dimension can be configured alone. It fails fast when a configured quota is smaller than `partition.count` (each task would get 0/sec).
- `DualWriteVeniceWriter` applies the per-region throttler immediately before each region's `batchPut`. Each region gets an independent instance (independent buckets) so per-region budgets are enforced separately; a throttle rejection skips the write, preserving external-first ordering.

Trade-off: the static even split assumes roughly uniform data across partitions; under skew, total throughput stays under the global cap rather than redistributing unused budget. This keeps the design coordination-free.

### Code changes
- [x] Added new code behind **a config**:
  - `push.job.external.storage.write.quota.records.per.second` — default `-1` (disabled)
  - `push.job.external.storage.write.quota.bytes.per.second` — default `-1` (disabled)
- [x] Introduced new **log lines**: one INFO line per partition-writer task at dual-write setup. Emitted once per task (not per record), so no rate limiting needed.

### Concurrency-Specific Checks
- [x] No race conditions: each throttler instance is used only by its single partition-writer task thread; the underlying `GuavaRateLimiter` is thread-safe regardless.
- [x] No blocking calls inside critical sections: throttling blocks the task thread by design, outside any lock.

## How was this PR tested?
- [x] New unit tests added: `ExternalStorageWriteThrottlerTest` (even-split math, fail-fast, byte saturation), `AbstractPartitionWriterThrottlingTest` (config → per-region throttler wiring).
- [x] Modified or extended existing tests: `DualWriteVeniceWriterTest` (throttle before `batchPut`, rejection blocks the write, null per-region entry, empty flush); `TestVPJDualWriteExternalStorageMultiRegion` E2E now injects both quotas — both `batchSize` cases pass.
- [x] Verified backward compatibility: throttling is off by default (`<=0`), so existing pushes are unchanged.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. New config defaults to disabled; behavior is unchanged unless a quota is set.
