### PR TITLE
[server][da-vinci][test]: Improve additional thread priorities and names

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -612,8 +612,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     if (heartbeatMonitoringService != null) {
       heartbeatMonitoringService.setKafkaStoreIngestionService(this);
     }
-    ingestionExecutorService = Executors.newCachedThreadPool(
-        new NamedThreadFactory("KafkaStoreIngestionService-IngestionTask", INGESTION_TASK_THREAD_PRIORITY));
+    ingestionExecutorService =
+        Executors.newCachedThreadPool(new NamedThreadFactory("StoreIngestionService", INGESTION_TASK_THREAD_PRIORITY));
     topicNameToIngestionTaskMap.values().forEach(ingestionExecutorService::submit);
 
     storeBufferService.start();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -93,6 +93,7 @@ import com.linkedin.venice.utils.ComplementSet;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.DiskUsage;
 import com.linkedin.venice.utils.LatencyUtils;
+import com.linkedin.venice.utils.NamedThreadFactory;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
@@ -150,6 +151,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
   private static final Logger LOGGER = LogManager.getLogger(KafkaStoreIngestionService.class);
   // Extra logger dedicated for ingestion info for slow partition.
   private static final Logger INGESTION_DEBUGGER_LOGGER = LogManager.getLogger(TopicPartitionIngestionInfo.class);
+  // Ingestion is important but should yield to the read path, so run it slightly below normal priority.
+  private static final int INGESTION_TASK_THREAD_PRIORITY = Thread.NORM_PRIORITY - 1;
 
   private final StorageService storageService;
 
@@ -609,7 +612,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     if (heartbeatMonitoringService != null) {
       heartbeatMonitoringService.setKafkaStoreIngestionService(this);
     }
-    ingestionExecutorService = Executors.newCachedThreadPool();
+    ingestionExecutorService = Executors.newCachedThreadPool(
+        new NamedThreadFactory("KafkaStoreIngestionService-IngestionTask", INGESTION_TASK_THREAD_PRIORITY));
     topicNameToIngestionTaskMap.values().forEach(ingestionExecutorService::submit);
 
     storeBufferService.start();

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/NamedThreadFactory.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/NamedThreadFactory.java
@@ -10,8 +10,10 @@ import org.apache.logging.log4j.Logger;
  */
 public class NamedThreadFactory implements ThreadFactory {
   private static final Logger LOGGER = LogManager.getLogger(NamedThreadFactory.class);
+  public static final int UNSPECIFIED_PRIORITY = -1;
   private String threadName;
   private final Runnable uncaughtExceptionHook;
+  private final int priority;
   private int threadSequenceNum;
 
   /**
@@ -25,9 +27,18 @@ public class NamedThreadFactory implements ThreadFactory {
     this(threadName, null);
   }
 
+  public NamedThreadFactory(String threadName, int priority) {
+    this(threadName, null, priority);
+  }
+
   public NamedThreadFactory(String threadName, Runnable uncaughtExceptionHook) {
+    this(threadName, uncaughtExceptionHook, UNSPECIFIED_PRIORITY);
+  }
+
+  public NamedThreadFactory(String threadName, Runnable uncaughtExceptionHook, int priority) {
     this.threadName = threadName;
     this.uncaughtExceptionHook = uncaughtExceptionHook;
+    this.priority = priority;
     this.threadSequenceNum = 0;
   }
 
@@ -39,6 +50,9 @@ public class NamedThreadFactory implements ThreadFactory {
   @Override
   public Thread newThread(Runnable runnable) {
     Thread thread = new Thread(runnable, this.threadName + "-" + this.threadSequenceNum);
+    if (priority != UNSPECIFIED_PRIORITY) {
+      thread.setPriority(priority);
+    }
     thread.setUncaughtExceptionHandler((t, e) -> {
       LOGGER.error("Thread {} throws uncaught exception. ", t.getName(), e);
       if (uncaughtExceptionHook != null) {

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/NamedThreadFactoryTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/NamedThreadFactoryTest.java
@@ -1,0 +1,33 @@
+package com.linkedin.venice.utils;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.testng.annotations.Test;
+
+
+public class NamedThreadFactoryTest {
+  @Test
+  public void testNamedThreadFactorySetsExplicitPriorityWithoutChangingDaemonBehavior() throws Exception {
+    NamedThreadFactory factory = new NamedThreadFactory("TestNamedThread", Thread.NORM_PRIORITY - 1);
+    AtomicBoolean executed = new AtomicBoolean(false);
+    CountDownLatch latch = new CountDownLatch(1);
+
+    Thread thread = factory.newThread(() -> {
+      executed.set(true);
+      latch.countDown();
+    });
+
+    assertEquals(thread.getName(), "TestNamedThread-0");
+    assertEquals(thread.getPriority(), Thread.NORM_PRIORITY - 1);
+    assertFalse(thread.isDaemon());
+
+    thread.start();
+    assertTrue(latch.await(5, TimeUnit.SECONDS));
+    assertTrue(executed.get());
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/grpc/VeniceGrpcServerConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/grpc/VeniceGrpcServerConfig.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.grpc;
 
 import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.utils.NamedThreadFactory;
 import io.grpc.BindableService;
 import io.grpc.ServerCredentials;
 import io.grpc.ServerInterceptor;
@@ -131,7 +132,8 @@ public class VeniceGrpcServerConfig {
         interceptors = Collections.emptyList();
       }
       if (executor == null) {
-        executor = Executors.newFixedThreadPool(numThreads);
+        executor = Executors
+            .newFixedThreadPool(numThreads, new NamedThreadFactory("VeniceGrpcServer-" + port, Thread.NORM_PRIORITY));
       }
     }
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/grpc/VeniceGrpcServerConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/grpc/VeniceGrpcServerConfigTest.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.grpc;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
@@ -14,7 +15,9 @@ import io.grpc.ServerInterceptor;
 import java.util.Collections;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.testng.annotations.Test;
 
 
@@ -55,14 +58,22 @@ public class VeniceGrpcServerConfigTest {
   }
 
   @Test
-  public void testBuilderWithDefaultExecutor() {
+  public void testBuilderWithDefaultExecutor() throws Exception {
     BindableService service = mock(BindableService.class);
 
     VeniceGrpcServerConfig config =
         new VeniceGrpcServerConfig.Builder().setPort(8080).addService(service).setNumThreads(4).build();
 
     assertNotNull(config.getExecutor());
-    assertEquals(((ThreadPoolExecutor) config.getExecutor()).getCorePoolSize(), 4);
+    ThreadPoolExecutor executor = (ThreadPoolExecutor) config.getExecutor();
+    assertEquals(executor.getCorePoolSize(), 4);
+    Future<String> threadName = executor.submit(() -> Thread.currentThread().getName());
+    Future<Boolean> isDaemon = executor.submit(() -> Thread.currentThread().isDaemon());
+    Future<Integer> priority = executor.submit(() -> Thread.currentThread().getPriority());
+    assertTrue(threadName.get(5, TimeUnit.SECONDS).startsWith("VeniceGrpcServer-8080-"));
+    assertFalse(isDaemon.get(5, TimeUnit.SECONDS));
+    assertEquals(priority.get(5, TimeUnit.SECONDS).intValue(), Thread.NORM_PRIORITY);
+    executor.shutdownNow();
   }
 
   @Test


### PR DESCRIPTION
## Problem Statement

Several thread pools still relied on generic or inherited thread behavior, which makes production diagnostics and scheduling behavior less explicit.

Specifically:
- `KafkaStoreIngestionService` ingestion task threads had generic executor-created names and inherited priority.
- Ingestion work is important, but it should yield to read-path work under CPU contention.
- `VeniceGrpcServerConfig` default executor threads also inherited priority and had generic names.
- `NamedThreadFactory` could name threads, but could not explicitly set priority.

## Solution

This PR makes the affected thread pools easier to identify and gives them explicit priorities.

Changes:
- Extended `NamedThreadFactory` with priority-aware constructors while preserving existing constructor behavior.
- Updated `KafkaStoreIngestionService` ingestion executor threads to:
  - Use the `KafkaStoreIngestionService-IngestionTask-*` name prefix.
  - Run at `Thread.NORM_PRIORITY - 1`, slightly below normal priority.
  - Preserve non-daemon behavior.
  - Include a code comment explaining that ingestion should yield to the read path.
- Updated `VeniceGrpcServerConfig` default executor threads to:
  - Use the `VeniceGrpcServer-<port>-*` name prefix.
  - Run at explicit `Thread.NORM_PRIORITY`.
  - Preserve non-daemon behavior.
- Added tests for `NamedThreadFactory` priority behavior and default gRPC executor thread attributes.

Performance considerations:
- Kafka ingestion threads are intentionally one priority level below normal so read-path work can take precedence under contention.
- gRPC server default executor behavior remains normal priority, but is now explicit rather than inherited.
- No new blocking behavior, synchronization, or data structure changes.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).
