### PR TITLE
[controller] Do not initialize errorPartitionResetTask in parent controller

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixResources.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixResources.java
@@ -47,6 +47,10 @@ public class TestVeniceHelixResources {
   }
 
   private HelixVeniceClusterResources getVeniceHelixResources(String cluster) {
+    return getVeniceHelixResources(cluster, mock(VeniceControllerClusterConfig.class));
+  }
+
+  private HelixVeniceClusterResources getVeniceHelixResources(String cluster, VeniceControllerClusterConfig config) {
     ZkClient zkClient = ZkClientFactory.newZkClient(zkServer.getAddress());
     ZKHelixManager controller =
         new ZKHelixManager(cluster, "localhost_1234", InstanceType.CONTROLLER, zkServer.getAddress());
@@ -75,7 +79,7 @@ public class TestVeniceHelixResources {
         zkClient,
         new HelixAdapterSerializer(),
         new SafeHelixManager(controller),
-        mock(VeniceControllerClusterConfig.class),
+        config,
         veniceHelixAdmin,
         new MetricsRepository(),
         mock(RealTimeTopicSwitcher.class),
@@ -120,6 +124,42 @@ public class TestVeniceHelixResources {
     Thread.sleep(300); // Let it run a few times
     resources.stopDeadStoreStatsPreFetchTask();
     Assert.assertTrue(true, "Dead store stats task started and stopped cleanly");
+  }
+
+  @Test
+  public void testErrorPartitionResetTaskNotInitializedInParentController() {
+    // Even when the auto reset limit is positive, the error partition reset task must not be initialized in the
+    // parent controller.
+    VeniceControllerClusterConfig parentConfig = mock(VeniceControllerClusterConfig.class);
+    when(parentConfig.isParent()).thenReturn(true);
+    when(parentConfig.getErrorPartitionAutoResetLimit()).thenReturn(1);
+    HelixVeniceClusterResources parentResources = getVeniceHelixResources("test-parent-error-partition", parentConfig);
+    Assert.assertNull(
+        parentResources.getErrorPartitionResetTask(),
+        "Error partition reset task should not be initialized in the parent controller.");
+  }
+
+  @Test
+  public void testErrorPartitionResetTaskInitializedInChildControllerWhenLimitIsPositive() {
+    VeniceControllerClusterConfig childConfig = mock(VeniceControllerClusterConfig.class);
+    when(childConfig.isParent()).thenReturn(false);
+    when(childConfig.getErrorPartitionAutoResetLimit()).thenReturn(1);
+    HelixVeniceClusterResources childResources = getVeniceHelixResources("test-child-error-partition", childConfig);
+    Assert.assertNotNull(
+        childResources.getErrorPartitionResetTask(),
+        "Error partition reset task should be initialized in the child controller when the limit is positive.");
+  }
+
+  @Test
+  public void testErrorPartitionResetTaskNotInitializedInChildControllerWhenLimitIsZero() {
+    VeniceControllerClusterConfig childConfig = mock(VeniceControllerClusterConfig.class);
+    when(childConfig.isParent()).thenReturn(false);
+    when(childConfig.getErrorPartitionAutoResetLimit()).thenReturn(0);
+    HelixVeniceClusterResources childResources =
+        getVeniceHelixResources("test-child-error-partition-disabled", childConfig);
+    Assert.assertNull(
+        childResources.getErrorPartitionResetTask(),
+        "Error partition reset task should not be initialized when the limit is zero.");
   }
 
   @Test

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.controller;
 import com.linkedin.venice.VeniceResource;
 import com.linkedin.venice.acl.AclCreationDeletionListener;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.annotation.VisibleForTesting;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controller.logcompaction.LogCompactionService;
 import com.linkedin.venice.controller.multitaskscheduler.MultiTaskSchedulerService;
@@ -238,7 +239,9 @@ public class HelixVeniceClusterResources implements VeniceResource {
         pushMonitor);
     this.storeConfigAccessor = new ZkStoreConfigAccessor(zkClient, adapterSerializer, metaStoreWriter);
     this.accessController = accessController;
-    if (config.getErrorPartitionAutoResetLimit() > 0) {
+    // Error partition reset is a child-controller-only feature; do not initialize it in the parent controller
+    // regardless of the configured limit.
+    if (!config.isParent() && config.getErrorPartitionAutoResetLimit() > 0) {
       errorPartitionResetTask = new ErrorPartitionResetTask(
           clusterName,
           helixAdminClient,
@@ -382,6 +385,11 @@ public class HelixVeniceClusterResources implements VeniceResource {
         Thread.currentThread().interrupt();
       }
     }
+  }
+
+  @VisibleForTesting
+  ErrorPartitionResetTask getErrorPartitionResetTask() {
+    return errorPartitionResetTask;
   }
 
   /**


### PR DESCRIPTION
## Problem Statement
PR #2862 flipped the default of error.partition.auto.reset.limit from 0 to 1, but error partition reset should not run in the parent controller. Gate the task initialization on !config.isParent() so it is never created in the parent regardless of the configured limit. This is because parent controllers are not expected to see any resources valid for error partition reset.

Add unit tests covering the parent gate as well as the existing child-controller behavior (limit > 0 initializes, limit == 0 does not).


## Solution
Prevent parent controller from running the error partition reset task


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.