### PR TITLE
[changelog] Null-guard CDC version-gate to prevent record loss

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -714,6 +714,15 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
     }
 
     /**
+     * Returns whether this partition is currently designated to be served by this consumer's store version.
+     * Null-checked to prevent an NPE during shutdown races.
+     */
+    private boolean isServedByThisVersion(int partitionId) {
+      Integer versionToServe = partitionToVersionToServe.get(partitionId);
+      return versionToServe != null && versionToServe == getStoreVersion();
+    }
+
+    /**
      * Add ChangeCapturePubSubMessage to the buffer based on record metadata.
      */
     public void addMessageToBuffer(
@@ -721,7 +730,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
         V value,
         int partitionId,
         DaVinciRecordTransformerRecordMetadata recordMetadata) {
-      if (partitionToVersionToServe.get(partitionId) == getStoreVersion()) {
+      if (isServedByThisVersion(partitionId)) {
         ChangeEvent<V> changeEvent = new ChangeEvent<>(null, value);
         ImmutableChangeCapturePubSubMessage<K, ChangeEvent<V>> pubSubMessage =
             new ImmutableChangeCapturePubSubMessage<>(
@@ -750,7 +759,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
         ControlMessage controlMessage,
         long pubSubMessageTimestamp,
         long producerTimestamp) {
-      if (partitionToVersionToServe.get(partitionId) == getStoreVersion()) {
+      if (isServedByThisVersion(partitionId)) {
         ImmutableChangeCapturePubSubMessage<K, ChangeEvent<V>> pubSubMessage =
             new ImmutableChangeCapturePubSubMessage<>(
                 null,
@@ -775,7 +784,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
     private void internalAddMessageToBuffer(
         int partitionId,
         ImmutableChangeCapturePubSubMessage<K, ChangeEvent<V>> pubSubMessage) {
-      if (partitionToVersionToServe.get(partitionId) != getStoreVersion()) {
+      if (!isServedByThisVersion(partitionId)) {
         return;
       }
 
@@ -927,7 +936,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
      * Receive heartbeat timestamp for a partition and update latest seen time.
      */
     public void onHeartbeat(int partitionId, long heartbeatTimestamp) {
-      if (partitionToVersionToServe.get(partitionId) == getStoreVersion()) {
+      if (isServedByThisVersion(partitionId)) {
         currentVersionLastHeartbeat.put(partitionId, heartbeatTimestamp);
       }
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
@@ -327,6 +327,39 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
   }
 
   @Test
+  public void testProcessPutForPartitionAbsentFromVersionMapDoesNotThrow() {
+    // Regression: a record processed for a partition that was never registered in partitionToVersionToServe
+    // (onStartVersionIngestion not invoked for it, e.g. a non-current version, or a record draining after
+    // shutdown teardown) makes the version-gate's map lookup return null. The gate must skip the record,
+    // not unbox null into a NullPointerException.
+    veniceChangelogConsumer.start();
+
+    recordTransformer.processPut(keys.get(0), lazyValue, 0, recordMetadata);
+
+    assertEquals(
+        veniceChangelogConsumer.poll(POLL_TIMEOUT).size(),
+        0,
+        "Record for a partition absent from the version map should be skipped, not buffered");
+  }
+
+  @Test
+  public void testProcessPutAfterPartitionStateClearedDoesNotThrow() {
+    // Regression for the host-shutdown path: stop()/unsubscribe() call clearPartitionState, removing entries
+    // from partitionToVersionToServe. A record still draining afterward must be skipped, not throw on the
+    // null version-map lookup.
+    veniceChangelogConsumer.start();
+    onStartVersionIngestionHelper(true, true);
+    veniceChangelogConsumer.clearPartitionState(partitionSet);
+
+    recordTransformer.processPut(keys.get(0), lazyValue, 0, recordMetadata);
+
+    assertEquals(
+        veniceChangelogConsumer.poll(POLL_TIMEOUT).size(),
+        0,
+        "Record arriving after partition-state teardown should be skipped, not buffered");
+  }
+
+  @Test
   public void testCompletableFutureFromStart() {
     CompletableFuture startCompletableFuture = veniceChangelogConsumer.start();
     onStartVersionIngestionHelper(true, true);


### PR DESCRIPTION
## Problem Statement

DVRT CDC can throw a `NullPointerException` while routing a record when the record's partition is missing from the
consumer's internal version map — which happens during teardown (`stop()`/`unsubscribe()` clears
that state).

The NPE aborts processing before the record is persisted, while the consumer has already advanced
its processed offset. The offset can then be checkpointed past a record that was never persisted,
and on the next bootstrap the record is silently and permanently dropped. This was seen in
production during host restarts, where in-flight records across many partitions were lost.

## Solution

Null-guard the version check so a missing partition is treated as "not served by this version" and
the record is skipped instead of throwing. Processing then completes and the record is persisted
normally. All four call sites go through one guarded helper.

Checkpointing before persistence needs to be addressed separately and needs some historical context on why it's structured this way.

### Code changes
- [ ] Added new code behind a config.
- [ ] Introduced new log lines.

### Concurrency-Specific Checks
- [x] No race conditions or thread-safety issues (replaces an unguarded read that threw under a
  concurrent teardown with a null-tolerant one).
- [x] Thread-safe collections unchanged (`VeniceConcurrentHashMap`).
- [x] Removes a silent drainer-thread NPE that was dropping records.

## How was this PR tested?
- [x] New unit tests added — two regression tests reproduce the NPE on the current code and pass
  after the fix; the full consumer test class passes.

## Does this PR introduce any user-facing or breaking changes?
- [x] No.
