### PR TITLE
Fix/log uri bad request

### DIFF
--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
@@ -28,6 +28,7 @@ import com.linkedin.venice.throttle.TokenBucket;
 import com.linkedin.venice.throttle.VeniceRateLimiter;
 import com.linkedin.venice.throttle.VeniceRateLimiter.RateLimiterType;
 import com.linkedin.venice.utils.DaemonThreadFactory;
+import com.linkedin.venice.utils.RedundantExceptionFilter;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -51,6 +52,8 @@ import org.apache.logging.log4j.Logger;
 public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<RouterRequest>
     implements RoutingDataRepository.RoutingDataChangedListener, StoreDataChangedListener {
   private static final Logger LOGGER = LogManager.getLogger(ReadQuotaEnforcementHandler.class);
+  private static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER =
+      RedundantExceptionFilter.getRedundantExceptionFilter();
   public static final String SERVER_OVER_CAPACITY_MSG = "Server over capacity";
   public static final String INVALID_REQUEST_RESOURCE_MSG = "Invalid request resource: ";
   private static final long WAIT_FOR_CUSTOMIZED_VIEW_TIMEOUT_SECONDS = 180;
@@ -298,6 +301,10 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
     QuotaEnforcementResult result = enforceQuota(request);
 
     if (result == QuotaEnforcementResult.BAD_REQUEST) {
+      String msg = INVALID_REQUEST_RESOURCE_MSG + request.getResourceName();
+      if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
+        LOGGER.warn("Rejecting request from {} - {}", ctx.channel(), msg);
+      }
       ctx.writeAndFlush(
           new HttpShortcutResponse(
               INVALID_REQUEST_RESOURCE_MSG + request.getResourceName(),

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
@@ -18,6 +18,7 @@ import com.linkedin.venice.listener.response.HttpShortcutResponse;
 import com.linkedin.venice.meta.QueryAction;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.request.RequestHelper;
+import com.linkedin.venice.utils.RedundantExceptionFilter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -45,6 +46,8 @@ import org.apache.logging.log4j.Logger;
  */
 public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
   private static final Logger LOGGER = LogManager.getLogger(RouterRequestHttpHandler.class);
+  private static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER =
+      RedundantExceptionFilter.getRedundantExceptionFilter();
   private final StatsHandler statsHandler;
   private final Map<String, Integer> storeToEarlyTerminationThresholdMSMap;
 
@@ -171,6 +174,11 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           throw new VeniceException("Unrecognized query action");
       }
     } catch (VeniceException e) {
+      Object remote = ctx.channel() == null ? null : ctx.channel().remoteAddress();
+      String filterKey = "URI parse failure: " + e.getMessage() + " uri=" + req.uri() + " remote=" + remote;
+      if (!REDUNDANT_LOGGING_FILTER.isRedundantException(filterKey)) {
+        LOGGER.warn("Failed to parse request URI '{}' from {}: {}", req.uri(), remote, e.getMessage(), e);
+      }
       ctx.writeAndFlush(new HttpShortcutResponse(e.getMessage(), HttpResponseStatus.BAD_REQUEST));
     }
   }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerStatsContext.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerStatsContext.java
@@ -44,6 +44,13 @@ public class ServerStatsContext {
   private final AggServerHttpRequestStats computeStats;
   private AggServerHttpRequestStats currentStats;
   private RequestType requestType = RequestType.SINGLE_GET;
+  /**
+   * Best-effort, observability-only copy of the raw request URI, used by {@link StatsHandler} when logging an error
+   * that was recorded without a store attribution. There is currently no handler upstream of the SSL/ACL rejection
+   * points that can populate this for those cases, so it is frequently {@code null}; the logging treats it as optional
+   * and never relies on it being present.
+   */
+  private String requestUri = null;
 
   // a flag that indicates if this is a new HttpRequest. Netty is TCP-based, so a HttpRequest is chunked into packages.
   // Set the startTimeInNS in ChannelRead if it is the first package within a HttpRequest.
@@ -86,6 +93,7 @@ public class ServerStatsContext {
     isMisroutedStoreVersion = false;
     flushLatency = -1;
     responseSize = -1;
+    requestUri = null;
 
     newRequest = false;
   }
@@ -120,6 +128,18 @@ public class ServerStatsContext {
 
   public void setStoreName(String name) {
     this.storeName = name;
+  }
+
+  public String getRequestUri() {
+    return requestUri;
+  }
+
+  /**
+   * Best-effort: records the raw request URI for observability only (see {@link #requestUri}). May be left unset, in
+   * which case {@link StatsHandler} simply logs the error without it.
+   */
+  public void setRequestUri(String requestUri) {
+    this.requestUri = requestUri;
   }
 
   public void setMetadataRequest(boolean metadataRequest) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StatsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StatsHandler.java
@@ -9,29 +9,56 @@ import com.linkedin.venice.listener.request.RouterRequest;
 import com.linkedin.venice.stats.AggServerHttpRequestStats;
 import com.linkedin.venice.stats.ServerHttpRequestStats;
 import com.linkedin.venice.utils.LatencyUtils;
+import com.linkedin.venice.utils.RedundantExceptionFilter;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import java.net.SocketAddress;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
 public class StatsHandler extends ChannelDuplexHandler {
+  private static final Logger LOGGER = LogManager.getLogger(StatsHandler.class);
   private final ServerStatsContext serverStatsContext;
   private final AggServerHttpRequestStats singleGetStats;
   private final AggServerHttpRequestStats multiGetStats;
   private final AggServerHttpRequestStats computeStats;
   private final ServerLoadControllerHandler loadControllerHandler;
+  /**
+   * Used to rate-limit the {@link #logUnattributedError} warnings so a noisy probe/scanner cannot flood the logs.
+   * Keyed on (status, remote, principal, uri), so each distinct source/cause is still logged within the filter window.
+   * Defaults to the process-wide shared filter so rate-limiting spans all channels; an alternate instance can be
+   * injected for deterministic testing.
+   */
+  private final RedundantExceptionFilter redundantExceptionFilter;
 
   public StatsHandler(
       AggServerHttpRequestStats singleGetStats,
       AggServerHttpRequestStats multiGetStats,
       AggServerHttpRequestStats computeStats,
       ServerLoadControllerHandler loadControllerHandler) {
+    this(
+        singleGetStats,
+        multiGetStats,
+        computeStats,
+        loadControllerHandler,
+        RedundantExceptionFilter.getRedundantExceptionFilter());
+  }
+
+  StatsHandler(
+      AggServerHttpRequestStats singleGetStats,
+      AggServerHttpRequestStats multiGetStats,
+      AggServerHttpRequestStats computeStats,
+      ServerLoadControllerHandler loadControllerHandler,
+      RedundantExceptionFilter redundantExceptionFilter) {
     this.singleGetStats = singleGetStats;
     this.multiGetStats = multiGetStats;
     this.computeStats = computeStats;
     this.loadControllerHandler = loadControllerHandler;
+    this.redundantExceptionFilter = redundantExceptionFilter;
 
     this.serverStatsContext = new ServerStatsContext(singleGetStats, multiGetStats, computeStats);
   }
@@ -127,6 +154,16 @@ public class StatsHandler extends ChannelDuplexHandler {
           serverStatsContext.successRequest(serverHttpRequestStats, elapsedTime);
         } else if (!serverStatsContext.getResponseStatus().equals(TOO_MANY_REQUESTS)) {
           serverStatsContext.errorRequest(serverHttpRequestStats, elapsedTime);
+          if (serverHttpRequestStats == null) {
+            /**
+             * No store name was resolved for this request, so the error only moved the aggregate
+             * {@code total--error_request} metric and is invisible at the store level. Such requests are rejected
+             * upstream of {@link RouterRequestHttpHandler} (e.g. malformed-URI BAD_REQUEST in the store ACL handler,
+             * an unauthorized 401/403, or an unexpected 5xx) and are otherwise unlogged. Log the source here so they
+             * can be attributed.
+             */
+            logUnattributedError(ctx, serverStatsContext);
+          }
         }
         if (loadControllerHandler != null) {
           loadControllerHandler.recordLatency(
@@ -137,5 +174,49 @@ public class StatsHandler extends ChannelDuplexHandler {
         serverStatsContext.setStatCallBackExecuted(true);
       }
     });
+  }
+
+  /**
+   * Logs the source of an error that was recorded against the aggregate {@code total--error_request} metric without a
+   * store attribution. These are requests rejected/failed before a store name was resolved (malformed-URI BAD_REQUEST,
+   * unauthorized 401/403, or an unexpected 5xx), which are otherwise invisible because the rejection points either do
+   * not log or log only at DEBUG.
+   *
+   * <p>Everything here is best-effort and fully guarded: this is observability only and must never disrupt request
+   * handling. The {@code remote}, client {@code principal} and {@code uri} are all best-effort and may be absent; the
+   * URI in particular is usually {@code null} for these upstream rejections (see {@link ServerStatsContext#getRequestUri()}).
+   */
+  private void logUnattributedError(ChannelHandlerContext ctx, ServerStatsContext statsContext) {
+    try {
+      HttpResponseStatus status = statsContext.getResponseStatus();
+      SocketAddress remote = ctx.channel() == null ? null : ctx.channel().remoteAddress();
+      // extractClientPrincipal is already best-effort: it returns "" rather than throwing when there is no client cert.
+      String principal = ServerHandlerUtils.extractClientPrincipal(ctx);
+      if (principal == null || principal.isEmpty()) {
+        principal = "none";
+      }
+      // Best-effort: include the URI only when something upstream managed to capture it, otherwise "unknown".
+      String uri = statsContext.getRequestUri();
+      if (uri == null || uri.isEmpty()) {
+        uri = "unknown";
+      }
+      String filterKey = "UNATTRIBUTED_ERROR_REQUEST:" + (status == null ? "?" : status.code()) + ':' + remote + ':'
+          + principal + ':' + uri;
+      if (!redundantExceptionFilter.isRedundantException(filterKey)) {
+        LOGGER.warn(
+            "Recorded an error_request with no store attribution (only the aggregate total--error_request metric "
+                + "moved); the request was rejected before a store name was resolved. status={}, remote={}, "
+                + "clientPrincipal={}, uri={}",
+            status,
+            remote,
+            principal,
+            uri);
+      }
+    } catch (Throwable t) {
+      // Observability must never disrupt request handling.
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Failed to log unattributed error_request source; continuing.", t);
+      }
+    }
   }
 }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StatsHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StatsHandlerTest.java
@@ -1,0 +1,205 @@
+package com.linkedin.venice.listener;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.venice.stats.AggServerHttpRequestStats;
+import com.linkedin.venice.stats.ServerHttpRequestStats;
+import com.linkedin.venice.utils.RedundantExceptionFilter;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.util.concurrent.GenericFutureListener;
+import java.io.Serializable;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Property;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
+
+
+public class StatsHandlerTest {
+  /**
+   * An unattributed error (no store name resolved, e.g. a malformed-URI BAD_REQUEST that is rejected upstream of
+   * {@link RouterRequestHttpHandler}) should:
+   * <ul>
+   *   <li>still be recorded against the aggregate {@code total--error_request} stats, and</li>
+   *   <li>have its source logged exactly once, with repeats suppressed by the redundant-exception filter.</li>
+   * </ul>
+   */
+  @Test
+  public void logsUnattributedErrorSourceAndIsRateLimited() throws Exception {
+    // The first agg is used for SINGLE_GET (the default request type); an unattributed error resolves a per-store
+    // stats object under the "unknown" store name, so error metrics land on this store-stats mock.
+    AggServerHttpRequestStats singleGetStats = mock(AggServerHttpRequestStats.class);
+    ServerHttpRequestStats unknownStoreStats = mock(ServerHttpRequestStats.class);
+    when(singleGetStats.getStoreStats(any())).thenReturn(unknownStoreStats);
+    // A fresh (non-singleton) filter so this test is deterministic and isolated from other tests' filter state.
+    StatsHandler statsHandler = new StatsHandler(
+        singleGetStats,
+        mock(AggServerHttpRequestStats.class),
+        mock(AggServerHttpRequestStats.class),
+        null,
+        new RedundantExceptionFilter());
+
+    // A unique remote host so the appender can match this test's WARN by substring.
+    String remoteHost = "unattributed-error-test-" + System.nanoTime() + ".invalid";
+
+    AtomicInteger warnCount = new AtomicInteger();
+    WarnMessageCountAppender appender =
+        new WarnMessageCountAppender.Builder().setCounter(warnCount).setMarker(remoteHost).build();
+    appender.start();
+    LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
+    Configuration config = loggerContext.getConfiguration();
+    config.addLoggerAppender((org.apache.logging.log4j.core.Logger) LogManager.getLogger(StatsHandler.class), appender);
+
+    // First unattributed BAD_REQUEST (no URI captured upstream): error recorded + one WARN identifying the source.
+    driveErrorResponse(statsHandler, remoteHost, null);
+    // Second identical request: error still recorded, but the WARN is suppressed by the redundant filter.
+    driveErrorResponse(statsHandler, remoteHost, null);
+
+    // The error is recorded (against the "unknown" store stats) for BOTH requests...
+    verify(unknownStoreStats, atLeast(2)).recordErrorRequestAndLatency(any(), any(), anyDouble(), anyInt());
+    // ...but the source is logged only once thanks to the redundant filter.
+    assertEquals(warnCount.get(), 1, "Identical unattributed errors should be logged exactly once");
+  }
+
+  /**
+   * When a URI was captured upstream (best-effort), it should be carried into the WARN identifying the unattributed
+   * error's source, and should also distinguish otherwise-identical requests in the redundant-exception filter.
+   */
+  @Test
+  public void includesRequestUriWhenAvailable() throws Exception {
+    AggServerHttpRequestStats singleGetStats = mock(AggServerHttpRequestStats.class);
+    when(singleGetStats.getStoreStats(any())).thenReturn(mock(ServerHttpRequestStats.class));
+    StatsHandler statsHandler = new StatsHandler(
+        singleGetStats,
+        mock(AggServerHttpRequestStats.class),
+        mock(AggServerHttpRequestStats.class),
+        null,
+        new RedundantExceptionFilter());
+
+    String uri = "/storage/some_store_v1/0/" + System.nanoTime();
+
+    AtomicInteger warnCount = new AtomicInteger();
+    WarnMessageCountAppender appender =
+        new WarnMessageCountAppender.Builder().setCounter(warnCount).setMarker(uri).build();
+    appender.start();
+    LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
+    Configuration config = loggerContext.getConfiguration();
+    config.addLoggerAppender((org.apache.logging.log4j.core.Logger) LogManager.getLogger(StatsHandler.class), appender);
+
+    driveErrorResponse(statsHandler, "10.0.0.1", uri);
+
+    assertEquals(warnCount.get(), 1, "The captured URI should appear in the unattributed-error WARN");
+  }
+
+  /**
+   * Drives a single error response (with no store name, hence "unattributed") through {@link StatsHandler#write} and
+   * invokes the write-completion listener that records the metrics and logs the source. A non-null {@code uri}
+   * simulates a URI having been captured upstream (best-effort); {@code null} simulates the common case where it was
+   * not.
+   */
+  private void driveErrorResponse(StatsHandler statsHandler, String remoteHost, String uri) throws Exception {
+    // Re-arm for a fresh request.
+    ServerStatsContext statsContext = statsHandler.getServerStatsContext();
+    statsContext.setStatCallBackExecuted(false);
+    statsHandler.setResponseStatus(BAD_REQUEST);
+    statsContext.setRequestUri(uri);
+    // storeName intentionally left null -> error attributed only to the aggregate "total" stats.
+
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    ChannelPipeline pipeline = mock(ChannelPipeline.class);
+    ChannelFuture future = mock(ChannelFuture.class);
+    when(ctx.channel()).thenReturn(channel);
+    when(ctx.pipeline()).thenReturn(pipeline);
+    when(pipeline.get(SslHandler.class)).thenReturn(null);
+    when(channel.parent()).thenReturn(null);
+    when(channel.remoteAddress()).thenReturn(InetSocketAddress.createUnresolved(remoteHost, 12345));
+    Object msg = new Object();
+    when(ctx.writeAndFlush(msg)).thenReturn(future);
+    when(future.isSuccess()).thenReturn(true);
+
+    ArgumentCaptor<GenericFutureListener> captor = ArgumentCaptor.forClass(GenericFutureListener.class);
+    statsHandler.write(ctx, msg, mock(ChannelPromise.class));
+    verify(future).addListener(captor.capture());
+    captor.getValue().operationComplete(future);
+  }
+
+  /**
+   * Counts WARN log events whose formatted message contains a marker substring. Modeled on {@link ErrorCountAppender}.
+   */
+  private static class WarnMessageCountAppender extends AbstractAppender {
+    private final AtomicInteger counter;
+    private final String marker;
+
+    protected WarnMessageCountAppender(
+        String name,
+        Filter filter,
+        Layout<? extends Serializable> layout,
+        boolean ignoreExceptions,
+        Property[] properties,
+        AtomicInteger counter,
+        String marker) {
+      super(name, filter, layout, ignoreExceptions, properties);
+      this.counter = counter;
+      this.marker = marker;
+    }
+
+    public static class Builder<B extends Builder<B>> extends AbstractAppender.Builder<B>
+        implements org.apache.logging.log4j.core.util.Builder<WarnMessageCountAppender> {
+      private AtomicInteger counter;
+      private String marker;
+
+      public B setCounter(AtomicInteger counter) {
+        this.counter = counter;
+        return asBuilder();
+      }
+
+      public B setMarker(String marker) {
+        this.marker = marker;
+        return asBuilder();
+      }
+
+      @Override
+      public WarnMessageCountAppender build() {
+        // Unique name per instance: log4j keys appenders by name within a LoggerConfig, so a shared name would let one
+        // test method's appender (and counter) silently replace another's, depending on execution order.
+        return new WarnMessageCountAppender(
+            "WarnMessageCountAppender-" + marker,
+            getFilter(),
+            null,
+            false,
+            getPropertyArray(),
+            counter,
+            marker);
+      }
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      if (event.getLevel().equals(Level.WARN) && event.getMessage().getFormattedMessage().contains(marker)) {
+        counter.addAndGet(1);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem Statement
When a request is rejected before a store name is resolved (malformed-URI BAD_REQUEST, unauthorized 401/403, or an unexpected 5xx), the error only moves the aggregate total--error_request metric and is otherwise invisible. Log the source (status, remote address, client principal) once per distinct source via StatsHandler#logUnattributedError, rate-limited by the RedundantExceptionFilter. The logging is fully guarded so observability never disrupts request handling.

## Solution
cherry pick https://github.com/linkedin/venice/pull/2903 to hotfix branch


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.