### PR TITLE
[server][da-vinci]: Improve thread names for diagnostics

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -146,7 +146,9 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
     // different per-consumer lock; extra threads would just wait on locks).
     this.batchUnsubscribeExecutor = Executors.newFixedThreadPool(
         numOfConsumersPerKafkaCluster,
-        new DaemonThreadFactory("KafkaConsumerService-batch-unsub", serverConfig.getLogContext()));
+        new DaemonThreadFactory(
+            "KafkaConsumerService-batch-unsub-" + kafkaUrlForLogger + "-" + poolType.getStatSuffix(),
+            serverConfig.getLogContext()));
     this.consumerToConsumptionTask = new IndexedHashMap<>(numOfConsumersPerKafkaCluster);
     this.aggStats = statsOverride != null
         ? statsOverride

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -350,7 +350,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected final BooleanSupplier isCurrentVersion;
   protected final Optional<HybridStoreConfig> hybridStoreConfig;
   protected final Consumer<DataValidationException> divErrorMetricCallback;
-  private final ExecutorService missingSOPCheckExecutor = Executors.newSingleThreadExecutor();
+  private final ExecutorService missingSOPCheckExecutor;
   private final VeniceStoreVersionConfig storeVersionConfig;
   protected final long readCycleDelayMs;
   protected final long emptyPollSleepMs;
@@ -548,6 +548,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.pubSubTopicRepository = pubSubContext.getPubSubTopicRepository();
     this.topicManagerRepository = pubSubContext.getTopicManagerRepository();
     this.versionTopic = pubSubTopicRepository.getTopic(kafkaVersionTopic);
+    this.missingSOPCheckExecutor = Executors.newSingleThreadExecutor(
+        new DaemonThreadFactory(
+            "StoreIngestionTask-missing-SOP-" + kafkaVersionTopic,
+            builder.getServerConfig().getLogContext()));
     this.storeName = versionTopic.getStoreName();
     this.storeVersionName = storeVersionConfig.getStoreVersionName();
     this.isUserSystemStore = VeniceSystemStoreUtils.isUserSystemStore(storeName);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/concurrent/ThreadPoolFactory.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/concurrent/ThreadPoolFactory.java
@@ -31,13 +31,29 @@ public final class ThreadPoolFactory {
       @Nullable LogContext logContext,
       int capacity,
       BlockingQueueType blockingQueueType) {
+    return createThreadPool(
+        threadCount,
+        threadNamePrefix,
+        logContext,
+        capacity,
+        blockingQueueType,
+        DaemonThreadFactory.UNSPECIFIED_PRIORITY);
+  }
+
+  public static ThreadPoolExecutor createThreadPool(
+      int threadCount,
+      String threadNamePrefix,
+      @Nullable LogContext logContext,
+      int capacity,
+      BlockingQueueType blockingQueueType,
+      int priority) {
     ThreadPoolExecutor executor = new ThreadPoolExecutor(
         threadCount,
         threadCount,
         0,
         TimeUnit.MILLISECONDS,
         getExecutionQueue(capacity, blockingQueueType),
-        new DaemonThreadFactory(threadNamePrefix, logContext));
+        new DaemonThreadFactory(threadNamePrefix, priority, logContext));
     /**
      * When the capacity is fully saturated, the scheduled task will be executed in the caller thread.
      * We will leverage this policy to propagate the back pressure to the caller, so that no more tasks will be

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
@@ -33,6 +33,7 @@ import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.List;
 import java.util.Optional;
@@ -105,7 +106,8 @@ public class ListenerService extends AbstractVeniceService {
       this.sslHandshakeExecutor = createThreadPool(
           serverConfig.getSslHandshakeThreadPoolSize(),
           "SSLHandShakeThread",
-          serverConfig.getSslHandshakeQueueCapacity());
+          serverConfig.getSslHandshakeQueueCapacity(),
+          Thread.NORM_PRIORITY);
     }
 
     StorageReadRequestHandler requestHandler = createRequestHandler(
@@ -136,9 +138,10 @@ public class ListenerService extends AbstractVeniceService {
     boolean epollEnabled = serverConfig.isRestServiceEpollEnabled();
     if (epollEnabled) {
       try {
-        bossGroup = new EpollEventLoopGroup(1);
-        workerGroup = new EpollEventLoopGroup(serverConfig.getNettyWorkerThreadCount()); // if 0, defaults to 2*cpu
-                                                                                         // count
+        bossGroup = new EpollEventLoopGroup(1, new DefaultThreadFactory("Venice-Rest-Listener-Epoll-Boss"));
+        workerGroup = new EpollEventLoopGroup( // if 0, defaults to 2*cpu count
+            serverConfig.getNettyWorkerThreadCount(),
+            new DefaultThreadFactory("Venice-Rest-Listener-Epoll-Worker"));
         serverSocketChannelClass = EpollServerSocketChannel.class;
         LOGGER.info("Epoll is enabled in Server Rest Service");
       } catch (LinkageError error) {
@@ -147,8 +150,10 @@ public class ListenerService extends AbstractVeniceService {
       }
     }
     if (!epollEnabled) {
-      bossGroup = new NioEventLoopGroup(1);
-      workerGroup = new NioEventLoopGroup(serverConfig.getNettyWorkerThreadCount()); // if 0, defaults to 2*cpu count
+      bossGroup = new NioEventLoopGroup(1, new DefaultThreadFactory("Venice-Rest-Listener-Nio-Boss"));
+      workerGroup = new NioEventLoopGroup( // if 0, defaults to 2*cpu count
+          serverConfig.getNettyWorkerThreadCount(),
+          new DefaultThreadFactory("Venice-Rest-Listener-Nio-Worker"));
       serverSocketChannelClass = NioServerSocketChannel.class;
     }
     bootstrap = new ServerBootstrap();
@@ -236,6 +241,16 @@ public class ListenerService extends AbstractVeniceService {
         serverConfig.getLogContext(),
         capacity,
         serverConfig.getBlockingQueueType());
+  }
+
+  protected ThreadPoolExecutor createThreadPool(int threadCount, String threadNamePrefix, int capacity, int priority) {
+    return ThreadPoolFactory.createThreadPool(
+        threadCount,
+        threadNamePrefix,
+        serverConfig.getLogContext(),
+        capacity,
+        serverConfig.getBlockingQueueType(),
+        priority);
   }
 
   protected StorageReadRequestHandler createRequestHandler(

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/HttpChannelInitializerSslTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/HttpChannelInitializerSslTest.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.listener;
 import com.linkedin.alpini.base.ssl.SslFactory;
 import com.linkedin.alpini.netty4.ssl.SslInitializer;
 import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.SslUtils;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
@@ -23,6 +24,8 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.net.ssl.SSLContext;
@@ -39,6 +42,7 @@ import org.testng.annotations.Test;
  */
 public class HttpChannelInitializerSslTest {
   private static final int NUM_CONNECTIONS = 10;
+  private static final String SSL_HANDSHAKE_EXECUTOR_THREAD_PREFIX = "SSLHandShakeThread";
 
   private EventLoopGroup bossGroup;
   private EventLoopGroup workerGroup;
@@ -142,6 +146,109 @@ public class HttpChannelInitializerSslTest {
 
     for (Channel ch: clientChannels) {
       ch.close().sync();
+    }
+  }
+
+  @Test(timeOut = 30000)
+  public void testSslHandshakeDelegatedTasksRunOnConfiguredExecutor() throws Exception {
+    SSLFactory sslFactory = SslUtils.getVeniceLocalSslFactory();
+    SslFactory cachedAlpiniSslFactory = SslUtils.toAlpiniSSLFactory(sslFactory);
+
+    CountDownLatch handshakeComplete = new CountDownLatch(1);
+    CountDownLatch delegatedTaskExecuted = new CountDownLatch(1);
+    AtomicInteger delegatedTaskExecutionCount = new AtomicInteger(0);
+    List<String> delegatedTaskThreadNames = new ArrayList<>();
+    List<Integer> delegatedTaskThreadPriorities = new ArrayList<>();
+    ThreadPoolExecutor sslHandshakeExecutor = new ThreadPoolExecutor(
+        1,
+        1,
+        0L,
+        TimeUnit.MILLISECONDS,
+        new LinkedBlockingQueue<>(),
+        new DaemonThreadFactory(SSL_HANDSHAKE_EXECUTOR_THREAD_PREFIX, Thread.NORM_PRIORITY, null)) {
+      @Override
+      protected void beforeExecute(Thread thread, Runnable runnable) {
+        super.beforeExecute(thread, runnable);
+        synchronized (delegatedTaskThreadNames) {
+          delegatedTaskThreadNames.add(thread.getName());
+        }
+        synchronized (delegatedTaskThreadPriorities) {
+          delegatedTaskThreadPriorities.add(thread.getPriority());
+        }
+        delegatedTaskExecutionCount.incrementAndGet();
+        delegatedTaskExecuted.countDown();
+      }
+    };
+
+    Channel clientChannel = null;
+    try {
+      ServerBootstrap serverBootstrap = new ServerBootstrap();
+      serverBootstrap.group(bossGroup, workerGroup)
+          .channel(NioServerSocketChannel.class)
+          .childHandler(new ChannelInitializer<SocketChannel>() {
+            @Override
+            protected void initChannel(SocketChannel ch) {
+              SslInitializer sslInitializer = new SslInitializer(cachedAlpiniSslFactory, false);
+              sslInitializer.enableSslTaskExecutor(sslHandshakeExecutor);
+              ch.pipeline().addLast(sslInitializer);
+            }
+          })
+          .option(ChannelOption.SO_BACKLOG, 128)
+          .childOption(ChannelOption.SO_KEEPALIVE, true);
+
+      serverChannel = serverBootstrap.bind(0).sync().channel();
+      serverPort = ((InetSocketAddress) serverChannel.localAddress()).getPort();
+
+      SSLContext clientSslContext = sslFactory.getSSLContext();
+      Bootstrap clientBootstrap = new Bootstrap();
+      clientBootstrap.group(clientGroup)
+          .channel(NioSocketChannel.class)
+          .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+          .handler(new ChannelInitializer<SocketChannel>() {
+            @Override
+            protected void initChannel(SocketChannel ch) {
+              SSLEngine engine = clientSslContext.createSSLEngine("localhost", serverPort);
+              engine.setUseClientMode(true);
+              ch.pipeline().addLast("ssl", new SslHandler(engine));
+              ch.pipeline().addLast("handshake-listener", new ChannelInboundHandlerAdapter() {
+                @Override
+                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                  if (evt instanceof SslHandshakeCompletionEvent) {
+                    SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
+                    Assert.assertTrue(handshakeEvent.isSuccess(), "SSL handshake should succeed");
+                    handshakeComplete.countDown();
+                  }
+                  ctx.fireUserEventTriggered(evt);
+                }
+              });
+            }
+          });
+
+      clientChannel = clientBootstrap.connect("localhost", serverPort).sync().channel();
+
+      Assert.assertTrue(handshakeComplete.await(15, TimeUnit.SECONDS), "SSL handshake did not complete in time");
+      Assert.assertTrue(
+          delegatedTaskExecuted.await(5, TimeUnit.SECONDS),
+          "Expected Netty SSL delegated tasks to execute on the configured sslHandshakeExecutor");
+      Assert.assertTrue(delegatedTaskExecutionCount.get() > 0, "Expected at least one SSL delegated task execution");
+      synchronized (delegatedTaskThreadNames) {
+        Assert.assertTrue(
+            delegatedTaskThreadNames.stream().allMatch(name -> name.startsWith(SSL_HANDSHAKE_EXECUTOR_THREAD_PREFIX)),
+            "SSL delegated tasks should run on the configured executor threads, but ran on: "
+                + delegatedTaskThreadNames);
+      }
+      synchronized (delegatedTaskThreadPriorities) {
+        Assert.assertTrue(
+            delegatedTaskThreadPriorities.stream().allMatch(priority -> priority == Thread.NORM_PRIORITY),
+            "SSL delegated tasks should run on normal-priority executor threads, but priorities were: "
+                + delegatedTaskThreadPriorities);
+      }
+    } finally {
+      if (clientChannel != null) {
+        clientChannel.close().sync();
+      }
+      sslHandshakeExecutor.shutdownNow();
+      Assert.assertTrue(sslHandshakeExecutor.awaitTermination(5, TimeUnit.SECONDS));
     }
   }
 }


### PR DESCRIPTION
## Summary

Improve thread naming for server diagnostics and make Venice Server SSL handshake threads use normal JVM priority.

This change makes several previously generic or ambiguous thread names easier to identify in thread dumps, especially for Venice Server and Da Vinci ingestion diagnostics. It also adds a priority-aware `ThreadPoolFactory` overload so the SSL handshake pool can explicitly create normal-priority daemon threads through the existing `DaemonThreadFactory` priority support.

## What changed

- Named Venice Server REST Netty event-loop threads:
  - `Venice-Rest-Listener-Epoll-Boss`
  - `Venice-Rest-Listener-Epoll-Worker`
  - `Venice-Rest-Listener-Nio-Boss`
  - `Venice-Rest-Listener-Nio-Worker`

- Updated Venice Server SSL handshake thread pool creation to use `Thread.NORM_PRIORITY`.

- Added a priority-aware overload to `ThreadPoolFactory.createThreadPool(...)` while preserving existing default behavior for current callers.

- Improved Da Vinci consumer diagnostic thread names:
  - `KafkaConsumerService` batch-unsubscribe executor now includes sanitized Kafka URL and pool type.
  - `StoreIngestionTask` missing-SOP checker executor now uses a named `DaemonThreadFactory`.

- Added an SSL test proving that Netty SSL delegated tasks execute on the configured SSL handshake executor, and that those executor threads use the expected name prefix and normal priority.

## Why

Thread dumps from Venice Server contained several ambiguous thread families, such as generic Netty event-loop names and default executor names. These make production diagnostics harder because it is difficult to map idle or busy threads back to their owning Venice component.

This PR improves debuggability by making the runtime thread names directly identify the owning subsystem. It also de-prioritizes SSL handshake threads from their previously inherited high priority by explicitly creating them at normal priority.

## How

- Pass Netty `DefaultThreadFactory` instances when constructing REST listener boss/worker event-loop groups.
- Route SSL handshake pool creation through a new `ThreadPoolFactory.createThreadPool(..., int priority)` overload.
- Reuse existing `DaemonThreadFactory(String threadNamePrefix, int priority, LogContext logContext)` support to set thread priority.
- Use `DaemonThreadFactory` for newly named Da Vinci executors.
- Add a real Netty SSL handshake test that observes execution through `ThreadPoolExecutor.beforeExecute(...)`, proving SSL delegated tasks are actually run by the supplied executor.

## Compatibility

No protocol, schema, config, or persisted-state compatibility changes.

Existing `ThreadPoolFactory.createThreadPool(...)` callers retain the previous behavior by delegating with `DaemonThreadFactory.UNSPECIFIED_PRIORITY`.

## New dependencies

None.

## Testing

Ran targeted formatting, compile, and SSL tests:

```bash
./gradlew spotlessJavaCheck :services:venice-server:compileJava --continue