### PR TITLE
[da-vinci][controller] Change defaults to production values

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
@@ -31,6 +31,7 @@ import com.linkedin.venice.utils.PartitionUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.lazy.Lazy;
+import com.linkedin.venice.views.VeniceView;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
@@ -101,8 +102,11 @@ public class VersionBackend {
     // push status store must be enabled both in Da Vinci and the store, and disabled for version-specific clients
     boolean isVersionSpecificClient =
         DaVinciBackend.ClientType.VERSION_SPECIFIC.equals(backend.getStoreClientType(version.getStoreName()));
+    // View stores inherit the parent store's push-status-store setting but have no push-status system store of their
+    // own, so attempting to report push status for them blocks the shared push-status writer. Exclude them here.
     this.reportPushStatus = !isVersionSpecificClient && store.isDaVinciPushStatusStoreEnabled()
-        && this.config.getClusterProperties().getBoolean(PUSH_STATUS_STORE_ENABLED, false);
+        && !VeniceView.isViewStore(version.getStoreName())
+        && this.config.getClusterProperties().getBoolean(PUSH_STATUS_STORE_ENABLED, true);
     this.heartbeatInterval = this.config.getClusterProperties()
         .getInt(PUSH_STATUS_STORE_HEARTBEAT_INTERVAL_IN_SECONDS, DEFAULT_PUSH_STATUS_HEARTBEAT_INTERVAL_IN_SECONDS);
     this.stopConsumptionTimeoutInSeconds =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
@@ -120,7 +120,10 @@ public class VersionBackend {
                 config.getZstdDictCompressionLevel()));
     backend.getVersionByTopicMap().put(version.kafkaTopicName(), this);
     long daVinciPushStatusCheckIntervalInMs = this.config.getDaVinciPushStatusCheckIntervalInMs();
-    if (daVinciPushStatusCheckIntervalInMs >= 0) {
+    // Only run the version-level push-status batching task when push-status reporting is actually enabled, so the same
+    // reportPushStatus gate (store setting, version-specific/view-store exclusions, and the cluster flag) reliably
+    // disables both the per-partition and batched push-status write paths.
+    if (reportPushStatus && daVinciPushStatusCheckIntervalInMs >= 0) {
       LogContext logContext =
           backend.getConfigLoader() != null ? backend.getConfigLoader().getVeniceServerConfig().getLogContext() : null;
       this.daVinciPushStatusUpdateTask = new DaVinciPushStatusUpdateTask(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -816,9 +816,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     blobTransferAclEnabled = serverProperties.getBoolean(BLOB_TRANSFER_ACL_ENABLED, false);
 
     snapshotRetentionTimeInMin = serverProperties.getInt(BLOB_TRANSFER_SNAPSHOT_RETENTION_TIME_IN_MIN, 60);
-    maxConcurrentSnapshotUser = serverProperties.getInt(BLOB_TRANSFER_MAX_CONCURRENT_SNAPSHOT_USER, 15);
-    blobTransferMaxTimeoutInMin = serverProperties.getInt(BLOB_TRANSFER_MAX_TIMEOUT_IN_MIN, 20);
-    blobReceiveMaxTimeoutInMin = serverProperties.getInt(BLOB_RECEIVE_MAX_TIMEOUT_IN_MIN, 30);
+    maxConcurrentSnapshotUser = serverProperties.getInt(BLOB_TRANSFER_MAX_CONCURRENT_SNAPSHOT_USER, 30);
+    blobTransferMaxTimeoutInMin = serverProperties.getInt(BLOB_TRANSFER_MAX_TIMEOUT_IN_MIN, 60);
+    blobReceiveMaxTimeoutInMin = serverProperties.getInt(BLOB_RECEIVE_MAX_TIMEOUT_IN_MIN, 20);
     blobReceiveReaderIdleTimeInSeconds = serverProperties.getInt(BLOB_RECEIVE_READER_IDLE_TIME_IN_SECONDS, 60);
     blobTransferPeersConnectivityFreshnessInSeconds =
         serverProperties.getInt(BLOB_TRANSFER_PEERS_CONNECTIVITY_FRESHNESS_IN_SECONDS, 30);
@@ -1203,17 +1203,17 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     consumerPoolSizeForNonCurrentVersionNonAAWCLeader =
         serverProperties.getInt(SERVER_CONSUMER_POOL_SIZE_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER, 10);
     useDaVinciSpecificExecutionStatusForError =
-        serverProperties.getBoolean(USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR, false);
+        serverProperties.getBoolean(USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR, true);
     daVinciPushStatusCheckIntervalInMs = serverProperties.getLong(DAVINCI_PUSH_STATUS_CHECK_INTERVAL_IN_MS, -1L);
     recordLevelMetricWhenBootstrappingCurrentVersionEnabled =
         serverProperties.getBoolean(SERVER_RECORD_LEVEL_METRICS_WHEN_BOOTSTRAPPING_CURRENT_VERSION_ENABLED, true);
     identityParserClassName = serverProperties.getString(IDENTITY_PARSER_CLASS, DefaultIdentityParser.class.getName());
     daVinciCurrentVersionBootstrappingSpeedupEnabled =
-        serverProperties.getBoolean(DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_SPEEDUP_ENABLED, false);
+        serverProperties.getBoolean(DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_SPEEDUP_ENABLED, true);
     daVinciCurrentVersionBootstrappingQuotaRecordsPerSecond =
-        serverProperties.getLong(DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_QUOTA_RECORDS_PER_SECOND, -1);
-    daVinciCurrentVersionBootstrappingQuotaBytesPerSecond =
-        serverProperties.getSizeInBytes(DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_QUOTA_BYTES_PER_SECOND, -1);
+        serverProperties.getLong(DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_QUOTA_RECORDS_PER_SECOND, 500000);
+    daVinciCurrentVersionBootstrappingQuotaBytesPerSecond = serverProperties
+        .getSizeInBytes(DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_QUOTA_BYTES_PER_SECOND, 300L * BYTES_PER_MB);
     resubscriptionTriggeredByVersionIngestionContextChangeEnabled =
         serverProperties.getBoolean(SERVER_RESUBSCRIPTION_TRIGGERED_BY_VERSION_INGESTION_CONTEXT_CHANGE_ENABLED, false);
     resubscriptionCheckIntervalInSeconds = serverProperties.getInt(SERVER_RESUBSCRIPTION_CHECK_INTERVAL_IN_SECONDS, 60);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -1221,7 +1221,7 @@ public class VeniceControllerClusterConfig {
     this.unusedSchemaCleanupIntervalSeconds = props.getInt(CONTROLLER_UNUSED_SCHEMA_CLEANUP_INTERVAL_SECONDS, 36000);
     this.minSchemaCountToKeep = props.getInt(CONTROLLER_MIN_SCHEMA_COUNT_TO_KEEP, 20);
     this.useDaVinciSpecificExecutionStatusForError =
-        props.getBoolean(USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR, false);
+        props.getBoolean(USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR, true);
     this.pubSubClientsFactory = new PubSubClientsFactory(props);
     this.pubSubPositionTypeRegistry = PubSubPositionTypeRegistry.fromPropertiesOrDefault(props);
     this.pubSubPositionDeserializer = new PubSubPositionDeserializer(pubSubPositionTypeRegistry);


### PR DESCRIPTION
## Summary

Aligns Da Vinci default configs with the values used in production, so OSS deployments get the same behavior and the test suite exercises it. Continues the prod-defaults effort from the `[controller]`, `[server]`, `[router]`, and `[fast-client]` PRs.

| Config | Old default | New default |
|---|---|---|
| `use.da.vinci.specific.execution.status.for.error` | `false` | `true` |
| `da.vinci.current.version.bootstrapping.speedup.enabled` | `false` | `true` |
| `da.vinci.current.version.bootstrapping.quota.records.per.second` | `-1` | `500000` |
| `da.vinci.current.version.bootstrapping.quota.bytes.per.second` | `-1` | `300MB` |
| `push.status.store.enabled` (Da Vinci side) | `false` | `true` |
| `blob.transfer.max.concurrent.snapshot.user` | `15` | `30` |
| `blob.transfer.max.timeout.in.min` | `20` | `60` |
| `blob.receive.max.timeout.in.min` | `30` | `20` |

### Notes for reviewers

- `use.da.vinci.specific.execution.status.for.error` is a coordinated config. Da Vinci Backend *reports* the specific `DVC_INGESTION_ERROR_*` status codes (`VeniceServerConfig`); the controller push monitor *interprets* them (`VeniceControllerClusterConfig`). Both defaults flip together so the reporter and interpreter stay in sync.
- **Push-status enablement + view-store fix.** Enabling `push.status.store.enabled` by default surfaced a latent hang: view stores inherit the parent store's push-status-store setting but have no push-status system store of their own, so reporting push status for them blocks the shared push-status writer (heartbeat thread holds the `VeniceWriter` lock while `reportPushStatus` waits) and deadlocks the view subscribe. `VersionBackend` now gates view stores out of push-status reporting. Push status keeps the OSS-default check interval (`-1`, immediate reporting, no batching task), so the batching path is not started by default.
- `da.vinci.current.version.bootstrapping.quota.bytes.per.second` uses the existing `BYTES_PER_MB` constant.

## Testing Done

- Compile: `clients:da-vinci-client`, `services:venice-controller` — clean.
- Unit: `VersionBackendTest`, `DaVinciBackendTest`, `PushMonitorUtilsTest`, `VeniceServerConfigTest`, `NativeMetadataRepositoryTest`.
- Integration (push-status on, with the view-store gate): `TestMaterializedViewEndToEnd` (DVC + stateless-CDC consumers), `TestFlinkMaterializedViewEndToEndWithMultipleConsumers`, `StatefulVeniceChangelogConsumerTest` (blob-transfer DVRT, including the forked process), `VersionSpecificCDCShutdownTest`, `PushStatusStoreTest`, `TestStoreMigration`, `DaVinciClientSubscribeTest`, `DaVinciClusterAgnosticTest`, `DaVinciClientDiskFullTest`, `DaVinciClientRecordTransformerTest`, `DaVinciClientP2PBlobTransferTest`, `TestBlobDiscovery`.
- Full integration/E2E coverage runs in CI.
