### PR TITLE
[controller] Unblock store after failed target-region deferred-swap push

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1378,11 +1378,17 @@ public class VeniceParentHelixAdmin implements Admin {
           }
         }
       } else if (isTargetRegionPushWithDeferredSwap) {
-        LOGGER.error(
-            "Future version {} exists for store {}, please wait till the future version is made current.",
-            versionNumber,
-            storeName);
-        return Optional.of(latestTopic.get().getName());
+        // Only a definitively-failed push (ERROR/KILLED, i.e. VersionStatus.canDelete) may be reclaimed
+        // and let a new push proceed; every other status still represents a live future version that
+        // must block a concurrent push.
+        if (!VersionStatus.canDelete(version.getStatus())) {
+          LOGGER.error(
+              "Future version {} exists for store {}, please wait till the future version is made current.",
+              versionNumber,
+              storeName);
+          return Optional.of(latestTopic.get().getName());
+        }
+        // Failed terminal states (ERROR/KILLED) fall through to the existing topic cleanup logic below.
       }
 
       if (!isTopicTruncated(latestTopicName)) {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2955,6 +2955,61 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     Assert.assertFalse(mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false).isPresent());
   }
 
+  /**
+   * Regression test for VENG-12709: a target-region deferred-swap version whose push failed in the
+   * target region (ERROR/KILLED) was permanently blocking all subsequent pushes with
+   * CONCURRENT_BATCH_PUSH. After the fix, only a failed terminal version (VersionStatus#canDelete)
+   * is reclaimed and lets the next push proceed; every other status still blocks.
+   */
+  @Test
+  public void testGetTopicForCurrentPushJobTopicBasedTrackingWithFailedTargetRegionDeferredSwap() {
+    String storeName = Utils.getUniqueString("test-store");
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    doCallRealMethod().when(mockParentAdmin)
+        .getTopicForCurrentPushJobTopicBasedTracking(clusterName, storeName, false, false);
+
+    Store store = new ZKStore(
+        storeName,
+        "test_owner",
+        1,
+        PersistenceType.ROCKS_DB,
+        RoutingStrategy.CONSISTENT_HASH,
+        ReadStrategy.ANY_OF_ONLINE,
+        OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION,
+        1);
+    VersionImpl version = new VersionImpl(storeName, 1, "test_push_id");
+    version.setVersionSwapDeferred(true);
+    version.setTargetSwapRegion("prod-lor1");
+    store.addVersion(version);
+    doReturn(store).when(mockParentAdmin).getStore(clusterName, storeName);
+
+    String latestTopicName = storeName + "_v1";
+    doReturn(Collections.singletonList(pubSubTopicRepository.getTopic(latestTopicName))).when(mockParentAdmin)
+        .getKafkaTopicsByAge(storeName);
+    // Topic is truncated so a non-blocking status short-circuits before any push-status polling.
+    doReturn(true).when(mockParentAdmin).isTopicTruncated(latestTopicName);
+
+    // Failed terminal statuses are reclaimed: the next push is admitted.
+    for (VersionStatus failed: new VersionStatus[] { VersionStatus.ERROR, VersionStatus.KILLED }) {
+      version.setStatus(failed);
+      Assert.assertFalse(
+          mockParentAdmin.getTopicForCurrentPushJobTopicBasedTracking(clusterName, storeName, false, false).isPresent(),
+          "A " + failed + " target-region deferred-swap version should not block the next push");
+    }
+
+    // Live statuses still block the concurrent push.
+    for (VersionStatus live: new VersionStatus[] { VersionStatus.STARTED, VersionStatus.PUSHED,
+        VersionStatus.ONLINE }) {
+      version.setStatus(live);
+      assertEquals(
+          mockParentAdmin.getTopicForCurrentPushJobTopicBasedTracking(clusterName, storeName, false, false)
+              .orElse(null),
+          latestTopicName,
+          "A " + live + " target-region deferred-swap version should block the next push");
+    }
+  }
+
   @Test
   public void testTruncateTopicsBasedOnMaxErroredTopicNumToKeep() {
     String storeName = Utils.getUniqueString("test-store");


### PR DESCRIPTION
## Problem Statement

A store using targeted-region deferred swap (`versionSwapDeferred=true` with a non-empty `targetSwapRegion`) is permanently wedged when a single push fails in the target region. After the failed push, every subsequent `/request_topic` is rejected with `ConcurrentBatchPushException` (`CONCURRENT_BATCH_PUSH`): "There is already a future version NNNN exists ... please make that version current before starting a next push." The failed future version is never cleaned up and never promoted, so only a manual `delete-old-version` unblocks the store.

The failed version falls into an ownership gap between two controller subsystems:
- `DeferredVersionSwapService` correctly refuses to promote a version whose push failed in the target region (the data is bad), and
- the push-start path defers cleanup to the swap service.

So the failed version sits above `currentVersion` forever with no automatic recovery. This caused a multi-day stale-data condition on a prod store (data stale >7 days), and the feature is ramped 100%, so every deferred-swap store is exposed.

Tracked in VENG-12709.

## Solution

Make the concurrent-push check status-aware. In `VeniceParentHelixAdmin.getTopicForCurrentPushJobTopicBasedTracking`, the `isTargetRegionPushWithDeferredSwap` branch previously returned the latest version topic unconditionally, with no version-status check, so a `KILLED`/`ERROR` future version was reported as a live "future version exists" block purely because its version topic still existed.

The branch now gates on version status using `VersionStatus.canDelete` (true only for `ERROR`/`KILLED`):
- A live version (anything other than `ERROR`/`KILLED`, e.g. `STARTED`/`PUSHED`/`ONLINE`/`CREATED`) still blocks a concurrent push, preserving the legitimate deferred-swap-pending case.
- A definitively-failed terminal version (`ERROR`/`KILLED`) falls through to the existing terminal-topic cleanup path, so the next push is admitted instead of being rejected.

This mirrors the status check the `onlyDeferredSwap` branch just above already performs, and matches how the version-status-based tracking path treats terminal failed states.

###  Code changes
- [ ] Added new code behind **a config**. N/A - no new config.
- [ ] Introduced new **log lines**. N/A - reuses the existing block-reason log.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed. N/A - no new shared state.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used. N/A.
- [x] Validated proper exception handling in multi-threaded code. N/A.

## How was this PR tested?

Added a regression test `testGetTopicForCurrentPushJobTopicBasedTrackingWithFailedTargetRegionDeferredSwap` that drives a targeted-region deferred-swap version through both terminal failed statuses (`ERROR`/`KILLED`) and live statuses (`STARTED`/`PUSHED`/`ONLINE`), asserting the next push is admitted for the former and still blocked for the latter. Verified the new test and the existing `testGetTopicForCurrentPushJob` pass.

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.

Behavior change (recovery, not a regression): a deferred-swap store whose target-region push has failed (`ERROR`/`KILLED`) will now accept the next push automatically instead of permanently rejecting it with `CONCURRENT_BATCH_PUSH`. A healthy future version still blocks concurrent pushes exactly as before.
