### PR TITLE
Relax projection schema validation for nullable-wrapped fields and validate the projection subset recursively across nested records/arrays/maps

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -11,6 +11,7 @@ import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENABLED_CONFIG;
 import static com.linkedin.venice.throttle.VeniceRateLimiter.RateLimiterType.GUAVA_RATE_LIMITER;
 import static com.linkedin.venice.utils.AvroSupersetSchemaUtils.validateSubsetValueSchema;
+import static com.linkedin.venice.utils.AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection;
 import static com.linkedin.venice.utils.ByteUtils.generateHumanReadableByteCountString;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ALLOW_DUPLICATE_KEY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ALLOW_REGULAR_PUSH_WITH_TTL_REPUSH;
@@ -2390,7 +2391,7 @@ public class VenicePushJob implements AutoCloseable {
               + "\nError from the server: " + writerSchemaResponse.getError());
     }
     Schema writerSchema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(writerSchemaResponse.getSchemaStr());
-    if (!validateSubsetValueSchema(writerSchema, setting.valueSchemaString)) {
+    if (!validateSubsetValueSchemaForProjection(writerSchema, setting.valueSchemaString)) {
       throw new VeniceSchemaMismatchException(
           "Input value schema is not a superset of the target writer value schema (id: " + writerSchemaId
               + "). Input value schema: " + setting.valueSchemaString + " , writer schema: "

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.ConfigKeys.MULTI_REGION;
 import static com.linkedin.venice.hadoop.VenicePushJob.getExecutionStatusFromControllerResponse;
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENABLED_CONFIG;
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
+import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_OH_SUPERSET_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_UPDATE_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V2_SCHEMA;
@@ -379,6 +380,73 @@ public class VenicePushJobTest {
     Assert.assertEquals(setting.valueSchemaId, 7);
     Assert.assertEquals(setting.writerValueSchemaString, NAME_RECORD_V1_SCHEMA.toString());
     Assert.assertEquals(setting.writerValueSchema, NAME_RECORD_V1_SCHEMA);
+  }
+
+  @Test
+  public void testValidateValueSchemaEnablesProjectionForNullableDriftSupersetInput() {
+    // OH schema evolution wraps the writer's non-nullable fields as [null, X] and appends extra nullable fields, so
+    // the input value schema is a projection-superset (but NOT a strict subset) of the V1 writer schema. The
+    // projection eligibility check must accept this nullability drift and enable projection.
+    ControllerClient mockClient = mock(ControllerClient.class);
+
+    Schema ohSupersetInput = NAME_RECORD_V1_OH_SUPERSET_SCHEMA;
+
+    // Input value schema does not match any registered value schema.
+    SchemaResponse valueSchemaIdResponse = new SchemaResponse();
+    valueSchemaIdResponse.setError("Could not find any registered value schema for the input value schema.");
+    doReturn(valueSchemaIdResponse).when(mockClient).getValueSchemaID(eq(TEST_STORE), eq(ohSupersetInput.toString()));
+
+    // The supplied target writer value schema id resolves to the non-nullable V1 writer schema.
+    SchemaResponse writerSchemaResponse = new SchemaResponse();
+    writerSchemaResponse.setId(7);
+    writerSchemaResponse.setSchemaStr(NAME_RECORD_V1_SCHEMA.toString());
+    doReturn(writerSchemaResponse).when(mockClient).getValueSchema(eq(TEST_STORE), eq(7));
+
+    VenicePushJob vpj = getSpyVenicePushJob(new Properties(), mockClient);
+    PushJobSetting setting = vpj.getPushJobSetting();
+    setting.storeName = TEST_STORE;
+    setting.controllerRetries = 1;
+    setting.enableWriteCompute = false;
+    setting.targetWriterValueSchemaId = 7;
+    setting.valueSchema = ohSupersetInput;
+    setting.valueSchemaString = ohSupersetInput.toString();
+
+    vpj.validateAndRetrieveValueSchemas(mockClient, setting, false);
+
+    Assert.assertTrue(setting.projectInputToWriterSchema);
+    Assert.assertEquals(setting.valueSchemaId, 7);
+    Assert.assertEquals(setting.writerValueSchemaString, NAME_RECORD_V1_SCHEMA.toString());
+    Assert.assertEquals(setting.writerValueSchema, NAME_RECORD_V1_SCHEMA);
+  }
+
+  @Test(expectedExceptions = VeniceSchemaMismatchException.class, expectedExceptionsMessageRegExp = ".*not a superset of the target writer value schema.*")
+  public void testValidateValueSchemaRejectsReverseNullableDriftProjectionInput() {
+    // The relaxed projection check must not become a blanket "accept everything". Here the input is the non-nullable V1
+    // schema while the target writer is the OH-superset (its fields are [null, X] and it has an extra "age"). That is
+    // reverse nullability drift plus a missing writer field -- the input is NOT a projection-superset of the writer --
+    // so projection eligibility must be rejected.
+    ControllerClient mockClient = mock(ControllerClient.class);
+
+    SchemaResponse valueSchemaIdResponse = new SchemaResponse();
+    valueSchemaIdResponse.setError("Could not find any registered value schema for the input value schema.");
+    doReturn(valueSchemaIdResponse).when(mockClient)
+        .getValueSchemaID(eq(TEST_STORE), eq(NAME_RECORD_V1_SCHEMA.toString()));
+
+    SchemaResponse writerSchemaResponse = new SchemaResponse();
+    writerSchemaResponse.setId(7);
+    writerSchemaResponse.setSchemaStr(NAME_RECORD_V1_OH_SUPERSET_SCHEMA.toString());
+    doReturn(writerSchemaResponse).when(mockClient).getValueSchema(eq(TEST_STORE), eq(7));
+
+    VenicePushJob vpj = getSpyVenicePushJob(new Properties(), mockClient);
+    PushJobSetting setting = vpj.getPushJobSetting();
+    setting.storeName = TEST_STORE;
+    setting.controllerRetries = 1;
+    setting.enableWriteCompute = false;
+    setting.targetWriterValueSchemaId = 7;
+    setting.valueSchema = NAME_RECORD_V1_SCHEMA;
+    setting.valueSchemaString = NAME_RECORD_V1_SCHEMA.toString();
+
+    vpj.validateAndRetrieveValueSchemas(mockClient, setting, false);
   }
 
   @Test

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/projection/VeniceSchemaProjector.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/projection/VeniceSchemaProjector.java
@@ -115,11 +115,15 @@ public class VeniceSchemaProjector {
   /**
    * Project a Replication Metadata (RMD) record down to the writer's RMD schema, in lockstep with the value.
    *
-   * <p>Projection only runs when write compute is <em>not</em> enabled. In that mode the RMD timestamp is always a
-   * whole-record (value-level) {@code long}, so projection reduces to copying the {@code long} timestamp and the
-   * value-independent replication_checkpoint_vector onto a record under the target RMD schema. A per-field timestamp
-   * only arises with write compute (partial updates), where the corresponding superset schema is used and no
-   * projection is needed; encountering one here therefore indicates a misuse and is rejected.</p>
+   * <p>The {@code replication_checkpoint_vector} is value-independent and is copied as-is. The {@code timestamp} is a
+   * union of a value-level {@code long} and (for record values) a per-field timestamp record:
+   * <ul>
+   *   <li>a value-level {@code long} is structure-independent and copied as-is; while</li>
+   *   <li>a per-field timestamp record (active-active stores) is projected to the writer's per-field timestamp schema.
+   *   The per-field RMD record is flat (one entry per top-level value field) and a value field's timestamp metadata is
+   *   unchanged by nullable wrapping, so projection is a field-by-field copy that drops the timestamp entries for value
+   *   fields the writer schema does not declare.</li>
+   * </ul>
    *
    * @param srcRmd the source RMD record (generated against the superset value schema), or {@code null} if the record
    *               carries no RMD (e.g. a batch record in a hybrid store)
@@ -143,15 +147,39 @@ public class VeniceSchemaProjector {
 
     Schema.Field targetTimestampField = targetRmdSchema.getField(TIMESTAMP_FIELD_NAME);
     Object srcTimestamp = srcRmd.get(TIMESTAMP_FIELD_NAME);
-    if (RmdUtils.getRmdTimestampType(srcTimestamp) == RmdTimestampType.PER_FIELD_TIMESTAMP) {
-      // Per-field timestamps only occur with write compute, where projection should never run (the superset schema is
-      // used instead). Reject rather than attempt to project a per-field RMD.
-      throw new VeniceException(
-          "Per-field timestamp RMD is not supported for schema projection; projection only applies to value-level "
-              + "(whole-record) timestamps. This indicates projection was attempted on a write-compute enabled store.");
+    if (RmdUtils.getRmdTimestampType(srcTimestamp) == RmdTimestampType.VALUE_LEVEL_TIMESTAMP) {
+      // Whole-record (value-level) long timestamp: structure-independent, set the long branch of the union as-is.
+      projected.put(targetTimestampField.pos(), srcTimestamp);
+    } else {
+      // Per-field timestamp record (active-active store): project it to the writer's per-field timestamp schema.
+      projected.put(
+          targetTimestampField.pos(),
+          projectPerFieldTimestamp((GenericRecord) srcTimestamp, targetTimestampField.schema()));
     }
-    // Whole-record (value-level) long timestamp: set the long branch of the union as-is.
-    projected.put(targetTimestampField.pos(), srcTimestamp);
+    return projected;
+  }
+
+  /**
+   * Project a per-field timestamp record down to the writer's per-field timestamp schema. The per-field RMD record is
+   * flat (one timestamp entry per top-level value field), so this copies each writer field's timestamp from the input
+   * by name and drops entries for value fields the writer schema does not declare.
+   */
+  private static GenericRecord projectPerFieldTimestamp(
+      GenericRecord srcPerFieldTimestamp,
+      Schema targetTimestampUnionSchema) {
+    Schema targetPerFieldSchema = targetTimestampUnionSchema.getTypes().get(1);
+    Schema srcPerFieldSchema = srcPerFieldTimestamp.getSchema();
+    GenericRecord projected = new GenericData.Record(targetPerFieldSchema);
+    for (Schema.Field targetField: targetPerFieldSchema.getFields()) {
+      if (srcPerFieldSchema.getField(targetField.name()) == null) {
+        // Invariant: the writer value schema is a subset of the input, so every writer field's timestamp must exist in
+        // the input RMD. The preflight subset check should already have rejected this; backstop it here.
+        throw new VeniceException(
+            "Writer value field '" + targetField.name() + "' has no per-field timestamp in the input RMD; writer "
+                + "schema is not a subset of the input schema.");
+      }
+      projected.put(targetField.pos(), srcPerFieldTimestamp.get(targetField.name()));
+    }
     return projected;
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/projection/VeniceSchemaProjector.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/projection/VeniceSchemaProjector.java
@@ -6,6 +6,11 @@ import static com.linkedin.venice.schema.rmd.RmdConstants.TIMESTAMP_FIELD_NAME;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.rmd.RmdTimestampType;
 import com.linkedin.venice.schema.rmd.RmdUtils;
+import com.linkedin.venice.utils.AvroSchemaUtils;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -15,11 +20,12 @@ import org.apache.avro.generic.GenericRecord;
  * Projects a value record (and its Replication Metadata) that was serialized against a superset schema down to a
  * chosen registered writer (target) schema.
  *
- * <p>The projection is a pure <em>structural drop</em>. The writer schema is guaranteed (by an upstream preflight
- * subset check) to be a strict subset of the input schema: every field the writer declares exists in the input and
- * is deeply, exactly equal; the input may only carry <em>extra top-level fields</em>. Projection therefore reduces
- * to: build a record under the writer schema, copy each writer field's value from the input by exact name, and let
- * the input's extra top-level fields fall away.</p>
+ * <p>The projection follows the writer schema, which is guaranteed (by an upstream preflight projection-subset check)
+ * to be obtainable from the input schema. At every nesting level (records, array elements, map values) the input may
+ * wrap a field as a nullable union ({@code [null, X]} vs writer {@code X}) and may carry extra fields the writer does
+ * not declare. Projection rebuilds each record under the writer schema, unwrapping nullable inputs and dropping the
+ * input's extra fields at every level. Subtrees that need no projection (the input subschema already equals the writer
+ * subschema) are copied by reference rather than rebuilt.</p>
  */
 public class VeniceSchemaProjector {
   /**
@@ -34,20 +40,76 @@ public class VeniceSchemaProjector {
       // Tombstone (delete) - nothing to project.
       return null;
     }
+    return projectRecord(src, writerValueSchema);
+  }
+
+  /**
+   * Rebuild {@code src} under {@code writerRecordSchema}: copy each writer field by name (projecting its value to the
+   * writer's field type), and drop any extra fields the input carries.
+   */
+  private static GenericRecord projectRecord(GenericRecord src, Schema writerRecordSchema) {
     Schema srcSchema = src.getSchema();
-    GenericRecord projected = new GenericData.Record(writerValueSchema);
-    for (Schema.Field writerField: writerValueSchema.getFields()) {
-      String fieldName = writerField.name();
-      if (srcSchema.getField(fieldName) == null) {
-        // Invariant: a strict-subset writer schema cannot declare a field absent from the input schema. The preflight
-        // subset check should already have rejected this; backstop it here.
+    GenericRecord projected = new GenericData.Record(writerRecordSchema);
+    for (Schema.Field writerField: writerRecordSchema.getFields()) {
+      Schema.Field srcField = srcSchema.getField(writerField.name());
+      if (srcField == null) {
+        // Invariant: a projection-subset writer schema cannot declare a field absent from the input schema. The
+        // preflight subset check should already have rejected this; backstop it here.
         throw new VeniceException(
-            "Writer value field '" + fieldName + "' is absent from the input value schema; writer schema is not a "
-                + "subset of the input schema.");
+            "Writer value field '" + writerField.name() + "' is absent from the input value schema; writer schema is "
+                + "not a subset of the input schema.");
       }
-      projected.put(writerField.pos(), src.get(fieldName));
+      projected
+          .put(writerField.pos(), projectField(writerField.schema(), srcField.schema(), src.get(writerField.name())));
     }
     return projected;
+  }
+
+  /**
+   * Project a single field {@code value} from its input type down to the writer type, recursing through records, array
+   * elements, and map values.
+   */
+  @SuppressWarnings("unchecked")
+  private static Object projectField(Schema writerType, Schema inputType, Object value) {
+    // Unwrap nullable wrapping on the input side: input null-first [null, X] against a non-union writer projects the
+    // value against X. The runtime value is already the (possibly null) non-null-branch value.
+    if (writerType.getType() != Schema.Type.UNION && AvroSchemaUtils.isNullableUnionPair(inputType)
+        && inputType.getTypes().get(0).getType() == Schema.Type.NULL) {
+      return projectField(writerType, inputType.getTypes().get(1), value);
+    }
+    // No projection needed when the writer and input subschemas already match: copy by reference rather than rebuild.
+    // This keeps primitives and unchanged subtrees shared. OH should not emit null for a non-nullable writer field; if
+    // it does, the null is copied through here and serialization (not projection) rejects it.
+    if (value == null || writerType.equals(inputType)) {
+      return value;
+    }
+    switch (writerType.getType()) {
+      case RECORD:
+        return projectRecord((GenericRecord) value, writerType);
+      case ARRAY: {
+        Schema writerElement = writerType.getElementType();
+        Schema inputElement = inputType.getElementType();
+        List<Object> srcList = (List<Object>) value;
+        List<Object> projectedList = new ArrayList<>(srcList.size());
+        for (Object element: srcList) {
+          projectedList.add(projectField(writerElement, inputElement, element));
+        }
+        return projectedList;
+      }
+      case MAP: {
+        Schema writerValue = writerType.getValueType();
+        Schema inputValue = inputType.getValueType();
+        Map<CharSequence, Object> srcMap = (Map<CharSequence, Object>) value;
+        Map<CharSequence, Object> projectedMap = new HashMap<>(srcMap.size());
+        for (Map.Entry<CharSequence, Object> entry: srcMap.entrySet()) {
+          projectedMap.put(entry.getKey(), projectField(writerValue, inputValue, entry.getValue()));
+        }
+        return projectedMap;
+      }
+      default:
+        // Primitives, enums, fixed, and unions: validation guarantees compatibility, so copy the value as-is.
+        return value;
+    }
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
@@ -343,4 +343,57 @@ public class AvroSupersetSchemaUtils {
     }
     return true;
   }
+
+  /**
+   * Relaxed variant of {@link #validateSubsetValueSchema} used to decide whether the input (superset) value schema can
+   * be projected down to {@param writerValueSchema}. On top of the strict subset rule, and recursively at every nesting
+   * level (records, array elements, map values), this tolerates the two artifacts of OpenHouse (OH) schema evolution:
+   * <ul>
+   *   <li>nullable wrapping on the input side -- an input field typed {@code [null, X]} (a null-first 2-branch union,
+   *   the shape OH produces so a field can default to null) matches a non-union writer field typed {@code X}; and</li>
+   *   <li>extra fields present in an input record but absent from the corresponding writer record (OH never removes
+   *   columns, so the superset accumulates them at every level).</li>
+   * </ul>
+   * The guardrails of the strict check still hold recursively: a writer field missing from the input, a type mismatch,
+   * reverse nullability drift ({@code [null, X]} writer vs {@code X} input), and null-last/complex unions all fail.
+   */
+  public static boolean validateSubsetValueSchemaForProjection(Schema writerValueSchema, String inputSchemaStr) {
+    Schema inputSchema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(inputSchemaStr);
+    return isProjectionSubset(writerValueSchema, inputSchema);
+  }
+
+  private static boolean isProjectionSubset(Schema writerSchema, Schema inputSchema) {
+    // Unwrap nullable wrapping on the input side only: an input null-first [null, X] against a non-union writer matches
+    // writer vs X. Null-last ([X, null]) is not OH-produced, so it is left to fail the type check below.
+    if (writerSchema.getType() != Schema.Type.UNION && AvroSchemaUtils.isNullableUnionPair(inputSchema)
+        && inputSchema.getTypes().get(0).getType() == Schema.Type.NULL) {
+      return isProjectionSubset(writerSchema, inputSchema.getTypes().get(1));
+    }
+    if (writerSchema.getType() != inputSchema.getType()) {
+      return false;
+    }
+    switch (writerSchema.getType()) {
+      case RECORD:
+        for (Schema.Field writerField: writerSchema.getFields()) {
+          Schema.Field inputField = inputSchema.getField(writerField.name());
+          // A writer field absent from the input means the writer is not a (projection) subset of the input. Extra
+          // input fields (absent from the writer) are tolerated -- they are simply never iterated here.
+          if (inputField == null) {
+            return false;
+          }
+          if (!isProjectionSubset(writerField.schema(), inputField.schema())) {
+            return false;
+          }
+        }
+        return true;
+      case ARRAY:
+        return isProjectionSubset(writerSchema.getElementType(), inputSchema.getElementType());
+      case MAP:
+        return isProjectionSubset(writerSchema.getValueType(), inputSchema.getValueType());
+      default:
+        // Primitives, enums, fixed, and unions (nullable on both sides or otherwise) must match exactly. Reverse
+        // nullability drift (writer union vs non-union input) is already rejected above by the type check.
+        return writerSchema.equals(inputSchema);
+    }
+  }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -958,6 +958,253 @@ public class TestAvroSupersetSchemaUtils {
         AvroSupersetSchemaUtils.validateSubsetValueSchema(NAME_RECORD_V6_SCHEMA, supersetSchemaForV5AndV4.toString()));
   }
 
+  @Test
+  public void testValidateSubsetSchemaForProjectionWithNullableSupersetFields() {
+    // Scenario from OpenHouse (OH) schema evolution: the store's initial (target writer) schema declares a
+    // non-nullable field X, but every schema evolution afterwards wraps fields as a nullable union [null, X]. The
+    // input (superset) value schema therefore carries [null, X] while the chosen writer schema keeps X. The
+    // projection check must accept input [null, X] against writer X (and ignore the input's extra fields), while the
+    // strict check must continue to reject the nullability drift.
+    Schema writer = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[" + "{\"name\":\"f1\",\"type\":\"string\"},"
+            + "{\"name\":\"f2\",\"type\":\"int\"}]}");
+    Schema inputNullable = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+            + "{\"name\":\"f1\",\"type\":[\"null\",\"string\"],\"default\":null},"
+            + "{\"name\":\"f2\",\"type\":\"int\"},"
+            + "{\"name\":\"extra\",\"type\":[\"null\",\"string\"],\"default\":null}]}");
+
+    // Strict check rejects the [null,X] (input) vs X (writer) drift.
+    Assert.assertFalse(AvroSupersetSchemaUtils.validateSubsetValueSchema(writer, inputNullable.toString()));
+    // Projection check accepts input [null,X] against writer X and tolerates the input's extra top-level field.
+    Assert.assertTrue(AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputNullable.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionBlocksReverseNullableDrift() {
+    // The reverse direction (input X, writer [null, X]) is NOT a side effect of OH evolution; it indicates the user
+    // may have messed something up, so it must stay blocked even under the projection check.
+    Schema writerNullable = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+            + "{\"name\":\"f1\",\"type\":[\"null\",\"string\"],\"default\":null}]}");
+    Schema inputNonNull = AvroCompatibilityHelper
+        .parse("{\"type\":\"record\",\"name\":\"R\",\"fields\":[" + "{\"name\":\"f1\",\"type\":\"string\"}]}");
+    Assert.assertFalse(AvroSupersetSchemaUtils.validateSubsetValueSchema(writerNullable, inputNonNull.toString()));
+    Assert.assertFalse(
+        AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writerNullable, inputNonNull.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionStillBlocksOtherDrift() {
+    // Relaxing nullable wrapping must not open the door to unrelated type drift.
+    Schema writer = AvroCompatibilityHelper
+        .parse("{\"type\":\"record\",\"name\":\"R\",\"fields\":[" + "{\"name\":\"f1\",\"type\":\"string\"}]}");
+
+    // Different non-null branch type (int vs string) must not match.
+    Schema inputWrongType = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+            + "{\"name\":\"f1\",\"type\":[\"null\",\"int\"],\"default\":null}]}");
+    Assert
+        .assertFalse(AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputWrongType.toString()));
+
+    // A non-nullable complex union (not a [null, X] pair) must not be treated as a nullable wrap.
+    Schema inputComplexUnion = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+            + "{\"name\":\"f1\",\"type\":[\"null\",\"string\",\"int\"],\"default\":null}]}");
+    Assert.assertFalse(
+        AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputComplexUnion.toString()));
+
+    // A missing writer field in the input still fails (writer not a subset of input).
+    Schema inputMissingField = AvroCompatibilityHelper
+        .parse("{\"type\":\"record\",\"name\":\"R\",\"fields\":[" + "{\"name\":\"other\",\"type\":\"string\"}]}");
+    Assert.assertFalse(
+        AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputMissingField.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionBlocksNullLastUnion() {
+    // OH wraps optional fields as [null, X] (null FIRST) so the field can default to null. A null-LAST union
+    // ([X, null]) cannot carry a null default and is therefore never produced by OH; it indicates a hand-authored
+    // schema, not the pattern we relax for. The nullable-unwrap must only fire for null-first unions, so [X, null]
+    // (input) vs writer X must stay blocked.
+    Schema writer = AvroCompatibilityHelper
+        .parse("{\"type\":\"record\",\"name\":\"R\",\"fields\":[" + "{\"name\":\"f1\",\"type\":\"int\"}]}");
+    Schema inputNullLast = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+            + "{\"name\":\"f1\",\"type\":[\"int\",\"null\"],\"default\":0}]}");
+    Assert
+        .assertFalse(AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputNullLast.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionBlocksNestedMultiUnion() {
+    // The complex-union guardrail also applies recursively: a 3-branch union ([null, string, int]) inside a
+    // nested record is not a [null, X] wrap and must stay blocked, mirroring the top-level guardrail.
+    Schema writer = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"nested\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"N\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"}]}}]}");
+    Schema inputNestedMultiUnion = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"nested\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"N\",\"fields\":[{\"name\":\"city\",\"type\":[\"null\",\"string\",\"int\"],\"default\":null}]}}]}");
+    Assert.assertFalse(
+        AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputNestedMultiUnion.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionKeepsExactMatch() {
+    // Exact matches (X == X and [null, X] == [null, X]) must still pass under the projection check.
+    Schema writer = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[" + "{\"name\":\"f1\",\"type\":\"string\"},"
+            + "{\"name\":\"f2\",\"type\":[\"null\",\"int\"],\"default\":null}]}");
+    Schema input = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[" + "{\"name\":\"f1\",\"type\":\"string\"},"
+            + "{\"name\":\"f2\",\"type\":[\"null\",\"int\"],\"default\":null},"
+            + "{\"name\":\"extra\",\"type\":[\"null\",\"string\"],\"default\":null}]}");
+    Assert.assertTrue(AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, input.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionRelaxesNestedNullableAdd() {
+    // OH schema evolution applies recursively: when a field is added to a NESTED record, the input (superset) value
+    // schema carries it as [null, X] while the chosen writer keeps the nested record's fields non-nullable. The
+    // relaxation is NOT top-level only -- the projection check must unwrap [null, X] vs X at every nesting level.
+    Schema writer = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"nested\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"N\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"}]}}]}");
+    Schema inputNestedNullable = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"nested\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"N\",\"fields\":[{\"name\":\"city\",\"type\":[\"null\",\"string\"],\"default\":null}]}}]}");
+    Assert.assertTrue(
+        AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputNestedNullable.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionToleratesNestedExtraField() {
+    // OH never removes columns (no deletion allowlist), so the superset accumulates fields at every level. A nested
+    // record in the input may therefore carry extra fields (a field deleted from the writer but retained in the ASL
+    // superset). The projection check must tolerate these extra nested fields, just as it does at the top level.
+    Schema writer = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"nested\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"N\",\"fields\":[{\"name\":\"b\",\"type\":\"int\"}]}}]}");
+    Schema inputNestedExtra = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"nested\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"N\",\"fields\":[{\"name\":\"b\",\"type\":\"int\"},"
+            + "{\"name\":\"c\",\"type\":\"int\",\"default\":5}]}}]}");
+    Assert.assertTrue(
+        AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputNestedExtra.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionBlocksNestedReverseDrift() {
+    // The guardrails also apply recursively: reverse nullability drift inside a nested record (writer nested field
+    // [null, X], input nested field X) is NOT an OH evolution artifact and must stay blocked at every level.
+    Schema writerNestedNullable = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"nested\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"N\",\"fields\":[{\"name\":\"city\",\"type\":[\"null\",\"string\"],\"default\":null}]}}]}");
+    Schema inputNestedNonNull = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"nested\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"N\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"}]}}]}");
+    Assert.assertFalse(
+        AvroSupersetSchemaUtils
+            .validateSubsetValueSchemaForProjection(writerNestedNullable, inputNestedNonNull.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionBlocksReverseDriftInArrayElement() {
+    // Reverse nullability drift must stay blocked inside array element records too (writer element field [null, X],
+    // input element field X).
+    Schema writerNullableElement = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"addresses\",\"type\":"
+            + "{\"type\":\"array\",\"items\":"
+            + "{\"type\":\"record\",\"name\":\"Address\",\"fields\":[{\"name\":\"city\",\"type\":[\"null\",\"string\"],\"default\":null}]}}}]}");
+    Schema inputNonNullElement = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"addresses\",\"type\":"
+            + "{\"type\":\"array\",\"items\":"
+            + "{\"type\":\"record\",\"name\":\"Address\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"}]}}}]}");
+    Assert.assertFalse(
+        AvroSupersetSchemaUtils
+            .validateSubsetValueSchemaForProjection(writerNullableElement, inputNonNullElement.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionBlocksReverseDriftInMapValue() {
+    // Reverse nullability drift must stay blocked inside map value records too.
+    Schema writerNullableValue = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"byId\",\"type\":" + "{\"type\":\"map\",\"values\":"
+            + "{\"type\":\"record\",\"name\":\"Address\",\"fields\":[{\"name\":\"city\",\"type\":[\"null\",\"string\"],\"default\":null}]}}}]}");
+    Schema inputNonNullValue = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"byId\",\"type\":" + "{\"type\":\"map\",\"values\":"
+            + "{\"type\":\"record\",\"name\":\"Address\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"}]}}}]}");
+    Assert.assertFalse(
+        AvroSupersetSchemaUtils
+            .validateSubsetValueSchemaForProjection(writerNullableValue, inputNonNullValue.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionBlocksReverseDriftDeeplyNested() {
+    // Reverse nullability drift must stay blocked no matter how deep the offending field is (here two record levels
+    // down: R -> outer -> inner.leaf), proving the guardrail holds at all nesting levels.
+    Schema writerDeepNullable = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"outer\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"Outer\",\"fields\":[{\"name\":\"inner\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"Inner\",\"fields\":[{\"name\":\"leaf\",\"type\":[\"null\",\"string\"],\"default\":null}]}}]}}]}");
+    Schema inputDeepNonNull = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"outer\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"Outer\",\"fields\":[{\"name\":\"inner\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"Inner\",\"fields\":[{\"name\":\"leaf\",\"type\":\"string\"}]}}]}}]}");
+    Assert.assertFalse(
+        AvroSupersetSchemaUtils
+            .validateSubsetValueSchemaForProjection(writerDeepNullable, inputDeepNonNull.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionRecursesIntoArrayElements() {
+    // Recursion must descend through array element records too: the element record evolved via OH (a field added as
+    // [null, X] and an extra retained field), while the writer keeps the original non-nullable element record.
+    Schema writer = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"addresses\",\"type\":"
+            + "{\"type\":\"array\",\"items\":"
+            + "{\"type\":\"record\",\"name\":\"Address\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"}]}}}]}");
+    Schema inputEvolvedElement = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"addresses\",\"type\":"
+            + "{\"type\":\"array\",\"items\":"
+            + "{\"type\":\"record\",\"name\":\"Address\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"},"
+            + "{\"name\":\"zip\",\"type\":[\"null\",\"int\"],\"default\":null}]}}}]}");
+    Assert.assertTrue(
+        AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputEvolvedElement.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionRecursesIntoMapValues() {
+    // Recursion must descend through map value records too, mirroring the array case.
+    Schema writer = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"byId\",\"type\":" + "{\"type\":\"map\",\"values\":"
+            + "{\"type\":\"record\",\"name\":\"Address\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"}]}}}]}");
+    Schema inputEvolvedValue = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"byId\",\"type\":" + "{\"type\":\"map\",\"values\":"
+            + "{\"type\":\"record\",\"name\":\"Address\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"},"
+            + "{\"name\":\"zip\",\"type\":[\"null\",\"int\"],\"default\":null}]}}}]}");
+    Assert.assertTrue(
+        AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputEvolvedValue.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionRelaxesDeeplyNestedNullableAdd() {
+    // Mirror of the deeply-nested reverse-drift block on the ACCEPT side: a nullable-add two record levels down
+    // (R -> outer -> inner.leaf, input [null, X] vs writer X) must be accepted, proving the relaxation also holds at
+    // arbitrary depth.
+    Schema writer = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"outer\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"Outer\",\"fields\":[{\"name\":\"inner\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"Inner\",\"fields\":[{\"name\":\"leaf\",\"type\":\"string\"}]}}]}}]}");
+    Schema inputDeepNullable = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"outer\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"Outer\",\"fields\":[{\"name\":\"inner\",\"type\":"
+            + "{\"type\":\"record\",\"name\":\"Inner\",\"fields\":[{\"name\":\"leaf\",\"type\":[\"null\",\"string\"],\"default\":null}]}}]}}]}");
+    Assert.assertTrue(
+        AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputDeepNullable.toString()));
+  }
+
   private static Map<String, String> toStringMap(Map<?, ?> map) {
     Map<String, String> result = new HashMap<>();
     map.forEach((k, v) -> result.put(k.toString(), v.toString()));

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/projection/TestVeniceSchemaProjector.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/projection/TestVeniceSchemaProjector.java
@@ -8,7 +8,9 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.rmd.v1.RmdSchemaGeneratorV1;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -20,10 +22,12 @@ import org.testng.annotations.Test;
 /**
  * Unit tests for {@link VeniceSchemaProjector}.
  *
- * <p>The projector is a pure structural drop: the writer (target) schema is guaranteed to be a strict subset of
- * the input schema (every retained field is deeply, exactly equal; the input may only carry extra top-level fields).
- * So projection just builds a record with the writer schema's fields, copies each by name, and drops the input's
- * extra top-level fields.</p>
+ * <p>The projector is a structural drop that follows the writer (target) schema, which is guaranteed to be a
+ * projection-subset of the input schema: every retained field matches the writer's, except that the input may wrap
+ * fields as a nullable union ([null, X] vs writer X) and may carry extra fields -- both at any nesting level (records,
+ * array elements, map values), since the OH superset accumulates fields recursively. Projection rebuilds each record
+ * under the writer schema, unwrapping nullable inputs and dropping the input's extra fields at every level. Subtrees
+ * that need no projection (input subschema already equals the writer subschema) are copied by reference.</p>
  */
 public class TestVeniceSchemaProjector {
   private VeniceSchemaProjector projector;
@@ -172,6 +176,337 @@ public class TestVeniceSchemaProjector {
     src.put("f1", "v");
 
     Assert.expectThrows(VeniceException.class, () -> projector.projectValue(src, writer));
+  }
+
+  @Test
+  public void testNullableInputFieldProjectedToNonNullableWriterField() {
+    // OH schema evolution wrapped the field as [null, string]; the chosen target writer schema keeps it
+    // non-nullable. Projection must drop the union wrapper and copy the (present) value across.
+    Schema input = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"f1\", \"type\": [\"null\", \"string\"], \"default\": null},\n"
+            + "    {\"name\": \"f2\", \"type\": \"int\"},\n"
+            + "    {\"name\": \"extra\", \"type\": [\"null\", \"string\"], \"default\": null}\n" + "  ]\n" + "}");
+    Schema writer = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"f1\", \"type\": \"string\"},\n" + "    {\"name\": \"f2\", \"type\": \"int\"}\n"
+            + "  ]\n" + "}");
+    GenericRecord src = new GenericData.Record(input);
+    src.put("f1", "hi");
+    src.put("f2", 9);
+    src.put("extra", "drop");
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    Assert.assertEquals(out.get("f1").toString(), "hi");
+    Assert.assertEquals(out.get("f2"), 9);
+    Assert.assertNull(out.getSchema().getField("extra"), "extra source field must be dropped");
+  }
+
+  @Test
+  public void testNullableInputRecordFieldProjectedToNonNullableWriterField() {
+    // The top-level field's type evolved from Address to [null, Address]; the writer keeps it non-nullable. With a
+    // present value, projection copies the record wholesale under the non-nullable writer field.
+    Schema input = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"address\",\n" + "      \"type\": [\"null\", {\n" + "        \"type\": \"record\",\n"
+            + "        \"name\": \"Address\",\n" + "        \"fields\": [\n"
+            + "          {\"name\": \"city\", \"type\": \"string\"}\n" + "        ]\n" + "      }],\n"
+            + "      \"default\": null\n" + "    }\n" + "  ]\n" + "}");
+    Schema writer = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"address\",\n" + "      \"type\": {\n" + "        \"type\": \"record\",\n"
+            + "        \"name\": \"Address\",\n" + "        \"fields\": [\n"
+            + "          {\"name\": \"city\", \"type\": \"string\"}\n" + "        ]\n" + "      }\n" + "    }\n"
+            + "  ]\n" + "}");
+    Schema inputAddressSchema = input.getField("address").schema().getTypes().get(1);
+    GenericRecord addr = new GenericData.Record(inputAddressSchema);
+    addr.put("city", "NYC");
+    GenericRecord src = new GenericData.Record(input);
+    src.put("address", addr);
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    GenericRecord outAddr = (GenericRecord) out.get("address");
+    Assert.assertEquals(outAddr.get("city").toString(), "NYC");
+  }
+
+  @Test
+  public void testNestedRecordExtraFieldDropped() {
+    // OH retains deleted columns at every level, so a NESTED input record may carry an extra field absent from the
+    // writer's nested record. Projection must rebuild the nested record under the writer schema and drop the extra.
+    Schema input = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"nested\",\n" + "      \"type\": {\n" + "        \"type\": \"record\",\n"
+            + "        \"name\": \"N\",\n" + "        \"fields\": [\n"
+            + "          {\"name\": \"b\", \"type\": \"int\"},\n"
+            + "          {\"name\": \"c\", \"type\": \"int\", \"default\": 5}\n" + "        ]\n" + "      }\n"
+            + "    }\n" + "  ]\n" + "}");
+    Schema writer = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"nested\",\n" + "      \"type\": {\n" + "        \"type\": \"record\",\n"
+            + "        \"name\": \"N\",\n" + "        \"fields\": [\n"
+            + "          {\"name\": \"b\", \"type\": \"int\"}\n" + "        ]\n" + "      }\n" + "    }\n" + "  ]\n"
+            + "}");
+    GenericRecord nested = new GenericData.Record(input.getField("nested").schema());
+    nested.put("b", 1);
+    nested.put("c", 2);
+    GenericRecord src = new GenericData.Record(input);
+    src.put("nested", nested);
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    GenericRecord outNested = (GenericRecord) out.get("nested");
+    Assert.assertEquals(outNested.get("b"), 1);
+    Assert.assertNull(outNested.getSchema().getField("c"), "extra nested field must be dropped");
+  }
+
+  @Test
+  public void testNestedNullableFieldUnwrapped() {
+    // A field added to a nested record arrives as [null, X] in the input while the writer keeps it non-nullable. With
+    // a present value, projection must unwrap the union and copy the value under the writer's non-nullable field.
+    Schema input = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"nested\",\n" + "      \"type\": {\n" + "        \"type\": \"record\",\n"
+            + "        \"name\": \"N\",\n" + "        \"fields\": [\n"
+            + "          {\"name\": \"city\", \"type\": [\"null\", \"string\"], \"default\": null}\n" + "        ]\n"
+            + "      }\n" + "    }\n" + "  ]\n" + "}");
+    Schema writer = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"nested\",\n" + "      \"type\": {\n" + "        \"type\": \"record\",\n"
+            + "        \"name\": \"N\",\n" + "        \"fields\": [\n"
+            + "          {\"name\": \"city\", \"type\": \"string\"}\n" + "        ]\n" + "      }\n" + "    }\n"
+            + "  ]\n" + "}");
+    GenericRecord nested = new GenericData.Record(input.getField("nested").schema());
+    nested.put("city", "NYC");
+    GenericRecord src = new GenericData.Record(input);
+    src.put("nested", nested);
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    GenericRecord outNested = (GenericRecord) out.get("nested");
+    Assert.assertEquals(outNested.get("city").toString(), "NYC");
+    Assert.assertEquals(outNested.getSchema().getField("city").schema().getType(), Schema.Type.STRING);
+  }
+
+  @Test
+  public void testArrayOfRecordsElementProjected() {
+    // The element record evolved via OH (extra retained field zip); the writer keeps the original element record.
+    // Projection must rebuild every element under the writer element schema and drop the extra field.
+    Schema input = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"addresses\",\n" + "      \"type\": {\n" + "        \"type\": \"array\",\n"
+            + "        \"items\": {\n" + "          \"type\": \"record\",\n" + "          \"name\": \"Address\",\n"
+            + "          \"fields\": [\n" + "            {\"name\": \"city\", \"type\": \"string\"},\n"
+            + "            {\"name\": \"zip\", \"type\": [\"null\", \"int\"], \"default\": null}\n" + "          ]\n"
+            + "        }\n" + "      }\n" + "    }\n" + "  ]\n" + "}");
+    Schema writer = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"addresses\",\n" + "      \"type\": {\n" + "        \"type\": \"array\",\n"
+            + "        \"items\": {\n" + "          \"type\": \"record\",\n" + "          \"name\": \"Address\",\n"
+            + "          \"fields\": [\n" + "            {\"name\": \"city\", \"type\": \"string\"}\n" + "          ]\n"
+            + "        }\n" + "      }\n" + "    }\n" + "  ]\n" + "}");
+    Schema inputElementSchema = input.getField("addresses").schema().getElementType();
+    GenericRecord a1 = new GenericData.Record(inputElementSchema);
+    a1.put("city", "NYC");
+    a1.put("zip", 10001);
+    GenericRecord a2 = new GenericData.Record(inputElementSchema);
+    a2.put("city", "SF");
+    a2.put("zip", 94016);
+    GenericRecord src = new GenericData.Record(input);
+    src.put("addresses", new ArrayList<>(Arrays.asList(a1, a2)));
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    @SuppressWarnings("unchecked")
+    List<GenericRecord> outAddresses = (List<GenericRecord>) out.get("addresses");
+    Assert.assertEquals(outAddresses.size(), 2);
+    Assert.assertEquals(outAddresses.get(0).get("city").toString(), "NYC");
+    Assert.assertEquals(outAddresses.get(1).get("city").toString(), "SF");
+    Assert.assertNull(
+        outAddresses.get(0).getSchema().getField("zip"),
+        "extra field must be dropped from every array element");
+  }
+
+  @Test
+  public void testMapOfRecordsValueProjected() {
+    // Mirror of the array case for map values: the value record evolved with an extra retained field that projection
+    // must drop while rebuilding each value under the writer value schema.
+    Schema input = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"byId\",\n" + "      \"type\": {\n" + "        \"type\": \"map\",\n"
+            + "        \"values\": {\n" + "          \"type\": \"record\",\n" + "          \"name\": \"Address\",\n"
+            + "          \"fields\": [\n" + "            {\"name\": \"city\", \"type\": \"string\"},\n"
+            + "            {\"name\": \"zip\", \"type\": [\"null\", \"int\"], \"default\": null}\n" + "          ]\n"
+            + "        }\n" + "      }\n" + "    }\n" + "  ]\n" + "}");
+    Schema writer = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"byId\",\n" + "      \"type\": {\n" + "        \"type\": \"map\",\n"
+            + "        \"values\": {\n" + "          \"type\": \"record\",\n" + "          \"name\": \"Address\",\n"
+            + "          \"fields\": [\n" + "            {\"name\": \"city\", \"type\": \"string\"}\n" + "          ]\n"
+            + "        }\n" + "      }\n" + "    }\n" + "  ]\n" + "}");
+    Schema inputValueSchema = input.getField("byId").schema().getValueType();
+    GenericRecord v = new GenericData.Record(inputValueSchema);
+    v.put("city", "NYC");
+    v.put("zip", 10001);
+    Map<String, GenericRecord> srcMap = new HashMap<>();
+    srcMap.put("a", v);
+    GenericRecord src = new GenericData.Record(input);
+    src.put("byId", srcMap);
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    @SuppressWarnings("unchecked")
+    Map<CharSequence, GenericRecord> outMap = (Map<CharSequence, GenericRecord>) out.get("byId");
+    Assert.assertEquals(outMap.size(), 1);
+    GenericRecord outValue = outMap.values().iterator().next();
+    Assert.assertEquals(outValue.get("city").toString(), "NYC");
+    Assert.assertNull(outValue.getSchema().getField("zip"), "extra field must be dropped from every map value");
+  }
+
+  @Test
+  public void testDeeplyNestedExtraFieldDropped() {
+    // Projection recurses to arbitrary depth: an extra retained field two record levels down (R -> outer -> inner)
+    // must still be dropped while the deeper non-nullable leaf is copied across.
+    Schema input = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"outer\",\n" + "      \"type\": {\n" + "        \"type\": \"record\",\n"
+            + "        \"name\": \"Outer\",\n" + "        \"fields\": [\n" + "          {\n"
+            + "            \"name\": \"inner\",\n" + "            \"type\": {\n"
+            + "              \"type\": \"record\",\n" + "              \"name\": \"Inner\",\n"
+            + "              \"fields\": [\n" + "                {\"name\": \"leaf\", \"type\": \"string\"},\n"
+            + "                {\"name\": \"extra\", \"type\": \"int\", \"default\": 0}\n" + "              ]\n"
+            + "            }\n" + "          }\n" + "        ]\n" + "      }\n" + "    }\n" + "  ]\n" + "}");
+    Schema writer = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"outer\",\n" + "      \"type\": {\n" + "        \"type\": \"record\",\n"
+            + "        \"name\": \"Outer\",\n" + "        \"fields\": [\n" + "          {\n"
+            + "            \"name\": \"inner\",\n" + "            \"type\": {\n"
+            + "              \"type\": \"record\",\n" + "              \"name\": \"Inner\",\n"
+            + "              \"fields\": [\n" + "                {\"name\": \"leaf\", \"type\": \"string\"}\n"
+            + "              ]\n" + "            }\n" + "          }\n" + "        ]\n" + "      }\n" + "    }\n"
+            + "  ]\n" + "}");
+    Schema inputOuterSchema = input.getField("outer").schema();
+    Schema inputInnerSchema = inputOuterSchema.getField("inner").schema();
+    GenericRecord inner = new GenericData.Record(inputInnerSchema);
+    inner.put("leaf", "deep");
+    inner.put("extra", 9);
+    GenericRecord outer = new GenericData.Record(inputOuterSchema);
+    outer.put("inner", inner);
+    GenericRecord src = new GenericData.Record(input);
+    src.put("outer", outer);
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    GenericRecord outInner = (GenericRecord) ((GenericRecord) out.get("outer")).get("inner");
+    Assert.assertEquals(outInner.get("leaf").toString(), "deep");
+    Assert.assertNull(outInner.getSchema().getField("extra"), "extra deeply-nested field must be dropped");
+  }
+
+  @Test
+  public void testNullableInputFieldWithNullValueCopiedThroughToNonNullableWriter() {
+    // OH should not emit null for a field the writer keeps non-nullable. If it does anyway, the projector adds no early
+    // guard: it copies the null through under the writer's non-nullable field, and the failure surfaces later at
+    // serialization (Avro rejects null for a non-nullable type). This pins that deferred-failure contract -- projection
+    // itself does not throw.
+    Schema input = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"f1\", \"type\": [\"null\", \"string\"], \"default\": null}\n" + "  ]\n" + "}");
+    Schema writer = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"f1\", \"type\": \"string\"}\n" + "  ]\n" + "}");
+    GenericRecord src = new GenericData.Record(input);
+    src.put("f1", null);
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    Assert.assertNull(out.get("f1"), "null is copied through; serialization (not projection) rejects it");
+  }
+
+  @Test
+  public void testArrayElementNullableFieldUnwrapped() {
+    // Recursion must unwrap nullable fields INSIDE array element records (not just drop extras): the element's city
+    // evolved to [null, string] while the writer keeps it non-nullable, with a present value.
+    Schema input = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"addresses\",\n" + "      \"type\": {\n" + "        \"type\": \"array\",\n"
+            + "        \"items\": {\n" + "          \"type\": \"record\",\n" + "          \"name\": \"Address\",\n"
+            + "          \"fields\": [\n"
+            + "            {\"name\": \"city\", \"type\": [\"null\", \"string\"], \"default\": null}\n"
+            + "          ]\n" + "        }\n" + "      }\n" + "    }\n" + "  ]\n" + "}");
+    Schema writer = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"addresses\",\n" + "      \"type\": {\n" + "        \"type\": \"array\",\n"
+            + "        \"items\": {\n" + "          \"type\": \"record\",\n" + "          \"name\": \"Address\",\n"
+            + "          \"fields\": [\n" + "            {\"name\": \"city\", \"type\": \"string\"}\n" + "          ]\n"
+            + "        }\n" + "      }\n" + "    }\n" + "  ]\n" + "}");
+    Schema inputElementSchema = input.getField("addresses").schema().getElementType();
+    GenericRecord a1 = new GenericData.Record(inputElementSchema);
+    a1.put("city", "NYC");
+    GenericRecord src = new GenericData.Record(input);
+    src.put("addresses", new ArrayList<>(Arrays.asList(a1)));
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    @SuppressWarnings("unchecked")
+    List<GenericRecord> outAddresses = (List<GenericRecord>) out.get("addresses");
+    Assert.assertEquals(outAddresses.get(0).get("city").toString(), "NYC");
+    Assert.assertEquals(
+        outAddresses.get(0).getSchema().getField("city").schema().getType(),
+        Schema.Type.STRING,
+        "nullable wrapper inside the array element must be unwrapped");
+  }
+
+  @Test
+  public void testDeeplyNestedNullableFieldUnwrapped() {
+    // Mirror of the deep extra-field-drop on the unwrap side: a nullable leaf two record levels down is unwrapped to
+    // the writer's non-nullable leaf, with a present value.
+    Schema input = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"outer\",\n" + "      \"type\": {\n" + "        \"type\": \"record\",\n"
+            + "        \"name\": \"Outer\",\n" + "        \"fields\": [\n" + "          {\n"
+            + "            \"name\": \"inner\",\n" + "            \"type\": {\n"
+            + "              \"type\": \"record\",\n" + "              \"name\": \"Inner\",\n"
+            + "              \"fields\": [\n"
+            + "                {\"name\": \"leaf\", \"type\": [\"null\", \"string\"], \"default\": null}\n"
+            + "              ]\n" + "            }\n" + "          }\n" + "        ]\n" + "      }\n" + "    }\n"
+            + "  ]\n" + "}");
+    Schema writer = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"fields\": [\n" + "    {\n"
+            + "      \"name\": \"outer\",\n" + "      \"type\": {\n" + "        \"type\": \"record\",\n"
+            + "        \"name\": \"Outer\",\n" + "        \"fields\": [\n" + "          {\n"
+            + "            \"name\": \"inner\",\n" + "            \"type\": {\n"
+            + "              \"type\": \"record\",\n" + "              \"name\": \"Inner\",\n"
+            + "              \"fields\": [\n" + "                {\"name\": \"leaf\", \"type\": \"string\"}\n"
+            + "              ]\n" + "            }\n" + "          }\n" + "        ]\n" + "      }\n" + "    }\n"
+            + "  ]\n" + "}");
+    Schema inputOuterSchema = input.getField("outer").schema();
+    Schema inputInnerSchema = inputOuterSchema.getField("inner").schema();
+    GenericRecord inner = new GenericData.Record(inputInnerSchema);
+    inner.put("leaf", "deep");
+    GenericRecord outer = new GenericData.Record(inputOuterSchema);
+    outer.put("inner", inner);
+    GenericRecord src = new GenericData.Record(input);
+    src.put("outer", outer);
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    GenericRecord outInner = (GenericRecord) ((GenericRecord) out.get("outer")).get("inner");
+    Assert.assertEquals(outInner.get("leaf").toString(), "deep");
+    Assert.assertEquals(
+        outInner.getSchema().getField("leaf").schema().getType(),
+        Schema.Type.STRING,
+        "deeply-nested nullable wrapper must be unwrapped");
   }
 
   // ----------------------------------------------------------------------------------------------------------

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/projection/TestVeniceSchemaProjector.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/projection/TestVeniceSchemaProjector.java
@@ -6,6 +6,8 @@ import static com.linkedin.venice.schema.rmd.RmdConstants.TIMESTAMP_FIELD_NAME;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.rmd.v1.RmdSchemaGeneratorV1;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.utils.AvroSchemaUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -534,9 +536,44 @@ public class TestVeniceSchemaProjector {
   }
 
   @Test
-  public void testRmdPerFieldTimestampThrows() {
-    // Per-field timestamps only arise with write compute (partial updates), where the superset schema is used and no
-    // projection runs. Encountering one in the projection path indicates misuse and must be rejected.
+  public void testRmdPerFieldTimestampProjectedForNullableDrift() {
+    // OH nullable drift: the input value wraps f2 as [null, string] while the writer keeps it non-nullable. The
+    // per-field RMD is identical on both sides (the RMD generator unwraps nullable unions), so projecting the per-field
+    // timestamp preserves both entries.
+    Schema inputValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"},\n"
+            + "    {\"name\": \"f2\", \"type\": [\"null\", \"string\"], \"default\": null}\n" + "  ]\n" + "}");
+    Schema writerValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"},\n"
+            + "    {\"name\": \"f2\", \"type\": \"string\"}\n" + "  ]\n" + "}");
+    Schema inputRmd = RMD_GEN.generateMetadataSchema(inputValue);
+    Schema writerRmd = RMD_GEN.generateMetadataSchema(writerValue);
+
+    Schema inputPerFieldSchema = inputRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
+    GenericRecord perField = new GenericData.Record(inputPerFieldSchema);
+    perField.put("f1", 100L);
+    perField.put("f2", 200L);
+    GenericRecord srcRmd = new GenericData.Record(inputRmd);
+    srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
+    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>(Arrays.asList(3L)));
+
+    GenericRecord out = projector.projectRmd(srcRmd, writerRmd);
+
+    Assert.assertEquals(out.getSchema(), writerRmd);
+    GenericRecord outPerField = (GenericRecord) out.get(TIMESTAMP_FIELD_NAME);
+    Assert.assertEquals(outPerField.get("f1"), 100L);
+    Assert.assertEquals(outPerField.get("f2"), 200L);
+    @SuppressWarnings("unchecked")
+    List<Long> rcv = (List<Long>) out.get(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME);
+    Assert.assertEquals(rcv, Arrays.asList(3L));
+  }
+
+  @Test
+  public void testRmdPerFieldTimestampProjectedDropsRemovedField() {
+    // The writer value schema has fewer fields than the input (no f2). Projecting the per-field RMD keeps f1's
+    // timestamp and drops f2's, in lockstep with the value projection dropping the f2 field.
     Schema inputValue = parse(
         "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
             + "  \"fields\": [\n" + "    {\"name\": \"f1\", \"type\": \"string\"},\n"
@@ -547,15 +584,68 @@ public class TestVeniceSchemaProjector {
     Schema inputRmd = RMD_GEN.generateMetadataSchema(inputValue);
     Schema writerRmd = RMD_GEN.generateMetadataSchema(writerValue);
 
-    Schema perFieldSchema = inputRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
-    GenericRecord perField = new GenericData.Record(perFieldSchema);
+    Schema inputPerFieldSchema = inputRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
+    GenericRecord perField = new GenericData.Record(inputPerFieldSchema);
     perField.put("f1", 100L);
     perField.put("f2", 200L);
     GenericRecord srcRmd = new GenericData.Record(inputRmd);
     srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
     srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>());
 
-    Assert.expectThrows(VeniceException.class, () -> projector.projectRmd(srcRmd, writerRmd));
+    GenericRecord out = projector.projectRmd(srcRmd, writerRmd);
+
+    Assert.assertEquals(out.getSchema(), writerRmd);
+    GenericRecord outPerField = (GenericRecord) out.get(TIMESTAMP_FIELD_NAME);
+    Assert.assertEquals(outPerField.get("f1"), 100L);
+    Assert.assertNull(outPerField.getSchema().getField("f2"), "dropped value field's per-field timestamp must be gone");
+  }
+
+  @Test
+  public void testRmdPerFieldTimestampWithCollectionFieldSerializesRoundTrip() {
+    // The in-memory assertions above never serialize the projected RMD. Here we serialize it against the writer RMD
+    // schema (as the real push does) and read it back. A per-field timestamp for a COLLECTION field is itself a record
+    // (CollectionMetadata), and the input has an extra collection field (droppedList) before the shared one (tags), so
+    // the input and writer collection-metadata records carry different generated names -- this proves projection +
+    // serialization tolerate that divergence.
+    Schema inputValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"name\", \"type\": \"string\"},\n"
+            + "    {\"name\": \"droppedList\", \"type\": {\"type\": \"array\", \"items\": \"int\"}},\n"
+            + "    {\"name\": \"tags\", \"type\": {\"type\": \"array\", \"items\": \"string\"}}\n" + "  ]\n" + "}");
+    Schema writerValue = parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"R\",\n" + "  \"namespace\": \"ns\",\n"
+            + "  \"fields\": [\n" + "    {\"name\": \"name\", \"type\": \"string\"},\n"
+            + "    {\"name\": \"tags\", \"type\": {\"type\": \"array\", \"items\": \"string\"}}\n" + "  ]\n" + "}");
+    Schema inputRmd = RMD_GEN.generateMetadataSchema(inputValue);
+    Schema writerRmd = RMD_GEN.generateMetadataSchema(writerValue);
+
+    Schema inputPerFieldSchema = inputRmd.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
+    GenericRecord perField = new GenericData.Record(inputPerFieldSchema);
+    perField.put("name", 100L);
+    perField
+        .put("droppedList", AvroSchemaUtils.createGenericRecord(inputPerFieldSchema.getField("droppedList").schema()));
+    GenericRecord tagsMd = AvroSchemaUtils.createGenericRecord(inputPerFieldSchema.getField("tags").schema());
+    tagsMd.put("topLevelFieldTimestamp", 200L);
+    perField.put("tags", tagsMd);
+
+    GenericRecord srcRmd = new GenericData.Record(inputRmd);
+    srcRmd.put(TIMESTAMP_FIELD_NAME, perField);
+    srcRmd.put(REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>(Arrays.asList(9L)));
+
+    GenericRecord projected = projector.projectRmd(srcRmd, writerRmd);
+
+    // Round-trip through the same serializer the push pipeline uses.
+    byte[] bytes = FastSerializerDeserializerFactory.getFastAvroGenericSerializer(writerRmd).serialize(projected);
+    GenericRecord roundTripped =
+        FastSerializerDeserializerFactory.<GenericRecord>getFastAvroGenericDeserializer(writerRmd, writerRmd)
+            .deserialize(bytes);
+
+    Assert.assertEquals(roundTripped.getSchema(), writerRmd);
+    GenericRecord rtPerField = (GenericRecord) roundTripped.get(TIMESTAMP_FIELD_NAME);
+    Assert.assertEquals(rtPerField.get("name"), 100L);
+    Assert.assertNull(rtPerField.getSchema().getField("droppedList"), "dropped collection field's RMD must be gone");
+    GenericRecord rtTagsMd = (GenericRecord) rtPerField.get("tags");
+    Assert.assertEquals(rtTagsMd.get("topLevelFieldTimestamp"), 200L);
   }
 
   @Test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithValueSchemaProjection.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithValueSchemaProjection.java
@@ -5,9 +5,12 @@ import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps
 import static com.linkedin.venice.utils.TestWriteUtils.DEFAULT_USER_DATA_RECORD_COUNT;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V2_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.NAME_WITH_DETAILS_V1_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToNameRecordV1OHSupersetSchemaWithNullFirstName;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToNameRecordV1Schema;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToNameRecordV2Schema;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToNameWithDetailsV1OHSupersetSchema;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TARGET_WRITER_VALUE_SCHEMA_ID_PROP;
 
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
@@ -25,6 +28,7 @@ import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import java.io.File;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.generic.GenericRecord;
@@ -101,6 +105,96 @@ public class TestPushJobWithValueSchemaProjection {
           Assert.assertNull(value.getSchema().getField("age"), "Projected record should not retain the 'age' field");
         }
       });
+    }
+  }
+
+  /**
+   * Recursive OH evolution end-to-end: the writer schema has a nested {@code address} record and a {@code contacts}
+   * array of records; the input superset wraps top-level fields as [null, X], appends a top-level {@code age}, and adds
+   * extra nullable fields inside the nested record ({@code zip}) and the array element record ({@code primary}).
+   * Projection must recurse through the record, the array elements, unwrap the nullable wrappers, and drop every extra
+   * field at every level. Reading back yields clean writer-schema records.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testProjectsNestedAndArrayOHEvolutionEndToEnd() throws Exception {
+    File inputDir = Utils.getTempDataDirectory();
+    writeSimpleAvroFileWithStringToNameWithDetailsV1OHSupersetSchema(inputDir);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("schema-projection-nested-store");
+
+    Properties props = defaultVPJProps(veniceCluster, inputDirPath, storeName);
+    int writerSchemaId;
+    try (ControllerClient controllerClient =
+        createStoreForJob(veniceCluster, STRING_SCHEMA.toString(), NAME_WITH_DETAILS_V1_SCHEMA.toString(), props)) {
+      SchemaResponse writerSchemaIdResponse =
+          controllerClient.getValueSchemaID(storeName, NAME_WITH_DETAILS_V1_SCHEMA.toString());
+      Assert.assertFalse(writerSchemaIdResponse.isError(), writerSchemaIdResponse.getError());
+      writerSchemaId = writerSchemaIdResponse.getId();
+      Assert.assertTrue(writerSchemaId > 0);
+    }
+
+    props.setProperty(TARGET_WRITER_VALUE_SCHEMA_ID_PROP, Integer.toString(writerSchemaId));
+
+    try (VenicePushJob job = new VenicePushJob("test-push-projection-nested", props)) {
+      job.run();
+    }
+
+    try (AvroGenericStoreClient<String, GenericRecord> avroClient = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceCluster.getRandomRouterURL()))) {
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, true, true, () -> {
+        for (int i = 1; i <= DEFAULT_USER_DATA_RECORD_COUNT; i++) {
+          GenericRecord value = avroClient.get(Integer.toString(i)).get();
+          Assert.assertNotNull(value, "Missing value for key: " + i);
+          // Top-level nullable wrappers unwrapped; extra top-level "age" dropped.
+          Assert.assertEquals(value.get("firstName").toString(), "first_name_" + i);
+          Assert.assertEquals(value.get("lastName").toString(), "last_name_" + i);
+          Assert.assertNull(value.getSchema().getField("age"), "extra top-level field must be dropped");
+          // Nested record projected: city retained, extra "zip" dropped.
+          GenericRecord address = (GenericRecord) value.get("address");
+          Assert.assertEquals(address.get("city").toString(), "city_" + i);
+          Assert.assertNull(address.getSchema().getField("zip"), "extra nested field must be dropped");
+          // Array element record projected: kind retained, extra "primary" dropped.
+          @SuppressWarnings("unchecked")
+          List<GenericRecord> contacts = (List<GenericRecord>) value.get("contacts");
+          Assert.assertEquals(contacts.size(), 1);
+          Assert.assertEquals(contacts.get(0).get("kind").toString(), "kind_" + i);
+          Assert
+              .assertNull(contacts.get(0).getSchema().getField("primary"), "extra array-element field must be dropped");
+        }
+      });
+    }
+  }
+
+  /**
+   * Null value into a non-nullable writer field: the input wraps {@code firstName} as {@code [null, string]} and a
+   * record actually carries null, while the writer keeps {@code firstName} non-nullable. Schema-level projection
+   * validation passes (the nullability drift is accepted), so the push proceeds; the null is copied through during
+   * projection and then fails when the record is serialized against the (non-nullable) writer schema. The push must
+   * therefore fail rather than silently write bad data.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testProjectionFailsWhenNullableInputValueIsNullForNonNullableWriterField() throws Exception {
+    File inputDir = Utils.getTempDataDirectory();
+    // Input data uses the OH-style superset of V1, but firstName (nullable in the input) is null.
+    writeSimpleAvroFileWithStringToNameRecordV1OHSupersetSchemaWithNullFirstName(inputDir);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("schema-projection-null-value-store");
+
+    Properties props = defaultVPJProps(veniceCluster, inputDirPath, storeName);
+    int writerSchemaId;
+    try (ControllerClient controllerClient =
+        createStoreForJob(veniceCluster, STRING_SCHEMA.toString(), NAME_RECORD_V1_SCHEMA.toString(), props)) {
+      SchemaResponse writerSchemaIdResponse =
+          controllerClient.getValueSchemaID(storeName, NAME_RECORD_V1_SCHEMA.toString());
+      Assert.assertFalse(writerSchemaIdResponse.isError(), writerSchemaIdResponse.getError());
+      writerSchemaId = writerSchemaIdResponse.getId();
+      Assert.assertTrue(writerSchemaId > 0);
+    }
+
+    props.setProperty(TARGET_WRITER_VALUE_SCHEMA_ID_PROP, Integer.toString(writerSchemaId));
+    try (VenicePushJob job = new VenicePushJob("test-push-projection-null-value", props)) {
+      // The job must fail; the null firstName cannot be serialized against the non-nullable writer schema.
+      Assert.expectThrows(VeniceException.class, job::run);
     }
   }
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
@@ -42,6 +42,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -122,6 +123,12 @@ public class TestWriteUtils {
       AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/NameV10.avsc"));
   public static final Schema NAME_RECORD_V11_SCHEMA =
       AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/NameV11.avsc"));
+  public static final Schema NAME_RECORD_V1_OH_SUPERSET_SCHEMA =
+      AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/NameV1OHSuperset.avsc"));
+  public static final Schema NAME_WITH_DETAILS_V1_SCHEMA =
+      AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/NameWithDetailsV1.avsc"));
+  public static final Schema NAME_WITH_DETAILS_V1_OH_SUPERSET_SCHEMA =
+      AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/NameWithDetailsV1OHSuperset.avsc"));
 
   public static final Schema UNION_RECORD_V1_SCHEMA =
       AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/UnionV1.avsc"));
@@ -187,6 +194,14 @@ public class TestWriteUtils {
       new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA).setValueSchema(NAME_RECORD_V10_SCHEMA).build();
   public static final Schema STRING_TO_NAME_RECORD_V11_SCHEMA =
       new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA).setValueSchema(NAME_RECORD_V11_SCHEMA).build();
+  public static final Schema STRING_TO_NAME_RECORD_V1_OH_SUPERSET_SCHEMA =
+      new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA)
+          .setValueSchema(NAME_RECORD_V1_OH_SUPERSET_SCHEMA)
+          .build();
+  public static final Schema STRING_TO_NAME_WITH_DETAILS_V1_OH_SUPERSET_SCHEMA =
+      new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA)
+          .setValueSchema(NAME_WITH_DETAILS_V1_OH_SUPERSET_SCHEMA)
+          .build();
   private static final Schema[] STRING_TO_NAME_RECORD_SCHEMAS = new Schema[] { STRING_TO_NAME_RECORD_V1_SCHEMA,
       STRING_TO_NAME_RECORD_V2_SCHEMA, STRING_TO_NAME_RECORD_V3_SCHEMA, STRING_TO_NAME_RECORD_V5_SCHEMA,
       STRING_TO_NAME_RECORD_V6_SCHEMA, STRING_TO_NAME_RECORD_V7_SCHEMA, STRING_TO_NAME_RECORD_V8_SCHEMA,
@@ -523,6 +538,54 @@ public class TestWriteUtils {
       valueRecord.put("firstName", firstName + i);
       valueRecord.put("lastName", lastName + i);
       valueRecord.put("age", -1);
+      keyValueRecord.put(DEFAULT_VALUE_FIELD_PROP, valueRecord); // Value
+      return keyValueRecord;
+    });
+  }
+
+  public static Schema writeSimpleAvroFileWithStringToNameWithDetailsV1OHSupersetSchema(File parentDir)
+      throws IOException {
+    String firstName = "first_name_";
+    String lastName = "last_name_";
+    Schema addressSchema = NAME_WITH_DETAILS_V1_OH_SUPERSET_SCHEMA.getField("address").schema();
+    Schema contactSchema = NAME_WITH_DETAILS_V1_OH_SUPERSET_SCHEMA.getField("contacts").schema().getElementType();
+
+    return writeSimpleAvroFile(parentDir, STRING_TO_NAME_WITH_DETAILS_V1_OH_SUPERSET_SCHEMA, i -> {
+      GenericRecord keyValueRecord = new GenericData.Record(STRING_TO_NAME_WITH_DETAILS_V1_OH_SUPERSET_SCHEMA);
+      keyValueRecord.put(DEFAULT_KEY_FIELD_PROP, String.valueOf(i)); // Key
+
+      GenericRecord address = new GenericData.Record(addressSchema);
+      address.put("city", "city_" + i);
+      address.put("zip", "zip_" + i);
+
+      GenericRecord contact = new GenericData.Record(contactSchema);
+      contact.put("kind", "kind_" + i);
+      contact.put("primary", true);
+
+      GenericRecord valueRecord = new GenericData.Record(NAME_WITH_DETAILS_V1_OH_SUPERSET_SCHEMA);
+      valueRecord.put("firstName", firstName + i);
+      valueRecord.put("lastName", lastName + i);
+      valueRecord.put("age", i);
+      valueRecord.put("address", address);
+      valueRecord.put("contacts", new ArrayList<>(Collections.singletonList(contact)));
+      keyValueRecord.put(DEFAULT_VALUE_FIELD_PROP, valueRecord); // Value
+      return keyValueRecord;
+    });
+  }
+
+  public static Schema writeSimpleAvroFileWithStringToNameRecordV1OHSupersetSchemaWithNullFirstName(File parentDir)
+      throws IOException {
+    String lastName = "last_name_";
+
+    return writeSimpleAvroFile(parentDir, STRING_TO_NAME_RECORD_V1_OH_SUPERSET_SCHEMA, i -> {
+      GenericRecord keyValueRecord = new GenericData.Record(STRING_TO_NAME_RECORD_V1_OH_SUPERSET_SCHEMA);
+      keyValueRecord.put(DEFAULT_KEY_FIELD_PROP, String.valueOf(i)); // Key
+      GenericRecord valueRecord = new GenericData.Record(NAME_RECORD_V1_OH_SUPERSET_SCHEMA);
+      // firstName is nullable in the input ([null, string]) and left null; the writer keeps it non-nullable, so
+      // projection copies the null through and serialization against the writer schema must fail.
+      valueRecord.put("firstName", null);
+      valueRecord.put("lastName", lastName + i);
+      valueRecord.put("age", i);
       keyValueRecord.put(DEFAULT_VALUE_FIELD_PROP, valueRecord); // Value
       return keyValueRecord;
     });

--- a/internal/venice-test-common/src/main/resources/valueSchema/NameV1OHSuperset.avsc
+++ b/internal/venice-test-common/src/main/resources/valueSchema/NameV1OHSuperset.avsc
@@ -1,0 +1,18 @@
+{
+  "type" : "record",
+  "name" : "nameRecord",
+  "namespace" : "example.avro",
+  "fields" : [ {
+    "name" : "firstName",
+    "type" : [ "null", "string" ],
+    "default" : null
+  }, {
+    "name" : "lastName",
+    "type" : [ "null", "string" ],
+    "default" : null
+  }, {
+    "name" : "age",
+    "type" : [ "null", "int" ],
+    "default" : null
+  } ]
+}

--- a/internal/venice-test-common/src/main/resources/valueSchema/NameWithDetailsV1.avsc
+++ b/internal/venice-test-common/src/main/resources/valueSchema/NameWithDetailsV1.avsc
@@ -1,0 +1,43 @@
+{
+  "type" : "record",
+  "name" : "nameRecord",
+  "namespace" : "example.avro",
+  "fields" : [ {
+    "name" : "firstName",
+    "type" : "string",
+    "default" : ""
+  }, {
+    "name" : "lastName",
+    "type" : "string",
+    "default" : ""
+  }, {
+    "name" : "address",
+    "type" : {
+      "type" : "record",
+      "name" : "Address",
+      "fields" : [ {
+        "name" : "city",
+        "type" : "string",
+        "default" : ""
+      } ]
+    },
+    "default" : {
+      "city" : ""
+    }
+  }, {
+    "name" : "contacts",
+    "type" : {
+      "type" : "array",
+      "items" : {
+        "type" : "record",
+        "name" : "Contact",
+        "fields" : [ {
+          "name" : "kind",
+          "type" : "string",
+          "default" : ""
+        } ]
+      }
+    },
+    "default" : [ ]
+  } ]
+}

--- a/internal/venice-test-common/src/main/resources/valueSchema/NameWithDetailsV1OHSuperset.avsc
+++ b/internal/venice-test-common/src/main/resources/valueSchema/NameWithDetailsV1OHSuperset.avsc
@@ -1,0 +1,55 @@
+{
+  "type" : "record",
+  "name" : "nameRecord",
+  "namespace" : "example.avro",
+  "fields" : [ {
+    "name" : "firstName",
+    "type" : [ "null", "string" ],
+    "default" : null
+  }, {
+    "name" : "lastName",
+    "type" : [ "null", "string" ],
+    "default" : null
+  }, {
+    "name" : "age",
+    "type" : [ "null", "int" ],
+    "default" : null
+  }, {
+    "name" : "address",
+    "type" : {
+      "type" : "record",
+      "name" : "Address",
+      "fields" : [ {
+        "name" : "city",
+        "type" : "string",
+        "default" : ""
+      }, {
+        "name" : "zip",
+        "type" : [ "null", "string" ],
+        "default" : null
+      } ]
+    },
+    "default" : {
+      "city" : ""
+    }
+  }, {
+    "name" : "contacts",
+    "type" : {
+      "type" : "array",
+      "items" : {
+        "type" : "record",
+        "name" : "Contact",
+        "fields" : [ {
+          "name" : "kind",
+          "type" : "string",
+          "default" : ""
+        }, {
+          "name" : "primary",
+          "type" : [ "null", "boolean" ],
+          "default" : null
+        } ]
+      }
+    },
+    "default" : [ ]
+  } ]
+}


### PR DESCRIPTION
## Problem Statement

When a push job projects input data down to a chosen target writer value schema, the eligibility check (validateSubsetValueSchema) required every retained field to be deeply, exactly equal between the input (superset) and writer schemas. However, some schema-evolution pipelines produce supersets that differ from the writer in two benign, projectable ways: fields get wrapped as nullable unions ([null, X] vs the writer's X) so they can carry a null default, and extra fields accumulate at every level (columns are added but never removed). Under strict equality, such inputs were rejected up front. And even had they passed, the projector only performed a flat top-level field copy — it could not unwrap the nullable wrappers or drop extra fields inside nested records, array elements, or map values.


## Solution

Relaxed projection validation (AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection): a new check, used only on the projection path, that tolerates the two benign differences — a null-first [null, X] input field against a non-union writer X, and extra input fields absent from the writer — applied recursively through records, array elements, and map values. All existing guardrails still hold at every level: missing writer fields, type mismatches, reverse nullability drift ([null, X] writer vs X input), and null-last/multi-branch unions all fail.

Recursive projection (VeniceSchemaProjector.projectValue): rebuilds each record under the writer schema, unwrapping nullable inputs and dropping extra fields at every nesting level, while copying unchanged subtrees by reference. VenicePushJob now calls the relaxed check on the projection path; the strict check remains unchanged for the partial-update/superset path.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
 - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [x] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.