### PR TITLE
[da-vinci] Fix NR remote-VT LCVP mismatch in addVtDivToProducerCallbackIfNeeded

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2396,7 +2396,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     PubSubTopicPartition topicPartition = pcs.getReplicaTopicPartition();
     PartitionTracker vtDiv =
         getConsumerDiv().cloneVtProducerStates(pcs.getPartition(), true, pcs.getLatestMessageTimeInMs());
-    sendVtDivSnapshotOnCompletion(callback, topicPartition, vtDiv, persistedToDBFuture);
+    // For NR leaders the consumed topic is the remote source VT, not the local VT. The local VT
+    // produce position (used by the RT-source path) belongs to a different topic and offset space,
+    // so it must not be used as the LCVP that determines the remote VT restart subscription position.
+    // Capture the remote VT offset now; sendVtDivSnapshotOnCompletion will use it instead of the
+    // local produce position.
+    sendVtDivSnapshotOnCompletion(callback, topicPartition, vtDiv, persistedToDBFuture, consumerRecord.getPosition());
     pcs.resetConsumedBytesSinceLastGlobalRtDivSync(getVersionTopic().getName());
   }
 
@@ -2404,14 +2409,32 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    * Installs an onCompletion callback on {@code callback} that, when the produce to local VT completes,
    * updates {@code vtDiv}'s LCVP to the produced position and queues a drainer-side OffsetRecord sync.
    * Restores the thread interrupt flag if the drainer rejects with {@link InterruptedException}.
-   * Shared by {@link #createGlobalRtDivCallback} (leader-RT-source) and
-   * {@link #addVtDivToProducerCallbackIfNeeded} (leader-VT-source).
+   * Used by {@link #createGlobalRtDivCallback} (leader-RT-source) where the local VT produce position
+   * is the correct LCVP.
    */
   private CompletableFuture<Void> sendVtDivSnapshotOnCompletion(
       LeaderProducerCallback callback,
       PubSubTopicPartition topicPartition,
       PartitionTracker vtDiv,
       CompletableFuture<Void> persistedToDBFuture) {
+    return sendVtDivSnapshotOnCompletion(callback, topicPartition, vtDiv, persistedToDBFuture, null);
+  }
+
+  /**
+   * Installs an onCompletion callback on {@code callback} that, when the produce to local VT completes,
+   * updates {@code vtDiv}'s LCVP and queues a drainer-side OffsetRecord sync.
+   *
+   * <p>When {@code lcvp} is non-null the snapshot is stamped with that position (used by
+   * {@link #addVtDivToProducerCallbackIfNeeded} for NR remote-VT-source leaders, where the consumed
+   * remote VT position must be used rather than the local VT produce position).
+   * When {@code lcvp} is null the produce result position is used (RT-source leader path).
+   */
+  private CompletableFuture<Void> sendVtDivSnapshotOnCompletion(
+      LeaderProducerCallback callback,
+      PubSubTopicPartition topicPartition,
+      PartitionTracker vtDiv,
+      CompletableFuture<Void> persistedToDBFuture,
+      PubSubPosition lcvp) {
     // Relay future the leader graceful-shutdown path awaits. It completes when the drainer-side VT DIV sync node has
     // run. The leader-produce callback only fires on produce success, so also fail the relay if the produce/persist
     // fails — otherwise the shutdown await would hang until its timeout instead of completing promptly.
@@ -2423,7 +2446,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     });
     callback.setOnCompletionCallback(produceResult -> {
       try {
-        vtDiv.updateLatestConsumedVtPosition(produceResult.getPubSubPosition());
+        vtDiv.updateLatestConsumedVtPosition(lcvp != null ? lcvp : produceResult.getPubSubPosition());
         storeBufferService.execSyncOffsetFromSnapshotAsync(topicPartition, vtDiv, persistedToDBFuture, this)
             .whenComplete((ignored, throwable) -> {
               if (throwable != null) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -1359,7 +1359,14 @@ public class PartitionConsumptionState {
    *
    * <p>If the leader topic is a version topic:
    * <ul>
-   *   <li>If remote consumption is enabled, returns the latest processed remote VT position.</li>
+   *   <li>If remote consumption is enabled and {@code useCheckpointedDivRtPosition} is true
+   *       (i.e., Global RT DIV is active and this is a transition), uses the last consumed
+   *       VT position (LCVP) as the remote VT subscribe position. LCVP is written atomically
+   *       with the DIV snapshot, so it is always consistent with the checkpointed producer
+   *       states. Falls back to {@code latestProcessedRemoteVtPosition} when LCVP is
+   *       EARLIEST (not yet initialized).</li>
+   *   <li>If remote consumption is enabled and {@code useCheckpointedDivRtPosition} is false,
+   *       returns the latest processed remote VT position.</li>
    *   <li>Otherwise, returns the latest processed local VT position.</li>
    * </ul>
    *
@@ -1375,6 +1382,17 @@ public class PartitionConsumptionState {
           ? getDivRtCheckpointPosition(pubSubBrokerAddress)
           : getLatestProcessedRtPosition(pubSubBrokerAddress);
     } else {
+      if (consumeRemotely() && useCheckpointedDivRtPosition) {
+        // LCVP is written atomically with the DIV snapshot (same consumer-thread moment),
+        // so it is always consistent with the saved producer states. Use it as the remote
+        // VT subscribe position when Global RT DIV is active to avoid the window where
+        // latestProcessedRemoteVtPosition (drainer-side) can diverge from the DIV snapshot
+        // (consumer-side) during shutdown. Fall back when LCVP is not yet initialized.
+        PubSubPosition lcvp = getLatestConsumedVtPosition();
+        if (!PubSubSymbolicPosition.EARLIEST.equals(lcvp)) {
+          return lcvp;
+        }
+      }
       return consumeRemotely() ? getLatestProcessedRemoteVtPosition() : getLatestProcessedVtPosition();
     }
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -176,6 +176,8 @@ public class LeaderFollowerStoreIngestionTaskTest {
   private static final PubSubTopicRepository TOPIC_REPOSITORY = new PubSubTopicRepository();
   private static final int GLOBAL_RT_DIV_VERSION =
       AvroProtocolDefinition.GLOBAL_RT_DIV_STATE.getCurrentProtocolVersion();
+  // Sentinel remote-VT consumed position used by addVtDivToProducerCallbackIfNeeded tests.
+  private static final PubSubPosition REMOTE_VT_CONSUMED_POSITION = InMemoryPubSubPosition.of(7L);
 
   private Store mockStore;
   private LeaderFollowerStoreIngestionTask leaderFollowerStoreIngestionTask;
@@ -1121,10 +1123,11 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
   /**
    * Verifies that {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallbackIfNeeded} installs an
-   * onCompletionCallback on the regular {@link LeaderProducerCallback} that, when fired, asynchronously
-   * syncs the OffsetRecord with LCVP set to the produced-local-VT position. This covers the leader
-   * consuming from a VT source (e.g., remote VT), whose LCVP would otherwise never be persisted —
-   * causing restart from EARLIEST.
+   * onCompletionCallback on the {@link LeaderProducerCallback} that, when fired, asynchronously syncs
+   * the OffsetRecord with LCVP set to the <em>consumed remote-VT position</em> — NOT the local VT
+   * produce position. This is the NR remote-VT-source path: the leader subscribes to the remote VT on
+   * restart, so LCVP must be the remote VT offset; using the local VT produce position (a different
+   * topic/offset space) would cause the leader to resume at a wrong position and miss the SOS.
    *
    * Also verifies the byte counter is reset synchronously, mirroring the leader-RT path's behavior
    * in {@link LeaderFollowerStoreIngestionTask#sendGlobalRtDivMessage}.
@@ -1140,11 +1143,19 @@ public class LeaderFollowerStoreIngestionTaskTest {
     // Byte counter is reset synchronously when the callback is installed (mirrors the RT path).
     verify(mockPartitionConsumptionState, times(1)).resetConsumedBytesSinceLastGlobalRtDivSync(versionTopicName);
 
-    fireProduceCallbackAndAssertLcvpSynced(callback, InMemoryPubSubPosition.of(42L));
-    // Confirm the sync was routed to the leader's replica topic-partition with the correct
-    // persisted-to-DB future from the leaderProducedRecordContext.
+    // Fire the produce-completion callback with a local VT produce position (99L). LCVP must be
+    // the consumer-record position (REMOTE_VT_CONSUMED_POSITION = 7L), not the produce position.
+    verify(mockStoreBufferService, never()).execSyncOffsetFromSnapshotAsync(any(), any(), any(), any());
+    PubSubProduceResult produceResult = mock(PubSubProduceResult.class);
+    doReturn(InMemoryPubSubPosition.of(99L)).when(produceResult).getPubSubPosition();
+    callback.onCompletion(produceResult, null);
+    ArgumentCaptor<PartitionTracker> vtDivCaptor = ArgumentCaptor.forClass(PartitionTracker.class);
     verify(mockStoreBufferService, times(1))
-        .execSyncOffsetFromSnapshotAsync(eq(mockTp), any(), eq(persistedFuture), any());
+        .execSyncOffsetFromSnapshotAsync(eq(mockTp), vtDivCaptor.capture(), eq(persistedFuture), any());
+    assertEquals(
+        vtDivCaptor.getValue().getLatestConsumedVtPosition(),
+        REMOTE_VT_CONSUMED_POSITION,
+        "LCVP must be the remote VT consumed position, not the local VT produce position");
   }
 
   /**
@@ -1222,12 +1233,15 @@ public class LeaderFollowerStoreIngestionTaskTest {
     // Build a consumer record on a non-RT topic so the install gate accepts it. Non-control-message
     // record so isNonSegmentControlMessage short-circuits and the install decision flows through
     // shouldSendGlobalRtDiv (which we stub to true below).
+    // getPosition() returns REMOTE_VT_CONSUMED_POSITION — this is the remote VT offset that must
+    // become the LCVP saved to the OffsetRecord (not the local VT produce position).
     DefaultPubSubMessage mockConsumerRecord = mock(DefaultPubSubMessage.class);
     PubSubTopicPartition mockSourceTp = mock(PubSubTopicPartition.class);
     PubSubTopic mockSourceTopic = mock(PubSubTopic.class);
     doReturn(mockSourceTp).when(mockConsumerRecord).getTopicPartition();
     doReturn(mockSourceTopic).when(mockSourceTp).getPubSubTopic();
     doReturn(false).when(mockSourceTopic).isRealTime();
+    doReturn(REMOTE_VT_CONSUMED_POSITION).when(mockConsumerRecord).getPosition();
     KafkaKey mockKey = mock(KafkaKey.class);
     doReturn(false).when(mockKey).isControlMessage();
     doReturn(mockKey).when(mockConsumerRecord).getKey();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
@@ -18,6 +18,7 @@ import com.linkedin.venice.pubsub.PubSubContext;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -492,6 +493,59 @@ public class PartitionConsumptionStateTest {
     // Don't init HLL
     assertFalse(disabledPcs.hasUniqueIngestedKeyCountHll());
     assertNull(disabledPcs.serializeUniqueIngestedKeyCountHll());
+  }
+
+  /**
+   * getLeaderPosition VT branch:
+   *   - consumeRemotely=true + useCheckpointedDivRtPosition=true + LCVP non-EARLIEST → return LCVP
+   *   - consumeRemotely=true + useCheckpointedDivRtPosition=true + LCVP=EARLIEST       → fall back to latestProcessedRemoteVtPosition
+   *   - consumeRemotely=true + useCheckpointedDivRtPosition=false                      → return latestProcessedRemoteVtPosition
+   *   - consumeRemotely=false                                                           → return latestProcessedVtPosition
+   */
+  @Test
+  public void testGetLeaderPositionVtBranch() {
+    PubSubPosition lcvp = mock(PubSubPosition.class);
+    PubSubPosition remoteVtPos = mock(PubSubPosition.class);
+    PubSubPosition localVtPos = mock(PubSubPosition.class);
+
+    // Use a mock OffsetRecord to avoid InMemoryPubSubPosition wire-format serialization issues
+    OffsetRecord offsetRecord = mock(OffsetRecord.class);
+    doReturn(TOPIC_REPOSITORY.getTopic("topic1_v1")).when(offsetRecord)
+        .getLeaderTopic(pubSubContext.getPubSubTopicRepository());
+    doReturn(lcvp).when(offsetRecord).getLatestConsumedVtPosition();
+
+    PartitionConsumptionState pcs =
+        new PartitionConsumptionState(TOPIC_PARTITION, offsetRecord, pubSubContext, false, false, false, null);
+    pcs.setLatestProcessedRemoteVtPosition(remoteVtPos);
+    pcs.setLatestProcessedVtPosition(localVtPos);
+
+    // consumeRemotely=true + Global RT DIV on (useCheckpointedDivRtPosition=true) + LCVP non-EARLIEST → LCVP
+    pcs.setConsumeRemotely(true);
+    assertEquals(
+        pcs.getLeaderPosition("broker", true),
+        lcvp,
+        "Global RT DIV + consumeRemotely + non-EARLIEST LCVP must return LCVP");
+
+    // consumeRemotely=true + Global RT DIV on + LCVP=EARLIEST → latestProcessedRemoteVtPosition
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(offsetRecord).getLatestConsumedVtPosition();
+    assertEquals(
+        pcs.getLeaderPosition("broker", true),
+        remoteVtPos,
+        "Global RT DIV + consumeRemotely + EARLIEST LCVP must fall back to latestProcessedRemoteVtPosition");
+
+    // consumeRemotely=true + Global RT DIV off (useCheckpointedDivRtPosition=false) → latestProcessedRemoteVtPosition
+    doReturn(lcvp).when(offsetRecord).getLatestConsumedVtPosition(); // restore non-EARLIEST LCVP
+    assertEquals(
+        pcs.getLeaderPosition("broker", false),
+        remoteVtPos,
+        "Global RT DIV off must use latestProcessedRemoteVtPosition regardless of LCVP");
+
+    // consumeRemotely=false → latestProcessedVtPosition
+    pcs.setConsumeRemotely(false);
+    assertEquals(
+        pcs.getLeaderPosition("broker", true),
+        localVtPos,
+        "consumeRemotely=false must use latestProcessedVtPosition");
   }
 
   private PartitionConsumptionState createPcsWithHll() {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestGlobalRtDiv.java
@@ -1355,6 +1355,120 @@ public class TestGlobalRtDiv {
   }
 
   /**
+   * Verifies that the LCVP saved by the NR remote-VT leader refers to the <em>remote</em> VT
+   * (source dc-0) position, not the <em>local</em> VT (dc-1 produce) position.
+   *
+   * <p>Before the fix in {@code addVtDivToProducerCallbackIfNeeded}, the callback used
+   * {@code produceResult.getPubSubPosition()} (local VT) as LCVP. The two positions come from
+   * different Kafka clusters and have different wire formats, so
+   * {@code getLatestConsumedVtPosition()} must not equal {@code getCheckpointedLocalVtPosition()}.
+   * If they are equal the leader will re-subscribe to the wrong offset on the remote VT after
+   * restart, miss the SOS, and immediately fail with a DIV {@code MissingDataException}.
+   */
+  @Test(timeOut = 180 * Time.MS_PER_SECOND)
+  public void testNRLeaderLcvpIsRemoteVTNotLocalVT() throws Exception {
+    int PARTITION = 0;
+    Properties extraServerProps = new Properties();
+    // Low sync threshold so byte-threshold LCVP syncs fire during the small batch push.
+    extraServerProps.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "500");
+
+    try (NRGlobalRtDivBatchEnv env =
+        setUpNRGlobalRtDivBatchPushed("venice-cluster0", "nrLcvpVsLocalVt", 100, 1, PARTITION, extraServerProps)) {
+
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+        Instance currentLeader = env.routingDataRepo.getLeaderInstance(env.topicName, PARTITION);
+        assertNotNull(currentLeader, "Leader should be assigned in remote dc for partition " + PARTITION);
+        VeniceServerWrapper leaderWrapper = env.remoteDcCluster.getVeniceServerByPort(currentLeader.getPort());
+        assertNotNull(leaderWrapper, "Leader server wrapper not found");
+        OffsetRecord offsetRecord = getRemoteDcLeaderOffsetRecord(leaderWrapper, env.topicName, PARTITION);
+
+        PubSubPosition lcvp = offsetRecord.getLatestConsumedVtPosition();
+        PubSubPosition localVtPosition = offsetRecord.getCheckpointedLocalVtPosition();
+
+        // Both positions must be real (non-EARLIEST) before we compare them.
+        assertNotEquals(lcvp, PubSubSymbolicPosition.EARLIEST, "LCVP must be synced (non-EARLIEST)");
+        assertNotEquals(
+            localVtPosition,
+            PubSubSymbolicPosition.EARLIEST,
+            "checkpointedLocalVtPosition must be set (non-EARLIEST)");
+
+        // The core assertion: LCVP tracks the remote VT consumed position, not the local VT produce
+        // position. The two positions originate from different Kafka clusters and therefore have
+        // different wire formats — they can never be equal in a correct implementation.
+        assertNotEquals(
+            lcvp,
+            localVtPosition,
+            "LCVP must be the remote VT consumed position, not the local VT produce position. "
+                + "If equal, addVtDivToProducerCallbackIfNeeded is saving the wrong offset as LCVP: " + "lcvp=" + lcvp
+                + " localVtPosition=" + localVtPosition);
+        LOGGER.info("event=globalRtDiv lcvp={} localVtPosition={} (correctly differ)", lcvp, localVtPosition);
+      });
+    }
+  }
+
+  /**
+   * Verifies that a second batch push succeeds after the NR remote-VT leader is restarted.
+   *
+   * <p>This is the end-to-end regression test for the LCVP offset-space mismatch in
+   * {@code addVtDivToProducerCallbackIfNeeded}: if the wrong (local VT) position is saved as LCVP,
+   * the NR leader re-subscribes to the remote VT at that position on the second startup, misses
+   * the SOS for the new version's segment, and immediately fails with a DIV
+   * {@code MissingDataException} — causing ERROR replicas and a stuck / failed push.
+   */
+  @Test(timeOut = 360 * Time.MS_PER_SECOND)
+  public void testNRLeaderRestartThenSecondPushSucceeds() throws Exception {
+    int PARTITION = 0;
+    Properties extraServerProps = new Properties();
+    extraServerProps.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "500");
+
+    try (NRGlobalRtDivBatchEnv env = setUpNRGlobalRtDivBatchPushed(
+        "venice-cluster0",
+        "nrLeaderRestartSecondPush",
+        100,
+        1,
+        PARTITION,
+        extraServerProps)) {
+
+      // Stop and restart the NR leader to load LCVP from the OffsetRecord.
+      LOGGER.info("event=globalRtDiv Stopping dc-1 leader: {}", env.leaderServer.getAddress());
+      env.remoteDcCluster.stopVeniceServer(env.leaderServer.getPort());
+      LOGGER.info("event=globalRtDiv Restarting dc-1 leader: {}", env.leaderServer.getAddress());
+      env.remoteDcCluster.restartVeniceServer(env.leaderServer.getPort());
+      TestUtils.waitForNonDeterministicAssertion(
+          30,
+          TimeUnit.SECONDS,
+          true,
+          true,
+          () -> assertTrue(
+              env.remoteDcCluster.getVeniceServerByPort(env.leaderServer.getPort()).isRunning(),
+              "Restarted server should be running"));
+
+      // Run a second push. If LCVP was saved as the local VT produce position, the NR leader
+      // re-subscribes to the remote VT at that wrong offset, misses the SOS for version 2's
+      // segment, and hits a DIV MissingDataException → ERROR replicas → VenicePushJob throws.
+      File inputDir2 = getTempDataDirectory();
+      TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir2, 50);
+      String inputDirPath2 = "file://" + inputDir2.getAbsolutePath();
+      Properties vpjProps2 = IntegrationTestPushUtils.defaultVPJProps(env.multiRegion, inputDirPath2, env.storeName);
+      vpjProps2.put(SEND_CONTROL_MESSAGES_DIRECTLY, true);
+      vpjProps2.put(SOURCE_GRID_FABRIC, env.sourceFabric);
+      try (VenicePushJob job = new VenicePushJob("Test push v2", vpjProps2)) {
+        job.run(); // throws if any dc doesn't reach version 2 (e.g., ERROR replicas in dc-1)
+      }
+
+      // Verify v2 is current in dc-1 and a sample of its data is readable.
+      try (AvroGenericStoreClient<Object, Object> client = ClientFactory.getAndStartGenericAvroClient(
+          ClientConfig.defaultGenericClientConfig(env.storeName)
+              .setVeniceURL(env.remoteDcCluster.getRandomRouterURL()))) {
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
+          Object value = client.get("1").get();
+          assertNotNull(value, "Key '1' must be readable from dc-1 after second push");
+        });
+      }
+    }
+  }
+
+  /**
    * Spins up a 2-region NR cluster with Global RT DIV enabled, runs a batch push, and resolves
    * the dc-1 (remote) leader. dc-0 is pinned as the source fabric so dc-1 is deterministically
    * the remote consumer (consumeRemotely=true on the dc-1 leader).
@@ -1464,7 +1578,8 @@ public class TestGlobalRtDiv {
           leaderServer,
           topicName,
           storeName,
-          routingDataRepo);
+          routingDataRepo,
+          sourceFabric);
     } catch (Throwable t) {
       try {
         multiRegion.close();
@@ -1480,12 +1595,13 @@ public class TestGlobalRtDiv {
    * Owns the multi-region cluster wrapper and shuts it down on {@link #close()}.
    */
   private static final class NRGlobalRtDivBatchEnv implements AutoCloseable {
-    private final VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegion;
+    final VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegion;
     final VeniceClusterWrapper remoteDcCluster;
     final VeniceServerWrapper leaderServer;
     final String topicName;
     final String storeName;
     final HelixExternalViewRepository routingDataRepo;
+    final String sourceFabric;
 
     NRGlobalRtDivBatchEnv(
         VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegion,
@@ -1493,13 +1609,15 @@ public class TestGlobalRtDiv {
         VeniceServerWrapper leaderServer,
         String topicName,
         String storeName,
-        HelixExternalViewRepository routingDataRepo) {
+        HelixExternalViewRepository routingDataRepo,
+        String sourceFabric) {
       this.multiRegion = multiRegion;
       this.remoteDcCluster = remoteDcCluster;
       this.leaderServer = leaderServer;
       this.topicName = topicName;
       this.storeName = storeName;
       this.routingDataRepo = routingDataRepo;
+      this.sourceFabric = sourceFabric;
     }
 
     @Override


### PR DESCRIPTION
# Summary

## Phase 1 — First-ever leader promotion (no prior checkpoint)

1. NR leader is promoted. `consumeRemotely()` = true (EOP not yet received from remote VT).
2. `getLeaderPosition()` VT branch: `useCheckpointedDivRtPosition=true` (Global RT DIV on + transition), but LCVP = EARLIEST (no prior checkpoint) → falls back to `latestProcessedRemoteVtPosition` = EARLIEST.
3. Leader subscribes to **remote VT at EARLIEST** (primary fabric's version topic, beginning).
4. First messages are SOS (start of segment) for each producer GUID → `consumerDiv` initialized correctly.

---

## Phase 2 — Normal remote VT consumption

Each message the consumer reads from the remote VT:

1. `consumerDiv.validateSequenceNumber(producerGUID, seq)` — verifies no gap.
2. Message is re-produced to **local VT** (secondary fabric's version topic).
3. Drainer persists the local VT record to RocksDB and updates `latestProcessedRemoteVtPosition`.

### Byte-threshold sync (fires in consumer thread every N bytes)

1. Consumer snapshots `consumerDiv` → captures all producer states at this exact moment.
2. `addVtDivToProducerCallbackIfNeeded` passes `consumerRecord.getPosition()` (the remote VT
   position of the triggering record) as LCVP.
   *(Fix: was previously using the local VT produce position.)*
3. `SyncVtDivNode` is queued in the drainer — executes after all pending records are drained.
4. `updateAndSyncOffsetFromSnapshot` writes to OffsetRecord atomically:
   - DIV producer states from the snapshot (consumer-thread, seq N)
   - LCVP = remote VT pos(N) — same record, same thread, same moment as the snapshot

**Key invariant**: LCVP and the DIV producer states on disk are always consistent — they were
captured in a single consumer-thread operation.

---
## Phase 3 — Graceful shutdown

`forceGlobalRtDivSync` fires for all partitions in the drainer thread (after consumer unsubscribes):

1. All remaining consumer records have been drained.
2. `syncGlobalRtDivFromSnapshot`: snapshots the now-stable `consumerDiv` + the current
   `latestProcessedRemoteVtPosition`, writes to OffsetRecord.
3. Both reflect the last record the server ever consumed from the remote VT → consistent.

---

## Phase 4 — Restart (the critical path)

1. PCS is restored from OffsetRecord: loads DIV producer states and LCVP from disk.
2. `consumeRemotely()` = true (EOP not yet received → server was still in the remote VT phase).
3. `getLeaderPosition()` VT branch:
   - `useCheckpointedDivRtPosition=true` (Global RT DIV on + transition)
   - LCVP ≠ EARLIEST (was set at last sync)
   - **Returns LCVP**
     *(Fix: previously returned `latestProcessedRemoteVtPosition`.)*
4. Leader subscribes to **remote VT at LCVP**.
5. First message from remote VT = seq(N)+1. DIV producer states expect seq(N)+1. No gap.

### Why LCVP is safer than `latestProcessedRemoteVtPosition`

`latestProcessedRemoteVtPosition` is a drainer-side watermark updated per-record in the drainer
thread. At the moment the shutdown sync writes it, there is a window where it can be slightly
ahead or behind the consumer-side DIV snapshot — particularly during a shutdown race. LCVP is
immune to this because it was written in the same operation as the DIV snapshot.

---

## Phase 5 — After EOP received from remote VT

1. Remote VT EOP received → `isEndOfPushReceived()` = true → `consumeRemotely()` transitions to false.
2. `checkLongRunningTaskState` fires → `shouldLeaderSwitchToLocalConsumption()` = true →
   unsubscribes from remote VT, subscribes to local VT.
3. On any subsequent restart: `consumeRemotely()` = false → `getLeaderPosition()` returns
   `getLatestProcessedVtPosition()` (local VT path, unaffected by the fix).

---

## The 1/3-server failure explained (pre-fix)

The race was in Phase 3 (graceful shutdown). If the shutdown sync ran while:

- `consumerDiv` was snapshotted at seq N (consumer-thread state)
- `latestProcessedRemoteVtPosition` was read at seq M where M ≠ N (drainer-thread state,
  slightly different timing)

Then on restart: subscribed at pos(M), DIV expected seq(N)+1.

- M < N → re-reads already-validated records → duplicate detection
- M > N → forward gap → `MissingDataException` with `previous: null`

The exact outcome depended on shutdown timing, explaining the non-deterministic 1/3-server pattern.



Three-part fix for NR remote VT leader data integrity (DIV) regression on ei4 after Global RT DIV was enabled:

**Commit 1 — root cause fix (`addVtDivToProducerCallbackIfNeeded`)**
The NR leader was storing the local VT produce position as LCVP (last consumed VT position). LCVP must hold the remote VT consumed position so it is consistent with the DIV snapshot it travels alongside.

**Commit 2 — regression tests (`TestGlobalRtDiv`)**
Two new integration tests for the NR remote VT path: one asserting LCVP is the remote VT position (not the local VT position), and one verifying a second push succeeds after an NR leader restart (no MissingDataException).

**Commit 3 — subscribe position fix (`getLeaderPosition`)**
When Global RT DIV is active and the leader is consuming the remote VT, use LCVP as the restart subscribe position instead of `latestProcessedRemoteVtPosition`.

`latestProcessedRemoteVtPosition` is a drainer-side watermark written independently at sync time; it can diverge from the consumer-side DIV snapshot during shutdown, producing a "previous position: null" MissingDataException on roughly 1/3 of NR leader restarts (timing-dependent). LCVP is written atomically with the DIV snapshot in the same consumer-thread moment, so it is always consistent with the persisted producer states. Falls back to `latestProcessedRemoteVtPosition` when LCVP is still EARLIEST (not yet initialized before the first byte-threshold sync fires).

## Testing Done

- Unit test `testGetLeaderPositionVtBranch` added to `PartitionConsumptionStateTest` covering all four cases: LCVP used when non-EARLIEST + Global RT DIV on, EARLIEST fallback, DIV-off uses `latestProcessedRemoteVtPosition`, `consumeRemotely=false` uses local VT position.
- Unit test `testAddVtDivToProducerCallbackIfNeeded` updated to assert LCVP = remote VT consumed position (not local VT produce position).
- Integration tests in `TestGlobalRtDiv` covering NR remote VT LCVP correctness and leader restart.
