### PR TITLE
[server][da-vinci]: Raise disk health check thread priority

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/DiskHealthCheckService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/DiskHealthCheckService.java
@@ -46,6 +46,8 @@ public class DiskHealthCheckService extends AbstractVeniceService {
   // Visible for testing
   static final String TMP_FILE_NAME = ".health_check_file";
   private static final int TMP_FILE_SIZE_IN_BYTES = 64 * 1024; // 64KB
+  // Keep the disk health check responsive even when other components are under heavy load, without using max priority.
+  static final int HEALTH_CHECK_THREAD_PRIORITY = 8;
 
   // lock object protects diskHealthy and lastStatusUpdateTimeInNS.
   private final Lock lock = new ReentrantLock();
@@ -118,7 +120,8 @@ public class DiskHealthCheckService extends AbstractVeniceService {
     setLastStatusUpdateTimeInNS(System.nanoTime());
     healthCheckTask = new DiskHealthCheckTask();
     runner =
-        new DaemonThreadFactory("Storage Disk Health Check Background Thread", logContext).newThread(healthCheckTask);
+        new DaemonThreadFactory("Storage Disk Health Check Background Thread", HEALTH_CHECK_THREAD_PRIORITY, logContext)
+            .newThread(healthCheckTask);
     runner.start();
 
     return true;
@@ -159,6 +162,11 @@ public class DiskHealthCheckService extends AbstractVeniceService {
   // Only for testing
   DiskHealthCheckTask getHealthCheckTask() {
     return healthCheckTask;
+  }
+
+  // Only for testing
+  Thread getHealthCheckThread() {
+    return runner;
   }
 
   // Visible for testing

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/DiskHealthCheckServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/DiskHealthCheckServiceTest.java
@@ -29,6 +29,9 @@ public class DiskHealthCheckServiceTest {
         LogContext.forTests(VeniceComponent.SERVER.name()))) {
       diskHealthCheckService.start();
 
+      assertEquals(
+          diskHealthCheckService.getHealthCheckThread().getPriority(),
+          DiskHealthCheckService.HEALTH_CHECK_THREAD_PRIORITY);
       assertTrue(diskHealthCheckService.isDiskHealthy());
       assertNull(diskHealthCheckService.getErrorMessage());
       assertTrue(diskHealthCheckService.getDiskHealthy());


### PR DESCRIPTION
## Problem Statement

The Venice Server `/health` endpoint depends on `DiskHealthCheckService.isDiskHealthy()`, whose state is updated by a background disk health check thread.

Currently, that background thread is created without an explicit priority, so it inherits the default JVM thread priority. Under heavy load, or when another server component misbehaves and consumes excessive CPU, the disk health check thread can be delayed. If the disk health status is not refreshed within the configured timeout, the server may report an unhealthy disk even though the health check thread was simply starved.

This change is necessary to make the disk health check more responsive and reduce the chance that a misbehaving component prevents timely health status updates.

## Solution

Set the disk health check background thread priority to slightly above normal.

`DiskHealthCheckService` already creates the background thread through `DaemonThreadFactory`, which supports explicit thread priorities. This PR switches the health check thread creation to use the priority-aware constructor while preserving the existing daemon behavior, thread naming, and `LogContext` propagation.

Performance considerations / trade-offs:

- The health check thread runs periodically and performs a small disk read/write validation, so raising its priority should not materially increase CPU usage.
- This only affects the disk health check background thread.
- No persisted state, wire protocol, public API, or config semantics are changed.

Testing performed:

- Ran the focused unit test class:

```bash
./gradlew :clients:da-vinci-client:test --tests com.linkedin.davinci.storage.DiskHealthCheckServiceTest