### PR TITLE
[da-vinci] Global RT DIV: Drain Produce-Side Messages Before Shutdown Snapshot

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2452,14 +2452,15 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    *       covers both halves; {@code sendGlobalRtDivMessage} returns that node's future, which completes only after the RT
    *       DIV produce has persisted and the VT DIV sync has run. Brokers whose LCRP is
    *       {@link PubSubSymbolicPosition#EARLIEST} are skipped (no RT progress yet).</li>
-   *   <li><b>Follower / leader with no RT progress or no RT brokers:</b> force a single waitable VT DIV snapshot sync.
-   *       RT DIV is already durable in the StorageEngine from when the follower consumed {@link GlobalRtDivState}.</li>
+   *   <li><b>Follower, or leader with no RT brokers (e.g. a batch-only or NR remote-VT leader):</b> flush a single
+   *       waitable VT DIV snapshot sync. RT DIV is already durable in the StorageEngine from when the follower consumed
+   *       {@link GlobalRtDivState}.</li>
    * </ul>
    *
    * @return a future completing once all produces have persisted and the corresponding VT DIV syncs have run.
    */
   @Override
-  protected CompletableFuture<Void> forceGlobalRtDivSync(PartitionConsumptionState pcs) {
+  protected CompletableFuture<Void> flushGlobalRtDivCheckpoint(PartitionConsumptionState pcs) {
     int partition = pcs.getPartition();
     PubSubTopicPartition localVtTopicPartition = pcs.getReplicaTopicPartition();
     List<CompletableFuture<Void>> futures = new ArrayList<>();
@@ -2496,7 +2497,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
                   kafkaClusterId));
         } catch (Exception e) {
           LOGGER.error(
-              "event=globalRtDiv Failed to force Global RT DIV sync for replica: {} broker: {}",
+              "event=globalRtDiv Failed to flush Global RT DIV checkpoint for replica: {} broker: {}",
               localVtTopicPartition,
               brokerUrl,
               e);
@@ -2504,7 +2505,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       }
     }
 
-    // Follower, or leader with no RT progress / no RT brokers: force a waitable VT DIV snapshot sync.
+    // Follower, or leader with no RT brokers (e.g. batch-only or NR remote-VT leader): flush the VT DIV snapshot only.
     if (futures.isEmpty()) {
       futures.add(enqueueWaitableVtDivSync(localVtTopicPartition));
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -765,7 +765,7 @@ public class StoreBufferService extends AbstractStoreBufferService {
 
   /**
    * Allows the ConsumptionTask to command the Drainer to sync the VT DIV to the OffsetRecord. Waitable: the leader
-   * graceful-shutdown path ({@link StoreIngestionTask#forceGlobalRtDivSync}) awaits {@link #getExecutedFuture()} on the
+   * graceful-shutdown path ({@link StoreIngestionTask#flushGlobalRtDivCheckpoint}) awaits {@link #getExecutedFuture()} on the
    * node enqueued by the leader-produce completion callback, so it does not need to enqueue a second redundant
    * {@link SyncGlobalRtDivNode}. Steady-state callers enqueue it fire-and-forget and ignore the future.
    */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2217,19 +2217,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       if (getServerConfig().isServerIngestionCheckpointDuringGracefulShutdownEnabled()) {
         try {
           PubSubTopicPartition topicPartition = partitionConsumptionState.getReplicaTopicPartition();
-          // Drain the produce frontier BEFORE checkpointing DIV state. A Global RT DIV leader advances its
-          // consumer-side DIV segments at consume time, but the local-VT produce of those records completes
-          // asynchronously, so the produce frontier lags the consume frontier. A DIV snapshot taken before those
-          // produces land would persist a baseline ahead of the durable local VT; on restart the leader re-consumes
-          // that tail, finds it already in the restored DIV, filters it as a duplicate (so it is never re-produced),
-          // and leaves a permanent local-VT sequence gap that followers report as MissingDataException. Awaiting
-          // here guarantees the persisted DIV baseline never exceeds what was durably produced to the local VT.
+          // Drain all messages, including the messages from the LEADER which are in the process of being produced to
+          // local-VT which haven't had their callbacks executed and messages enqueued to the drainer.
           waitForAllMessageToBeProcessedFromTopicPartition(topicPartition, partitionConsumptionState);
-          // Global RT DIV is consumer-driven, so its drainer SYNC_OFFSET path is disabled to not interfere. Instead,
-          // flush the accumulated RT/VT DIV deltas on-demand via flushGlobalRtDivCheckpoint. We are inside
-          // shutdownPartitionConsumptionStates() (after consumerBatchUnsubscribeAllTopics, before closeVeniceWriters),
-          // so the VeniceWriter is alive and no new RT records are arriving. Both paths await with the shutdown
-          // sync-offset timeout, reusing waitForSyncOffsetCmd's timeout/cancel semantics so shutdown never hangs.
+          // Flush the checkpointed offsets to disk, so we know where to resume upon startup. Global RT DIV is
+          // consumer-driven and periodically sent, so without this additional flush on shutdown, the server would need
+          // to reingest a bit of data after resuming from the previous checkpoint, significantly delaying the restart.
           CompletableFuture<Void> syncFuture = isGlobalRtDivEnabled()
               ? flushGlobalRtDivCheckpoint(partitionConsumptionState)
               : getStoreBufferService().execSyncOffsetCommandAsync(topicPartition, this);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2217,6 +2217,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       if (getServerConfig().isServerIngestionCheckpointDuringGracefulShutdownEnabled()) {
         try {
           PubSubTopicPartition topicPartition = partitionConsumptionState.getReplicaTopicPartition();
+          // Drain the produce frontier BEFORE checkpointing DIV state. A Global RT DIV leader advances its
+          // consumer-side DIV segments at consume time, but the local-VT produce of those records completes
+          // asynchronously, so the produce frontier lags the consume frontier. A DIV snapshot taken before those
+          // produces land would persist a baseline ahead of the durable local VT; on restart the leader re-consumes
+          // that tail, finds it already in the restored DIV, filters it as a duplicate (so it is never re-produced),
+          // and leaves a permanent local-VT sequence gap that followers report as MissingDataException. Awaiting
+          // here guarantees the persisted DIV baseline never exceeds what was durably produced to the local VT.
+          waitForAllMessageToBeProcessedFromTopicPartition(topicPartition, partitionConsumptionState);
           // Global RT DIV is consumer-driven, so its drainer SYNC_OFFSET path is disabled to not interfere. Instead,
           // flush the accumulated RT/VT DIV deltas on-demand via forceGlobalRtDivSync. We are inside
           // shutdownPartitionConsumptionStates() (after consumerBatchUnsubscribeAllTopics, before closeVeniceWriters),
@@ -2226,7 +2234,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
               ? forceGlobalRtDivSync(partitionConsumptionState)
               : getStoreBufferService().execSyncOffsetCommandAsync(topicPartition, this);
           waitForSyncOffsetCmd(syncFuture, topicPartition);
-          waitForAllMessageToBeProcessedFromTopicPartition(topicPartition, partitionConsumptionState);
         } catch (InterruptedException e) {
           throw new VeniceException(e);
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2226,12 +2226,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           // here guarantees the persisted DIV baseline never exceeds what was durably produced to the local VT.
           waitForAllMessageToBeProcessedFromTopicPartition(topicPartition, partitionConsumptionState);
           // Global RT DIV is consumer-driven, so its drainer SYNC_OFFSET path is disabled to not interfere. Instead,
-          // flush the accumulated RT/VT DIV deltas on-demand via forceGlobalRtDivSync. We are inside
+          // flush the accumulated RT/VT DIV deltas on-demand via flushGlobalRtDivCheckpoint. We are inside
           // shutdownPartitionConsumptionStates() (after consumerBatchUnsubscribeAllTopics, before closeVeniceWriters),
           // so the VeniceWriter is alive and no new RT records are arriving. Both paths await with the shutdown
           // sync-offset timeout, reusing waitForSyncOffsetCmd's timeout/cancel semantics so shutdown never hangs.
           CompletableFuture<Void> syncFuture = isGlobalRtDivEnabled()
-              ? forceGlobalRtDivSync(partitionConsumptionState)
+              ? flushGlobalRtDivCheckpoint(partitionConsumptionState)
               : getStoreBufferService().execSyncOffsetCommandAsync(topicPartition, this);
           waitForSyncOffsetCmd(syncFuture, topicPartition);
         } catch (InterruptedException e) {
@@ -3577,7 +3577,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * completes once the flush has fully persisted. The base implementation is a no-op (returns an already-completed
    * future); only {@link LeaderFollowerStoreIngestionTask} performs real work.
    */
-  protected CompletableFuture<Void> forceGlobalRtDivSync(PartitionConsumptionState pcs) {
+  protected CompletableFuture<Void> flushGlobalRtDivCheckpoint(PartitionConsumptionState pcs) {
     return CompletableFuture.completedFuture(null);
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -783,12 +783,12 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
-   * AC 1: a LEADER's {@link LeaderFollowerStoreIngestionTask#forceGlobalRtDivSync} produces exactly one
+   * AC 1: a LEADER's {@link LeaderFollowerStoreIngestionTask#flushGlobalRtDivCheckpoint} produces exactly one
    * GlobalRtDivState per RT source broker (LCRP != EARLIEST), carrying that broker's getLatestConsumedRtPosition, and
    * the aggregate future completes once each produce has persisted and the chained waitable VT DIV sync has run.
    */
   @Test
-  public void testForceGlobalRtDivSyncLeaderProducesPerBroker() throws Exception {
+  public void testFlushGlobalRtDivCheckpointLeaderProducesPerBroker() throws Exception {
     setUp();
     int partition = 0;
     PubSubTopicPartition localVtTp = mock(PubSubTopicPartition.class);
@@ -801,7 +801,8 @@ public class LeaderFollowerStoreIngestionTaskTest {
     String brokerB = "brokerB:1234";
     PubSubPosition lcrpA = InMemoryPubSubPosition.of(5L);
     PubSubPosition lcrpB = InMemoryPubSubPosition.of(9L);
-    // A/A-style topology: multiple RT sources, each with its own per-URL LCRP. forceGlobalRtDivSync reads the LCRP
+    // A/A-style topology: multiple RT sources, each with its own per-URL LCRP. flushGlobalRtDivCheckpoint reads the
+    // LCRP
     // through the per-mode accessor (the A/A override keys by broker URL), so stub that accessor per broker.
     doReturn(lcrpA).when(leaderFollowerStoreIngestionTask)
         .getLatestConsumedUpstreamPositionForHybridOffsetLagMeasurement(mockPartitionConsumptionState, brokerA);
@@ -823,7 +824,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
         .sendGlobalRtDivMessage(any(), any(), any(), anyInt(), anyString(), anyLong(), anyInt());
 
     CompletableFuture<Void> future =
-        leaderFollowerStoreIngestionTask.forceGlobalRtDivSync(mockPartitionConsumptionState);
+        leaderFollowerStoreIngestionTask.flushGlobalRtDivCheckpoint(mockPartitionConsumptionState);
     future.get(30, TimeUnit.SECONDS);
     assertTrue(future.isDone());
 
@@ -854,7 +855,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
    * to a single waitable VT DIV snapshot sync (no GlobalRtDivState produce).
    */
   @Test
-  public void testForceGlobalRtDivSyncLeaderSkipsEarliestBrokers() throws Exception {
+  public void testFlushGlobalRtDivCheckpointLeaderSkipsEarliestBrokers() throws Exception {
     setUp();
     int partition = 0;
     PubSubTopicPartition localVtTp = mock(PubSubTopicPartition.class);
@@ -886,7 +887,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
         .sendGlobalRtDivMessage(any(), any(), any(), anyInt(), anyString(), anyLong(), anyInt());
 
     CompletableFuture<Void> future =
-        leaderFollowerStoreIngestionTask.forceGlobalRtDivSync(mockPartitionConsumptionState);
+        leaderFollowerStoreIngestionTask.flushGlobalRtDivCheckpoint(mockPartitionConsumptionState);
     future.get(30, TimeUnit.SECONDS);
     assertTrue(future.isDone());
 
@@ -909,12 +910,12 @@ public class LeaderFollowerStoreIngestionTaskTest {
   /**
    * Regression for the non-A/A map-key mismatch: a non-A/A leader keys its latest-consumed-RT-position map by
    * {@link com.linkedin.venice.offsets.OffsetRecord#NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY}, not by broker URL.
-   * forceGlobalRtDivSync must read the LCRP through the per-mode accessor (here the real non-A/A override, NOT stubbed)
+   * flushGlobalRtDivCheckpoint must read the LCRP through the per-mode accessor (here the real non-A/A override, NOT stubbed)
    * so it resolves the NON_AA key; a direct getLatestConsumedRtPosition(brokerUrl) would miss, return EARLIEST, and
    * silently skip the leader RT DIV flush — falling back to a VT-only sync that never persists the RT DIV deltas.
    */
   @Test
-  public void testForceGlobalRtDivSyncNonAaLeaderResolvesNonAaKey() throws Exception {
+  public void testFlushGlobalRtDivCheckpointNonAaLeaderResolvesNonAaKey() throws Exception {
     setUp();
     int partition = 0;
     PubSubTopicPartition localVtTp = mock(PubSubTopicPartition.class);
@@ -940,7 +941,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
         .sendGlobalRtDivMessage(any(), any(), any(), anyInt(), anyString(), anyLong(), anyInt());
 
     CompletableFuture<Void> future =
-        leaderFollowerStoreIngestionTask.forceGlobalRtDivSync(mockPartitionConsumptionState);
+        leaderFollowerStoreIngestionTask.flushGlobalRtDivCheckpoint(mockPartitionConsumptionState);
     future.get(30, TimeUnit.SECONDS);
     assertTrue(future.isDone());
 
@@ -959,12 +960,12 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
-   * AC 2: a FOLLOWER forces a single waitable VT DIV snapshot sync and produces no GlobalRtDivState (RT DIV is already
+   * AC 2: a FOLLOWER flushes a single waitable VT DIV snapshot sync and produces no GlobalRtDivState (RT DIV is already
    * durable from when the follower consumed it). Also covers a leader with no RT brokers (batch-only) via the same
    * VT-snapshot-only fallback.
    */
   @Test
-  public void testForceGlobalRtDivSyncFollowerSyncsVtOnly() throws Exception {
+  public void testFlushGlobalRtDivCheckpointFollowerSyncsVtOnly() throws Exception {
     setUp();
     int partition = 0;
     PubSubTopicPartition localVtTp = mock(PubSubTopicPartition.class);
@@ -976,7 +977,7 @@ public class LeaderFollowerStoreIngestionTaskTest {
         .execSyncGlobalRtDivAsync(eq(localVtTp), eq(leaderFollowerStoreIngestionTask));
 
     CompletableFuture<Void> future =
-        leaderFollowerStoreIngestionTask.forceGlobalRtDivSync(mockPartitionConsumptionState);
+        leaderFollowerStoreIngestionTask.flushGlobalRtDivCheckpoint(mockPartitionConsumptionState);
     future.get(30, TimeUnit.SECONDS);
     assertTrue(future.isDone());
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -6705,8 +6705,10 @@ public abstract class StoreIngestionTaskTest {
 
   /**
    * With Global RT DIV enabled, the graceful-shutdown path must drive {@link StoreIngestionTask#forceGlobalRtDivSync}
-   * (instead of the drainer SYNC_OFFSET command) and await it before returning, then drain messages. It must NOT call
-   * the non-global execSyncOffsetCommandAsync path. Covers AC 4 (flush completes before shutdown proceeds).
+   * (instead of the drainer SYNC_OFFSET command). Crucially, it must drain the produce frontier
+   * ({@link StoreIngestionTask#waitForAllMessageToBeProcessedFromTopicPartition}) BEFORE taking the DIV snapshot, so
+   * the persisted consumer-side DIV baseline never exceeds what was durably produced to the local VT. It must NOT
+   * call the non-global execSyncOffsetCommandAsync path. Covers AC 4 (flush completes before shutdown proceeds).
    */
   @Test
   public void testExecuteShutdownRunnableGlobalRtDivEnabled() throws InterruptedException {
@@ -6729,13 +6731,21 @@ public abstract class StoreIngestionTaskTest {
 
     verify(storeIngestionTask).forceGlobalRtDivSync(pcs);
     verify(storeIngestionTask).waitForAllMessageToBeProcessedFromTopicPartition(topicPartition, pcs);
+    // The produce frontier must be drained BEFORE the DIV snapshot is taken. Otherwise the snapshot can persist a
+    // DIV baseline ahead of the durable local VT; on restart the leader re-consumes the consumed-but-unproduced
+    // tail, filters it as a duplicate, never re-produces it, and leaves a permanent local-VT gap (followers then
+    // throw MissingDataException).
+    InOrder inOrder = inOrder(storeIngestionTask);
+    inOrder.verify(storeIngestionTask).waitForAllMessageToBeProcessedFromTopicPartition(topicPartition, pcs);
+    inOrder.verify(storeIngestionTask).forceGlobalRtDivSync(pcs);
     // The Global RT DIV path must not use the non-global drainer SYNC_OFFSET command.
     verify(storeIngestionTask, never()).getStoreBufferService();
   }
 
   /**
-   * A produce/await failure during the Global RT DIV shutdown sync must never hang shutdown: the bounded
-   * getShutdownSyncOffsetTimeoutMs() wait swallows the timeout, then message draining still proceeds. Covers AC 5.
+   * A produce/await failure during the Global RT DIV shutdown sync must never hang shutdown: after draining the
+   * produce frontier, the bounded getShutdownSyncOffsetTimeoutMs() wait swallows the stalled DIV sync's timeout so
+   * shutdown still completes. Covers AC 5.
    */
   @Test
   public void testExecuteShutdownRunnableGlobalRtDivTimeoutDoesNotHang() throws InterruptedException {
@@ -6761,7 +6771,7 @@ public abstract class StoreIngestionTaskTest {
     long elapsed = System.currentTimeMillis() - start;
 
     assertTrue(elapsed < 30_000L, "Shutdown must not hang on a stalled Global RT DIV sync; elapsed=" + elapsed + "ms");
-    // Even after timing out the sync, draining must still run so shutdown completes.
+    // The produce-frontier drain runs ahead of the DIV sync, so it completes regardless of the stalled sync.
     verify(storeIngestionTask).waitForAllMessageToBeProcessedFromTopicPartition(topicPartition, pcs);
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -6704,7 +6704,7 @@ public abstract class StoreIngestionTaskTest {
   }
 
   /**
-   * With Global RT DIV enabled, the graceful-shutdown path must drive {@link StoreIngestionTask#forceGlobalRtDivSync}
+   * With Global RT DIV enabled, the graceful-shutdown path must drive {@link StoreIngestionTask#flushGlobalRtDivCheckpoint}
    * (instead of the drainer SYNC_OFFSET command). Crucially, it must drain the produce frontier
    * ({@link StoreIngestionTask#waitForAllMessageToBeProcessedFromTopicPartition}) BEFORE taking the DIV snapshot, so
    * the persisted consumer-side DIV baseline never exceeds what was durably produced to the local VT. It must NOT
@@ -6724,12 +6724,12 @@ public abstract class StoreIngestionTaskTest {
 
     PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(new PubSubTopicImpl("test_topic_v1"), 0);
     when(pcs.getReplicaTopicPartition()).thenReturn(topicPartition);
-    when(storeIngestionTask.forceGlobalRtDivSync(pcs)).thenReturn(CompletableFuture.completedFuture(null));
+    when(storeIngestionTask.flushGlobalRtDivCheckpoint(pcs)).thenReturn(CompletableFuture.completedFuture(null));
 
     doCallRealMethod().when(storeIngestionTask).executeShutdownRunnable(any(), anyList(), any());
     storeIngestionTask.executeShutdownRunnable(pcs, shutdownFutures, null);
 
-    verify(storeIngestionTask).forceGlobalRtDivSync(pcs);
+    verify(storeIngestionTask).flushGlobalRtDivCheckpoint(pcs);
     verify(storeIngestionTask).waitForAllMessageToBeProcessedFromTopicPartition(topicPartition, pcs);
     // The produce frontier must be drained BEFORE the DIV snapshot is taken. Otherwise the snapshot can persist a
     // DIV baseline ahead of the durable local VT; on restart the leader re-consumes the consumed-but-unproduced
@@ -6737,7 +6737,7 @@ public abstract class StoreIngestionTaskTest {
     // throw MissingDataException).
     InOrder inOrder = inOrder(storeIngestionTask);
     inOrder.verify(storeIngestionTask).waitForAllMessageToBeProcessedFromTopicPartition(topicPartition, pcs);
-    inOrder.verify(storeIngestionTask).forceGlobalRtDivSync(pcs);
+    inOrder.verify(storeIngestionTask).flushGlobalRtDivCheckpoint(pcs);
     // The Global RT DIV path must not use the non-global drainer SYNC_OFFSET command.
     verify(storeIngestionTask, never()).getStoreBufferService();
   }
@@ -6763,7 +6763,7 @@ public abstract class StoreIngestionTaskTest {
     PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(new PubSubTopicImpl("test_topic_v1"), 0);
     when(pcs.getReplicaTopicPartition()).thenReturn(topicPartition);
     // A future that never completes simulates a produce/await failure stalling the sync.
-    when(storeIngestionTask.forceGlobalRtDivSync(pcs)).thenReturn(new CompletableFuture<>());
+    when(storeIngestionTask.flushGlobalRtDivCheckpoint(pcs)).thenReturn(new CompletableFuture<>());
 
     doCallRealMethod().when(storeIngestionTask).executeShutdownRunnable(any(), anyList(), any());
     long start = System.currentTimeMillis();


### PR DESCRIPTION
## Problem Statement

With Global RT DIV enabled, a graceful-shutdown leader on an NR secondary fabric can persist a DIV checkpoint that is **ahead of the data it actually produced to the local VT**, which manifests on restart as a permanent local-VT sequence gap that followers report as `MissingDataException`.

Root cause is an ordering bug in `executeShutdownRunnable`. A leader advances its **consumer-side** DIV segments at *consume* time (`validateAndFilterOutDuplicateMessagesFromLeaderTopic`), but the local-VT produce of those records completes **asynchronously** — so the produce frontier lags the consume frontier. At shutdown the code took the DIV snapshot (`flushGlobalRtDivCheckpoint`) **before** awaiting the produce frontier (`waitForAllMessageToBeProcessedFromTopicPartition`):

```
flushGlobalRtDivCheckpoint(pcs)                        // snapshot at the CONSUME frontier
waitForSyncOffsetCmd(syncFuture, topicPartition)
waitForAllMessageToBeProcessedFromTopicPartition(...)  // produce frontier awaited only here
```

If the process stops (or the produce-await times out) after the snapshot is persisted but before the consumed-but-unproduced tail lands durably, the persisted DIV baseline exceeds the durable local VT. On restart the leader resumes at the produce frontier, re-consumes that tail, finds it already present in the restored consumer-side DIV, filters it as a `DuplicateDataException` (so it is **never re-produced**), and continues past it — leaving a permanent hole in the local-VT producer sequence. Followers consuming the local VT then fail DIV with `MissingDataException` (`previous sequence N`, `incoming sequence N+K`, same segment).

This only affects NR secondary fabrics (where leaders re-produce remote VT to local VT under DIV pass-through, so an unproduced record is a real sequence gap), and only the subset of partitions whose produce frontier lagged the consume frontier at the shutdown instant.

## Solution

Await the produce frontier **before** taking the DIV snapshot, so the persisted DIV baseline never exceeds what was durably produced to the local VT. This is a one-line reorder in `executeShutdownRunnable`: `waitForAllMessageToBeProcessedFromTopicPartition(...)` now runs ahead of the `flushGlobalRtDivCheckpoint` / `execSyncOffsetCommandAsync` sync.

After the drain, every consumed record is durably in the local VT, so the consume-frontier DIV snapshot is consistent with the data — and on restart the re-consumed tail is correctly recognized as already-present (and is already in the local VT, so no re-production is needed). The await reuses the existing, bounded shutdown primitive (`getShutdownSyncOffsetTimeoutMs()` / `WAITING_TIME_FOR_LAST_RECORD_TO_BE_PROCESSED`, swallow-on-timeout), so shutdown never hangs.

The await sits one level above `flushGlobalRtDivCheckpoint`, so it covers both of that method's branches — the RT-broker produce path and the VT-snapshot fallback (`futures.isEmpty()`), which is the branch a batch-only / NR remote-VT leader actually takes. For an NR leader, every local-VT produce is a re-emitted remote-VT record (tracked by `getLastLeaderPersistFuture` via `produceToLocalKafka`), so draining that frontier is what makes both the remote-VT checkpoint (`remoteVtPosition`) and the pass-through DIV baseline consistent with the durable local VT.

The non-global (`execSyncOffsetCommandAsync`) path is unaffected behaviorally — its DIV state is drainer/produce-side, so draining first is a no-op for correctness.

**Also includes a pure rename** (no behavior change): `forceGlobalRtDivSync` → `flushGlobalRtDivCheckpoint`. The old name read as RT-only, but the method also checkpoints VT DIV (the `futures.isEmpty()` fallback) — exactly the path the bug's batch / NR remote-VT store takes. The new name conveys the on-demand drain and its restart-recovery purpose, and stays in the `GlobalRtDiv` naming family.

###  Code changes
- [ ] Added new code behind **a config**. — No.
- [ ] Introduced new **log lines**. — No.

###  **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. — The change *removes* a race window (snapshot vs. produce frontier) by ordering the produce-frontier await before the snapshot.
- [x] Proper **synchronization mechanisms** are used where needed. — Reuses the existing bounded futures (`getLastLeaderPersistFuture` / `getLastQueuedRecordPersistedFuture`).
- [x] No **blocking calls** inside critical sections that could lead to deadlocks. — The await is bounded by the shutdown timeout and swallows on timeout, so shutdown never hangs.
- [x] Verified **thread-safe collections** are used. — No collection changes.
- [x] Validated proper exception handling. — `InterruptedException` propagates as before; timeout is swallowed.

## How was this PR tested?

- [x] Modified or extended existing tests. Added an `InOrder` assertion to `testExecuteShutdownRunnableGlobalRtDivEnabled` proving the produce-frontier drain precedes the DIV snapshot. Verified the assertion is live: inverting the expected order makes the test fail with `VerificationInOrderFailure`; the production order makes it pass.
- [x] Verified backward compatibility. `testParallelShutdown` (non-global path), `testExecuteShutdownRunnableGlobalRtDivTimeoutDoesNotHang` (stalled-sync no-hang), and the four renamed `testFlushGlobalRtDivCheckpoint*` LFSIT tests still pass.

Commands (the `SITWith*` classes are the concrete subclasses of the abstract `StoreIngestionTaskTest`):
```
./gradlew :clients:da-vinci-client:test \
  --tests "*.SITWithPWiseAndBufferAfterLeaderTest.testParallelShutdown" \
  --tests "*.SITWithPWiseAndBufferAfterLeaderTest.testExecuteShutdownRunnableGlobalRtDivEnabled" \
  --tests "*.SITWithPWiseAndBufferAfterLeaderTest.testExecuteShutdownRunnableGlobalRtDivTimeoutDoesNotHang" \
  --tests "*.LeaderFollowerStoreIngestionTaskTest.testFlushGlobalRtDivCheckpoint*"
```

## Does this PR introduce any user-facing or breaking changes?

- [x] No.
