### PR TITLE
[compat] [server] [dvc] Global RT DIV: Use Remote LCVP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -328,12 +328,7 @@ subprojects {
       // Protocol changes should pin the current version via this override and remove the override in a follow-up PR
       // when actually using the new protocol. Example to pin KME to v12 when introducing v13:
       // project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
-      def versionOverrides = [
-          // PartitionState v24 introduces `upstreamLastConsumedVersionTopicPubSubPosition` (the remote/upstream
-          // last-consumed VT position, "remote LCVP"). Pinned to v23 until the consumer code (OffsetRecord +
-          // PartitionTracker + LeaderFollowerStoreIngestionTask + PartitionConsumptionState) lands in a follow-up PR.
-          project(':internal:venice-common').file('src/main/resources/avro/PartitionState/v23', PathValidation.DIRECTORY)
-      ]
+      def versionOverrides = []
 
       def schemaDirs = [sourceDir]
       sourceDir.eachDir { typeDir ->

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3266,6 +3266,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           topicType = TopicType.of(REALTIME_TOPIC_TYPE, kafkaUrl);
         }
         validateMessage(topicType, consumerDiv, record, pcs, false);
+        // Advance the remote LCVP in lockstep with the remote VT segments registered just above, so an F->L resume
+        // (PartitionConsumptionState#getCheckpointedVtLeaderPosition) starts the remote VT consistently with the
+        // snapshotted VT DIV producer state instead of an in-memory processed position that can outrun it.
+        if (pcs.consumeRemotely() && TopicType.isVersionTopic(topicType)) {
+          getConsumerDiv().updateLatestConsumedRemoteVtPosition(pcs.getPartition(), record.getPosition());
+        }
         versionedDIVStats.recordSuccessMsg(storeName, versionNumber);
       } catch (FatalDataValidationException e) {
         if (!pcs.isEndOfPushReceived()) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2396,7 +2396,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     PubSubTopicPartition topicPartition = pcs.getReplicaTopicPartition();
     PartitionTracker vtDiv =
         getConsumerDiv().cloneVtProducerStates(pcs.getPartition(), true, pcs.getLatestMessageTimeInMs());
-    sendVtDivSnapshotOnCompletion(callback, topicPartition, vtDiv, persistedToDBFuture);
+    sendVtDivSnapshotOnCompletion(callback, topicPartition, vtDiv, persistedToDBFuture, pcs);
     pcs.resetConsumedBytesSinceLastGlobalRtDivSync(getVersionTopic().getName());
   }
 
@@ -2411,7 +2411,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       LeaderProducerCallback callback,
       PubSubTopicPartition topicPartition,
       PartitionTracker vtDiv,
-      CompletableFuture<Void> persistedToDBFuture) {
+      CompletableFuture<Void> persistedToDBFuture,
+      PartitionConsumptionState pcs) {
     // Relay future the leader graceful-shutdown path awaits. It completes when the drainer-side VT DIV sync node has
     // run. The leader-produce callback only fires on produce success, so also fail the relay if the produce/persist
     // fails — otherwise the shutdown await would hang until its timeout instead of completing promptly.
@@ -2430,14 +2431,23 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         // leader whose upstream is a non-RT topic, and skipped when there is no corresponding upstream message (e.g.
         // leader-generated chunks or TopicSwitch) or on the RT-source path (whose position is checkpointed as the
         // LCRP).
+        // The domain is gated on the leader's upstream topic (leaderTopic), NOT the source consumer record's topic:
+        // the graceful-shutdown flush (sendGlobalRtDivMessage) synthesizes a local-VT source record while
+        // getConsumedPosition() carries the RT-domain LCRP, so gating on the source record would cross-write an RT
+        // position into the remote-VT LCVP field. leaderTopic is the same predicate updateOffsetsAsRemoteConsumeLeader
+        // uses to route getConsumedPosition() to the RT vs remote-VT domain, so it stays correct on the flush path
+        // (leaderTopic == RT there) and preserves the steady-state VT-source behavior (leaderTopic == VT).
         // The sync runs only after persistedToDBFuture completes, so the persisted remote LCVP never leads the
         // persisted
         // data; an F->L resume (PartitionConsumptionState#getCheckpointedVtLeaderPosition) then re-subscribes the
         // remote
         // VT at a position that is durable by construction.
-        DefaultPubSubMessage sourceRecord = callback.getSourceConsumerRecord();
         LeaderProducedRecordContext leaderProducedRecordContext = callback.getLeaderProducedRecordContext();
-        if (!sourceRecord.getTopicPartition().getPubSubTopic().isRealTime() && leaderProducedRecordContext != null
+        PubSubTopic upstreamTopic = pcs.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
+        if (upstreamTopic == null) {
+          upstreamTopic = versionTopic;
+        }
+        if (!upstreamTopic.isRealTime() && leaderProducedRecordContext != null
             && leaderProducedRecordContext.hasCorrespondingUpstreamMessage()) {
           vtDiv.updateLatestConsumedRemoteVtPosition(leaderProducedRecordContext.getConsumedPosition());
         }
@@ -4536,7 +4546,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         divCallback,
         topicPartition,
         vtDiv,
-        divCallback.getLeaderProducedRecordContext().getPersistedToDBFuture());
+        divCallback.getLeaderProducedRecordContext().getPersistedToDBFuture(),
+        pcs);
 
     // Read the old manifest (if any) so VeniceWriter can delete orphaned old chunks in Kafka.
     ChunkedValueManifestContainer valueManifestContainer = new ChunkedValueManifestContainer();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2424,6 +2424,23 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     callback.setOnCompletionCallback(produceResult -> {
       try {
         vtDiv.updateLatestConsumedVtPosition(produceResult.getPubSubPosition());
+        // Stamp the consumed upstream position onto the snapshot as the remote LCVP, mirroring the local LCVP set from
+        // the produced position above. It uses the same offset the OffsetRecord checkpoint uses
+        // (LeaderProducedRecordContext#getConsumedPosition, see updateOffsetsAsRemoteConsumeLeader): advanced for any
+        // leader whose upstream is a non-RT topic, and skipped when there is no corresponding upstream message (e.g.
+        // leader-generated chunks or TopicSwitch) or on the RT-source path (whose position is checkpointed as the
+        // LCRP).
+        // The sync runs only after persistedToDBFuture completes, so the persisted remote LCVP never leads the
+        // persisted
+        // data; an F->L resume (PartitionConsumptionState#getCheckpointedVtLeaderPosition) then re-subscribes the
+        // remote
+        // VT at a position that is durable by construction.
+        DefaultPubSubMessage sourceRecord = callback.getSourceConsumerRecord();
+        LeaderProducedRecordContext leaderProducedRecordContext = callback.getLeaderProducedRecordContext();
+        if (!sourceRecord.getTopicPartition().getPubSubTopic().isRealTime() && leaderProducedRecordContext != null
+            && leaderProducedRecordContext.hasCorrespondingUpstreamMessage()) {
+          vtDiv.updateLatestConsumedRemoteVtPosition(leaderProducedRecordContext.getConsumedPosition());
+        }
         storeBufferService.execSyncOffsetFromSnapshotAsync(topicPartition, vtDiv, persistedToDBFuture, this)
             .whenComplete((ignored, throwable) -> {
               if (throwable != null) {
@@ -3266,12 +3283,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           topicType = TopicType.of(REALTIME_TOPIC_TYPE, kafkaUrl);
         }
         validateMessage(topicType, consumerDiv, record, pcs, false);
-        // Advance the remote LCVP in lockstep with the remote VT segments registered just above, so an F->L resume
-        // (PartitionConsumptionState#getCheckpointedVtLeaderPosition) starts the remote VT consistently with the
-        // snapshotted VT DIV producer state instead of an in-memory processed position that can outrun it.
-        if (pcs.consumeRemotely() && TopicType.isVersionTopic(topicType)) {
-          getConsumerDiv().updateLatestConsumedRemoteVtPosition(pcs.getPartition(), record.getPosition());
-        }
         versionedDIVStats.recordSuccessMsg(storeName, versionNumber);
       } catch (FatalDataValidationException e) {
         if (!pcs.isEndOfPushReceived()) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2438,10 +2438,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         // uses to route getConsumedPosition() to the RT vs remote-VT domain, so it stays correct on the flush path
         // (leaderTopic == RT there) and preserves the steady-state VT-source behavior (leaderTopic == VT).
         // The sync runs only after persistedToDBFuture completes, so the persisted remote LCVP never leads the
-        // persisted
-        // data; an F->L resume (PartitionConsumptionState#getCheckpointedVtLeaderPosition) then re-subscribes the
-        // remote
-        // VT at a position that is durable by construction.
+        // persisted data; an F->L resume (PartitionConsumptionState#getCheckpointedVtLeaderPosition) then
+        // re-subscribes the remote VT at a position that is durable by construction.
         LeaderProducedRecordContext leaderProducedRecordContext = callback.getLeaderProducedRecordContext();
         PubSubTopic upstreamTopic = pcs.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
         if (upstreamTopic == null) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -1359,12 +1359,17 @@ public class PartitionConsumptionState {
    *
    * <p>If the leader topic is a version topic:
    * <ul>
-   *   <li>If remote consumption is enabled, returns the latest processed remote VT position.</li>
-   *   <li>Otherwise, returns the latest processed local VT position.</li>
+   *   <li>If {@code useCheckpointedDivRtPosition} is true (the F-&gt;L transition path), returns the durable,
+   *       DIV-consistent checkpointed VT position via {@link #getCheckpointedVtLeaderPosition()} so the leader never
+   *       resumes ahead of the VT DIV producer state it persisted. See that method for why the in-memory processed
+   *       position is unsafe here.</li>
+   *   <li>Otherwise (steady state), returns the latest processed remote/local VT position from in-memory state.</li>
    * </ul>
    *
    * @param pubSubBrokerAddress the upstream PubSub broker address
-   * @param useCheckpointedDivRtPosition whether to use the global DIV checkpoint (LCRP) as the RT start position
+   * @param useCheckpointedDivRtPosition whether this is the F-&gt;L transition path and the durable DIV checkpoint
+   *                                     should be used as the start position (LCRP for RT, checkpointed VT position
+   *                                     for VT)
    * @return the position the leader should consume from
    */
   public PubSubPosition getLeaderPosition(String pubSubBrokerAddress, boolean useCheckpointedDivRtPosition) {
@@ -1374,9 +1379,46 @@ public class PartitionConsumptionState {
       return (useCheckpointedDivRtPosition)
           ? getDivRtCheckpointPosition(pubSubBrokerAddress)
           : getLatestProcessedRtPosition(pubSubBrokerAddress);
+    } else if (useCheckpointedDivRtPosition) {
+      return getCheckpointedVtLeaderPosition();
     } else {
       return consumeRemotely() ? getLatestProcessedRemoteVtPosition() : getLatestProcessedVtPosition();
     }
+  }
+
+  /**
+   * Resolves the VT (version-topic) leader start position for the F-&gt;L transition path to the durable,
+   * DIV-consistent last-consumed VT position (LCVP), falling back to {@link PubSubSymbolicPosition#EARLIEST} when none
+   * was ever checkpointed.
+   *
+   * <p>Background: the in-memory processed VT positions ({@link #getLatestProcessedRemoteVtPosition()} /
+   * {@link #getLatestProcessedVtPosition()}) are advanced per-record by {@code updateLatestInMemoryProcessedOffset}
+   * as the leader drains records. After a server restart that wipes RocksDB, the leader can re-consume the local VT
+   * during the data-on-leader (DoL) phase and advance the in-memory processed-remote-VT position from the local-VT
+   * records' {@code leaderMetadataFooter.upstreamOffset} - without registering the source-VT producer's DIV segments.
+   * On F-&gt;L promotion, subscribing the source VT at that in-memory position can land many records past where the
+   * persisted VT DIV producer state is valid, producing {@code ImproperlyStartedSegmentException} /
+   * {@code MissingDataException}.
+   *
+   * <p>The LCVP, in contrast, is snapshotted into the {@link OffsetRecord} atomically with the {@code consumerDiv} VT
+   * producer-state segments (see {@code PartitionTracker#updateOffsetRecord}), so resuming from it is DIV-consistent by
+   * construction.
+   *
+   * <ul>
+   *   <li>Remote source-VT leader ({@link #consumeRemotely()} == true): uses the remote LCVP
+   *       {@link OffsetRecord#getLatestConsumedRemoteVtPosition()} (last position consumed from the remote/source VT).
+   *       The local LCVP is intentionally NOT used here: it tracks the local VT (re-)produce position, a different
+   *       position domain from the remote source VT this leader subscribes to.</li>
+   *   <li>Local-VT leader ({@link #consumeRemotely()} == false): uses the local LCVP
+   *       {@link OffsetRecord#getLatestConsumedVtPosition()}, matching
+   *       {@code LeaderFollowerStoreIngestionTask#getLocalVtSubscribePosition} under Global RT DIV.</li>
+   * </ul>
+   */
+  PubSubPosition getCheckpointedVtLeaderPosition() {
+    PubSubPosition checkpointedPosition = consumeRemotely()
+        ? getOffsetRecord().getLatestConsumedRemoteVtPosition()
+        : getOffsetRecord().getLatestConsumedVtPosition();
+    return checkpointedPosition == null ? PubSubSymbolicPosition.EARLIEST : checkpointedPosition;
   }
 
   public void setStartOfPushTimestamp(long startOfPushTimestamp) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DataIntegrityValidator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/DataIntegrityValidator.java
@@ -200,6 +200,11 @@ public class DataIntegrityValidator {
     partitionTracker.updateLatestConsumedVtPosition(vtPosition);
   }
 
+  public void updateLatestConsumedRemoteVtPosition(int partition, PubSubPosition vtPosition) {
+    PartitionTracker partitionTracker = registerPartition(partition);
+    partitionTracker.updateLatestConsumedRemoteVtPosition(vtPosition);
+  }
+
   /**
    * N.B. Intended for tests only
    *

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -92,6 +92,15 @@ public class PartitionTracker {
       new AtomicReference(PubSubSymbolicPosition.EARLIEST);
 
   /**
+   * The remote/upstream counterpart of {@link #latestConsumedVtPosition}: the last position consumed from the remote
+   * version topic by a remote-consume leader. Tracked separately because {@link #latestConsumedVtPosition} follows the
+   * local VT (produce/consume), which is a different position domain from the remote source VT this leader subscribes
+   * to.
+   */
+  private final AtomicReference<PubSubPosition> latestConsumedRemoteVtPosition =
+      new AtomicReference(PubSubSymbolicPosition.EARLIEST);
+
+  /**
    * rtSegments is a map of source broker URL to a map of GUID to Segment.
    * There should only be one {@code ConsumptionTask} for each broker URL, so there shouldn't need to be any locking.
    *
@@ -120,6 +129,14 @@ public class PartitionTracker {
 
   public void updateLatestConsumedVtPosition(PubSubPosition vtPosition) {
     latestConsumedVtPosition.updateAndGet(current -> vtPosition);
+  }
+
+  public PubSubPosition getLatestConsumedRemoteVtPosition() {
+    return latestConsumedRemoteVtPosition.get();
+  }
+
+  public void updateLatestConsumedRemoteVtPosition(PubSubPosition vtPosition) {
+    latestConsumedRemoteVtPosition.updateAndGet(current -> vtPosition);
   }
 
   public final String toString() {
@@ -249,6 +266,7 @@ public class PartitionTracker {
       logger.info("event=globalRtDiv Removed {} stale VT producer state(s) for store {}", removedCount, topicName);
     }
     destProducerTracker.updateLatestConsumedVtPosition(latestConsumedVtPosition.get());
+    destProducerTracker.updateLatestConsumedRemoteVtPosition(latestConsumedRemoteVtPosition.get());
   }
 
   /**
@@ -344,6 +362,7 @@ public class PartitionTracker {
     if (TopicType.isVersionTopic(type)) {
       // Without this, the OffsetRecord keeps latestConsumedVtPosition=EARLIEST
       offsetRecord.setLatestConsumedVtPosition(getLatestConsumedVtPosition());
+      offsetRecord.setLatestConsumedRemoteVtPosition(getLatestConsumedRemoteVtPosition());
     }
     for (Map.Entry<GUID, Segment> entry: getSegments(type).entrySet()) {
       updateOffsetRecord(type, entry.getKey(), entry.getValue(), offsetRecord);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -179,6 +179,12 @@ public class PartitionTracker {
     long earliestAllowableTimestamp =
         computeEarliestAllowableTimestamp(maxAgeInMs, offsetRecord.calculateLatestMessageTimeInMs());
     setPartitionState(type, offsetRecord.getProducerPartitionStateMap(), earliestAllowableTimestamp);
+    if (TopicType.isVersionTopic(type)) {
+      // Rehydrate the durable remote LCVP so a follower's VT-DIV checkpoint writes back the persisted value instead of
+      // EARLIEST across a restart. Unlike the local LCVP (re-advanced live on the consume path), the remote LCVP is
+      // only advanced by a remote-consume leader, so without this it would collapse to EARLIEST before an F->L resume.
+      updateLatestConsumedRemoteVtPosition(offsetRecord.getLatestConsumedRemoteVtPosition());
+    }
   }
 
   public void setPartitionState(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -726,11 +726,14 @@ public class LeaderFollowerStoreIngestionTaskTest {
     PubSubTopicPartition mockTopicPartition = mock(PubSubTopicPartition.class);
     PubSubPosition p3 = ApacheKafkaOffsetPosition.of(offset);
     doReturn(partition).when(mockTopicPartition).getPartitionNumber();
-    // The RT DIV callback's source record sits on this RT topic-partition; the remote-LCVP stamp in
-    // sendVtDivSnapshotOnCompletion must skip RT-source sends (their position is checkpointed as the LCRP).
-    PubSubTopic mockRtTopic = mock(PubSubTopic.class);
-    doReturn(true).when(mockRtTopic).isRealTime();
-    doReturn(mockRtTopic).when(mockTopicPartition).getPubSubTopic();
+    // The graceful-shutdown flush produces the GlobalRtDivState to the LOCAL VT, so the callback's synthetic source
+    // record sits on a non-RT (VT) topic-partition, while the leader's upstream (leaderTopic) is the RT topic whose
+    // LCRP is carried as the consumed position. The remote-LCVP stamp in sendVtDivSnapshotOnCompletion keys off
+    // leaderTopic (RT here) and must skip the stamp, since that RT-domain position is checkpointed separately as the
+    // LCRP; keying off the source record's topic would cross-write the RT LCRP into the remote-VT LCVP field.
+    PubSubTopic mockLocalVtTopic = mock(PubSubTopic.class);
+    doReturn(false).when(mockLocalVtTopic).isRealTime();
+    doReturn(mockLocalVtTopic).when(mockTopicPartition).getPubSubTopic();
     VeniceWriter mockWriter = mock(VeniceWriter.class);
     Lazy<VeniceWriter<byte[], byte[], byte[]>> lazyMockWriter = Lazy.of(() -> mockWriter);
     doReturn(lazyMockWriter).when(mockPartitionConsumptionState).getVeniceWriterLazyRef();
@@ -741,6 +744,9 @@ public class LeaderFollowerStoreIngestionTaskTest {
         LeaderFollowerStoreIngestionTask.getGlobalRtDivKeyName(partition, brokerUrl).getBytes(StandardCharsets.UTF_8);
 
     OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
+    PubSubTopic mockLeaderRtTopic = mock(PubSubTopic.class);
+    doReturn(true).when(mockLeaderRtTopic).isRealTime();
+    doReturn(mockLeaderRtTopic).when(mockOffsetRecord).getLeaderTopic(any());
     doReturn(mockOffsetRecord).when(mockPartitionConsumptionState).getOffsetRecord();
 
     leaderFollowerStoreIngestionTask
@@ -786,8 +792,9 @@ public class LeaderFollowerStoreIngestionTaskTest {
     // Verify that completing the future from put() causes execSyncOffsetFromSnapshotAsync to be called
     // and that produceResult should override the LCVP of the VT DIV sent to the drainer
     PartitionTracker captured = fireProduceCallbackAndAssertLcvpSynced(callback, InMemoryPubSubPosition.of(11L));
-    // The RT-source send must not advance the remote VT LCVP (its position is the RT/LCRP domain, checkpointed
-    // separately); it stays at its default rather than picking up the produced (11L) or upstream RT position.
+    // The flush send must not advance the remote VT LCVP: its consumed position (p3) is the RT/LCRP domain,
+    // checkpointed separately, and leaderTopic is RT. It stays at its default rather than picking up the produced
+    // (11L) or the RT LCRP (p3) - a regression guard against cross-writing an RT position into the remote-VT LCVP.
     assertNotEquals(captured.getLatestConsumedRemoteVtPosition(), InMemoryPubSubPosition.of(11L));
     assertNotEquals(captured.getLatestConsumedRemoteVtPosition(), p3);
   }
@@ -1255,6 +1262,14 @@ public class LeaderFollowerStoreIngestionTaskTest {
     // remote LCVP - the LeaderProducedRecordContext offset the OffsetRecord checkpoint uses, not the raw source record.
     doReturn(true).when(mockContext).hasCorrespondingUpstreamMessage();
     doReturn(InMemoryPubSubPosition.of(99L)).when(mockContext).getConsumedPosition();
+
+    // The remote-LCVP stamp gate keys off the leader's upstream topic (leaderTopic), not the source consumer record.
+    // A non-RT (VT) leaderTopic models the steady-state remote-VT-source leader, so the stamp runs.
+    OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
+    PubSubTopic mockLeaderVtTopic = mock(PubSubTopic.class);
+    doReturn(false).when(mockLeaderVtTopic).isRealTime();
+    doReturn(mockLeaderVtTopic).when(mockOffsetRecord).getLeaderTopic(any());
+    doReturn(mockOffsetRecord).when(mockPartitionConsumptionState).getOffsetRecord();
 
     // Build a consumer record on a non-RT topic so the install gate accepts it. Non-control-message
     // record so isNonSegmentControlMessage short-circuits and the install decision flows through

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertNull;
@@ -725,6 +726,11 @@ public class LeaderFollowerStoreIngestionTaskTest {
     PubSubTopicPartition mockTopicPartition = mock(PubSubTopicPartition.class);
     PubSubPosition p3 = ApacheKafkaOffsetPosition.of(offset);
     doReturn(partition).when(mockTopicPartition).getPartitionNumber();
+    // The RT DIV callback's source record sits on this RT topic-partition; the remote-LCVP stamp in
+    // sendVtDivSnapshotOnCompletion must skip RT-source sends (their position is checkpointed as the LCRP).
+    PubSubTopic mockRtTopic = mock(PubSubTopic.class);
+    doReturn(true).when(mockRtTopic).isRealTime();
+    doReturn(mockRtTopic).when(mockTopicPartition).getPubSubTopic();
     VeniceWriter mockWriter = mock(VeniceWriter.class);
     Lazy<VeniceWriter<byte[], byte[], byte[]>> lazyMockWriter = Lazy.of(() -> mockWriter);
     doReturn(lazyMockWriter).when(mockPartitionConsumptionState).getVeniceWriterLazyRef();
@@ -779,7 +785,11 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     // Verify that completing the future from put() causes execSyncOffsetFromSnapshotAsync to be called
     // and that produceResult should override the LCVP of the VT DIV sent to the drainer
-    fireProduceCallbackAndAssertLcvpSynced(callback, InMemoryPubSubPosition.of(11L));
+    PartitionTracker captured = fireProduceCallbackAndAssertLcvpSynced(callback, InMemoryPubSubPosition.of(11L));
+    // The RT-source send must not advance the remote VT LCVP (its position is the RT/LCRP domain, checkpointed
+    // separately); it stays at its default rather than picking up the produced (11L) or upstream RT position.
+    assertNotEquals(captured.getLatestConsumedRemoteVtPosition(), InMemoryPubSubPosition.of(11L));
+    assertNotEquals(captured.getLatestConsumedRemoteVtPosition(), p3);
   }
 
   /**
@@ -1149,6 +1159,28 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   /**
+   * Verifies that {@link LeaderFollowerStoreIngestionTask#addVtDivToProducerCallbackIfNeeded} stamps the consumed
+   * upstream position carried by the {@link LeaderProducedRecordContext} onto the VT DIV snapshot as the remote LCVP
+   * ({@link PartitionTracker#getLatestConsumedRemoteVtPosition()}) whenever the leader's upstream is a non-RT topic -
+   * the same offset the OffsetRecord checkpoint uses ({@code updateOffsetsAsRemoteConsumeLeader}), independent of
+   * {@code consumeRemotely()}. That is the position an F-&gt;L resume subscribes the remote VT from, and it is synced to
+   * the OffsetRecord only after the record persists - mirroring the local LCVP, rather than being advanced eagerly
+   * per-record during batch validation.
+   */
+  @Test
+  public void testAddVtDivToProducerCallbackIfNeededStampsRemoteLcvp() throws InterruptedException {
+    setUp();
+    LeaderProducerCallback callback = addVtDivToProducerCallbackIfNeededWithMocks(
+        mock(PubSubTopicPartition.class),
+        CompletableFuture.completedFuture(null));
+
+    PartitionTracker captured = fireProduceCallbackAndAssertLcvpSynced(callback, InMemoryPubSubPosition.of(42L));
+    // Remote LCVP is the consumed upstream position carried by the LeaderProducedRecordContext (99L), distinct from the
+    // produced local-VT position (42L) carried by the local LCVP asserted above.
+    assertEquals(captured.getLatestConsumedRemoteVtPosition(), InMemoryPubSubPosition.of(99L));
+  }
+
+  /**
    * Verifies that when {@link StoreBufferService#execSyncOffsetFromSnapshotAsync} throws
    * {@link InterruptedException} from inside the produce-completion callback, the exception is
    * caught (so it doesn't propagate up to the producer) and the current thread's interrupt flag
@@ -1219,6 +1251,10 @@ public class LeaderFollowerStoreIngestionTaskTest {
 
     LeaderProducedRecordContext mockContext = mock(LeaderProducedRecordContext.class);
     doReturn(persistedFuture).when(mockContext).getPersistedToDBFuture();
+    // Stub the consumed upstream position and its presence so the non-RT-source path stamps it onto the snapshot as the
+    // remote LCVP - the LeaderProducedRecordContext offset the OffsetRecord checkpoint uses, not the raw source record.
+    doReturn(true).when(mockContext).hasCorrespondingUpstreamMessage();
+    doReturn(InMemoryPubSubPosition.of(99L)).when(mockContext).getConsumedPosition();
 
     // Build a consumer record on a non-RT topic so the install gate accepts it. Non-control-message
     // record so isNonSegmentControlMessage short-circuits and the install decision flows through

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.venice.utils.TestUtils.DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
@@ -18,7 +19,10 @@ import com.linkedin.venice.pubsub.PubSubContext;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.pubsub.mock.InMemoryPubSubPosition;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.stats.dimensions.VeniceChunkingStatus;
@@ -633,5 +637,73 @@ public class PartitionConsumptionStateTest {
       pcs.incrementBatchPushRecordCount();
     }
     assertEquals(pcs.getBatchPushRecordCount(), expectedFinalCount, description);
+  }
+
+  // The version topic the F->L prepare path resolves as the leader topic.
+  private PubSubTopic versionLeaderTopic() {
+    return TOPIC_REPOSITORY.getTopic("topic1_v1");
+  }
+
+  /**
+   * F->L transition (useCheckpointedDivRtPosition=true), remote source-VT leader (consumeRemotely=true):
+   * even when the in-memory processed-remote-VT position has raced ahead (offset 9677) of the durable remote
+   * LCVP (offset 2) during a post-wipe DoL re-consume, the resolved leader start must be the durable remote LCVP
+   * (2), never the in-memory 9677 that outruns the persisted VT DIV.
+   */
+  @Test
+  public void testGetLeaderPositionRemoteVtTransitionUsesRemoteLcvpNotInMemory() {
+    OffsetRecord offsetRecord = mock(OffsetRecord.class);
+    doReturn(versionLeaderTopic()).when(offsetRecord).getLeaderTopic(any());
+    PubSubPosition remoteLcvp = InMemoryPubSubPosition.of(2L);
+    doReturn(remoteLcvp).when(offsetRecord).getLatestConsumedRemoteVtPosition();
+
+    PartitionConsumptionState pcs =
+        new PartitionConsumptionState(TOPIC_PARTITION, offsetRecord, pubSubContext, true, false, false, null);
+    pcs.setConsumeRemotely(true);
+    // In-memory processed-remote-VT raced ahead during DoL re-consume of the local VT.
+    pcs.setLatestProcessedRemoteVtPosition(InMemoryPubSubPosition.of(9677L));
+
+    // F->L transition path: resolve to the durable remote LCVP, not the in-memory position.
+    assertEquals(pcs.getLeaderPosition("broker", true), remoteLcvp);
+    // Steady-state path is unchanged: still returns the in-memory processed position.
+    assertEquals(pcs.getLeaderPosition("broker", false), InMemoryPubSubPosition.of(9677L));
+  }
+
+  /**
+   * F->L transition with no durable remote LCVP (e.g. first leader / never checkpointed) must fall back to
+   * EARLIEST rather than the in-memory position.
+   */
+  @Test
+  public void testGetLeaderPositionRemoteVtTransitionFallsBackToEarliestWhenNoLcvp() {
+    OffsetRecord offsetRecord = mock(OffsetRecord.class);
+    doReturn(versionLeaderTopic()).when(offsetRecord).getLeaderTopic(any());
+    doReturn(PubSubSymbolicPosition.EARLIEST).when(offsetRecord).getLatestConsumedRemoteVtPosition();
+
+    PartitionConsumptionState pcs =
+        new PartitionConsumptionState(TOPIC_PARTITION, offsetRecord, pubSubContext, true, false, false, null);
+    pcs.setConsumeRemotely(true);
+    pcs.setLatestProcessedRemoteVtPosition(InMemoryPubSubPosition.of(9677L));
+
+    assertEquals(pcs.getLeaderPosition("broker", true), PubSubSymbolicPosition.EARLIEST);
+  }
+
+  /**
+   * Symmetric local-VT case (consumeRemotely=false): F->L transition resolves to the durable local LCVP, not the
+   * in-memory processed local VT position which can likewise outrun the VT DIV.
+   */
+  @Test
+  public void testGetLeaderPositionLocalVtTransitionUsesLocalLcvpNotInMemory() {
+    OffsetRecord offsetRecord = mock(OffsetRecord.class);
+    doReturn(versionLeaderTopic()).when(offsetRecord).getLeaderTopic(any());
+    PubSubPosition localLcvp = InMemoryPubSubPosition.of(2L);
+    doReturn(localLcvp).when(offsetRecord).getLatestConsumedVtPosition();
+
+    PartitionConsumptionState pcs =
+        new PartitionConsumptionState(TOPIC_PARTITION, offsetRecord, pubSubContext, false, false, false, null);
+    // consumeRemotely defaults to false.
+    pcs.setLatestProcessedVtPosition(InMemoryPubSubPosition.of(9677L));
+
+    assertEquals(pcs.getLeaderPosition("broker", true), localLcvp);
+    assertEquals(pcs.getLeaderPosition("broker", false), InMemoryPubSubPosition.of(9677L));
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/validation/TestPartitionTracker.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/validation/TestPartitionTracker.java
@@ -748,6 +748,31 @@ public class TestPartitionTracker {
   }
 
   /**
+   * The remote LCVP must be snapshotted into the OffsetRecord by updateOffsetRecord (independently of the local LCVP),
+   * and carried by cloneVtProducerStates, so an F->L remote-VT resume reads a DIV-consistent start position.
+   */
+  @Test(timeOut = 10 * Time.MS_PER_SECOND)
+  public void testUpdateOffsetRecordPersistsRemoteLcvp() {
+    PubSubPosition remoteLcvp = ApacheKafkaOffsetPosition.of(9677L);
+    partitionTracker.updateLatestConsumedRemoteVtPosition(remoteLcvp);
+    assertEquals(partitionTracker.getLatestConsumedRemoteVtPosition(), remoteLcvp);
+
+    OffsetRecord offsetRecord = TestUtils
+        .getOffsetRecord(ApacheKafkaOffsetPosition.of(0L), Optional.empty(), DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
+    partitionTracker.updateOffsetRecord(vt, offsetRecord);
+    assertEquals(
+        offsetRecord.getLatestConsumedRemoteVtPosition(),
+        remoteLcvp,
+        "Remote LCVP must be written to OffsetRecord even when no VT producer segments have been tracked yet");
+
+    // cloneVtProducerStates carries the remote LCVP to the destination tracker.
+    PartitionTracker destTracker = createDestTracker();
+    partitionTracker
+        .cloneVtProducerStates(destTracker, DataIntegrityValidator.DISABLED, System.currentTimeMillis(), false);
+    assertEquals(destTracker.getLatestConsumedRemoteVtPosition(), remoteLcvp, "remote LCVP should be copied on clone");
+  }
+
+  /**
    * Tests that cloneVtProducerStates correctly handles the maxAgeInMs threshold and data-relative anchor:
    * <ul>
    *   <li>With DISABLED maxAgeInMs: all segments retained regardless of age.</li>

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/validation/TestPartitionTracker.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/validation/TestPartitionTracker.java
@@ -749,51 +749,75 @@ public class TestPartitionTracker {
   }
 
   /**
-   * The remote LCVP must be snapshotted into the OffsetRecord by updateOffsetRecord (independently of the local LCVP),
-   * and carried by cloneVtProducerStates, so an F->L remote-VT resume reads a DIV-consistent start position.
+   * End-to-end remote LCVP durability: it is snapshotted into the OffsetRecord by updateOffsetRecord (independently of
+   * the local LCVP), carried by cloneVtProducerStates, and rehydrated on restart by setPartitionState - so an F->L
+   * remote-VT resume reads a DIV-consistent start position instead of collapsing to EARLIEST across a bounce.
    */
   @Test(timeOut = 10 * Time.MS_PER_SECOND)
-  public void testUpdateOffsetRecordPersistsRemoteLcvp() {
+  public void testRemoteLcvpPersistsClonesAndRehydrates() {
     PubSubPosition remoteLcvp = ApacheKafkaOffsetPosition.of(9677L);
     partitionTracker.updateLatestConsumedRemoteVtPosition(remoteLcvp);
     assertEquals(partitionTracker.getLatestConsumedRemoteVtPosition(), remoteLcvp);
 
+    // Snapshotted into the OffsetRecord even when no VT producer segments have been tracked yet.
     OffsetRecord offsetRecord = TestUtils
         .getOffsetRecord(ApacheKafkaOffsetPosition.of(0L), Optional.empty(), DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
     partitionTracker.updateOffsetRecord(vt, offsetRecord);
-    assertEquals(
-        offsetRecord.getLatestConsumedRemoteVtPosition(),
-        remoteLcvp,
-        "Remote LCVP must be written to OffsetRecord even when no VT producer segments have been tracked yet");
+    assertEquals(offsetRecord.getLatestConsumedRemoteVtPosition(), remoteLcvp);
 
-    // cloneVtProducerStates carries the remote LCVP to the destination tracker.
+    // Carried by cloneVtProducerStates.
     PartitionTracker destTracker = createDestTracker();
     partitionTracker
         .cloneVtProducerStates(destTracker, DataIntegrityValidator.DISABLED, System.currentTimeMillis(), false);
     assertEquals(destTracker.getLatestConsumedRemoteVtPosition(), remoteLcvp, "remote LCVP should be copied on clone");
-  }
 
-  /**
-   * On restart, {@link PartitionTracker#setPartitionState(TopicType, OffsetRecord, long)} must rehydrate the remote
-   * LCVP from the durable OffsetRecord. Otherwise a follower's VT-DIV checkpoint would write the in-memory EARLIEST
-   * back over the persisted value, collapsing the F->L remote-VT resume position to EARLIEST across any bounce.
-   */
-  @Test(timeOut = 10 * Time.MS_PER_SECOND)
-  public void testSetPartitionStateRehydratesRemoteLcvp() {
-    PubSubPosition remoteLcvp = ApacheKafkaOffsetPosition.of(100L);
-    OffsetRecord offsetRecord = TestUtils
-        .getOffsetRecord(ApacheKafkaOffsetPosition.of(0L), Optional.empty(), DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
-    offsetRecord.setLatestConsumedRemoteVtPosition(remoteLcvp);
-
-    // Fresh tracker starts at EARLIEST, mirroring a restart before any remote-VT record is consumed.
+    // Rehydrated on restart from the durable OffsetRecord (a fresh tracker starts at EARLIEST), so a follower's VT-DIV
+    // checkpoint writes back the real value instead of clobbering it to EARLIEST before an F->L resume.
     PartitionTracker restartedTracker = createDestTracker();
     assertEquals(restartedTracker.getLatestConsumedRemoteVtPosition(), PubSubSymbolicPosition.EARLIEST);
-
     restartedTracker.setPartitionState(vt, offsetRecord, MAX_AGE_IN_MS);
     assertEquals(
         restartedTracker.getLatestConsumedRemoteVtPosition(),
         remoteLcvp,
-        "Remote LCVP must be rehydrated from the OffsetRecord on restart so it is not clobbered back to EARLIEST");
+        "Remote LCVP must be rehydrated from the OffsetRecord on restart");
+  }
+
+  /**
+   * Backwards compatibility for the remote-LCVP (v24) field: a pre-v24 version resumes its remote source VT from
+   * {@link PubSubSymbolicPosition#EARLIEST} (the default when the field was never persisted) while already holding VT
+   * DIV producer state that is ahead. Re-consuming an already-validated non-SOS record from EARLIEST must be a benign
+   * {@link DuplicateDataException} (which the leader skips) - because the producer is already registered, trackSegment
+   * short-circuits to duplicate handling instead of a fatal {@link ImproperlyStartedSegmentException} - so an F->L
+   * resume on an upgraded-but-not-yet-recheckpointed replica does not error out.
+   */
+  @Test(timeOut = 10 * Time.MS_PER_SECOND)
+  public void testEarliestRemoteVtResumeToleratesPreExistingVtDivState() {
+    PubSubTopicPartition tp = getPubSubTopicPartition(vt);
+    Segment segment = new Segment(partitionId, 0, CheckSumType.NONE);
+
+    // Pre-existing VT DIV state: SOS + one data record register the producer at segment 0, seq 1.
+    partitionTracker.validateMessage(vt, buildVtRecord(tp, MessageType.CONTROL_MESSAGE, segment, 0), true, Lazy.FALSE);
+    partitionTracker.validateMessage(vt, buildVtRecord(tp, MessageType.PUT, segment, 1), true, Lazy.FALSE);
+
+    // An EARLIEST resume re-delivers the already-seen non-SOS record: benign duplicate, not a fatal DIV error.
+    assertThrows(
+        DuplicateDataException.class,
+        () -> partitionTracker.validateMessage(vt, buildVtRecord(tp, MessageType.PUT, segment, 1), true, Lazy.FALSE));
+  }
+
+  /** Builds a VT SOS (segment 0) or PUT {@link DefaultPubSubMessage} with an explicit producer sequence number. */
+  private DefaultPubSubMessage buildVtRecord(PubSubTopicPartition tp, MessageType type, Segment segment, int seq) {
+    boolean isControl = type == MessageType.CONTROL_MESSAGE;
+    Object payload = isControl ? getStartOfSegment() : getPutMessage(("v" + seq).getBytes());
+    KafkaMessageEnvelope envelope = getKafkaMessageEnvelope(type, guid, segment, Optional.of(seq), payload);
+    KafkaKey key = isControl ? getControlMessageKey(envelope) : getPutMessageKey(("k" + seq).getBytes());
+    return new ImmutablePubSubMessage(
+        key,
+        envelope,
+        tp,
+        ApacheKafkaOffsetPosition.of(seq),
+        System.currentTimeMillis(),
+        0);
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/validation/TestPartitionTracker.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/validation/TestPartitionTracker.java
@@ -41,6 +41,7 @@ import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.mock.InMemoryPubSubPosition;
@@ -770,6 +771,29 @@ public class TestPartitionTracker {
     partitionTracker
         .cloneVtProducerStates(destTracker, DataIntegrityValidator.DISABLED, System.currentTimeMillis(), false);
     assertEquals(destTracker.getLatestConsumedRemoteVtPosition(), remoteLcvp, "remote LCVP should be copied on clone");
+  }
+
+  /**
+   * On restart, {@link PartitionTracker#setPartitionState(TopicType, OffsetRecord, long)} must rehydrate the remote
+   * LCVP from the durable OffsetRecord. Otherwise a follower's VT-DIV checkpoint would write the in-memory EARLIEST
+   * back over the persisted value, collapsing the F->L remote-VT resume position to EARLIEST across any bounce.
+   */
+  @Test(timeOut = 10 * Time.MS_PER_SECOND)
+  public void testSetPartitionStateRehydratesRemoteLcvp() {
+    PubSubPosition remoteLcvp = ApacheKafkaOffsetPosition.of(100L);
+    OffsetRecord offsetRecord = TestUtils
+        .getOffsetRecord(ApacheKafkaOffsetPosition.of(0L), Optional.empty(), DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
+    offsetRecord.setLatestConsumedRemoteVtPosition(remoteLcvp);
+
+    // Fresh tracker starts at EARLIEST, mirroring a restart before any remote-VT record is consumed.
+    PartitionTracker restartedTracker = createDestTracker();
+    assertEquals(restartedTracker.getLatestConsumedRemoteVtPosition(), PubSubSymbolicPosition.EARLIEST);
+
+    restartedTracker.setPartitionState(vt, offsetRecord, MAX_AGE_IN_MS);
+    assertEquals(
+        restartedTracker.getLatestConsumedRemoteVtPosition(),
+        remoteLcvp,
+        "Remote LCVP must be rehydrated from the OffsetRecord on restart so it is not clobbered back to EARLIEST");
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -111,6 +111,8 @@ public class OffsetRecord {
     emptyPartitionState.lastProcessedVersionTopicPubSubPosition = PubSubSymbolicPosition.EARLIEST.toWireFormatBuffer();
     emptyPartitionState.lastConsumedVersionTopicPubSubPosition = PubSubSymbolicPosition.EARLIEST.toWireFormatBuffer();
     emptyPartitionState.upstreamVersionTopicPubSubPosition = PubSubSymbolicPosition.EARLIEST.toWireFormatBuffer();
+    emptyPartitionState.upstreamLastConsumedVersionTopicPubSubPosition =
+        PubSubSymbolicPosition.EARLIEST.toWireFormatBuffer();
     emptyPartitionState.activeKeyCount = ACTIVE_KEY_COUNT_NOT_TRACKED;
     return emptyPartitionState;
   }
@@ -383,6 +385,17 @@ public class OffsetRecord {
 
   public PubSubPosition getLatestConsumedVtPosition() {
     return pubSubPositionDeserializer.toPosition(this.partitionState.getLastConsumedVersionTopicPubSubPosition());
+  }
+
+  // Updated from {@link PartitionTracker#updateOffsetRecord}; the remote/upstream counterpart of the local LCVP above.
+  public void setLatestConsumedRemoteVtPosition(PubSubPosition latestConsumedRemoteVtPosition) {
+    this.partitionState
+        .setUpstreamLastConsumedVersionTopicPubSubPosition(latestConsumedRemoteVtPosition.toWireFormatBuffer());
+  }
+
+  public PubSubPosition getLatestConsumedRemoteVtPosition() {
+    return pubSubPositionDeserializer
+        .toPosition(this.partitionState.getUpstreamLastConsumedVersionTopicPubSubPosition());
   }
 
   public long getActiveKeyCount() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -394,8 +394,13 @@ public class OffsetRecord {
   }
 
   public PubSubPosition getLatestConsumedRemoteVtPosition() {
-    return pubSubPositionDeserializer
-        .toPosition(this.partitionState.getUpstreamLastConsumedVersionTopicPubSubPosition());
+    ByteBuffer wireFormat = this.partitionState.getUpstreamLastConsumedVersionTopicPubSubPosition();
+    // Records persisted before PartitionState v24 lack this field, so Avro schema resolution supplies the field
+    // default (empty bytes). Treat null/empty as EARLIEST rather than deserializing an empty payload, which throws.
+    if (wireFormat == null || !wireFormat.hasRemaining()) {
+      return PubSubSymbolicPosition.EARLIEST;
+    }
+    return pubSubPositionDeserializer.toPosition(wireFormat);
   }
 
   public long getActiveKeyCount() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -50,7 +50,7 @@ public enum AvroProtocolDefinition {
    * Used to persist the state of a partition in Storage Nodes, including offset,
    * Data Ingest Validation state, etc.
    */
-  PARTITION_STATE(24, 23, PartitionState.class),
+  PARTITION_STATE(24, 24, PartitionState.class),
 
   /**
    * Used to persist state related to a store-version, including Start of Buffer Replay

--- a/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
@@ -6,6 +6,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.kafka.protocol.GUID;
+import com.linkedin.venice.kafka.protocol.state.PartitionState;
 import com.linkedin.venice.kafka.protocol.state.ProducerPartitionState;
 import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
@@ -62,6 +63,19 @@ public class TestOffsetRecord {
         AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
         DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
     Assert.assertEquals(offsetRecord2, offsetRecord1);
+  }
+
+  @Test
+  public void testLatestConsumedRemoteVtPositionEmptyBufferDefaultsToEarliest() {
+    // Simulates a pre-v24 persisted record: Avro schema resolution supplies the field default (empty bytes) for the
+    // newly added field. The getter must resolve that to EARLIEST rather than deserializing an empty payload.
+    PartitionState partitionState = new PartitionState();
+    partitionState.upstreamLastConsumedVersionTopicPubSubPosition = ByteBuffer.allocate(0);
+    OffsetRecord offsetRecord = new OffsetRecord(
+        partitionState,
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
+        DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
+    assertEquals(offsetRecord.getLatestConsumedRemoteVtPosition(), PubSubSymbolicPosition.EARLIEST);
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
@@ -65,6 +65,23 @@ public class TestOffsetRecord {
   }
 
   @Test
+  public void testLatestConsumedRemoteVtPositionRoundTrip() {
+    OffsetRecord fresh = new OffsetRecord(
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
+        DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
+    // Unset -> EARLIEST (empty-state default), never null.
+    assertEquals(fresh.getLatestConsumedRemoteVtPosition(), PubSubSymbolicPosition.EARLIEST);
+
+    PubSubPosition remoteLcvp = ApacheKafkaOffsetPosition.of(9677);
+    fresh.setLatestConsumedRemoteVtPosition(remoteLcvp);
+    OffsetRecord restored = new OffsetRecord(
+        fresh.toBytes(),
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
+        DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
+    assertEquals(restored.getLatestConsumedRemoteVtPosition(), remoteLcvp);
+  }
+
+  @Test
   public void testResetUpstreamOffsetMap() {
     OffsetRecord offsetRecord = TestUtils
         .getOffsetRecord(ApacheKafkaOffsetPosition.of(100), Optional.empty(), DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
@@ -66,26 +66,24 @@ public class TestOffsetRecord {
   }
 
   @Test
-  public void testLatestConsumedRemoteVtPositionEmptyBufferDefaultsToEarliest() {
-    // Simulates a pre-v24 persisted record: Avro schema resolution supplies the field default (empty bytes) for the
-    // newly added field. The getter must resolve that to EARLIEST rather than deserializing an empty payload.
-    PartitionState partitionState = new PartitionState();
-    partitionState.upstreamLastConsumedVersionTopicPubSubPosition = ByteBuffer.allocate(0);
-    OffsetRecord offsetRecord = new OffsetRecord(
-        partitionState,
-        AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
-        DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
-    assertEquals(offsetRecord.getLatestConsumedRemoteVtPosition(), PubSubSymbolicPosition.EARLIEST);
-  }
-
-  @Test
-  public void testLatestConsumedRemoteVtPositionRoundTrip() {
+  public void testLatestConsumedRemoteVtPosition() {
     OffsetRecord fresh = new OffsetRecord(
         AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
         DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
     // Unset -> EARLIEST (empty-state default), never null.
     assertEquals(fresh.getLatestConsumedRemoteVtPosition(), PubSubSymbolicPosition.EARLIEST);
 
+    // Pre-v24 persisted record: Avro supplies the empty-bytes field default, which must also resolve to EARLIEST
+    // rather than attempting to deserialize an empty payload.
+    PartitionState preV24 = new PartitionState();
+    preV24.upstreamLastConsumedVersionTopicPubSubPosition = ByteBuffer.allocate(0);
+    OffsetRecord preV24Record = new OffsetRecord(
+        preV24,
+        AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
+        DEFAULT_PUBSUB_CONTEXT_FOR_UNIT_TESTING);
+    assertEquals(preV24Record.getLatestConsumedRemoteVtPosition(), PubSubSymbolicPosition.EARLIEST);
+
+    // A set value round-trips through serialization.
     PubSubPosition remoteLcvp = ApacheKafkaOffsetPosition.of(9677);
     fresh.setLatestConsumedRemoteVtPosition(remoteLcvp);
     OffsetRecord restored = new OffsetRecord(

--- a/internal/venice-common/src/test/java/com/linkedin/venice/schema/TestAvroSchema.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/schema/TestAvroSchema.java
@@ -75,6 +75,7 @@ public class TestAvroSchema {
     ps.lastConsumedVersionTopicPubSubPosition = ByteBuffer.wrap("".getBytes());
     ps.upstreamRealTimeTopicPubSubPositionMap = new VeniceConcurrentHashMap<>();
     ps.upstreamVersionTopicPubSubPosition = ByteBuffer.wrap("".getBytes());
+    ps.upstreamLastConsumedVersionTopicPubSubPosition = ByteBuffer.wrap("".getBytes());
 
     AvroSerializer serializer = new AvroSerializer(ps.getSchema());
     byte[] serializedBytes = serializer.serialize(ps);


### PR DESCRIPTION
> **Stacked on #2905** (PartitionState v24 schema). Review/merge #2905 first; until then this PR's diff includes that commit. Part of the `fix-global-rt-div-lcvp-eop-persistence` line of work.

## Problem Statement

With the Global RT DIV feature enabled, an Active/Active **remote-source-VT leader** can fail to resume after a
server restart that wipes RocksDB, throwing `ImproperlyStartedSegmentException` / `MissingDataException` on the
restarted replica. Only the restarted leader is affected; followers are fine.

Root cause: `getLeaderPosition` resolves the leader's version-topic start from the **in-memory processed** VT
position. After a RocksDB wipe, the leader re-consumes the **local** VT during the data-on-leader (DoL) phase and
advances the in-memory processed-remote-VT position from the local-VT records'
`leaderMetadataFooter.upstreamOffset` — **without** registering the source-VT producer's DIV segments. On F→L
promotion, subscribing the source VT at that in-memory position can land many records past where the persisted VT
DIV producer state is valid, so the first validated segment is improperly started / has a gap.

Concretely, the in-memory processed position can be far ahead of the durable, DIV-consistent checkpoint (e.g. the
restarted leader tried to resume the source VT around offset `9677`, while the durable VT-DIV-consistent position
was `2`).

Why the existing Global RT DIV shutdown work doesn't cover this:
- **#2836** (flush Global RT DIV state on graceful shutdown) and **#2886** (drain produce-side messages before the
  shutdown snapshot) harden the **write/flush** side so the snapshot isn't lost on a *clean* bounce.
- This failure is on the **resume/read** side — *which* position the leader starts from — and the trigger is a
  **RocksDB wipe** (not a clean shutdown with intact state). Even with a perfect shutdown flush, resuming from the
  in-memory processed position instead of the durable checkpoint reintroduces the desync.

There was also no persisted "last consumed **remote** VT position": `PartitionState` tracked only a single **local**
last-consumed VT position (LCVP) and the remote **processed** position — no remote counterpart to the local LCVP to
resume from.

## Solution

Track and persist a remote/upstream counterpart to the local VT last-consumed position (the "remote LCVP"), and
resolve the F→L leader start from the durable LCVP instead of the in-memory processed position.

- **Activate** the `upstreamLastConsumedVersionTopicPubSubPosition` field added in #2905 (remove the v23
  `versionOverride`; bump `PARTITION_STATE` current protocol version 23 → 24).
- **`PartitionTracker`**: a new `latestConsumedRemoteVtPosition`, advanced per remote-VT record right after
  `consumerDiv` validation (gated on `consumeRemotely() && version-topic`), cloned in `cloneVtProducerStates` and
  snapshotted into the `OffsetRecord` **atomically with the VT DIV producer segments** — so the LCVP and the DIV
  state it must agree with always move together.
- **`OffsetRecord`**: `get/setLatestConsumedRemoteVtPosition` (EARLIEST when unset).
- **`PartitionConsumptionState.getLeaderPosition`** (version-topic branch, F→L transition): resolve via
  `getCheckpointedVtLeaderPosition` → remote LCVP for a remote-consume leader, local LCVP
  (`getLatestConsumedVtPosition`, matching `getLocalVtSubscribePosition`) for a local-VT leader; EARLIEST when never
  checkpointed.

This path is gated on `isTransition && isGlobalRtDivEnabled()`, so it is a **strict no-op when Global RT DIV is
disabled** — the leader still resolves the same in-memory processed position as before.

###  Code changes
- [ ] Added new code behind **a config**. (Gated on the existing per-store Global RT DIV flag; no new config.)
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**. (Remote LCVP mirrors the existing local LCVP: an `AtomicReference` updated on the consumer thread and snapshotted with the VT segments.)
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

- `PartitionConsumptionStateTest`: F→L transition resolves to the durable remote/local LCVP, not the in-memory
  processed position (synthetic offsets `2` durable vs `9677` in-memory), and falls back to EARLIEST when never
  checkpointed; the steady-state (non-transition) path is unchanged.
- `TestOffsetRecord`: remote LCVP round-trips through serialization and defaults to EARLIEST when unset.
- `TestPartitionTracker`: the remote LCVP is snapshotted into the `OffsetRecord` and carried by
  `cloneVtProducerStates`.
- Targeted suites green: `PartitionConsumptionStateTest`, `TestOffsetRecord`, `TestPartitionTracker`,
  `DataIntegrityValidatorTest`, and the schema enumeration test.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

Additive Avro field with a default; the new resume path is gated on Global RT DIV and is a no-op when it is disabled.
