### PR TITLE
[vpj] Handle union writer schemas in value schema projection

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -188,9 +188,10 @@ public class PushJobSetting implements Serializable {
   public Map<Integer, String> newKmeSchemasFromController;
 
   /**
-   * Schema-projection: target writer value schema to project superset
-   * input records down to (see {@code TARGET_WRITER_VALUE_SCHEMA_ID_PROP}).
-   * */
+   * Schema projection (internal / advanced use only &mdash; see {@code TARGET_WRITER_VALUE_SCHEMA_ID_PROP}): the
+   * target writer value schema ID to project superset input records down to. {@code -1} (default) disables projection.
+   * Not intended for regular push jobs; misuse silently drops fields absent from the target writer schema.
+   */
   public int targetWriterValueSchemaId = -1;
   public boolean projectInputToWriterSchema;
   public Schema writerValueSchema;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2370,8 +2370,11 @@ public class VenicePushJob implements AutoCloseable {
   /**
    * Configure projection of input records down to a user-specified registered writer (target) value schema, used when
    * the input value schema does not match any registered value schema. Fetches the writer schema by ID, validates that
-   * the input value schema is a strict superset of it, and enables
-   * {@link com.linkedin.venice.schema.projection.VeniceSchemaProjector}-based projection.
+   * the input value schema is a projection-compatible superset of it (it may add fields and wrap fields as nullable
+   * unions), and enables {@link com.linkedin.venice.schema.projection.VeniceSchemaProjector}-based projection.
+   *
+   * <p>Note: this is an internal / advanced-use flow (see {@code TARGET_WRITER_VALUE_SCHEMA_ID_PROP}), not intended
+   * for regular push jobs.
    */
   private void configureValueSchemaProjection(ControllerClient controllerClient, PushJobSetting setting) {
     int writerSchemaId = setting.targetWriterValueSchemaId;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -348,9 +348,12 @@ public final class VenicePushJobConstants {
   public static final String VALUE_SCHEMA_ID_PROP = "value.schema.id";
 
   /**
-   * Optional writer (target) value schema ID. When set, input records are projected down to this schema
-   * via {@link com.linkedin.venice.schema.projection.VeniceSchemaProjector}; the input schema must
-   * be a strict superset of it.
+   * <strong>Internal / advanced use only &mdash; NOT for regular push jobs.</strong> Optional writer (target) value
+   * schema ID; when set, input records are projected down to that registered schema (via
+   * {@link com.linkedin.venice.schema.projection.VeniceSchemaProjector}) before serialization. The input schema must
+   * be a projection-compatible superset. Supports full (batch) pushes only. Projection <em>drops</em> fields absent
+   * from the target schema (silent, irreversible data loss if misused); leave unset (default {@code -1}) unless
+   * operating an internal flow (e.g. purger/re-push) that requires it.
    */
   public static final String TARGET_WRITER_VALUE_SCHEMA_ID_PROP = "target.writer.value.schema.id";
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/projection/VeniceSchemaProjector.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/projection/VeniceSchemaProjector.java
@@ -71,6 +71,17 @@ public class VeniceSchemaProjector {
    */
   @SuppressWarnings("unchecked")
   private static Object projectField(Schema writerType, Schema inputType, Object value) {
+    // Normalize single-element unions [X] to X (semantically equivalent) so they project like the bare type.
+    if (writerType.getType() == Schema.Type.UNION && writerType.getTypes().size() == 1) {
+      return projectField(writerType.getTypes().get(0), inputType, value);
+    }
+    if (inputType.getType() == Schema.Type.UNION && inputType.getTypes().size() == 1) {
+      return projectField(writerType, inputType.getTypes().get(0), value);
+    }
+    // Unwrap a nullable-union writer [null, X] to its non-null branch (complex unions are blocked upstream).
+    if (AvroSchemaUtils.isNullableUnionPair(writerType) && writerType.getTypes().get(0).getType() == Schema.Type.NULL) {
+      return projectField(writerType.getTypes().get(1), inputType, value);
+    }
     // Unwrap nullable wrapping on the input side: input null-first [null, X] against a non-union writer projects the
     // value against X. The runtime value is already the (possibly null) non-null-branch value.
     if (writerType.getType() != Schema.Type.UNION && AvroSchemaUtils.isNullableUnionPair(inputType)
@@ -107,7 +118,7 @@ public class VeniceSchemaProjector {
         return projectedMap;
       }
       default:
-        // Primitives, enums, fixed, and unions: validation guarantees compatibility, so copy the value as-is.
+        // Primitives, enums, and fixed: validation guarantees compatibility, so copy the value as-is.
         return value;
     }
   }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
@@ -363,6 +363,18 @@ public class AvroSupersetSchemaUtils {
   }
 
   private static boolean isProjectionSubset(Schema writerSchema, Schema inputSchema) {
+    // Normalize single-element unions [X] to X (semantically equivalent) so they project like the bare type.
+    writerSchema = unwrapSingleElementUnion(writerSchema);
+    inputSchema = unwrapSingleElementUnion(inputSchema);
+    rejectComplexUnion(writerSchema);
+    rejectComplexUnion(inputSchema);
+    // A nullable-union writer [null, X] requires a nullable-union input [null, X']; unwrap both to the non-null branch.
+    if (AvroSchemaUtils.isNullableUnionPair(writerSchema)
+        && writerSchema.getTypes().get(0).getType() == Schema.Type.NULL) {
+      return AvroSchemaUtils.isNullableUnionPair(inputSchema)
+          && inputSchema.getTypes().get(0).getType() == Schema.Type.NULL
+          && isProjectionSubset(writerSchema.getTypes().get(1), inputSchema.getTypes().get(1));
+    }
     // Unwrap nullable wrapping on the input side only: an input null-first [null, X] against a non-union writer matches
     // writer vs X. Null-last ([X, null]) is not OH-produced, so it is left to fail the type check below.
     if (writerSchema.getType() != Schema.Type.UNION && AvroSchemaUtils.isNullableUnionPair(inputSchema)
@@ -391,9 +403,29 @@ public class AvroSupersetSchemaUtils {
       case MAP:
         return isProjectionSubset(writerSchema.getValueType(), inputSchema.getValueType());
       default:
-        // Primitives, enums, fixed, and unions (nullable on both sides or otherwise) must match exactly. Reverse
-        // nullability drift (writer union vs non-union input) is already rejected above by the type check.
+        // Primitives, enums, and fixed must match exactly.
         return writerSchema.equals(inputSchema);
+    }
+  }
+
+  /**
+   * Complex unions (more than one non-null branch, e.g. {@code [X, Y]} or {@code [null, X, Y]}) are not supported for
+   * value schema projection. Only nullable wrapping ({@code [null, X]}) is allowed. Throws if {@param schema} is a
+   * complex union.
+   */
+  private static void rejectComplexUnion(Schema schema) {
+    if (schema.getType() != Schema.Type.UNION) {
+      return;
+    }
+    int nonNullBranchCount = 0;
+    for (Schema branch: schema.getTypes()) {
+      if (branch.getType() != Schema.Type.NULL) {
+        nonNullBranchCount++;
+      }
+    }
+    if (nonNullBranchCount > 1) {
+      throw new VeniceException(
+          "Complex unions (more than one non-null branch) are not supported for value schema projection: " + schema);
     }
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -1007,12 +1007,13 @@ public class TestAvroSupersetSchemaUtils {
     Assert
         .assertFalse(AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputWrongType.toString()));
 
-    // A non-nullable complex union (not a [null, X] pair) must not be treated as a nullable wrap.
+    // A non-nullable complex union (not a [null, X] pair) is blocked with a clear error.
     Schema inputComplexUnion = AvroCompatibilityHelper.parse(
         "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
             + "{\"name\":\"f1\",\"type\":[\"null\",\"string\",\"int\"],\"default\":null}]}");
-    Assert.assertFalse(
-        AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputComplexUnion.toString()));
+    Assert.expectThrows(
+        VeniceException.class,
+        () -> AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputComplexUnion.toString()));
 
     // A missing writer field in the input still fails (writer not a subset of input).
     Schema inputMissingField = AvroCompatibilityHelper
@@ -1039,15 +1040,95 @@ public class TestAvroSupersetSchemaUtils {
   @Test
   public void testValidateSubsetSchemaForProjectionBlocksNestedMultiUnion() {
     // The complex-union guardrail also applies recursively: a 3-branch union ([null, string, int]) inside a
-    // nested record is not a [null, X] wrap and must stay blocked, mirroring the top-level guardrail.
+    // nested record is not a [null, X] wrap and is blocked with a clear error, mirroring the top-level guardrail.
     Schema writer = AvroCompatibilityHelper.parse(
         "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"nested\",\"type\":"
             + "{\"type\":\"record\",\"name\":\"N\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"}]}}]}");
     Schema inputNestedMultiUnion = AvroCompatibilityHelper.parse(
         "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"nested\",\"type\":"
             + "{\"type\":\"record\",\"name\":\"N\",\"fields\":[{\"name\":\"city\",\"type\":[\"null\",\"string\",\"int\"],\"default\":null}]}}]}");
-    Assert.assertFalse(
-        AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputNestedMultiUnion.toString()));
+    Assert.expectThrows(
+        VeniceException.class,
+        () -> AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, inputNestedMultiUnion.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionRelaxesNullableUnionWriterEvolvedBranch() {
+    // A nullable-union writer [null, Addr{city}] projects from a nullable-union input whose non-null branch evolved
+    // into a superset ([null, Addr{city, zip}]): the non-null branch is a projection-subset, so this is allowed.
+    Schema writer = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"addr\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"Addr\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"}]}],"
+            + "\"default\":null}]}");
+    Schema input = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"addr\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"Addr\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"},"
+            + "{\"name\":\"zip\",\"type\":[\"null\",\"int\"],\"default\":null}]}],\"default\":null}]}");
+    Assert.assertTrue(AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, input.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionBlocksNullableUnionWriterNonSubsetBranch() {
+    // A nullable-union writer still enforces the subset rule on its non-null branch: writer [null, Addr{city}] vs
+    // input [null, Addr{zip}] fails because the writer's `city` field is absent from the input's non-null branch.
+    Schema writer = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"addr\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"Addr\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"}]}],"
+            + "\"default\":null}]}");
+    Schema input = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"addr\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"Addr\",\"fields\":[{\"name\":\"zip\",\"type\":\"int\"}]}],"
+            + "\"default\":null}]}");
+    Assert.assertFalse(AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, input.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionBlocksComplexUnionOnWriterSide() {
+    // The complex-union guardrail applies to the writer schema too: a writer field typed [null, string, int] is
+    // blocked with a clear error, mirroring the input-side guardrail.
+    Schema writerComplexUnion = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+            + "{\"name\":\"f1\",\"type\":[\"null\",\"string\",\"int\"],\"default\":null}]}");
+    Schema input = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+            + "{\"name\":\"f1\",\"type\":[\"null\",\"string\",\"int\"],\"default\":null}]}");
+    Assert.expectThrows(
+        VeniceException.class,
+        () -> AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writerComplexUnion, input.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionAllowsEmptyStructWriterAgainstDummyFilledInput() {
+    // An empty-struct writer (fields: []) is a projection-subset of the OH input that fills the struct with a synthetic
+    // dummy field: the writer declares no fields, so the input's dummy filler is a tolerated extra field.
+    Schema writer = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"recordWithEmptyStruct\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"emptyStructRecord\","
+            + "\"namespace\":\"com.linkedin.SchemaWithEmptyStructs.emptyStruct\",\"doc\":\"record with empty struct\","
+            + "\"fields\":[{\"name\":\"emptyStructUnionField\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"emptyStructField\",\"fields\":[]}],\"default\":null}]}],"
+            + "\"default\":null}]}");
+    Schema input = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"recordWithEmptyStruct\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"emptyStructRecord\","
+            + "\"namespace\":\"com.linkedin.SchemaWithEmptyStructs.emptyStruct\",\"doc\":\"record with empty struct\","
+            + "\"fields\":[{\"name\":\"emptyStructUnionField\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"emptyStructField\",\"fields\":[{\"name\":"
+            + "\"__dummy_field_to_fill_empty_struct__\",\"type\":\"int\",\"doc\":"
+            + "\"Dummy field added to handle empty struct records.\",\"default\":-1}]}],\"default\":null}]}],"
+            + "\"default\":null}]}");
+    Assert.assertTrue(AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, input.toString()));
+  }
+
+  @Test
+  public void testValidateSubsetSchemaForProjectionAllowsSingleElementUnionWriter() {
+    // Input field: nullable union [null, long]. Writer field: single-element union [long], which is semantically
+    // equivalent to a bare long, so the nullable input projects onto it.
+    Schema writer = AvroCompatibilityHelper
+        .parse("{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"f1\",\"type\":[\"long\"]}]}");
+    Schema input = AvroCompatibilityHelper.parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"f1\",\"type\":[\"null\",\"long\"],\"default\":null}]}");
+    Assert.assertTrue(AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection(writer, input.toString()));
   }
 
   @Test

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/projection/TestVeniceSchemaProjector.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/projection/TestVeniceSchemaProjector.java
@@ -373,6 +373,113 @@ public class TestVeniceSchemaProjector {
   }
 
   @Test
+  public void testNullableUnionWriterFieldProjectedAndExtraDropped() {
+    // A nullable-union writer [null, Addr{city}] against a nullable-union input whose non-null branch evolved into a
+    // superset [null, Addr{city, zip}]: the present record value is rebuilt under the writer's non-null branch and the
+    // extra `zip` field is dropped.
+    Schema writer = parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"addr\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"Addr\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"}]}],"
+            + "\"default\":null}]}");
+    Schema input = parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"addr\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"Addr\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"},"
+            + "{\"name\":\"zip\",\"type\":[\"null\",\"int\"],\"default\":null}]}],\"default\":null}]}");
+    Schema inputAddrSchema = input.getField("addr").schema().getTypes().get(1);
+    GenericRecord addr = new GenericData.Record(inputAddrSchema);
+    addr.put("city", "NYC");
+    addr.put("zip", 10001);
+    GenericRecord src = new GenericData.Record(input);
+    src.put("addr", addr);
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    GenericRecord outAddr = (GenericRecord) out.get("addr");
+    Assert.assertEquals(outAddr.getSchema().getName(), "Addr");
+    Assert.assertEquals(outAddr.get("city").toString(), "NYC");
+    Assert.assertNull(outAddr.getSchema().getField("zip"), "extra field in the nullable-union branch must be dropped");
+  }
+
+  @Test
+  public void testNullableUnionWriterFieldWithNullValueProjectedToNull() {
+    // Null value against a nullable-union writer [null, Addr] projects to null (the null branch needs no rebuild).
+    Schema writer = parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"addr\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"Addr\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"}]}],"
+            + "\"default\":null}]}");
+    Schema input = parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"addr\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"Addr\",\"fields\":[{\"name\":\"city\",\"type\":\"string\"},"
+            + "{\"name\":\"zip\",\"type\":[\"null\",\"int\"],\"default\":null}]}],\"default\":null}]}");
+    GenericRecord src = new GenericData.Record(input);
+    src.put("addr", null);
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    Assert.assertNull(out.get("addr"));
+  }
+
+  @Test
+  public void testSingleElementUnionWriterFieldProjectsValue() {
+    // Input field: nullable union [null, long]. Writer field: single-element union [long] (equivalent to bare long).
+    // The present value projects onto the writer's single-element union.
+    Schema writer = parse("{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"f1\",\"type\":[\"long\"]}]}");
+    Schema input = parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"f1\",\"type\":[\"null\",\"long\"],\"default\":null}]}");
+    GenericRecord src = new GenericData.Record(input);
+    src.put("f1", 42L);
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    Assert.assertEquals(out.get("f1"), 42L);
+  }
+
+  @Test
+  public void testEmptyStructWriterDropsDummyFillerField() {
+    // OH cannot represent an empty struct, so it fills it with a synthetic dummy field. The registered writer keeps the
+    // empty struct; projection must rebuild the (empty) writer record and drop the input's dummy filler field.
+    Schema writer = parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"recordWithEmptyStruct\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"emptyStructRecord\","
+            + "\"namespace\":\"com.linkedin.SchemaWithEmptyStructs.emptyStruct\",\"doc\":\"record with empty struct\","
+            + "\"fields\":[{\"name\":\"emptyStructUnionField\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"emptyStructField\",\"fields\":[]}],\"default\":null}]}],"
+            + "\"default\":null}]}");
+    Schema input = parse(
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"recordWithEmptyStruct\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"emptyStructRecord\","
+            + "\"namespace\":\"com.linkedin.SchemaWithEmptyStructs.emptyStruct\",\"doc\":\"record with empty struct\","
+            + "\"fields\":[{\"name\":\"emptyStructUnionField\",\"type\":[\"null\","
+            + "{\"type\":\"record\",\"name\":\"emptyStructField\",\"fields\":[{\"name\":"
+            + "\"__dummy_field_to_fill_empty_struct__\",\"type\":\"int\",\"doc\":"
+            + "\"Dummy field added to handle empty struct records.\",\"default\":-1}]}],\"default\":null}]}],"
+            + "\"default\":null}]}");
+    Schema inputEmptyStructRecord = input.getField("recordWithEmptyStruct").schema().getTypes().get(1);
+    Schema inputEmptyStructField = inputEmptyStructRecord.getField("emptyStructUnionField").schema().getTypes().get(1);
+    GenericRecord innerStruct = new GenericData.Record(inputEmptyStructField);
+    innerStruct.put("__dummy_field_to_fill_empty_struct__", -1);
+    GenericRecord outerStruct = new GenericData.Record(inputEmptyStructRecord);
+    outerStruct.put("emptyStructUnionField", innerStruct);
+    GenericRecord src = new GenericData.Record(input);
+    src.put("recordWithEmptyStruct", outerStruct);
+
+    GenericRecord out = projector.projectValue(src, writer);
+
+    Assert.assertEquals(out.getSchema(), writer);
+    GenericRecord outOuter = (GenericRecord) out.get("recordWithEmptyStruct");
+    Assert.assertEquals(outOuter.getSchema().getName(), "emptyStructRecord");
+    GenericRecord outInner = (GenericRecord) outOuter.get("emptyStructUnionField");
+    Assert.assertEquals(outInner.getSchema().getName(), "emptyStructField");
+    Assert.assertTrue(outInner.getSchema().getFields().isEmpty(), "projected empty struct must have no fields");
+    Assert.assertNull(
+        outInner.getSchema().getField("__dummy_field_to_fill_empty_struct__"),
+        "OH dummy filler field must be dropped");
+  }
+
+  @Test
   public void testDeeplyNestedExtraFieldDropped() {
     // Projection recurses to arbitrary depth: an extra retained field two record levels down (R -> outer -> inner)
     // must still be dropped while the deeper non-nullable leaf is copied across.


### PR DESCRIPTION
## Problem Statement

Value-schema projection maps a value serialized against a superset schema down to the registered writer schema (dropping extra fields). The projector and its preflight subset check switched only on RECORD / ARRAY / MAP / default, with no handling for union-typed fields. Union writer fields fell through to exact-equality, so a valid  [null, X]  writer against a  [null, X']  superset input (where  X'  extends  X ) failed projection.


## Solution

• Nullable unions  [null, X]  — unwrapped to the non-null branch and projected recursively, so nullable records/arrays and nested nullability drift project correctly.
• Single-element unions  [X]  — normalized to  X .
• Complex unions (>1 non-null branch, e.g.  [X, Y] ) — explicitly rejected with a clear  VeniceException  instead of silently failing.
• Input-side nullable unwrapping retained; reverse nullability drift (writer  [null, X]  vs input  X ) stays blocked.


###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
- [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [x] New unit tests added.
- [x] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.