### PR TITLE
[vpj]: Always refresh storage quota to honor mid-push quota changes

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1979,8 +1979,11 @@ public class VenicePushJob implements AutoCloseable {
    * quota is retained so a transient controller error does not derail the push.
    */
   private void refreshStorageQuota() {
-    // Repush intentionally disables the quota check by setting an unlimited quota; don't override it.
-    if (pushJobSetting.storeStorageQuota == Store.UNLIMITED_STORAGE_QUOTA) {
+    // Repush (source Kafka) intentionally disables the quota check; don't re-fetch and re-enable it.
+    // Note: this is gated on isSourceKafka rather than the quota value, so a regular store that is
+    // genuinely configured with an unlimited quota is still refreshed and a mid-push reduction to a
+    // finite quota is honored.
+    if (pushJobSetting.isSourceKafka) {
       return;
     }
     try {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1924,11 +1924,24 @@ public class VenicePushJob implements AutoCloseable {
     final boolean writersMayHaveTruncated =
         (dataWriterComputeJob == null || dataWriterComputeJob.truncatesDataExceedingQuota())
             && new InputStorageQuotaTracker(quotaUsedByWriters).exceedQuota(totalInputDataSizeInBytes);
-    if (inputStorageQuotaTracker.exceedQuota(totalInputDataSizeInBytes) || writersMayHaveTruncated) {
+    final boolean refreshedQuotaExceeded = inputStorageQuotaTracker.exceedQuota(totalInputDataSizeInBytes);
+    if (refreshedQuotaExceeded || writersMayHaveTruncated) {
       updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.QUOTA_EXCEEDED);
-      // Report against the quota the writers actually used as the truncation boundary when they may
-      // have truncated, otherwise the (refreshed) store quota.
-      Long storeQuota = writersMayHaveTruncated ? quotaUsedByWriters : inputStorageQuotaTracker.getStoreStorageQuota();
+      if (writersMayHaveTruncated && !refreshedQuotaExceeded) {
+        // The current quota now covers the input, but the writers already truncated the dataset against
+        // the quota that was in effect when the job started, so this version is incomplete. The operator
+        // does not need more quota (they may have already raised it) — they need to re-run the push.
+        return String.format(
+            "Storage quota exceeded while writing the data. The store quota when the push started was %s"
+                + " and the input data size is %s, so the data writer truncated the dataset. The quota has"
+                + " since been increased to %s; please re-run the push to write the complete dataset.",
+            generateHumanReadableByteCountString(quotaUsedByWriters),
+            generateHumanReadableByteCountString(totalInputDataSizeInBytes),
+            generateHumanReadableByteCountString(inputStorageQuotaTracker.getStoreStorageQuota()));
+      }
+      // Report the shortfall against the current (refreshed) store quota so the operator requests the
+      // right amount.
+      Long storeQuota = inputStorageQuotaTracker.getStoreStorageQuota();
       return String.format(
           "Storage quota exceeded. Store quota %s, Input data size %s."
               + " Please request at least %s additional quota.",

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1910,15 +1910,25 @@ public class VenicePushJob implements AutoCloseable {
     // Quota exceeded
     final long totalInputDataSizeInBytes =
         dataWriterTaskTracker.getTotalKeySize() + dataWriterTaskTracker.getTotalValueSize();
-    // Always re-fetch the quota from the controller before evaluating it. The store quota can change
-    // (either increased or reduced) while the push is running, so relying on the value cached at job
-    // initialization can both fail a push spuriously (after an increase) and let one through that should
-    // now be rejected (after a reduction). Refreshing here keeps the decision consistent with the
-    // current store configuration.
+    // Re-fetch the store quota from the controller so a mid-push quota change is honored. The store
+    // quota can be raised (or lowered) while a push is running; because this driver-side check runs
+    // after the data writer job completes, refreshing here lets the push reflect the current quota.
+    //
+    // Safety for engines that truncate data beyond the quota while writing (e.g. MapReduce): such
+    // engines drop records once the job-start quota is hit, leaving a partial dataset on the topic. For
+    // those we must NOT accept a mid-push increase, or we would promote an incomplete version. Spark
+    // never truncates (the full dataset is always written), so accepting an increase is safe.
+    final long quotaUsedByWriters = pushJobSetting.storeStorageQuota;
     refreshStorageQuota();
-    if (inputStorageQuotaTracker.exceedQuota(totalInputDataSizeInBytes)) {
+    // If the engine is unknown (null) assume it truncates (fail-safe); Spark reports false, MR true.
+    final boolean writersMayHaveTruncated =
+        (dataWriterComputeJob == null || dataWriterComputeJob.truncatesDataExceedingQuota())
+            && new InputStorageQuotaTracker(quotaUsedByWriters).exceedQuota(totalInputDataSizeInBytes);
+    if (inputStorageQuotaTracker.exceedQuota(totalInputDataSizeInBytes) || writersMayHaveTruncated) {
       updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.QUOTA_EXCEEDED);
-      Long storeQuota = inputStorageQuotaTracker.getStoreStorageQuota();
+      // Report against the quota the writers actually used as the truncation boundary when they may
+      // have truncated, otherwise the (refreshed) store quota.
+      Long storeQuota = writersMayHaveTruncated ? quotaUsedByWriters : inputStorageQuotaTracker.getStoreStorageQuota();
       return String.format(
           "Storage quota exceeded. Store quota %s, Input data size %s."
               + " Please request at least %s additional quota.",
@@ -1967,12 +1977,12 @@ public class VenicePushJob implements AutoCloseable {
 
   /**
    * Re-fetch the store storage quota from the controller and update the quota tracker if it changed.
-   * This is invoked on every push before the quota check so that both increases and reductions that
-   * happen while the push is running are honored.
+   * This is invoked from the driver-side quota check ({@link #updatePushJobDetailsWithJobDetails}) after
+   * the data writer job completes, so a quota change that happened while the push was running is honored.
    *
    * <p>This performs a targeted quota-only fetch and intentionally does not reuse
    * {@link #getStoreResponse(String, boolean)} so it won't mutate the other cached store settings
-   * (compression strategy, chunking, max record size, etc.) on the happy path.
+   * (compression strategy, chunking, max record size, etc.).
    *
    * <p>Repush jobs (source Kafka) deliberately set the quota to {@link Store#UNLIMITED_STORAGE_QUOTA}
    * to skip the quota check, so those are left untouched. If the controller call fails, the cached

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1911,14 +1911,25 @@ public class VenicePushJob implements AutoCloseable {
     final long totalInputDataSizeInBytes =
         dataWriterTaskTracker.getTotalKeySize() + dataWriterTaskTracker.getTotalValueSize();
     if (inputStorageQuotaTracker.exceedQuota(totalInputDataSizeInBytes)) {
-      updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.QUOTA_EXCEEDED);
-      Long storeQuota = inputStorageQuotaTracker.getStoreStorageQuota();
-      return String.format(
-          "Storage quota exceeded. Store quota %s, Input data size %s."
-              + " Please request at least %s additional quota.",
-          generateHumanReadableByteCountString(storeQuota),
-          generateHumanReadableByteCountString(totalInputDataSizeInBytes),
-          generateHumanReadableByteCountString(totalInputDataSizeInBytes - storeQuota));
+      // Re-fetch quota from the controller before failing. The quota may have been increased
+      // after the push started (e.g., a Nuage approval that landed mid-push). Without this
+      // refresh the VPJ uses the stale value from job initialization and fails spuriously.
+      refreshStorageQuota();
+      if (inputStorageQuotaTracker.exceedQuota(totalInputDataSizeInBytes)) {
+        updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.QUOTA_EXCEEDED);
+        Long storeQuota = inputStorageQuotaTracker.getStoreStorageQuota();
+        return String.format(
+            "Storage quota exceeded. Store quota %s, Input data size %s."
+                + " Please request at least %s additional quota.",
+            generateHumanReadableByteCountString(storeQuota),
+            generateHumanReadableByteCountString(totalInputDataSizeInBytes),
+            generateHumanReadableByteCountString(totalInputDataSizeInBytes - storeQuota));
+      }
+      LOGGER.info(
+          "Storage quota was exceeded based on cached value, but after refreshing from the controller "
+              + "the updated quota ({}) accommodates the input data size ({}). Continuing.",
+          generateHumanReadableByteCountString(pushJobSetting.storeStorageQuota),
+          generateHumanReadableByteCountString(totalInputDataSizeInBytes));
     }
     // Write ACL failed
     final long writeAclFailureCount = dataWriterTaskTracker.getWriteAclAuthorizationFailureCount();
@@ -1957,6 +1968,29 @@ public class VenicePushJob implements AutoCloseable {
           formatRecordTooLargeCompressionStatus());
     }
     return null;
+  }
+
+  /**
+   * Re-fetch the storage quota from the controller and update the quota tracker.
+   * Called only when the cached quota would cause a QUOTA_EXCEEDED failure, so
+   * there is no extra controller call on the happy path.
+   */
+  private void refreshStorageQuota() {
+    try {
+      StoreResponse storeResponse = getStoreResponse(pushJobSetting.storeName, true);
+      long freshQuota = storeResponse.getStore().getStorageQuotaInByte();
+      if (freshQuota != pushJobSetting.storeStorageQuota) {
+        LOGGER.info(
+            "Storage quota for store {} changed during push from {} to {}.",
+            pushJobSetting.storeName,
+            pushJobSetting.storeStorageQuota,
+            freshQuota);
+        pushJobSetting.storeStorageQuota = freshQuota;
+        inputStorageQuotaTracker = new InputStorageQuotaTracker(freshQuota);
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Failed to refresh storage quota from controller. Using cached value.", e);
+    }
   }
 
   /* Helper function to format part of the record too large compression status */

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1910,26 +1910,21 @@ public class VenicePushJob implements AutoCloseable {
     // Quota exceeded
     final long totalInputDataSizeInBytes =
         dataWriterTaskTracker.getTotalKeySize() + dataWriterTaskTracker.getTotalValueSize();
+    // Always re-fetch the quota from the controller before evaluating it. The store quota can change
+    // (either increased or reduced) while the push is running, so relying on the value cached at job
+    // initialization can both fail a push spuriously (after an increase) and let one through that should
+    // now be rejected (after a reduction). Refreshing here keeps the decision consistent with the
+    // current store configuration.
+    refreshStorageQuota();
     if (inputStorageQuotaTracker.exceedQuota(totalInputDataSizeInBytes)) {
-      // Re-fetch quota from the controller before failing. The quota may have been increased
-      // after the push started (e.g., a Nuage approval that landed mid-push). Without this
-      // refresh the VPJ uses the stale value from job initialization and fails spuriously.
-      refreshStorageQuota();
-      if (inputStorageQuotaTracker.exceedQuota(totalInputDataSizeInBytes)) {
-        updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.QUOTA_EXCEEDED);
-        Long storeQuota = inputStorageQuotaTracker.getStoreStorageQuota();
-        return String.format(
-            "Storage quota exceeded. Store quota %s, Input data size %s."
-                + " Please request at least %s additional quota.",
-            generateHumanReadableByteCountString(storeQuota),
-            generateHumanReadableByteCountString(totalInputDataSizeInBytes),
-            generateHumanReadableByteCountString(totalInputDataSizeInBytes - storeQuota));
-      }
-      LOGGER.info(
-          "Storage quota was exceeded based on cached value, but after refreshing from the controller "
-              + "the updated quota ({}) accommodates the input data size ({}). Continuing.",
-          generateHumanReadableByteCountString(pushJobSetting.storeStorageQuota),
-          generateHumanReadableByteCountString(totalInputDataSizeInBytes));
+      updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.QUOTA_EXCEEDED);
+      Long storeQuota = inputStorageQuotaTracker.getStoreStorageQuota();
+      return String.format(
+          "Storage quota exceeded. Store quota %s, Input data size %s."
+              + " Please request at least %s additional quota.",
+          generateHumanReadableByteCountString(storeQuota),
+          generateHumanReadableByteCountString(totalInputDataSizeInBytes),
+          generateHumanReadableByteCountString(totalInputDataSizeInBytes - storeQuota));
     }
     // Write ACL failed
     final long writeAclFailureCount = dataWriterTaskTracker.getWriteAclAuthorizationFailureCount();
@@ -1971,13 +1966,35 @@ public class VenicePushJob implements AutoCloseable {
   }
 
   /**
-   * Re-fetch the storage quota from the controller and update the quota tracker.
-   * Called only when the cached quota would cause a QUOTA_EXCEEDED failure, so
-   * there is no extra controller call on the happy path.
+   * Re-fetch the store storage quota from the controller and update the quota tracker if it changed.
+   * This is invoked on every push before the quota check so that both increases and reductions that
+   * happen while the push is running are honored.
+   *
+   * <p>This performs a targeted quota-only fetch and intentionally does not reuse
+   * {@link #getStoreResponse(String, boolean)} so it won't mutate the other cached store settings
+   * (compression strategy, chunking, max record size, etc.) on the happy path.
+   *
+   * <p>Repush jobs (source Kafka) deliberately set the quota to {@link Store#UNLIMITED_STORAGE_QUOTA}
+   * to skip the quota check, so those are left untouched. If the controller call fails, the cached
+   * quota is retained so a transient controller error does not derail the push.
    */
   private void refreshStorageQuota() {
+    // Repush intentionally disables the quota check by setting an unlimited quota; don't override it.
+    if (pushJobSetting.storeStorageQuota == Store.UNLIMITED_STORAGE_QUOTA) {
+      return;
+    }
     try {
-      StoreResponse storeResponse = getStoreResponse(pushJobSetting.storeName, true);
+      StoreResponse storeResponse = ControllerClient.retryableRequest(
+          controllerClient,
+          pushJobSetting.controllerRetries,
+          c -> c.getStore(pushJobSetting.storeName));
+      if (storeResponse.isError()) {
+        LOGGER.warn(
+            "Failed to refresh storage quota for store {} from controller: {}. Using cached value.",
+            pushJobSetting.storeName,
+            storeResponse.getError());
+        return;
+      }
       long freshQuota = storeResponse.getStore().getStorageQuotaInByte();
       if (freshQuota != pushJobSetting.storeStorageQuota) {
         LOGGER.info(

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/jobs/DataWriterComputeJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/jobs/DataWriterComputeJob.java
@@ -98,6 +98,22 @@ public abstract class DataWriterComputeJob implements ComputeJob {
     return Optional.empty();
   }
 
+  /**
+   * Whether this engine <em>truncates</em> the dataset while writing: i.e. once the running size hits the
+   * configured storage quota it stops emitting further records, leaving a partial dataset on the version
+   * topic. Note this is not "quota enforcement" (the push is failed by the driver, not by the writer) —
+   * it is a write-time optimization that drops data beyond the quota.
+   *
+   * <p>This matters for the driver-side quota re-check: if the quota is raised mid-push, the driver may
+   * only accept the (now-larger) quota when the complete dataset was written. Engines that truncate may
+   * have produced an incomplete dataset against the job-start quota, so the driver must not accept an
+   * increased quota for them. The default is {@code true} (fail-safe); engines that never truncate and
+   * always write the full dataset (e.g. Spark) override this to {@code false}.
+   */
+  public boolean truncatesDataExceedingQuota() {
+    return true;
+  }
+
   @VisibleForTesting
   public void validateJob() {
     DataWriterTaskTracker dataWriterTaskTracker = getTaskTracker();

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -184,6 +184,17 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
   }
 
   /**
+   * Spark never truncates the dataset while writing: the per-partition writers cannot see the
+   * whole-dataset size during execution (see {@code AbstractPartitionWriter#getTotalIncomingDataSizeInBytes}
+   * which returns 0 for Spark), so the complete dataset is always written and the driver-side check is the
+   * authoritative gate. This makes it safe for the driver to accept a mid-push quota increase.
+   */
+  @Override
+  public boolean truncatesDataExceedingQuota() {
+    return false;
+  }
+
+  /**
    * Common configuration for all the Mapreduce Jobs run as part of VPJ
    *
    * @param config

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.ConfigKeys.MULTI_REGION;
 import static com.linkedin.venice.hadoop.VenicePushJob.getExecutionStatusFromControllerResponse;
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENABLED_CONFIG;
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
+import static com.linkedin.venice.utils.ByteUtils.generateHumanReadableByteCountString;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_OH_SUPERSET_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_UPDATE_SCHEMA;
@@ -1641,8 +1642,17 @@ public class VenicePushJobTest {
     }
   }
 
+  /** Spark-like (never truncates) or MR-like (truncates) data writer job for the quota-check tests. */
+  private void setDataWriterComputeJobTruncation(VenicePushJob vpj, boolean truncatesDataExceedingQuota) {
+    DataWriterComputeJob job = mock(DataWriterComputeJob.class);
+    doReturn(truncatesDataExceedingQuota).when(job).truncatesDataExceedingQuota();
+    vpj.setDataWriterComputeJob(job);
+  }
+
   @Test
-  public void testUpdatePushJobDetailsRefreshesQuotaBeforeFailing() {
+  public void testDriverAcceptsMidPushQuotaIncreaseForSpark() {
+    // The 1102 pattern: quota raised mid-push to a value that covers the input. Spark writes the full
+    // dataset, so the driver check must refresh and accept the increase.
     final long cachedQuota = 100L;
     final long refreshedQuota = 1000L;
     final long totalInputDataSize = 600L;
@@ -1652,6 +1662,7 @@ public class VenicePushJobTest {
       setPushJobSettingDefaults(vpj.getPushJobSetting());
       vpj.getPushJobSetting().storeStorageQuota = cachedQuota;
       vpj.setInputStorageQuotaTracker(new InputStorageQuotaTracker(cachedQuota));
+      setDataWriterComputeJobTruncation(vpj, false); // Spark: never truncates
 
       final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
       doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalKeySize();
@@ -1664,17 +1675,17 @@ public class VenicePushJobTest {
   }
 
   @Test
-  public void testUpdatePushJobDetailsStillFailsWhenRefreshedQuotaIsInsufficient() {
+  public void testDriverStillFailsWhenRefreshedQuotaIsInsufficient() {
     final long cachedQuota = 100L;
     final long refreshedQuota = 500L;
     final long totalInputDataSize = 600L;
-    // Force refresh returns a higher-but-still-insufficient quota, so the push must still fail.
     ControllerClient client = getClient(storeInfo -> storeInfo.setStorageQuotaInByte(refreshedQuota));
 
     try (final VenicePushJob vpj = getSpyVenicePushJob(getVpjRequiredProperties(), client)) {
       setPushJobSettingDefaults(vpj.getPushJobSetting());
       vpj.getPushJobSetting().storeStorageQuota = cachedQuota;
       vpj.setInputStorageQuotaTracker(new InputStorageQuotaTracker(cachedQuota));
+      setDataWriterComputeJobTruncation(vpj, false);
 
       final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
       doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalKeySize();
@@ -1692,11 +1703,10 @@ public class VenicePushJobTest {
   }
 
   @Test
-  public void testUpdatePushJobDetailsFallsBackToCachedQuotaWhenRefreshFails() {
+  public void testDriverFallsBackToCachedQuotaWhenRefreshFails() {
     final long cachedQuota = 100L;
     final long totalInputDataSize = 600L;
     ControllerClient client = getClient();
-    // Force refresh from the controller fails; the push must fall back to the cached quota and still fail.
     StoreResponse errorResponse = new StoreResponse();
     errorResponse.setError("Simulated controller failure");
     doReturn(errorResponse).when(client).getStore(TEST_STORE);
@@ -1705,6 +1715,7 @@ public class VenicePushJobTest {
       setPushJobSettingDefaults(vpj.getPushJobSetting());
       vpj.getPushJobSetting().storeStorageQuota = cachedQuota;
       vpj.setInputStorageQuotaTracker(new InputStorageQuotaTracker(cachedQuota));
+      setDataWriterComputeJobTruncation(vpj, false);
 
       final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
       doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalKeySize();
@@ -1713,7 +1724,6 @@ public class VenicePushJobTest {
       final String errorMessage = vpj.updatePushJobDetailsWithJobDetails(dataWriterTaskTracker);
       assertNotNull(errorMessage);
       assertTrue(errorMessage.contains("Storage quota exceeded"), errorMessage);
-      // Cached quota is retained because the refresh failed.
       assertEquals(vpj.getPushJobSetting().storeStorageQuota, cachedQuota);
       assertEquals(
           vpj.getPushJobDetails().pushJobLatestCheckpoint.intValue(),
@@ -1722,18 +1732,19 @@ public class VenicePushJobTest {
   }
 
   @Test
-  public void testUpdatePushJobDetailsRejectsPushWhenQuotaReducedDuringPush() {
+  public void testDriverRejectsPushWhenQuotaReducedDuringPush() {
+    // Cached quota (1000) would have allowed the 600 input, but the quota was reduced to 500 mid-push.
+    // The unconditional refresh must pick up the reduction and fail.
     final long cachedQuota = 1000L;
     final long refreshedQuota = 500L;
     final long totalInputDataSize = 600L;
-    // The cached quota (1000) would have allowed this push, but the quota was reduced to 500 during
-    // the push, so the refreshed value must cause the push to fail.
     ControllerClient client = getClient(storeInfo -> storeInfo.setStorageQuotaInByte(refreshedQuota));
 
     try (final VenicePushJob vpj = getSpyVenicePushJob(getVpjRequiredProperties(), client)) {
       setPushJobSettingDefaults(vpj.getPushJobSetting());
       vpj.getPushJobSetting().storeStorageQuota = cachedQuota;
       vpj.setInputStorageQuotaTracker(new InputStorageQuotaTracker(cachedQuota));
+      setDataWriterComputeJobTruncation(vpj, false);
 
       final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
       doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalKeySize();
@@ -1751,17 +1762,47 @@ public class VenicePushJobTest {
   }
 
   @Test
-  public void testUpdatePushJobDetailsSkipsQuotaRefreshForRepush() {
+  public void testDriverRejectsMidPushIncreaseWhenWriterTruncated() {
+    // MR truncates the dataset against the job-start quota (100), so even though the quota was raised to
+    // 1000 mid-push, the driver must NOT accept it (the topic data is incomplete).
+    final long cachedQuota = 100L;
+    final long refreshedQuota = 1000L;
+    final long totalInputDataSize = 600L;
+    ControllerClient client = getClient(storeInfo -> storeInfo.setStorageQuotaInByte(refreshedQuota));
+
+    try (final VenicePushJob vpj = getSpyVenicePushJob(getVpjRequiredProperties(), client)) {
+      setPushJobSettingDefaults(vpj.getPushJobSetting());
+      vpj.getPushJobSetting().storeStorageQuota = cachedQuota;
+      vpj.setInputStorageQuotaTracker(new InputStorageQuotaTracker(cachedQuota));
+      setDataWriterComputeJobTruncation(vpj, true); // MR: truncates
+
+      final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
+      doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalKeySize();
+      doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalValueSize();
+
+      final String errorMessage = vpj.updatePushJobDetailsWithJobDetails(dataWriterTaskTracker);
+      assertNotNull(errorMessage);
+      assertTrue(errorMessage.contains("Storage quota exceeded"), errorMessage);
+      // Reported against the quota the writers used as the truncation boundary (100), not the refreshed one.
+      assertTrue(errorMessage.contains(generateHumanReadableByteCountString(cachedQuota)), errorMessage);
+      assertEquals(
+          vpj.getPushJobDetails().pushJobLatestCheckpoint.intValue(),
+          PushJobCheckpoints.QUOTA_EXCEEDED.getValue());
+    }
+  }
+
+  @Test
+  public void testDriverSkipsQuotaRefreshForRepush() {
     final long totalInputDataSize = 600L;
     ControllerClient client = getClient();
 
     try (final VenicePushJob vpj = getSpyVenicePushJob(getVpjRequiredProperties(), client)) {
       setPushJobSettingDefaults(vpj.getPushJobSetting());
-      // Repush (source Kafka) disables the quota check via an unlimited quota; the refresh must be
-      // skipped for repush so it is not re-enabled by re-fetching the store's real quota.
+      // Repush (source Kafka) disables the quota check via an unlimited quota; refresh must be skipped.
       vpj.getPushJobSetting().isSourceKafka = true;
       vpj.getPushJobSetting().storeStorageQuota = Store.UNLIMITED_STORAGE_QUOTA;
       vpj.setInputStorageQuotaTracker(new InputStorageQuotaTracker(Store.UNLIMITED_STORAGE_QUOTA));
+      setDataWriterComputeJobTruncation(vpj, false);
 
       final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
       doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalKeySize();
@@ -1774,11 +1815,11 @@ public class VenicePushJobTest {
   }
 
   @Test
-  public void testUpdatePushJobDetailsEnforcesQuotaWhenUnlimitedStoreReducedDuringPush() {
+  public void testDriverEnforcesQuotaWhenUnlimitedStoreReducedDuringPush() {
+    // A regular (non-repush) store starts unlimited, then the quota is set to a finite value during the
+    // push. The refresh must pick up the reduction and fail.
     final long refreshedQuota = 500L;
     final long totalInputDataSize = 600L;
-    // A regular (non-repush) store starts with an unlimited quota, then the quota is set to a finite
-    // value during the push. The refresh must pick up the reduction and fail the push.
     ControllerClient client = getClient(storeInfo -> storeInfo.setStorageQuotaInByte(refreshedQuota));
 
     try (final VenicePushJob vpj = getSpyVenicePushJob(getVpjRequiredProperties(), client)) {
@@ -1786,6 +1827,7 @@ public class VenicePushJobTest {
       vpj.getPushJobSetting().isSourceKafka = false;
       vpj.getPushJobSetting().storeStorageQuota = Store.UNLIMITED_STORAGE_QUOTA;
       vpj.setInputStorageQuotaTracker(new InputStorageQuotaTracker(Store.UNLIMITED_STORAGE_QUOTA));
+      setDataWriterComputeJobTruncation(vpj, false);
 
       final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
       doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalKeySize();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -92,6 +92,7 @@ import com.linkedin.venice.jobs.DataWriterComputeJob;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.MaterializedViewParameters;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
@@ -1659,6 +1660,114 @@ public class VenicePushJobTest {
       assertNull(vpj.updatePushJobDetailsWithJobDetails(dataWriterTaskTracker));
       assertEquals(vpj.getPushJobSetting().storeStorageQuota, refreshedQuota);
       verify(client, times(1)).getStore(TEST_STORE);
+    }
+  }
+
+  @Test
+  public void testUpdatePushJobDetailsStillFailsWhenRefreshedQuotaIsInsufficient() {
+    final long cachedQuota = 100L;
+    final long refreshedQuota = 500L;
+    final long totalInputDataSize = 600L;
+    // Force refresh returns a higher-but-still-insufficient quota, so the push must still fail.
+    ControllerClient client = getClient(storeInfo -> storeInfo.setStorageQuotaInByte(refreshedQuota));
+
+    try (final VenicePushJob vpj = getSpyVenicePushJob(getVpjRequiredProperties(), client)) {
+      setPushJobSettingDefaults(vpj.getPushJobSetting());
+      vpj.getPushJobSetting().storeStorageQuota = cachedQuota;
+      vpj.setInputStorageQuotaTracker(new InputStorageQuotaTracker(cachedQuota));
+
+      final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
+      doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalKeySize();
+      doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalValueSize();
+
+      final String errorMessage = vpj.updatePushJobDetailsWithJobDetails(dataWriterTaskTracker);
+      assertNotNull(errorMessage);
+      assertTrue(errorMessage.contains("Storage quota exceeded"), errorMessage);
+      assertEquals(vpj.getPushJobSetting().storeStorageQuota, refreshedQuota);
+      assertEquals(
+          vpj.getPushJobDetails().pushJobLatestCheckpoint.intValue(),
+          PushJobCheckpoints.QUOTA_EXCEEDED.getValue());
+      verify(client, times(1)).getStore(TEST_STORE);
+    }
+  }
+
+  @Test
+  public void testUpdatePushJobDetailsFallsBackToCachedQuotaWhenRefreshFails() {
+    final long cachedQuota = 100L;
+    final long totalInputDataSize = 600L;
+    ControllerClient client = getClient();
+    // Force refresh from the controller fails; the push must fall back to the cached quota and still fail.
+    StoreResponse errorResponse = new StoreResponse();
+    errorResponse.setError("Simulated controller failure");
+    doReturn(errorResponse).when(client).getStore(TEST_STORE);
+
+    try (final VenicePushJob vpj = getSpyVenicePushJob(getVpjRequiredProperties(), client)) {
+      setPushJobSettingDefaults(vpj.getPushJobSetting());
+      vpj.getPushJobSetting().storeStorageQuota = cachedQuota;
+      vpj.setInputStorageQuotaTracker(new InputStorageQuotaTracker(cachedQuota));
+
+      final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
+      doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalKeySize();
+      doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalValueSize();
+
+      final String errorMessage = vpj.updatePushJobDetailsWithJobDetails(dataWriterTaskTracker);
+      assertNotNull(errorMessage);
+      assertTrue(errorMessage.contains("Storage quota exceeded"), errorMessage);
+      // Cached quota is retained because the refresh failed.
+      assertEquals(vpj.getPushJobSetting().storeStorageQuota, cachedQuota);
+      assertEquals(
+          vpj.getPushJobDetails().pushJobLatestCheckpoint.intValue(),
+          PushJobCheckpoints.QUOTA_EXCEEDED.getValue());
+    }
+  }
+
+  @Test
+  public void testUpdatePushJobDetailsRejectsPushWhenQuotaReducedDuringPush() {
+    final long cachedQuota = 1000L;
+    final long refreshedQuota = 500L;
+    final long totalInputDataSize = 600L;
+    // The cached quota (1000) would have allowed this push, but the quota was reduced to 500 during
+    // the push, so the refreshed value must cause the push to fail.
+    ControllerClient client = getClient(storeInfo -> storeInfo.setStorageQuotaInByte(refreshedQuota));
+
+    try (final VenicePushJob vpj = getSpyVenicePushJob(getVpjRequiredProperties(), client)) {
+      setPushJobSettingDefaults(vpj.getPushJobSetting());
+      vpj.getPushJobSetting().storeStorageQuota = cachedQuota;
+      vpj.setInputStorageQuotaTracker(new InputStorageQuotaTracker(cachedQuota));
+
+      final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
+      doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalKeySize();
+      doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalValueSize();
+
+      final String errorMessage = vpj.updatePushJobDetailsWithJobDetails(dataWriterTaskTracker);
+      assertNotNull(errorMessage);
+      assertTrue(errorMessage.contains("Storage quota exceeded"), errorMessage);
+      assertEquals(vpj.getPushJobSetting().storeStorageQuota, refreshedQuota);
+      assertEquals(
+          vpj.getPushJobDetails().pushJobLatestCheckpoint.intValue(),
+          PushJobCheckpoints.QUOTA_EXCEEDED.getValue());
+      verify(client, times(1)).getStore(TEST_STORE);
+    }
+  }
+
+  @Test
+  public void testUpdatePushJobDetailsSkipsQuotaRefreshForUnlimitedQuota() {
+    final long totalInputDataSize = 600L;
+    ControllerClient client = getClient();
+
+    try (final VenicePushJob vpj = getSpyVenicePushJob(getVpjRequiredProperties(), client)) {
+      setPushJobSettingDefaults(vpj.getPushJobSetting());
+      // Repush disables the quota check via an unlimited quota; the refresh must not override it.
+      vpj.getPushJobSetting().storeStorageQuota = Store.UNLIMITED_STORAGE_QUOTA;
+      vpj.setInputStorageQuotaTracker(new InputStorageQuotaTracker(Store.UNLIMITED_STORAGE_QUOTA));
+
+      final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
+      doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalKeySize();
+      doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalValueSize();
+
+      assertNull(vpj.updatePushJobDetailsWithJobDetails(dataWriterTaskTracker));
+      assertEquals(vpj.getPushJobSetting().storeStorageQuota, Store.UNLIMITED_STORAGE_QUOTA);
+      verify(client, never()).getStore(TEST_STORE);
     }
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -63,6 +63,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -1639,6 +1640,28 @@ public class VenicePushJobTest {
     }
   }
 
+  @Test
+  public void testUpdatePushJobDetailsRefreshesQuotaBeforeFailing() {
+    final long cachedQuota = 100L;
+    final long refreshedQuota = 1000L;
+    final long totalInputDataSize = 600L;
+    ControllerClient client = getClient(storeInfo -> storeInfo.setStorageQuotaInByte(refreshedQuota));
+
+    try (final VenicePushJob vpj = getSpyVenicePushJob(getVpjRequiredProperties(), client)) {
+      setPushJobSettingDefaults(vpj.getPushJobSetting());
+      vpj.getPushJobSetting().storeStorageQuota = cachedQuota;
+      vpj.setInputStorageQuotaTracker(new InputStorageQuotaTracker(cachedQuota));
+
+      final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
+      doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalKeySize();
+      doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalValueSize();
+
+      assertNull(vpj.updatePushJobDetailsWithJobDetails(dataWriterTaskTracker));
+      assertEquals(vpj.getPushJobSetting().storeStorageQuota, refreshedQuota);
+      verify(client, times(1)).getStore(TEST_STORE);
+    }
+  }
+
   /**
    * Tests that the error message for the {@link com.linkedin.venice.PushJobCheckpoints#RECORD_TOO_LARGE_FAILED} code path of
    * {@link VenicePushJob#updatePushJobDetailsWithJobDetails(DataWriterTaskTracker)} uses maxRecordSizeBytes.
@@ -1681,7 +1704,7 @@ public class VenicePushJobTest {
 
   /**
    * These are mainly for code coverage for the code paths of {@link VenicePushJob#getVeniceWriter(PushJobSetting)} and
-   * {@link VenicePushJob#getVeniceWriterProperties(PushJobSetting)}.
+   * {@code VenicePushJob#getVeniceWriterProperties(PushJobSetting)}.
    */
   @Test
   public void testGetVeniceWriter() {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -1751,13 +1751,15 @@ public class VenicePushJobTest {
   }
 
   @Test
-  public void testUpdatePushJobDetailsSkipsQuotaRefreshForUnlimitedQuota() {
+  public void testUpdatePushJobDetailsSkipsQuotaRefreshForRepush() {
     final long totalInputDataSize = 600L;
     ControllerClient client = getClient();
 
     try (final VenicePushJob vpj = getSpyVenicePushJob(getVpjRequiredProperties(), client)) {
       setPushJobSettingDefaults(vpj.getPushJobSetting());
-      // Repush disables the quota check via an unlimited quota; the refresh must not override it.
+      // Repush (source Kafka) disables the quota check via an unlimited quota; the refresh must be
+      // skipped for repush so it is not re-enabled by re-fetching the store's real quota.
+      vpj.getPushJobSetting().isSourceKafka = true;
       vpj.getPushJobSetting().storeStorageQuota = Store.UNLIMITED_STORAGE_QUOTA;
       vpj.setInputStorageQuotaTracker(new InputStorageQuotaTracker(Store.UNLIMITED_STORAGE_QUOTA));
 
@@ -1768,6 +1770,35 @@ public class VenicePushJobTest {
       assertNull(vpj.updatePushJobDetailsWithJobDetails(dataWriterTaskTracker));
       assertEquals(vpj.getPushJobSetting().storeStorageQuota, Store.UNLIMITED_STORAGE_QUOTA);
       verify(client, never()).getStore(TEST_STORE);
+    }
+  }
+
+  @Test
+  public void testUpdatePushJobDetailsEnforcesQuotaWhenUnlimitedStoreReducedDuringPush() {
+    final long refreshedQuota = 500L;
+    final long totalInputDataSize = 600L;
+    // A regular (non-repush) store starts with an unlimited quota, then the quota is set to a finite
+    // value during the push. The refresh must pick up the reduction and fail the push.
+    ControllerClient client = getClient(storeInfo -> storeInfo.setStorageQuotaInByte(refreshedQuota));
+
+    try (final VenicePushJob vpj = getSpyVenicePushJob(getVpjRequiredProperties(), client)) {
+      setPushJobSettingDefaults(vpj.getPushJobSetting());
+      vpj.getPushJobSetting().isSourceKafka = false;
+      vpj.getPushJobSetting().storeStorageQuota = Store.UNLIMITED_STORAGE_QUOTA;
+      vpj.setInputStorageQuotaTracker(new InputStorageQuotaTracker(Store.UNLIMITED_STORAGE_QUOTA));
+
+      final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
+      doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalKeySize();
+      doReturn(totalInputDataSize / 2).when(dataWriterTaskTracker).getTotalValueSize();
+
+      final String errorMessage = vpj.updatePushJobDetailsWithJobDetails(dataWriterTaskTracker);
+      assertNotNull(errorMessage);
+      assertTrue(errorMessage.contains("Storage quota exceeded"), errorMessage);
+      assertEquals(vpj.getPushJobSetting().storeStorageQuota, refreshedQuota);
+      assertEquals(
+          vpj.getPushJobDetails().pushJobLatestCheckpoint.intValue(),
+          PushJobCheckpoints.QUOTA_EXCEEDED.getValue());
+      verify(client, times(1)).getStore(TEST_STORE);
     }
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -1783,8 +1783,12 @@ public class VenicePushJobTest {
       final String errorMessage = vpj.updatePushJobDetailsWithJobDetails(dataWriterTaskTracker);
       assertNotNull(errorMessage);
       assertTrue(errorMessage.contains("Storage quota exceeded"), errorMessage);
-      // Reported against the quota the writers used as the truncation boundary (100), not the refreshed one.
+      // The dataset was truncated against the job-start quota, so the operator should re-run the push,
+      // not "request more" quota (the quota was already raised to cover the input).
+      assertTrue(errorMessage.contains("re-run the push"), errorMessage);
+      assertFalse(errorMessage.contains("additional quota"), errorMessage);
       assertTrue(errorMessage.contains(generateHumanReadableByteCountString(cachedQuota)), errorMessage);
+      assertTrue(errorMessage.contains(generateHumanReadableByteCountString(refreshedQuota)), errorMessage);
       assertEquals(
           vpj.getPushJobDetails().pushJobLatestCheckpoint.intValue(),
           PushJobCheckpoints.QUOTA_EXCEEDED.getValue());


### PR DESCRIPTION
## Problem Statement

VPJ initializes the storage quota tracker (`InputStorageQuotaTracker`) from the store quota fetched near job startup. That value is then used, unchanged, to decide whether the push exceeds quota after the data writer job completes.

Because the quota can change while a push is running, relying on the value cached at initialization is wrong in both directions:
- If the quota is **increased** mid-push (e.g. an approval that lands while the job runs), VPJ can still fail with `QUOTA_EXCEEDED` based on the stale, lower value.
- If the quota is **reduced** mid-push, VPJ can let a push through that should now be rejected.

## Solution

Always re-fetch the store storage quota from the controller before evaluating it, then perform a single quota check against the fresh value. This keeps the decision consistent with the current store configuration regardless of the direction of the change.

Details:
- Added `refreshStorageQuota()`, invoked unconditionally at the start of the quota check.
- It uses a **targeted quota-only** controller call (`ControllerClient.retryableRequest(... getStore ...)`) rather than the broader cached `getStoreResponse(..., true)`, so it does not mutate other cached store settings (compression strategy, chunking, max record size) on every push.
- Repush jobs (source Kafka) intentionally set the quota to `UNLIMITED_STORAGE_QUOTA` to skip the check; the refresh is skipped in that case so the skip semantics are preserved.
- If the controller call fails, VPJ logs a warning and retains the cached quota so a transient controller error does not derail the push.

Trade-off: this adds one controller `getStore` call per push at quota-check time (skipped for unlimited/repush). This is intentional so both increases and reductions are honored.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

New log lines fire at most once per push (quota-changed info line, or a warning on refresh failure), so no rate limiting is needed.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

The refresh and quota check run on the single job-control thread; `inputStorageQuotaTracker` is only reassigned from that flow, and no new async execution or shared concurrent state is introduced.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

Added `VenicePushJobTest` cases covering:
- quota increased mid-push → push proceeds
- quota refreshed but still insufficient → push fails with `QUOTA_EXCEEDED`
- quota reduced mid-push → push now fails
- controller refresh failure → falls back to cached quota and fails
- unlimited/repush quota → refresh skipped (`getStore` never called)

Existing record-too-large tests still pass, and `spotlessJavaCheck` passes.

```bash
./gradlew :clients:venice-push-job:test --tests "com.linkedin.venice.hadoop.VenicePushJobTest.testUpdatePushJobDetails*"
./gradlew spotlessJavaCheck