### PR TITLE
[controller][test] Remove legacy log.compaction.threshold.ms config

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -470,11 +470,6 @@ public class ConfigKeys {
   public static final String LOG_COMPACTION_INTERVAL_MS = "log.compaction.interval.ms";
 
   /**
-   * Time since last log compaction before a store is considered for log compaction
-   */
-  public static final String LOG_COMPACTION_THRESHOLD_MS = "log.compaction.threshold.ms";
-
-  /**
    * Version staleness threshold to decide when a store should be nominated for compaction
    */
   public static final String LOG_COMPACTION_VERSION_STALENESS_THRESHOLD_MS =

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -7,7 +7,7 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.LOG_COMPACTION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.LOG_COMPACTION_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.LOG_COMPACTION_SCHEDULING_ENABLED;
-import static com.linkedin.venice.ConfigKeys.LOG_COMPACTION_THRESHOLD_MS;
+import static com.linkedin.venice.ConfigKeys.LOG_COMPACTION_VERSION_STALENESS_THRESHOLD_MS;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.REPUSH_ORCHESTRATOR_CLASS_NAME;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY;
@@ -152,7 +152,7 @@ public class TestHybrid {
   // Log compaction test constants
   private static final long TEST_LOG_COMPACTION_INTERVAL_MS = TimeUnit.SECONDS.toMillis(1);
   private static final long TEST_LOG_COMPACTION_TIMEOUT = TEST_LOG_COMPACTION_INTERVAL_MS * 10; // ms
-  private static final long TEST_TIME_SINCE_LAST_LOG_COMPACTION_THRESHOLD_MS = 0;
+  private static final long TEST_VERSION_STALENESS_THRESHOLD_MS = 0;
 
   /**
    * IMPORTANT NOTE: if you use this sharedVenice cluster, please do not close it. The {@link #cleanUp()} function
@@ -1706,8 +1706,9 @@ public class TestHybrid {
     extraProperties.setProperty(LOG_COMPACTION_ENABLED, "true");
     extraProperties.setProperty(LOG_COMPACTION_SCHEDULING_ENABLED, "true");
     extraProperties.setProperty(LOG_COMPACTION_INTERVAL_MS, String.valueOf(TEST_LOG_COMPACTION_INTERVAL_MS));
-    extraProperties
-        .setProperty(LOG_COMPACTION_THRESHOLD_MS, String.valueOf(TEST_TIME_SINCE_LAST_LOG_COMPACTION_THRESHOLD_MS));
+    extraProperties.setProperty(
+        LOG_COMPACTION_VERSION_STALENESS_THRESHOLD_MS,
+        String.valueOf(TEST_VERSION_STALENESS_THRESHOLD_MS));
     VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
         .numberOfServers(0)
         .numberOfRouters(0)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -176,7 +176,6 @@ import static com.linkedin.venice.ConfigKeys.LOG_COMPACTION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.LOG_COMPACTION_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.LOG_COMPACTION_SCHEDULING_ENABLED;
 import static com.linkedin.venice.ConfigKeys.LOG_COMPACTION_THREAD_COUNT;
-import static com.linkedin.venice.ConfigKeys.LOG_COMPACTION_THRESHOLD_MS;
 import static com.linkedin.venice.ConfigKeys.LOG_COMPACTION_VERSION_STALENESS_THRESHOLD_MS;
 import static com.linkedin.venice.ConfigKeys.META_STORE_WRITER_CLOSE_CONCURRENCY;
 import static com.linkedin.venice.ConfigKeys.META_STORE_WRITER_CLOSE_TIMEOUT_MS;
@@ -1257,9 +1256,8 @@ public class VeniceControllerClusterConfig {
     this.repushOrchestratorConfigs = props.clipAndFilterNamespace(CONTROLLER_REPUSH_PREFIX);
     this.logCompactionThreadCount = props.getInt(LOG_COMPACTION_THREAD_COUNT, 1);
     this.logCompactionIntervalMS = props.getLong(LOG_COMPACTION_INTERVAL_MS, TimeUnit.HOURS.toMillis(1));
-    this.logCompactionVersionStalenessThresholdMS = props.getLong(
-        LOG_COMPACTION_VERSION_STALENESS_THRESHOLD_MS,
-        props.getLong(LOG_COMPACTION_THRESHOLD_MS, TimeUnit.HOURS.toMillis(24)));
+    this.logCompactionVersionStalenessThresholdMS =
+        props.getLong(LOG_COMPACTION_VERSION_STALENESS_THRESHOLD_MS, TimeUnit.HOURS.toMillis(24));
     this.logCompactionDuplicateKeyThreshold = props.getLong(LOG_COMPACTION_DUPLICATE_KEY_THRESHOLD, 0);
 
     this.isDeadStoreEndpointEnabled = props.getBoolean(ConfigKeys.CONTROLLER_DEAD_STORE_ENDPOINT_ENABLED, false);


### PR DESCRIPTION
## Problem Statement

The log-compaction version-staleness threshold is configured by two keys: the current `log.compaction.version.staleness.threshold.ms` and a legacy `log.compaction.threshold.ms`. `VeniceControllerClusterConfig` reads the current key first and only falls back to the legacy one:

```java
this.logCompactionVersionStalenessThresholdMS = props.getLong(
    LOG_COMPACTION_VERSION_STALENESS_THRESHOLD_MS,
    props.getLong(LOG_COMPACTION_THRESHOLD_MS, TimeUnit.HOURS.toMillis(24)));
```

For any deployment that sets the current key, the legacy key is dead. Keeping two keys for the same value is a maintenance hazard: an operator can set the legacy key and have it silently shadowed by the current one (or by the default).

## Solution

- Remove `LOG_COMPACTION_THRESHOLD_MS` from `ConfigKeys` and drop the fallback read in `VeniceControllerClusterConfig`. The threshold now reads only `log.compaction.version.staleness.threshold.ms`, defaulting to 24h.
- Migrate the `TestHybrid` integration test off the legacy key onto `LOG_COMPACTION_VERSION_STALENESS_THRESHOLD_MS`, and rename its local constant to match.

No behavior change for deployments already on the current key; the default stays 24h.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Not applicable. Config-key removal only.

## How was this PR tested?

- [x] Modified or extended existing tests.

`TestHybrid` migrated to the current key. Built `venice-common`, `venice-controller`, and the `venice-test-common` integration-test source set; `TestVeniceControllerClusterConfig` passes; `spotlessCheck` passes.

## Does this PR introduce any user-facing or breaking changes?

- [x] Yes. Deployments still setting `log.compaction.threshold.ms` must switch to `log.compaction.version.staleness.threshold.ms`. After this change the legacy key is ignored, so such a deployment falls back to the 24h default instead of its configured value.
