### PR TITLE
[vpj] Throw a clear error instead of NPE on a missing timestamp.field

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/utils/RmdPushUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/utils/RmdPushUtils.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.spark.utils;
 
 import com.linkedin.venice.hadoop.PushJobSetting;
+import com.linkedin.venice.hadoop.exceptions.VeniceSchemaFieldNotFoundException;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
@@ -26,7 +27,16 @@ public final class RmdPushUtils {
       throw new IllegalArgumentException(
           "Push job setting missing rmd field. Please set the rmd field in the job properties.");
     }
-    return pushJobSetting.inputDataSchema.getField(pushJobSetting.rmdField).schema();
+    Schema.Field rmdField = pushJobSetting.inputDataSchema.getField(pushJobSetting.rmdField);
+    if (rmdField == null) {
+      throw new VeniceSchemaFieldNotFoundException(
+          pushJobSetting.rmdField,
+          "Could not find the configured timestamp.field '" + pushJobSetting.rmdField
+              + "' at the top level of the push input record schema. The timestamp field must be a top-level field "
+              + "of the input record (a sibling of the key and value fields), not nested inside the value. "
+              + "Input record schema: " + pushJobSetting.inputDataSchema);
+    }
+    return rmdField.schema();
   }
 
   public static boolean containsLogicalTimestamp(PushJobSetting pushJobSetting) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/utils/RmdPushUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/utils/RmdPushUtils.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.spark.utils;
 
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.PushJobSetting;
 import com.linkedin.venice.hadoop.exceptions.VeniceSchemaFieldNotFoundException;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
@@ -26,6 +27,12 @@ public final class RmdPushUtils {
     if (!rmdFieldPresent(pushJobSetting)) {
       throw new IllegalArgumentException(
           "Push job setting missing rmd field. Please set the rmd field in the job properties.");
+    }
+    if (pushJobSetting.inputDataSchema == null) {
+      throw new VeniceException(
+          "The configured timestamp.field '" + pushJobSetting.rmdField
+              + "' cannot be resolved because the push input record schema is not available. A top-level Avro "
+              + "input record schema is required to use timestamp.field (for example, VSON inputs do not populate it).");
     }
     Schema.Field rmdField = pushJobSetting.inputDataSchema.getField(pushJobSetting.rmdField);
     if (rmdField == null) {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/TestRmdPushUtils.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/TestRmdPushUtils.java
@@ -8,6 +8,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.hadoop.PushJobSetting;
+import com.linkedin.venice.hadoop.exceptions.VeniceSchemaFieldNotFoundException;
 import com.linkedin.venice.spark.utils.RmdPushUtils;
 import org.apache.avro.Schema;
 import org.testng.annotations.Test;
@@ -32,6 +33,20 @@ public class TestRmdPushUtils {
   public void testGetInputRmdSchemaWithNoRmdField() {
     PushJobSetting pushJobSetting = new PushJobSetting();
     pushJobSetting.inputDataSchema = mock(Schema.class);
+    RmdPushUtils.getInputRmdSchema(pushJobSetting);
+  }
+
+  @Test(expectedExceptions = VeniceSchemaFieldNotFoundException.class)
+  public void testGetInputRmdSchemaWhenRmdFieldNotInInputSchema() {
+    // timestamp.field is configured, but the named field is absent from the top level of the input record schema
+    // (e.g. it is nested inside the value). getField returns null, so the call must fail with a clear error, not an
+    // NPE.
+    final String rmdField = "createdTimeEpoch";
+    Schema mockSchema = mock(Schema.class);
+    when(mockSchema.getField(eq(rmdField))).thenReturn(null);
+    PushJobSetting pushJobSetting = new PushJobSetting();
+    pushJobSetting.rmdField = rmdField;
+    pushJobSetting.inputDataSchema = mockSchema;
     RmdPushUtils.getInputRmdSchema(pushJobSetting);
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/TestRmdPushUtils.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/TestRmdPushUtils.java
@@ -7,6 +7,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.PushJobSetting;
 import com.linkedin.venice.hadoop.exceptions.VeniceSchemaFieldNotFoundException;
 import com.linkedin.venice.spark.utils.RmdPushUtils;
@@ -47,6 +48,16 @@ public class TestRmdPushUtils {
     PushJobSetting pushJobSetting = new PushJobSetting();
     pushJobSetting.rmdField = rmdField;
     pushJobSetting.inputDataSchema = mockSchema;
+    RmdPushUtils.getInputRmdSchema(pushJobSetting);
+  }
+
+  @Test(expectedExceptions = VeniceException.class)
+  public void testGetInputRmdSchemaWhenInputDataSchemaIsNull() {
+    // timestamp.field is configured but the input record schema was never populated (e.g. a VSON input). The
+    // configured-but-unavailable schema must fail with a clear error, not an NPE.
+    PushJobSetting pushJobSetting = new PushJobSetting();
+    pushJobSetting.rmdField = "createdTimeEpoch";
+    pushJobSetting.inputDataSchema = null;
     RmdPushUtils.getInputRmdSchema(pushJobSetting);
   }
 


### PR DESCRIPTION
## Problem Statement

When a batch push sets `timestamp.field` (the `RMD_FIELD_PROP` config) so that records carry a per-record replication-metadata (RMD) timestamp, the Spark data-writer validates the input's RMD schema in `RmdPushUtils.getInputRmdSchema()`:

```java
return pushJobSetting.inputDataSchema.getField(pushJobSetting.rmdField).schema();
```

This line had no null checks, so it threw an opaque `NullPointerException` in two distinct situations:

1. **`inputDataSchema` is null** — the input never populated a top-level Avro record schema. For example, VSON inputs set `rmdField` from `RMD_FIELD_PROP` in `DefaultInputDataInfoProvider` without ever setting `inputDataSchema`.
2. **The configured field is absent** — `Schema.getField()` returns `null` when `timestamp.field` is not a top-level field of the input record (nested inside the value, misnamed, or simply absent).

In both cases the user got a bare NPE at `RmdPushUtils.getInputRmdSchema` with no hint that the real problem is a misconfigured or missing `timestamp.field`. The MR record-reader path (`AbstractAvroRecordReader.getField`) already throws `VeniceSchemaFieldNotFoundException` for the missing-field case, so the same misconfiguration was legible on the MR engine but surfaced as a bare NPE on the Spark engine.

## Solution

Add explicit guards in `RmdPushUtils.getInputRmdSchema()`:

- If `inputDataSchema` is `null` → throw `VeniceException` naming the configured `timestamp.field` and noting that a top-level Avro input record schema is required (VSON inputs called out as the example).
- If the looked-up field is `null` → throw `VeniceSchemaFieldNotFoundException` naming the configured `timestamp.field` and stating it must be a top-level field of the input record (a sibling of the key and value fields, not nested inside the value). This mirrors the existing MR-path behavior.

The success path is unchanged.

## How was this PR tested?

- [x] Modified or extended existing tests. Added two cases to `TestRmdPushUtils`:
  - `testGetInputRmdSchemaWhenInputDataSchemaIsNull` — asserts `VeniceException` when `inputDataSchema` is null.
  - `testGetInputRmdSchemaWhenRmdFieldNotInInputSchema` — asserts `VeniceSchemaFieldNotFoundException` (not `NullPointerException`) when the configured field is absent from the input schema.

```
./gradlew :clients:venice-push-job:test --tests "com.linkedin.venice.hadoop.utils.TestRmdPushUtils"
```
→ 6/6 tests pass.

## Does this PR introduce any user-facing or breaking changes?

- [x] Yes (error-message improvement only). A batch push that configures `timestamp.field` either without a populated input schema, or with a field that is not present at the top level of the input record, previously failed with a `NullPointerException`. It now fails with a clear `VeniceException` / `VeniceSchemaFieldNotFoundException` whose message explains the requirement. The job still fails in the same situations — only the error is now actionable. There is no change to the success path.
