### PR TITLE
[fast-client] Change defaults to production values

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -449,10 +449,10 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     private long metadataRefreshIntervalInSeconds = -1;
     private long metadataConnWarmupTimeoutInSeconds = -1;
 
-    private boolean longTailRetryEnabledForSingleGet = false;
+    private boolean longTailRetryEnabledForSingleGet = true;
     private int longTailRetryThresholdForSingleGetInMicroSeconds = 1000; // 1ms.
 
-    private boolean longTailRetryEnabledForBatchGet = false;
+    private boolean longTailRetryEnabledForBatchGet = true;
     private int longTailRetryThresholdForBatchGetInMicroSeconds = 0;
 
     private String longTailRangeBasedRetryThresholdForBatchGetInMilliSeconds =

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
@@ -209,7 +209,9 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(r2Client)
-            .setDualReadEnabled(dualRead);
+            .setDualReadEnabled(dualRead)
+            .setLongTailRetryEnabledForSingleGet(false)
+            .setLongTailRetryEnabledForBatchGet(false);
     // Test HAR algorithm in this test.
     Set<String> harClusters = new HashSet<>();
     harClusters.add(veniceCluster.getServerD2ServiceName());
@@ -314,7 +316,9 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(r2Client)
-            .setDualReadEnabled(false);
+            .setDualReadEnabled(false)
+            .setLongTailRetryEnabledForSingleGet(false)
+            .setLongTailRetryEnabledForBatchGet(false);
     // single get
     Consumer<MetricsRepository> fastClientStatsValidation =
         metricsRepository -> validateSingleGetMetrics(metricsRepository, false, false);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientTest.java
@@ -131,7 +131,9 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(r2Client)
-            .setDualReadEnabled(false);
+            .setDualReadEnabled(false)
+            .setLongTailRetryEnabledForSingleGet(false)
+            .setLongTailRetryEnabledForBatchGet(false);
 
     if (retryEnabled) {
       // enable retry to test the code path: to mimic retry in integration tests
@@ -169,7 +171,9 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(r2Client)
-            .setDualReadEnabled(false);
+            .setDualReadEnabled(false)
+            .setLongTailRetryEnabledForSingleGet(false)
+            .setLongTailRetryEnabledForBatchGet(false);
 
     VeniceMetricsRepository metricsRepository = createVeniceMetricsRepository(true);
     AvroSpecificStoreClient<String, TestValueSchema> specificFastClient =
@@ -199,7 +203,9 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(r2Client)
-            .setDualReadEnabled(false);
+            .setDualReadEnabled(false)
+            .setLongTailRetryEnabledForSingleGet(false)
+            .setLongTailRetryEnabledForBatchGet(false);
 
     if (retryEnabled) {
       // enable retry to test the code path: to mimic retry in integration tests
@@ -257,7 +263,9 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(r2Client)
-            .setDualReadEnabled(false);
+            .setDualReadEnabled(false)
+            .setLongTailRetryEnabledForSingleGet(false)
+            .setLongTailRetryEnabledForBatchGet(false);
 
     VeniceMetricsRepository metricsRepository = createVeniceMetricsRepository(true);
     AvroGenericStoreClient<String, GenericRecord> genericFastClient =
@@ -301,7 +309,9 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(r2Client)
-            .setDualReadEnabled(false);
+            .setDualReadEnabled(false)
+            .setLongTailRetryEnabledForSingleGet(false)
+            .setLongTailRetryEnabledForBatchGet(false);
 
     if (retryEnabled) {
       // enable retry to test the code path: to mimic retry in integration tests


### PR DESCRIPTION
## Problem Statement

The Venice fast client ships OSS defaults that differ from the values run in production. Long-tail retry is disabled by default in OSS but enabled in production, so the community does not get the latency-smoothing behavior that production relies on, and OSS does not exercise the production code path. This is the fast-client installment of the component-by-component default-alignment effort (controller in #2862, server in #2863, router in #2887).

## Solution

Enable long-tail retry by default for single-get and batch-get, matching production:

| Config | Old | New |
| --- | --- | --- |
| `longTailRetryEnabledForSingleGet` | `false` | `true` |
| `longTailRetryEnabledForBatchGet` | `false` | `true` |

The retry thresholds are unchanged because they already match production: single-get uses `longTailRetryThresholdForSingleGetInMicroSeconds` (1ms), and batch-get falls back to the existing range-based threshold map (`1-12:8,13-20:30,21-150:50,151-500:100,501-:500` ms) when the fixed threshold is `0`. Compute long-tail retry is left disabled, also matching production.

This is bounded by the existing retry budget, which is already enabled by default (`retryBudgetEnabled = true`, `retryBudgetPercentage = 0.1`), so at most 10% of requests can trigger a long-tail retry. Both flags remain individually overridable through the client config builder.

### Code changes
- [x] Added new code behind **a config**. Config names and new defaults:
  - `longTailRetryEnabledForSingleGet` = `true` (was `false`)
  - `longTailRetryEnabledForBatchGet` = `true` (was `false`)

## How was this PR tested?

These are default-value changes to two existing boolean configs; no new code paths are introduced. The fast-client end-to-end tests that assert long-tail retry is not triggered (`AvroStoreClientEndToEndTest`, `BatchGetAvroStoreClientTest`) previously relied on the disabled-by-default behavior; they now disable long-tail retry explicitly on their client configs so the no-retry assertions stay deterministic. Verified the fast-client and integration-test modules compile.

- [x] Modified or extended existing tests.
- [x] Verified backward compatibility.

## Does this PR introduce any user-facing or breaking changes?
- [x] Yes. Fast clients that do not explicitly set these configs will now perform long-tail retries for single-get and batch-get by default, bounded by the existing 10% retry budget. This is the production-tested behavior. Either flag can be restored to the prior default by setting it to `false`.
