### PR TITLE
[controller] Purify the Venice-metadata zkClient of Helix-data reads (ZK client re-architecture, PR 2)

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixResources.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixResources.java
@@ -74,6 +74,11 @@ public class TestVeniceHelixResources {
     when(controllerConfig.isPreFetchDeadStoreStatsEnabled()).thenReturn(true);
     when(controllerConfig.getDeadStoreStatsPreFetchRefreshIntervalInMs()).thenReturn(100L); // Must be Long
 
+    // The spectator HelixManager is now constructed from config.getZkAddress() (previously zkClient.getServers()), so
+    // the injected config must expose the test ZK address. Stubbing it here covers both the no-arg overload and
+    // caller-supplied configs.
+    when(config.getZkAddress()).thenReturn(zkServer.getAddress());
+
     return new HelixVeniceClusterResources(
         cluster,
         zkClient,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixResources.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixResources.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixAdapterSerializer;
 import com.linkedin.venice.helix.HelixReadOnlyZKSharedSchemaRepository;
@@ -30,6 +31,7 @@ import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -91,6 +93,130 @@ public class TestVeniceHelixResources {
         Optional.empty(),
         mock(HelixAdminClient.class),
         mock(VeniceVersionLifecycleEventManager.class));
+  }
+
+  /**
+   * The ZK address {@link HelixVeniceClusterResources} selects for the spectator Helix manager, captured by
+   * {@link CapturingHelixVeniceClusterResources} during construction (no real connection is opened).
+   */
+  private static final ThreadLocal<String> CAPTURED_SPECTATOR_ZK_ADDRESS = new ThreadLocal<>();
+
+  /**
+   * Subclass that intercepts {@link HelixVeniceClusterResources#getSpectatorManager(String, String)} to record the ZK
+   * address chosen for the spectator manager, returning a stubbed manager instead of opening a real ZK connection.
+   */
+  private static class CapturingHelixVeniceClusterResources extends HelixVeniceClusterResources {
+    CapturingHelixVeniceClusterResources(
+        String clusterName,
+        ZkClient zkClient,
+        HelixAdapterSerializer adapterSerializer,
+        SafeHelixManager helixManager,
+        VeniceControllerClusterConfig config,
+        VeniceHelixAdmin admin,
+        MetricsRepository metricsRepository,
+        RealTimeTopicSwitcher realTimeTopicSwitcher,
+        Optional<DynamicAccessController> accessController,
+        HelixAdminClient helixAdminClient,
+        VeniceVersionLifecycleEventManager veniceVersionLifecycleEventManager) {
+      super(
+          clusterName,
+          zkClient,
+          adapterSerializer,
+          helixManager,
+          config,
+          admin,
+          metricsRepository,
+          realTimeTopicSwitcher,
+          accessController,
+          helixAdminClient,
+          veniceVersionLifecycleEventManager);
+    }
+
+    @Override
+    SafeHelixManager getSpectatorManager(String clusterName, String zkAddress) {
+      // Invoked from the super constructor; record the selected address without opening a real ZK connection.
+      CAPTURED_SPECTATOR_ZK_ADDRESS.set(zkAddress);
+      SafeHelixManager manager = mock(SafeHelixManager.class);
+      // HelixExternalViewRepository's constructor reads the cluster name off the manager.
+      when(manager.getClusterName()).thenReturn(clusterName);
+      return manager;
+    }
+  }
+
+  /**
+   * Construct a {@link CapturingHelixVeniceClusterResources} and return the ZK address it selected for the spectator
+   * Helix manager. {@code metadataZkAddress} backs the Venice-metadata {@link ZkClient} (must be a live test ZK);
+   * {@code configHelixZkAddress} is what {@link VeniceControllerClusterConfig#getZkAddress()} reports.
+   */
+  private String captureSpectatorZkAddress(String cluster, String metadataZkAddress, String configHelixZkAddress) {
+    ZkClient zkClient = ZkClientFactory.newZkClient(metadataZkAddress);
+    ZKHelixManager controller =
+        new ZKHelixManager(cluster, "localhost_1234", InstanceType.CONTROLLER, metadataZkAddress);
+    ZKHelixAdmin admin = new ZKHelixAdmin(metadataZkAddress);
+    admin.addCluster(cluster);
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    doReturn(mock(MetaStoreWriter.class)).when(veniceHelixAdmin).getMetaStoreWriter();
+    doReturn(mock(HelixReadOnlyZKSharedSystemStoreRepository.class)).when(veniceHelixAdmin)
+        .getReadOnlyZKSharedSystemStoreRepository();
+    doReturn(mock(HelixReadOnlyZKSharedSchemaRepository.class)).when(veniceHelixAdmin)
+        .getReadOnlyZKSharedSchemaRepository();
+    doReturn(Collections.emptyList()).when(veniceHelixAdmin).getAllStores(cluster);
+
+    VeniceControllerClusterConfig config = mock(VeniceControllerClusterConfig.class);
+    when(config.getZkAddress()).thenReturn(configHelixZkAddress);
+
+    CAPTURED_SPECTATOR_ZK_ADDRESS.remove();
+    new CapturingHelixVeniceClusterResources(
+        cluster,
+        zkClient,
+        new HelixAdapterSerializer(),
+        new SafeHelixManager(controller),
+        config,
+        veniceHelixAdmin,
+        new MetricsRepository(),
+        mock(RealTimeTopicSwitcher.class),
+        Optional.empty(),
+        mock(HelixAdminClient.class),
+        mock(VeniceVersionLifecycleEventManager.class));
+    String captured = CAPTURED_SPECTATOR_ZK_ADDRESS.get();
+    CAPTURED_SPECTATOR_ZK_ADDRESS.remove();
+    return captured;
+  }
+
+  @DataProvider(name = "spectatorZkAddressCases")
+  public Object[][] spectatorZkAddressCases() {
+    // name, configHelixZkAddress (null -> reuse the live metadata ZK address), expectMatchesMetadataAddress
+    return new Object[][] { { "config-only-specified", "helix-zk-standalone.example.com:2181", false },
+        { "both-specified-and-identical", null, true },
+        { "both-specified-and-different", "helix-zk-different.example.com:2181", false } };
+  }
+
+  /**
+   * Guards the ZK-client re-architecture: the spectator Helix manager must bind to the Helix ZK address from
+   * {@link VeniceControllerClusterConfig#getZkAddress()}, independent of the Venice-metadata {@link ZkClient}. When the
+   * metadata client is later repointed to a backup ensemble for HA, Helix-coordination reads must stay on the Helix ZK.
+   * Covers the address-source combinations: config-only, both-identical (today's prod), and both-different (post-HA).
+   */
+  @Test(dataProvider = "spectatorZkAddressCases")
+  public void testSpectatorManagerBindsToConfigZkAddress(
+      String name,
+      String configHelixZkAddress,
+      boolean expectMatchesMetadataAddress) {
+    String metadataZkAddress = zkServer.getAddress();
+    String configZkAddress = configHelixZkAddress == null ? metadataZkAddress : configHelixZkAddress;
+
+    String captured = captureSpectatorZkAddress("test-spectator-" + name, metadataZkAddress, configZkAddress);
+
+    Assert.assertEquals(
+        captured,
+        configZkAddress,
+        "[" + name + "] spectator manager must bind to the config Helix ZK address.");
+    if (!expectMatchesMetadataAddress) {
+      Assert.assertNotEquals(
+          captured,
+          metadataZkAddress,
+          "[" + name + "] spectator manager must not fall back to the Venice-metadata zkClient address.");
+    }
   }
 
   @Test

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
@@ -166,8 +166,9 @@ public class HelixVeniceClusterResources implements VeniceResource {
       spectatorManager = this.helixManager;
     } else {
       // Use a separate helix manger for listening on the external view to prevent it from blocking state transition and
-      // messages.
-      spectatorManager = getSpectatorManager(clusterName, zkClient.getServers());
+      // messages. Source the Helix (System #1) ZK address from config rather than off the Venice-metadata zkClient, so
+      // this spectator session stays tied to the Helix ZK if/when the metadata zkClient is later repointed for HA.
+      spectatorManager = getSpectatorManager(clusterName, config.getZkAddress());
     }
     this.routingDataRepository = new HelixExternalViewRepository(spectatorManager);
     this.customizedViewRepo =

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
@@ -165,9 +165,8 @@ public class HelixVeniceClusterResources implements VeniceResource {
       // used directly for external view purposes.
       spectatorManager = this.helixManager;
     } else {
-      // Use a separate helix manger for listening on the external view to prevent it from blocking state transition and
-      // messages. Source the Helix (System #1) ZK address from config rather than off the Venice-metadata zkClient, so
-      // this spectator session stays tied to the Helix ZK if/when the metadata zkClient is later repointed for HA.
+      // Use a separate helix manager with specified helix zk address for listening on the external view to prevent it
+      // from blocking state transition and messages.
       spectatorManager = getSpectatorManager(clusterName, config.getZkAddress());
     }
     this.routingDataRepository = new HelixExternalViewRepository(spectatorManager);
@@ -602,7 +601,9 @@ public class HelixVeniceClusterResources implements VeniceResource {
     return clusterName.equals(storeConfig.getCluster());
   }
 
-  private SafeHelixManager getSpectatorManager(String clusterName, String zkAddress) {
+  // Package-private (not private) so tests can capture the ZK address this is invoked with, verifying the spectator
+  // manager binds to the Helix ZK address from config rather than the Venice-metadata zkClient.
+  SafeHelixManager getSpectatorManager(String clusterName, String zkAddress) {
     SafeHelixManager manager =
         new SafeHelixManager(HelixManagerFactory.getZKHelixManager(clusterName, "", InstanceType.SPECTATOR, zkAddress));
     try {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerStateModel.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerStateModel.java
@@ -252,8 +252,10 @@ public class VeniceControllerStateModel extends StateModel {
     }
     InstanceType instanceType =
         clusterConfig.isVeniceClusterLeaderHAAS() ? InstanceType.SPECTATOR : InstanceType.CONTROLLER;
+    // Source the Helix (System #1) ZK address from config rather than off the Venice-metadata zkClient, so the live
+    // Helix manager session stays tied to the Helix ZK if/when the metadata zkClient is later repointed for HA.
     helixManager = new SafeHelixManager(
-        HelixManagerFactory.getZKHelixManager(clusterName, controllerName, instanceType, zkClient.getServers()));
+        HelixManagerFactory.getZKHelixManager(clusterName, controllerName, instanceType, clusterConfig.getZkAddress()));
     helixManager.connect();
     helixManager.startTimerTasks();
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -365,6 +365,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   private final HelixAdminClient helixAdminClient;
   private TopicManagerRepository topicManagerRepository;
   private final ZkClient zkClient;
+  /**
+   * A dedicated Zk client for reading Helix cluster metadata (System #1 — LIVEINSTANCES, EXTERNALVIEW) directly from
+   * ZK. This is intentionally kept separate from {@link #zkClient}, which owns Venice metadata (System #2). Helix reads
+   * must not ride on {@link #zkClient}: a later HA change repoints {@link #zkClient} at a separate/backup ensemble for
+   * Venice-metadata availability, and these Helix reads must stay on the Helix ZK rather than follow it.
+   */
+  private final ZkClient helixZkClient;
   private final HelixAdapterSerializer adapterSerializer;
   private final ZkAllowlistAccessor allowlistAccessor;
   private final ExecutionIdAccessor executionIdAccessor;
@@ -539,6 +546,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     // There is no way to get the internal zkClient from HelixManager or HelixAdmin. So create a new one here.
     this.zkClient = ZkClientFactory.newZkClient(multiClusterConfigs.getZkAddress());
     this.zkClient.subscribeStateChanges(new ZkClientStatusStats(metricsRepository, "controller-zk-client"));
+    // System #1 (Helix cluster metadata) reads get their own Zk client on the Helix ZK address, kept off the
+    // Venice-metadata zkClient above. See {@link #helixZkClient}.
+    this.helixZkClient = ZkClientFactory.newZkClient(multiClusterConfigs.getZkAddress());
+    this.helixZkClient.subscribeStateChanges(new ZkClientStatusStats(metricsRepository, "controller-helix-zk-client"));
     this.adapterSerializer = new HelixAdapterSerializer();
     this.asyncStoreChangeNotifier = new AsyncStoreChangeNotifier(
         VeniceComponent.CONTROLLER,
@@ -766,7 +777,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         continue;
       }
 
-      HelixLiveInstanceMonitor liveInstanceMonitor = new HelixLiveInstanceMonitor(this.zkClient, clusterName);
+      HelixLiveInstanceMonitor liveInstanceMonitor = new HelixLiveInstanceMonitor(this.helixZkClient, clusterName);
       DisabledPartitionStats disabledPartitionStats = new DisabledPartitionStats(metricsRepository, clusterName);
       PushJobStatusStats pushJobStatusStats = new PushJobStatusStats(metricsRepository, clusterName);
       disabledPartitionStatMap.put(clusterName, disabledPartitionStats);
@@ -1083,11 +1094,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   private boolean isResourceStillAlive(String clusterName, String resourceName) {
     String externalViewPath = "/" + clusterName + "/EXTERNALVIEW/" + resourceName;
-    return zkClient.exists(externalViewPath);
+    return helixZkClient.exists(externalViewPath);
   }
 
   List<String> getAllLiveHelixResources(String clusterName) {
-    return zkClient.getChildren("/" + clusterName + "/EXTERNALVIEW");
+    return helixZkClient.getChildren("/" + clusterName + "/EXTERNALVIEW");
   }
 
   /**
@@ -6567,6 +6578,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       helixManager.disconnect();
       topicManagerRepository.close();
       zkClient.close();
+      helixZkClient.close();
       helixAdminClient.close();
     } catch (Exception e) {
       throw new VeniceException("Can not stop controller correctly.", e);
@@ -7941,6 +7953,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         zkClient.close();
       } catch (Exception e) {
         LOGGER.error("Failed to close zkClient. Swallowing and moving on.", e);
+      }
+      try {
+        helixZkClient.close();
+      } catch (Exception e) {
+        LOGGER.error("Failed to close helixZkClient. Swallowing and moving on.", e);
       }
       Utils.closeQuietlyWithErrorLogged(this.pushJobDetailsManager);
       Utils.closeQuietlyWithErrorLogged(this.dataRecoveryManager);


### PR DESCRIPTION
## Summary

Follow-up to #2872 (ZK client re-architecture, PR 1 of the series). That PR consolidated all Helix-admin operations behind a single owner. This PR continues the cleanup by moving the remaining **Helix-coordination reads** off the controller's **Venice-metadata** ZK client.

ZooKeeper is used by the controller for two distinct things:

1. **Helix cluster coordination** (owned by Helix APIs): IdealState, ExternalView, LiveInstances, InstanceConfig, ClusterConfig, StateModelDefs, CustomizedState.
2. **Venice metadata and controller state** (owned by Venice code): Stores, Schemas, StoreConfig, OfflinePushStatus, AdminTopicMetadata, StoreGraveyard, Personas.

A later HA change needs to repoint the **Venice-metadata** client at a separate/backup ZK ensemble for write availability. Today a few Helix-coordination reads still ride on that same metadata `zkClient`; if it were repointed, those Helix reads would follow it to the wrong ensemble. This PR moves them onto a Helix-owned client so the metadata client serves Venice metadata exclusively.

## Changes

**Behaviour-preserving** — every read still targets the same Helix ZK address it does today; only the owning client object changes.

- **`VeniceHelixAdmin`**: add a dedicated `ZkClient` (`helixZkClient`) for Helix-coordination reads on the Helix ZK address, kept separate from the Venice-metadata `zkClient`. Closed alongside `zkClient` in both `stopVeniceController()` and `close()`.
  - `HelixLiveInstanceMonitor` (watches `/<cluster>/LIVEINSTANCES`) is now constructed on `helixZkClient`.
  - Raw ExternalView reads (`isResourceStillAlive`, `getAllLiveHelixResources`) now use `helixZkClient`.
- **`VeniceControllerStateModel`** / **`HelixVeniceClusterResources`**: source the live Helix-manager session's ZK address from config (`clusterConfig`/`config.getZkAddress()`) instead of `zkClient.getServers()`, so the Helix managers are no longer tied to the metadata `zkClient` object.

After this change, `VeniceHelixAdmin.zkClient` is used only for Venice metadata.

## Why `helixZkClient` is a separate client (not the Helix manager)

`HelixLiveInstanceMonitor` is documented to require its own `ZkClient`, distinct from the `HelixManager`, so live-instance change notifications aren't delayed behind state-transition traffic. The ExternalView reads are raw-ZK existence/children checks. A dedicated Helix-owned `ZkClient` preserves those exact read semantics while keeping them off the metadata client — no behavioural change.

## Testing

| Test | Coverage | Status |
|---|---|---|
| `:services:venice-controller:compileJava` / `compileTestJava` / `:internal:venice-test-common:compileIntegrationTestJava` | Build | Pass |
| spotless | Format | Pass |
| `TestVeniceControllerStateModel` | Helix-manager init path (now via config address) | Pass |
| Integration suite | Live-instance monitoring + ExternalView reads under a booted controller | CI |

## Follow-ups (not in this PR)

- A Venice-metadata client wrapper so the Venice-metadata accessors go through one owned client.
- The HA repoint: add a config to point only the Venice-metadata client at a backup ZK ensemble.