### PR TITLE
[common] Clamp topic retention to alternative-backend max on create

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubConstants.java
@@ -119,6 +119,17 @@ public class PubSubConstants {
 
   public static final long ETERNAL_TOPIC_RETENTION_POLICY_MS = Long.MAX_VALUE;
 
+  /**
+   * Some PubSub backends do not support an effectively-infinite ({@link #ETERNAL_TOPIC_RETENTION_POLICY_MS})
+   * retention and reject (or silently clamp) topic creations whose retention exceeds a backend-specific
+   * maximum. When a topic is created/updated against an alternative backend (see
+   * {@link com.linkedin.venice.pubsub.PubSubTopicConfiguration#isUseAlternativeBackend()}), Venice clamps
+   * the requested retention down to this value so it passes an explicit, supported retention instead of
+   * relying on the backend to clamp it. This is the default; deployments can override it via
+   * {@link com.linkedin.venice.pubsub.manager.TopicManagerContext.Builder#setAlternativeBackendMaxRetentionMs(long)}.
+   */
+  public static final long DEFAULT_ALTERNATIVE_BACKEND_MAX_RETENTION_MS = 365 * Time.MS_PER_DAY;
+
   public static final long DEFAULT_TOPIC_RETENTION_POLICY_MS = 5 * Time.MS_PER_DAY;
 
   public static final long BUFFER_REPLAY_MINIMAL_SAFETY_MARGIN = 2 * Time.MS_PER_DAY;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
@@ -252,6 +252,13 @@ public class TopicManager implements Closeable {
       boolean useFastPubSubOperationTimeout,
       boolean useAlternativeBackend,
       Optional<Boolean> uncleanLeaderElectionEnable) {
+    if (useAlternativeBackend) {
+      /*
+       * Clamp once here so both the create config below and the "topic already exists" recreate branch
+       * (which reuses retentionTimeMs via updateTopicRetention) pass the supported value to the backend.
+       */
+      retentionTimeMs = clampRetentionForAlternativeBackend(topicName, retentionTimeMs);
+    }
     long startTimeMs = System.currentTimeMillis();
     long deadlineMs = startTimeMs + (useFastPubSubOperationTimeout
         ? PUBSUB_FAST_OPERATION_TIMEOUT_MS
@@ -299,6 +306,28 @@ public class TopicManager implements Closeable {
     waitUntilTopicCreated(topicName, numPartitions, deadlineMs);
     boolean eternal = retentionTimeMs == PubSubConstants.ETERNAL_TOPIC_RETENTION_POLICY_MS;
     logger.info("Successfully created {}topic: {}", eternal ? "eternal " : "", topicName);
+  }
+
+  /**
+   * Some alternative PubSub backends reject retentions above a backend-specific maximum (for example, they do
+   * not support effectively-infinite / {@link PubSubConstants#ETERNAL_TOPIC_RETENTION_POLICY_MS} retention).
+   * When a topic targets such a backend, clamp the requested retention down to
+   * {@link TopicManagerContext#getAlternativeBackendMaxRetentionMs()} so Venice passes an explicit, supported
+   * value instead of relying on the backend to silently clamp (or reject) it. The backend adapter remains the
+   * authoritative enforcement point; clamping here keeps Venice's intended retention consistent with what the
+   * backend will actually store.
+   */
+  long clampRetentionForAlternativeBackend(PubSubTopic topicName, long retentionTimeMs) {
+    long maxRetentionMs = topicManagerContext.getAlternativeBackendMaxRetentionMs();
+    if (retentionTimeMs > maxRetentionMs) {
+      logger.info(
+          "Clamping retention for topic: {} on alternative backend from {}ms to max supported: {}ms",
+          topicName,
+          retentionTimeMs,
+          maxRetentionMs);
+      return maxRetentionMs;
+    }
+    return retentionTimeMs;
   }
 
   protected void waitUntilTopicCreated(PubSubTopic topicName, int partitionCount, long deadlineMs) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManagerContext.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManagerContext.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.pubsub.manager;
 
+import static com.linkedin.venice.pubsub.PubSubConstants.DEFAULT_ALTERNATIVE_BACKEND_MAX_RETENTION_MS;
 import static com.linkedin.venice.pubsub.PubSubConstants.DEFAULT_KAFKA_MIN_LOG_COMPACTION_LAG_MS;
 import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE;
 import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_TOPIC_DELETION_STATUS_POLL_INTERVAL_MS_DEFAULT_VALUE;
@@ -30,6 +31,7 @@ public class TopicManagerContext {
   private final long pubSubOperationTimeoutMs;
   private final long topicDeletionStatusPollIntervalMs;
   private final long topicMinLogCompactionLagMs;
+  private final long alternativeBackendMaxRetentionMs;
   private final long topicOffsetCheckIntervalMs;
   private final int topicMetadataFetcherConsumerPoolSize;
   private final int topicMetadataFetcherThreadPoolSize;
@@ -41,6 +43,7 @@ public class TopicManagerContext {
     this.pubSubOperationTimeoutMs = builder.pubSubOperationTimeoutMs;
     this.topicDeletionStatusPollIntervalMs = builder.topicDeletionStatusPollIntervalMs;
     this.topicMinLogCompactionLagMs = builder.topicMinLogCompactionLagMs;
+    this.alternativeBackendMaxRetentionMs = builder.alternativeBackendMaxRetentionMs;
     this.pubSubAdminAdapterFactory = builder.pubSubAdminAdapterFactory;
     this.pubSubConsumerAdapterFactory = builder.pubSubConsumerAdapterFactory;
     this.pubSubTopicRepository = builder.pubSubTopicRepository;
@@ -65,6 +68,15 @@ public class TopicManagerContext {
 
   public long getTopicMinLogCompactionLagMs() {
     return topicMinLogCompactionLagMs;
+  }
+
+  /**
+   * @return the maximum retention, in ms, that Venice will request when creating/updating a topic on an
+   *         alternative PubSub backend (see {@link com.linkedin.venice.pubsub.PubSubTopicConfiguration#isUseAlternativeBackend()}).
+   *         Requested retentions above this value are clamped down to it.
+   */
+  public long getAlternativeBackendMaxRetentionMs() {
+    return alternativeBackendMaxRetentionMs;
   }
 
   public PubSubAdminAdapterFactory<PubSubAdminAdapter> getPubSubAdminAdapterFactory() {
@@ -127,8 +139,9 @@ public class TopicManagerContext {
   public String toString() {
     return "TopicManagerContext{veniceComponent=" + veniceComponent + ", pubSubOperationTimeoutMs="
         + pubSubOperationTimeoutMs + ", topicDeletionStatusPollIntervalMs=" + topicDeletionStatusPollIntervalMs
-        + ", topicMinLogCompactionLagMs=" + topicMinLogCompactionLagMs + ", topicOffsetCheckIntervalMs="
-        + topicOffsetCheckIntervalMs + ", topicMetadataFetcherConsumerPoolSize=" + topicMetadataFetcherConsumerPoolSize
+        + ", topicMinLogCompactionLagMs=" + topicMinLogCompactionLagMs + ", alternativeBackendMaxRetentionMs="
+        + alternativeBackendMaxRetentionMs + ", topicOffsetCheckIntervalMs=" + topicOffsetCheckIntervalMs
+        + ", topicMetadataFetcherConsumerPoolSize=" + topicMetadataFetcherConsumerPoolSize
         + ", topicMetadataFetcherThreadPoolSize=" + topicMetadataFetcherThreadPoolSize + ", pubSubAdminAdapterFactory="
         + pubSubAdminAdapterFactory.getClass().getSimpleName() + ", pubSubConsumerAdapterFactory="
         + pubSubConsumerAdapterFactory.getClass().getSimpleName() + '}';
@@ -147,6 +160,7 @@ public class TopicManagerContext {
     private long pubSubOperationTimeoutMs = PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE;
     private long topicDeletionStatusPollIntervalMs = PUBSUB_TOPIC_DELETION_STATUS_POLL_INTERVAL_MS_DEFAULT_VALUE;
     private long topicMinLogCompactionLagMs = DEFAULT_KAFKA_MIN_LOG_COMPACTION_LAG_MS;
+    private long alternativeBackendMaxRetentionMs = DEFAULT_ALTERNATIVE_BACKEND_MAX_RETENTION_MS;
     private long topicOffsetCheckIntervalMs = 60_000L; // 1 minute
     private int topicMetadataFetcherConsumerPoolSize = 1;
     private int topicMetadataFetcherThreadPoolSize = 2;
@@ -163,6 +177,11 @@ public class TopicManagerContext {
 
     public Builder setTopicMinLogCompactionLagMs(long topicMinLogCompactionLagMs) {
       this.topicMinLogCompactionLagMs = topicMinLogCompactionLagMs;
+      return this;
+    }
+
+    public Builder setAlternativeBackendMaxRetentionMs(long alternativeBackendMaxRetentionMs) {
+      this.alternativeBackendMaxRetentionMs = alternativeBackendMaxRetentionMs;
       return this;
     }
 
@@ -263,6 +282,10 @@ public class TopicManagerContext {
 
       if (topicMetadataFetcherThreadPoolSize <= 0) {
         throw new IllegalArgumentException("topicMetadataFetcherThreadPoolSize must be positive");
+      }
+
+      if (alternativeBackendMaxRetentionMs <= 0) {
+        throw new IllegalArgumentException("alternativeBackendMaxRetentionMs must be positive");
       }
     }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
@@ -222,6 +222,55 @@ public class TopicManagerTest {
   }
 
   @Test
+  public void testCreateTopicClampsRetentionForAlternativeBackend() {
+    // Eternal (Long.MAX) retention targeting the alternative backend is clamped to the configured max.
+    PubSubTopic eternalAltBackendTopic = getTopic();
+    topicManager.createTopic(
+        eternalAltBackendTopic,
+        1,
+        1,
+        PubSubConstants.ETERNAL_TOPIC_RETENTION_POLICY_MS,
+        false,
+        Optional.empty(),
+        false,
+        true /* useAlternativeBackend */);
+    assertTrue(topicManager.containsTopicAndAllPartitionsAreOnline(eternalAltBackendTopic));
+    assertEquals(
+        topicManager.getTopicRetention(eternalAltBackendTopic),
+        PubSubConstants.DEFAULT_ALTERNATIVE_BACKEND_MAX_RETENTION_MS);
+
+    // The same eternal retention is preserved when NOT targeting the alternative backend (e.g. Kafka).
+    PubSubTopic eternalDefaultBackendTopic = getTopic();
+    topicManager.createTopic(
+        eternalDefaultBackendTopic,
+        1,
+        1,
+        PubSubConstants.ETERNAL_TOPIC_RETENTION_POLICY_MS,
+        false,
+        Optional.empty(),
+        false,
+        false /* useAlternativeBackend */);
+    assertEquals(
+        topicManager.getTopicRetention(eternalDefaultBackendTopic),
+        PubSubConstants.ETERNAL_TOPIC_RETENTION_POLICY_MS);
+
+    // A retention already at/below the max is left unchanged on the alternative backend.
+    PubSubTopic shortRetentionAltBackendTopic = getTopic();
+    topicManager.createTopic(
+        shortRetentionAltBackendTopic,
+        1,
+        1,
+        PubSubConstants.DEFAULT_TOPIC_RETENTION_POLICY_MS,
+        false,
+        Optional.empty(),
+        false,
+        true /* useAlternativeBackend */);
+    assertEquals(
+        topicManager.getTopicRetention(shortRetentionAltBackendTopic),
+        PubSubConstants.DEFAULT_TOPIC_RETENTION_POLICY_MS);
+  }
+
+  @Test
   public void testCreateTopicWhenTopicExists() throws Exception {
     PubSubTopic topicNameWithEternalRetentionPolicy = getTopic();
     PubSubTopic topicNameWithDefaultRetentionPolicy = getTopic();


### PR DESCRIPTION
## Summary

Some PubSub backends do not support effectively-infinite (`Long.MAX_VALUE`) retention and reject (or silently clamp) topic creations whose retention exceeds a backend-specific maximum. Venice creates several topics with eternal retention, which such a backend cannot honor.

When a topic targets the alternative PubSub backend (`PubSubTopicConfiguration#isUseAlternativeBackend()`), `TopicManager` now clamps the requested retention down to a configurable maximum (`TopicManagerContext#getAlternativeBackendMaxRetentionMs`, default 365 days), so Venice passes an explicit, supported value instead of relying on the backend to clamp or reject it.

The clamp is applied once in `createTopic`, so both the initial create and the "topic already exists" retention-update branch use the supported value. Topics that do not target the alternative backend keep their requested (possibly eternal) retention.

## Testing Done

- New unit test `TopicManagerTest#testCreateTopicClampsRetentionForAlternativeBackend`: eternal retention on the alternative backend is clamped to the configured max; the same eternal retention is preserved on the default backend; a retention already below the max is left unchanged.
- `./gradlew :internal:venice-common:test --tests "com.linkedin.venice.pubsub.manager.TopicManagerTest"` passes.
- `spotlessApply` clean.
