### PR TITLE
[server] Log request URI on BAD_REQUEST parse failures (#2866)

### DIFF
--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
@@ -28,6 +28,7 @@ import com.linkedin.venice.throttle.TokenBucket;
 import com.linkedin.venice.throttle.VeniceRateLimiter;
 import com.linkedin.venice.throttle.VeniceRateLimiter.RateLimiterType;
 import com.linkedin.venice.utils.DaemonThreadFactory;
+import com.linkedin.venice.utils.RedundantExceptionFilter;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -51,6 +52,8 @@ import org.apache.logging.log4j.Logger;
 public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<RouterRequest>
     implements RoutingDataRepository.RoutingDataChangedListener, StoreDataChangedListener {
   private static final Logger LOGGER = LogManager.getLogger(ReadQuotaEnforcementHandler.class);
+  private static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER =
+      RedundantExceptionFilter.getRedundantExceptionFilter();
   public static final String SERVER_OVER_CAPACITY_MSG = "Server over capacity";
   public static final String INVALID_REQUEST_RESOURCE_MSG = "Invalid request resource: ";
   private static final long WAIT_FOR_CUSTOMIZED_VIEW_TIMEOUT_SECONDS = 180;
@@ -298,6 +301,10 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
     QuotaEnforcementResult result = enforceQuota(request);
 
     if (result == QuotaEnforcementResult.BAD_REQUEST) {
+      String msg = INVALID_REQUEST_RESOURCE_MSG + request.getResourceName();
+      if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
+        LOGGER.warn("Rejecting request from {} - {}", ctx.channel(), msg);
+      }
       ctx.writeAndFlush(
           new HttpShortcutResponse(
               INVALID_REQUEST_RESOURCE_MSG + request.getResourceName(),

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
@@ -18,6 +18,7 @@ import com.linkedin.venice.listener.response.HttpShortcutResponse;
 import com.linkedin.venice.meta.QueryAction;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.request.RequestHelper;
+import com.linkedin.venice.utils.RedundantExceptionFilter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -45,6 +46,8 @@ import org.apache.logging.log4j.Logger;
  */
 public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
   private static final Logger LOGGER = LogManager.getLogger(RouterRequestHttpHandler.class);
+  private static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER =
+      RedundantExceptionFilter.getRedundantExceptionFilter();
   private final StatsHandler statsHandler;
   private final Map<String, Integer> storeToEarlyTerminationThresholdMSMap;
 
@@ -171,6 +174,11 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           throw new VeniceException("Unrecognized query action");
       }
     } catch (VeniceException e) {
+      Object remote = ctx.channel() == null ? null : ctx.channel().remoteAddress();
+      String filterKey = "URI parse failure: " + e.getMessage() + " uri=" + req.uri() + " remote=" + remote;
+      if (!REDUNDANT_LOGGING_FILTER.isRedundantException(filterKey)) {
+        LOGGER.warn("Failed to parse request URI '{}' from {}: {}", req.uri(), remote, e.getMessage(), e);
+      }
       ctx.writeAndFlush(new HttpShortcutResponse(e.getMessage(), HttpResponseStatus.BAD_REQUEST));
     }
   }


### PR DESCRIPTION
* [server] Log request URI on BAD_REQUEST parse failures

Both BAD_REQUEST paths in venice-server were silent:

1. RouterRequestHttpHandler.channelRead0 catch block (line 173) — when request URI / QueryAction parsing throws VeniceException, the handler writes HTTP 400 without any log. The LOGGER field was declared in this file but never used.

2. ReadQuotaEnforcementHandler.channelRead0 BAD_REQUEST branch (line 300) — when enforceQuota() returns BAD_REQUEST because the store is unknown to storeRepository, the handler writes HTTP 400 with no log.

Together these two paths fully populate the server-side error_request counter under the "unknown_store" tag. Recent production triage saw HTTP 400 spikes peaking above 400 req/s on a cluster with zero matching log entries, making client/source attribution impossible from logs.

This change logs the offending URI plus the channel at WARN level, deduped through REDUNDANT_LOGGING_FILTER (same pattern used in StorageReadRequestHandler) so the high-volume path stays safe.

* [server] Use stable filter key for parse-failure dedupe

Address review feedback from xunyin8: ctx.channel().toString() includes the unique netty channel id, so embedding it in the REDUNDANT_LOGGING_FILTER key defeats deduplication entirely (each new HTTP/2 connection produces a distinct key even for identical malformed URIs).

Switch the filter key to (exception message, URI, remoteAddress). The remote address is stable per client, so a flood of identical bad URIs from one client dedupes; distinct bad URIs or distinct clients each get logged once per filter window.

Also pass the exception object to LOGGER.warn so the stack trace is preserved, and use parameterized logging instead of string concatenation so the message isn't built when the filter suppresses it.

* [server] Null-safe remoteAddress lookup in parse-failure log

The previous commit chained ctx.channel().remoteAddress() in the RouterRequestHttpHandler catch block. In production this is fine — netty guarantees ctx.channel() is non-null inside a handler — but the existing RouterRequestHttpHandlerTest mocks ChannelHandlerContext and lets ctx.channel() return null, so the chained call NPEs out of the catch (NPE is not a VeniceException) and writeAndFlush(BAD_REQUEST) is never invoked. Two existing tests (parsesRequests,
malformedKeyPartitionProfilerUrlReturnsBadRequest) regressed for this reason.

Guard the call so a null channel resolves to a null remote. The log line and filter key still record "remote=null" in that case, which keeps the test contract intact and is also defensive against any future code path that hands the handler a half-initialized context.

---------

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
<!--
Describe
- What problem are you trying to solve
- What issues or limitations exist in the current code
- Why this change is necessary 
-->


## Solution
<!--
Describe
- What changes you are making and why. 
- How these changes solve the problem.
- Any performance considerations or trade-offs. 
- Describe what testings you have done, for example, performance testing etc.
-->


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.