### PR TITLE
[changelog][da-vinci][server] Don't checkpoint a VT offset before writing to RocksDB

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1908,7 +1908,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
        * metadata after successfully produce a corresponding message.
        */
       KafkaMessageEnvelope kafkaValue = consumerRecord.getValue();
-      updateVersionTopicOffsetFunction.apply(consumerRecord.getPosition());
+      // Advance the processed VT position only on the post-persist pass. Advancing it on the pre-persist (dry-run) pass
+      // would leave the position pointing at a record that has not been durably written yet; if the write then fails,
+      // a shutdown checkpoint could persist that position and the record would be skipped on restart (data loss).
+      if (!dryRun) {
+        updateVersionTopicOffsetFunction.apply(consumerRecord.getPosition());
+      }
 
       OffsetRecord offsetRecord = partitionConsumptionState.getOffsetRecord();
       // DaVinci clients don't need to maintain leader production states

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2274,6 +2274,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       LOGGER.info("Skipping updateOffsetMetadataAndSyncOffset() because Global RT DIV is enabled.");
       return;
     }
+    int partition = pcs.getPartition();
+    if (failedPartitions.contains(partition) || pcs.isErrorReported()) {
+      // Never checkpoint an errored replica: its in-memory offset may point past a record that was never persisted.
+      // Leaving the last good durable offset in place lets the failed record be re-read on restart.
+      LOGGER.warn("Skipping offset checkpoint for errored replica: {}", pcs.getReplicaId());
+      return;
+    }
     /**
      * Offset metadata and producer states must be updated at the same time in OffsetRecord; otherwise, one checkpoint
      * could be ahead of the other.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2305,6 +2305,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       LOGGER.warn("event=globalRtDiv No PCS found for {}. Skipping VT DIV OffsetRecord sync.", topicPartition);
       return;
     }
+    int partition = pcs.getPartition();
+    if (failedPartitions.contains(partition) || pcs.isErrorReported()) {
+      // Never checkpoint an errored replica: its in-memory offset may point past a record that was never persisted.
+      // Leaving the last good durable offset in place lets the failed record be re-read on restart. The Global-RT-DIV
+      // graceful-shutdown checkpoint reaches storage through this method, so the error gate is enforced here.
+      LOGGER.warn("Skipping offset checkpoint for errored replica: {}", pcs.getReplicaId());
+      return;
+    }
     vtDivSnapshot.updateOffsetRecord(PartitionTracker.VERSION_TOPIC, pcs.getOffsetRecord());
     updateOffsetMetadataInOffsetRecord(pcs);
     syncOffset(pcs);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2310,7 +2310,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       // Never checkpoint an errored replica: its in-memory offset may point past a record that was never persisted.
       // Leaving the last good durable offset in place lets the failed record be re-read on restart. The Global-RT-DIV
       // graceful-shutdown checkpoint reaches storage through this method, so the error gate is enforced here.
-      LOGGER.warn("Skipping offset checkpoint for errored replica: {}", pcs.getReplicaId());
+      LOGGER.warn("event=globalRtDiv Skipping offset checkpoint for errored replica: {}", pcs.getReplicaId());
       return;
     }
     vtDivSnapshot.updateOffsetRecord(PartitionTracker.VERSION_TOPIC, pcs.getOffsetRecord());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4966,6 +4966,122 @@ public abstract class StoreIngestionTaskTest {
     Assert.assertEquals(mockNotifierError.size(), 0);
   }
 
+  /**
+   * Verifies that the in-memory VT position ({@link PartitionConsumptionState#getLatestProcessedVtPosition()}) is only
+   * advanced after the record has been successfully persisted. Two records are produced to PARTITION_FOO and the write
+   * (RocksDB put) of the second record is made to throw. The processed VT position must remain at the first (durably
+   * written) record's position rather than being advanced to the second (failed) record's position; otherwise a
+   * subsequent shutdown SYNC_OFFSET would checkpoint a position whose record was never persisted, causing data loss on
+   * restart.
+   */
+  @Test(dataProvider = "aaConfigProvider")
+  public void testVtOffsetNotAdvancedWhenPersistFails(AAConfig aaConfig) throws Exception {
+    // Produce 2 data records to PARTITION_FOO within a batch push; capture each record's VT position.
+    localVeniceWriter.broadcastStartOfPush(new HashMap<>());
+    InMemoryPubSubPosition firstRecordPosition = getPosition(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
+    InMemoryPubSubPosition secondRecordPosition = getPosition(localVeniceWriter.put(putKeyFoo2, putValue, SCHEMA_ID));
+    localVeniceWriter.broadcastEndOfPush(new HashMap<>());
+
+    // Make the persist (RocksDB put) of the SECOND record fail.
+    doThrow(new VeniceException("fake storage engine exception on second record")).when(mockAbstractStorageEngine)
+        .put(eq(PARTITION_FOO), eq(putKeyFoo2), any(ByteBuffer.class));
+
+    StoreIngestionTaskTestConfig testConfig = new StoreIngestionTaskTestConfig(Utils.setOf(PARTITION_FOO), () -> {
+      // Wait until the first record has been durably persisted (its write succeeds).
+      verify(mockAbstractStorageEngine, timeout(TEST_TIMEOUT_MS))
+          .put(eq(PARTITION_FOO), eq(putKeyFoo), any(ByteBuffer.class));
+      // Wait until the second record's write has been attempted (and thrown). After this point the second record has
+      // been processed, so any (buggy) unconditional advance of the VT position to the second record will have
+      // happened.
+      verify(mockAbstractStorageEngine, timeout(TEST_TIMEOUT_MS))
+          .put(eq(PARTITION_FOO), eq(putKeyFoo2), any(ByteBuffer.class));
+
+      PartitionConsumptionState pcs = storeIngestionTaskUnderTest.getPartitionConsumptionState(PARTITION_FOO);
+      assertNotNull(pcs, "pcs for PARTITION_FOO is null!");
+      // The processed VT position must remain at the first (durably written) record, NOT the second (failed) one.
+      Assert.assertEquals(
+          pcs.getLatestProcessedVtPosition(),
+          firstRecordPosition,
+          "latestProcessedVtPosition must stay at the first record's position (" + firstRecordPosition
+              + ") when the second record's write fails; it must NOT be advanced to the second record's position ("
+              + secondRecordPosition + ")");
+    }, aaConfig);
+
+    testConfig.setStoreVersionConfigOverride(configOverride -> {
+      // Very high sync threshold so the OffsetRecord isn't synced during regular consumption.
+      doReturn(100_000L).when(configOverride).getDatabaseSyncBytesIntervalForTransactionalMode();
+    });
+    runTest(testConfig);
+  }
+
+  /**
+   * Defense-in-depth: an errored replica must never have its offset checkpointed, even on the graceful-shutdown
+   * SYNC_OFFSET path. PARTITION_FOO's write is made to fail (driving the replica into an error state that is retained
+   * via the current-version reset-error path), while PARTITION_BAR ingests healthily. On graceful shutdown the healthy
+   * PARTITION_BAR must get its offset checkpointed, but the errored PARTITION_FOO must NOT — otherwise the checkpoint
+   * would advance past a record that was never persisted, skipping it on restart (data loss).
+   */
+  @Test(dataProvider = "aaConfigProvider")
+  public void testErroredPartitionNotCheckpointedOnGracefulShutdown(AAConfig aaConfig) throws Exception {
+    // Make every storage-engine put for PARTITION_FOO fail; PARTITION_BAR writes succeed.
+    doThrow(new VeniceException("fake storage engine exception for errored partition")).when(mockAbstractStorageEngine)
+        .put(eq(PARTITION_FOO), any(), any(ByteBuffer.class));
+    // Current-version + reset-error-replica path marks the errored replica ERROR (Helix) instead of unsubscribing it,
+    // so its PartitionConsumptionState is retained in the map at shutdown (where the checkpoint gate is exercised).
+    isCurrentVersion = () -> true;
+    doNothing().when(zkHelixAdmin).setPartitionsToError(anyString(), anyString(), anyString(), anyList());
+
+    localVeniceWriter.broadcastStartOfPush(new HashMap<>());
+    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID);
+    localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID);
+    localVeniceWriter.broadcastEndOfPush(new HashMap<>());
+
+    StoreIngestionTaskTestConfig testConfig =
+        new StoreIngestionTaskTestConfig(Utils.setOf(PARTITION_FOO, PARTITION_BAR), () -> {
+          // Wait until PARTITION_FOO's failing write has been attempted and the replica has been marked ERROR
+          // (retained).
+          verify(mockAbstractStorageEngine, timeout(TEST_TIMEOUT_MS))
+              .put(eq(PARTITION_FOO), any(), any(ByteBuffer.class));
+          verify(zkHelixAdmin, timeout(TEST_TIMEOUT_MS).atLeast(1))
+              .setPartitionsToError(anyString(), anyString(), anyString(), anyList());
+          // Wait until the healthy PARTITION_BAR has been durably persisted.
+          verify(mockAbstractStorageEngine, timeout(TEST_TIMEOUT_MS))
+              .put(eq(PARTITION_BAR), eq(putKeyBar), any(ByteBuffer.class));
+
+          // The errored PARTITION_FOO must still be present at shutdown so the checkpoint gate is actually exercised.
+          assertNotNull(
+              storeIngestionTaskUnderTest.getPartitionConsumptionState(PARTITION_FOO),
+              "errored PARTITION_FOO PCS must be retained (not unsubscribed) at shutdown");
+
+          // Scope the checkpoint verification to the graceful-shutdown window only. (A control-message checkpoint for
+          // PARTITION_FOO legitimately occurs earlier, before the partition errors, at a position prior to the failed
+          // record; that pre-error checkpoint is safe and is not what this test is about.)
+          clearInvocations(mockStorageMetadataService);
+
+          storeIngestionTaskUnderTest.close();
+
+          // The errored partition must NOT be checkpointed at any point during the shutdown window. Because the
+          // shutdown
+          // SYNC_OFFSET runs asynchronously on a drainer thread, assert with a timed never() that spans the whole
+          // window
+          // rather than a point-in-time check that could pass before a late checkpoint attempt lands.
+          verify(mockStorageMetadataService, after(TEST_TIMEOUT_MS).never()).put(eq(topic), eq(PARTITION_FOO), any());
+          // The healthy partition IS checkpointed during the same shutdown.
+          verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS).atLeastOnce())
+              .put(eq(topic), eq(PARTITION_BAR), any());
+        }, aaConfig);
+
+    testConfig
+        .setExtraServerProperties(
+            Collections.singletonMap(SERVER_INGESTION_CHECKPOINT_DURING_GRACEFUL_SHUTDOWN_ENABLED, true))
+        .setStoreVersionConfigOverride(configOverride -> {
+          doReturn(true).when(configOverride).isResetErrorReplicaEnabled();
+          // Very high sync threshold so offsets aren't synced during regular consumption (only at shutdown).
+          doReturn(100_000L).when(configOverride).getDatabaseSyncBytesIntervalForTransactionalMode();
+        });
+    runTest(testConfig);
+  }
+
   @Test(dataProvider = "aaConfigProvider", timeOut = 60_000)
   public void testProduceToStoreBufferService(AAConfig aaConfig) throws Exception {
     byte[] keyBytes = new byte[1];

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -5058,8 +5058,10 @@ public abstract class StoreIngestionTaskTest {
 
           storeIngestionTaskUnderTest.close();
 
-          // The errored partition must NOT be checkpointed at any point during the shutdown window. Because the shutdown
-          // SYNC_OFFSET runs asynchronously on a drainer thread, assert with a timed never() that spans the whole window
+          // The errored partition must NOT be checkpointed at any point during the shutdown window. Because the
+          // shutdown
+          // SYNC_OFFSET runs asynchronously on a drainer thread, assert with a timed never() that spans the whole
+          // window
           // rather than a point-in-time check that could pass before a late checkpoint attempt lands.
           verify(mockStorageMetadataService, after(TEST_TIMEOUT_MS).never()).put(eq(topic), eq(PARTITION_FOO), any());
           // The healthy partition IS checkpointed during the same shutdown.

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -5058,10 +5058,8 @@ public abstract class StoreIngestionTaskTest {
 
           storeIngestionTaskUnderTest.close();
 
-          // The errored partition must NOT be checkpointed at any point during the shutdown window. Because the
-          // shutdown
-          // SYNC_OFFSET runs asynchronously on a drainer thread, assert with a timed never() that spans the whole
-          // window
+          // The errored partition must NOT be checkpointed at any point during the shutdown window. Because the shutdown
+          // SYNC_OFFSET runs asynchronously on a drainer thread, assert with a timed never() that spans the whole window
           // rather than a point-in-time check that could pass before a late checkpoint attempt lands.
           verify(mockStorageMetadataService, after(TEST_TIMEOUT_MS).never()).put(eq(topic), eq(PARTITION_FOO), any());
           // The healthy partition IS checkpointed during the same shutdown.

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4967,12 +4967,8 @@ public abstract class StoreIngestionTaskTest {
   }
 
   /**
-   * Verifies that the in-memory VT position ({@link PartitionConsumptionState#getLatestProcessedVtPosition()}) is only
-   * advanced after the record has been successfully persisted. Two records are produced to PARTITION_FOO and the write
-   * (RocksDB put) of the second record is made to throw. The processed VT position must remain at the first (durably
-   * written) record's position rather than being advanced to the second (failed) record's position; otherwise a
-   * subsequent shutdown SYNC_OFFSET would checkpoint a position whose record was never persisted, causing data loss on
-   * restart.
+   * The processed VT position must advance only after a record is persisted: when the second record's write throws, the
+   * position must stay at the first (persisted) record, not the failed one, or a shutdown checkpoint would skip it.
    */
   @Test(dataProvider = "aaConfigProvider")
   public void testVtOffsetNotAdvancedWhenPersistFails(AAConfig aaConfig) throws Exception {
@@ -5015,11 +5011,8 @@ public abstract class StoreIngestionTaskTest {
   }
 
   /**
-   * Defense-in-depth: an errored replica must never have its offset checkpointed, even on the graceful-shutdown
-   * SYNC_OFFSET path. PARTITION_FOO's write is made to fail (driving the replica into an error state that is retained
-   * via the current-version reset-error path), while PARTITION_BAR ingests healthily. On graceful shutdown the healthy
-   * PARTITION_BAR must get its offset checkpointed, but the errored PARTITION_FOO must NOT — otherwise the checkpoint
-   * would advance past a record that was never persisted, skipping it on restart (data loss).
+   * An errored replica must not be checkpointed on graceful shutdown: the failed PARTITION_FOO must be skipped while the
+   * healthy PARTITION_BAR is checkpointed, so the checkpoint never advances past an un-persisted record.
    */
   @Test(dataProvider = "aaConfigProvider")
   public void testErroredPartitionNotCheckpointedOnGracefulShutdown(AAConfig aaConfig) throws Exception {
@@ -7786,8 +7779,7 @@ public abstract class StoreIngestionTaskTest {
 
   /**
    * The Global-RT-DIV checkpoint path ({@code updateAndSyncOffsetFromSnapshot}) must not checkpoint an errored replica.
-   * Needs a real SIT because the gate reads the {@code failedPartitions} field; errored state is set via
-   * {@code setIngestionException}, as in the Fix 2 graceful-shutdown test.
+   * Uses a real SIT because the gate reads the {@code failedPartitions} field (set via {@code setIngestionException}).
    */
   @Test
   public void testUpdateAndSyncOffsetFromSnapshotSkipsErroredReplica() throws Exception {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4990,9 +4990,7 @@ public abstract class StoreIngestionTaskTest {
       // Wait until the first record has been durably persisted (its write succeeds).
       verify(mockAbstractStorageEngine, timeout(TEST_TIMEOUT_MS))
           .put(eq(PARTITION_FOO), eq(putKeyFoo), any(ByteBuffer.class));
-      // Wait until the second record's write has been attempted (and thrown). After this point the second record has
-      // been processed, so any (buggy) unconditional advance of the VT position to the second record will have
-      // happened.
+      // Wait until the second record's write is attempted and throws; any buggy VT advance has now happened.
       verify(mockAbstractStorageEngine, timeout(TEST_TIMEOUT_MS))
           .put(eq(PARTITION_FOO), eq(putKeyFoo2), any(ByteBuffer.class));
 
@@ -5036,8 +5034,7 @@ public abstract class StoreIngestionTaskTest {
 
     StoreIngestionTaskTestConfig testConfig =
         new StoreIngestionTaskTestConfig(Utils.setOf(PARTITION_FOO, PARTITION_BAR), () -> {
-          // Wait until PARTITION_FOO's failing write has been attempted and the replica has been marked ERROR
-          // (retained).
+          // Wait until PARTITION_FOO's failing write is attempted and the replica is marked ERROR (retained).
           verify(mockAbstractStorageEngine, timeout(TEST_TIMEOUT_MS))
               .put(eq(PARTITION_FOO), any(), any(ByteBuffer.class));
           verify(zkHelixAdmin, timeout(TEST_TIMEOUT_MS).atLeast(1))
@@ -5058,11 +5055,7 @@ public abstract class StoreIngestionTaskTest {
 
           storeIngestionTaskUnderTest.close();
 
-          // The errored partition must NOT be checkpointed at any point during the shutdown window. Because the
-          // shutdown
-          // SYNC_OFFSET runs asynchronously on a drainer thread, assert with a timed never() that spans the whole
-          // window
-          // rather than a point-in-time check that could pass before a late checkpoint attempt lands.
+          // Use a timed never() spanning the shutdown window; the async SYNC_OFFSET could checkpoint late.
           verify(mockStorageMetadataService, after(TEST_TIMEOUT_MS).never()).put(eq(topic), eq(PARTITION_FOO), any());
           // The healthy partition IS checkpointed during the same shutdown.
           verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS).atLeastOnce())

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -7784,6 +7784,62 @@ public abstract class StoreIngestionTaskTest {
     verify(storeIngestionTask, never()).updateOffsetMetadataInOffsetRecord(any());
   }
 
+  /**
+   * The Global-RT-DIV checkpoint path ({@code updateAndSyncOffsetFromSnapshot}) must not checkpoint an errored replica.
+   * Needs a real SIT because the gate reads the {@code failedPartitions} field; errored state is set via
+   * {@code setIngestionException}, as in the Fix 2 graceful-shutdown test.
+   */
+  @Test
+  public void testUpdateAndSyncOffsetFromSnapshotSkipsErroredReplica() throws Exception {
+    StoreIngestionTaskFactory ingestionTaskFactory = getIngestionTaskFactoryBuilder(
+        new RandomPollStrategy(),
+        Utils.setOf(PARTITION_FOO),
+        Optional.empty(),
+        new HashMap<>(),
+        false,
+        null,
+        null,
+        this.mockStorageService).build();
+
+    MockStoreVersionConfigs storeAndVersionConfigs = setupStoreAndVersionMocks(
+        PARTITION_COUNT,
+        new PartitionerConfigImpl(),
+        Optional.empty(),
+        false,
+        false,
+        AAConfig.AA_OFF);
+
+    Properties kafkaProps = new Properties();
+    kafkaProps.put(KAFKA_BOOTSTRAP_SERVERS, inMemoryLocalKafkaBroker.getPubSubBrokerAddress());
+
+    storeIngestionTaskUnderTest = ingestionTaskFactory.getNewIngestionTask(
+        this.mockStorageService,
+        storeAndVersionConfigs.store,
+        storeAndVersionConfigs.version,
+        kafkaProps,
+        isCurrentVersion,
+        storeAndVersionConfigs.storeVersionConfig,
+        PARTITION_FOO,
+        Optional.empty(),
+        null,
+        null);
+
+    // A PCS must be present so the method gets past its null-PCS guard and actually evaluates the error gate.
+    PartitionConsumptionState erroredPcs = mock(PartitionConsumptionState.class);
+    doReturn(PARTITION_FOO).when(erroredPcs).getPartition();
+    storeIngestionTaskUnderTest.setPartitionConsumptionState(PARTITION_FOO, erroredPcs);
+    // Record the partition as failed, mirroring how an ingestion exception drives the Fix 2 graceful-shutdown test.
+    storeIngestionTaskUnderTest.setIngestionException(PARTITION_FOO, new VeniceException("fake ingestion exception"));
+
+    PartitionTracker vtDivSnapshot = mock(PartitionTracker.class);
+
+    storeIngestionTaskUnderTest.updateAndSyncOffsetFromSnapshot(vtDivSnapshot, fooTopicPartition);
+
+    // The gate returns before any checkpoint work, so the errored partition's OffsetRecord write and put() never run.
+    verify(vtDivSnapshot, never()).updateOffsetRecord(any(), any());
+    verify(mockStorageMetadataService, never()).put(eq(topic), eq(PARTITION_FOO), any());
+  }
+
   @Test
   public void testGetHeartbeatProducerTimestamp() {
     long producerTimestamp = 1780749996366L;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4981,6 +4981,10 @@ public abstract class StoreIngestionTaskTest {
     // Make the persist (RocksDB put) of the SECOND record fail.
     doThrow(new VeniceException("fake storage engine exception on second record")).when(mockAbstractStorageEngine)
         .put(eq(PARTITION_FOO), eq(putKeyFoo2), any(ByteBuffer.class));
+    // Retain the errored replica (current-version + reset-error-replica marks it ERROR instead of unsubscribing) so its
+    // PCS stays in the map for a deterministic position read.
+    isCurrentVersion = () -> true;
+    doNothing().when(zkHelixAdmin).setPartitionsToError(anyString(), anyString(), anyString(), anyList());
 
     StoreIngestionTaskTestConfig testConfig = new StoreIngestionTaskTestConfig(Utils.setOf(PARTITION_FOO), () -> {
       // Wait until the first record has been durably persisted (its write succeeds).
@@ -5004,6 +5008,7 @@ public abstract class StoreIngestionTaskTest {
     }, aaConfig);
 
     testConfig.setStoreVersionConfigOverride(configOverride -> {
+      doReturn(true).when(configOverride).isResetErrorReplicaEnabled();
       // Very high sync threshold so the OffsetRecord isn't synced during regular consumption.
       doReturn(100_000L).when(configOverride).getDatabaseSyncBytesIntervalForTransactionalMode();
     });

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VersionSpecificCDCShutdownTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VersionSpecificCDCShutdownTest.java
@@ -248,6 +248,17 @@ public class VersionSpecificCDCShutdownTest {
     newConsumerA.seekToCheckpoint(checkpoints).get();
     LOGGER.info("Restarted consumer A seeked to {} checkpoints.", checkpoints.size());
 
+    // seekToCheckpoint(...).get() only awaits the subscribe, not the inclusive re-scan backlog the
+    // seek schedules. Drain that backlog before producing the next batch so the new records (keys
+    // 120-129) never share the consumer pipeline with the re-scan of the pre-restart nearline tail.
+    // Key 119 is the last record produced before the restart, so re-observing it confirms the
+    // re-scan frontier has reached the checkpoint position and the backlog is quiesced.
+    Map<String, GenericRecord> drainEvents = new HashMap<>();
+    drainUntilKeyObserved(newConsumerA, drainEvents, "119");
+    LOGGER.info(
+        "Restarted consumer A drained re-scan backlog ({} events) before producing new batch.",
+        drainEvents.size());
+
     // Produce new nearline records after restart
     try (
         VeniceSystemProducer producerA =
@@ -273,6 +284,20 @@ public class VersionSpecificCDCShutdownTest {
     closeInBackground(consumerB);
     cleanUpStore(storeA);
     cleanUpStore(storeB);
+  }
+
+  /**
+   * Polls until the given key is observed, draining whatever the consumer has buffered (e.g. an
+   * inclusive seekToCheckpoint re-scan backlog) so it does not contend with records produced next.
+   */
+  private void drainUntilKeyObserved(
+      VeniceChangelogConsumer<GenericRecord, GenericRecord> consumer,
+      Map<String, GenericRecord> eventsMap,
+      String key) {
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
+      pollAndCollect(consumer, eventsMap);
+      assertNotNull(eventsMap.get(key), "Drain did not observe re-scanned key " + key);
+    });
   }
 
   private void pollAndVerifyNearlineRecords(
@@ -392,7 +417,11 @@ public class VersionSpecificCDCShutdownTest {
         .setLocalD2ZkHosts(zkAddress)
         .setControllerRequestRetryCount(3)
         .setD2Client(d2Client)
-        .setMaxBufferSize(10);
+        // The buffer must stay well above the per-restart nearline batch size (10). At parity (10),
+        // the inclusive seekToCheckpoint storage re-scan contends with the freshly produced target
+        // records for the same ArrayBlockingQueue slots, intermittently starving keys at the batch
+        // boundary and failing pollAndVerifyNearlineRecords within its 30s window.
+        .setMaxBufferSize(100);
     return new VeniceChangelogConsumerClientFactory(globalConfig, metricsRepository);
   }
 


### PR DESCRIPTION
## Problem Statement

During ingestion, the processed version-topic offset is advanced *before* the record is durably written to RocksDB. If the write then fails, the in-memory offset is left pointing at a record that was never persisted.

In normal operation this is harmless: the partition errors and re-bootstraps from its last durable checkpoint, re-reading the record. But during a graceful shutdown the failure is swallowed and the shutdown checkpoint persists that offset anyway. On restart the consumer resumes past the un-persisted record, so it is silently and permanently skipped.

This path is shared by server follower, DaVinci, and CDC ingestion. It was first seen on a stateful DaVinci-record-transformer CDC consumer, where a version-gate NPE (fixed separately in #2884) triggered it; the advance-before-persist is the underlying root cause.

## Solution

1. **Root cause:** advance the processed offset only after the record is successfully written, so a failure between processing and the write can never leave the checkpoint ahead of storage. (Active/Active inherits the changed methods, so the same edits fix it too; the leader produce path already advances offsets only after producing and is unchanged.)
2. **Defense in depth:** never checkpoint an errored replica, so its offset is not persisted even if it was somehow advanced; the last good durable offset is left in place and the failed record is re-read on restart. The gate covers both the standard graceful-shutdown checkpoint and the Global-RT-DIV checkpoint path.
3. **Test stabilization:** fixes a pre-existing flaky CDC integration test (`VersionSpecificCDCConsumerRestartWithinFlinkTimeout`, ~75% fail on `main`) that was reddening this PR's CI: a fixture race where the consumer buffer sat at parity with the post-restart batch size, so newly produced records contended with the inclusive-seek re-scan for the same buffer slots. Raises the buffer above the batch size and drains the re-scan backlog after the seek; verified 18/18 single-attempt runs with test-retry disabled.

### Code changes
- [ ] Added new code behind a config.
- [x] Introduced new log lines. (a `WARN` when an errored replica's checkpoint is skipped)

### Concurrency-Specific Checks
- [x] No race conditions or thread-safety issues.
- [x] Closes a graceful-shutdown race that could checkpoint an un-persisted record's offset.

## How was this PR tested?
- [x] New unit tests, written red-first: one asserts the offset is not advanced when a record's persist fails; one asserts an errored partition is not checkpointed on graceful shutdown while a healthy partition is. Both cover the leader/follower and Active/Active paths.
- [x] A unit test (`testUpdateAndSyncOffsetFromSnapshotSkipsErroredReplica`) covers the Global-RT-DIV checkpoint gate, written red-first.
- [x] Full da-vinci-client unit suite passes.

## Does this PR introduce any user-facing or breaking changes?
- [x] No.
