### PR TITLE
[controller] Fix stuck push on ONLINE parent version and child-verify rollback retention

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
@@ -296,9 +296,30 @@ public abstract class AbstractStore implements Store {
   @Override
   public List<Version> retrieveVersionsToDelete(int clusterNumVersionsToPreserve) {
     checkVersionSupplier();
+    return computeVersionsToDelete(
+        storeVersionsSupplier.getForRead(),
+        getCurrentVersion(),
+        clusterNumVersionsToPreserve,
+        getNumVersionsToPreserve(),
+        isMigrating());
+  }
+
+  /**
+   * Same version-deletion policy as {@link #retrieveVersionsToDelete(int)}, but over raw fields so
+   * callers that only hold a version snapshot (e.g. a child {@code StoreInfo}) can reuse it without a
+   * full {@link Store}. {@code storeNumVersionsToPreserve} is the store-level override
+   * ({@link #NUM_VERSION_PRESERVE_NOT_SET} when unset, in which case {@code clusterNumVersionsToPreserve}
+   * applies). Assumes {@code versions} is sorted by version number ascending.
+   */
+  public static List<Version> computeVersionsToDelete(
+      List<Version> versions,
+      int currentVersion,
+      int clusterNumVersionsToPreserve,
+      int storeNumVersionsToPreserve,
+      boolean isMigrating) {
     int curNumVersionsToPreserve = clusterNumVersionsToPreserve;
-    if (getNumVersionsToPreserve() != NUM_VERSION_PRESERVE_NOT_SET) {
-      curNumVersionsToPreserve = getNumVersionsToPreserve();
+    if (storeNumVersionsToPreserve != NUM_VERSION_PRESERVE_NOT_SET) {
+      curNumVersionsToPreserve = storeNumVersionsToPreserve;
     }
     // when numVersionsToPreserve is less than 1, it usually means a config issue.
     // Setting it to zero, will cause the store to be deleted as soon as push completes.
@@ -307,13 +328,11 @@ public abstract class AbstractStore implements Store {
           "At least 1 version should be preserved. Parameter " + curNumVersionsToPreserve);
     }
 
-    List<Version> versions = storeVersionsSupplier.getForRead();
     int versionCnt = versions.size();
     if (versionCnt == 0) {
       return Collections.emptyList();
     }
 
-    // The code assumes that Versions are sorted in increasing order by addVersion and increaseVersion
     int lastElementIndex = versionCnt - 1;
     List<Version> versionsToDelete = new ArrayList<>();
 
@@ -327,8 +346,7 @@ public abstract class AbstractStore implements Store {
      */
     // current version need not be the largest version, preseve it before finding other versions > current version
     for (int i = lastElementIndex; i >= 0; i--) {
-      Version version = versions.get(i);
-      if (version.getNumber() == getCurrentVersion()) { // currentVersion is always preserved
+      if (versions.get(i).getNumber() == currentVersion) { // currentVersion is always preserved
         curNumVersionsToPreserve--;
       }
     }
@@ -336,7 +354,7 @@ public abstract class AbstractStore implements Store {
     for (int i = lastElementIndex; i >= 0; i--) {
       Version version = versions.get(i);
 
-      if (version.getNumber() == getCurrentVersion()) { // currentVersion is always preserved
+      if (version.getNumber() == currentVersion) { // currentVersion is always preserved
         continue;
       }
       if (VersionStatus.isVersionRolledBack(version.getStatus())) {
@@ -354,7 +372,7 @@ public abstract class AbstractStore implements Store {
         } else {
           versionsToDelete.add(version);
         }
-      } else if (VersionStatus.STARTED.equals(version.getStatus()) && (i != lastElementIndex) && !isMigrating()) {
+      } else if (VersionStatus.STARTED.equals(version.getStatus()) && (i != lastElementIndex) && !isMigrating) {
         // For the non-last started version, if it's not the current version(STARTED version should not be the current
         // version, just prevent some edge cases here.), we should delete it only if the store is not migrating
         // as during store migration are there are concurrent pushes with STARTED version.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3047,16 +3047,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             return new Pair<>(false, null);
           }
 
-          // Block the push if backup versions are pending deletion but still within the min cleanup delay.
-          VersionLifecyclePolicy.checkBackupVersionCleanupCapacityForNewPush(
-              clusterName,
-              storeName,
-              store,
-              store.getBackupStrategy(),
-              minNumberOfStoreVersionsToPreserve,
-              multiClusterConfigs.getControllerConfig(clusterName).getBackupVersionMinCleanupDelayMs(),
-              System.currentTimeMillis());
-
           backupStrategy = store.getBackupStrategy();
           offlinePushStrategy = store.getOffLinePushStrategy();
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3057,15 +3057,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               multiClusterConfigs.getControllerConfig(clusterName).getBackupVersionMinCleanupDelayMs(),
               System.currentTimeMillis());
 
-          // Block the push if any rollback-origin version (ROLLED_BACK, or rollback-origin
-          // PARTIALLY_ONLINE on the parent) is still within its retention window. Gives fat clients time
-          // to switch to the new version.
-          VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
-              clusterName,
-              storeName,
-              store,
-              multiClusterConfigs.getControllerConfig(clusterName).getRolledBackVersionRetentionMs(),
-              System.currentTimeMillis());
           backupStrategy = store.getBackupStrategy();
           offlinePushStrategy = store.getOffLinePushStrategy();
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1783,10 +1783,9 @@ public class VeniceParentHelixAdmin implements Admin {
 
       // Block on the parent if a child still has a ROLLED_BACK version within retention, or backup
       // versions pending deletion within the min cleanup delay — verified from LIVE child status,
-      // not stale parent metadata. See each method's javadoc for rationale.
+      // not stale parent metadata. See the method javadoc for rationale.
       if (VeniceSystemStoreType.getSystemStoreType(storeName) == null) {
-        checkRollbackOriginVersionCapacityFromChildren(clusterName, storeName);
-        checkBackupVersionCleanupCapacityFromChildren(clusterName, storeName);
+        checkNewPushCapacityFromChildren(clusterName, storeName);
       }
     }
 
@@ -2433,30 +2432,34 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   /**
-   * Blocks a new push if any reachable child region still has a {@code ROLLED_BACK} version within
-   * its retention window, using LIVE child status. We do NOT consult parent metadata, which can go
-   * stale and either falsely block or falsely allow. This runs once per new-push start, so querying
-   * every child is negligible. It runs only on the parent — a throw during child admin-message
-   * consumption ({@code VeniceHelixAdmin.addVersion}) would wedge the admin channel.
+   * Parent-only push-start gate: for each reachable child region, fetch its LIVE {@code StoreInfo}
+   * once and apply both capacity guards — rollback-origin retention and backup-version cleanup
+   * delay — to that single snapshot. We use live child status, not parent metadata, which can go
+   * stale and either falsely block or falsely allow. It runs only on the parent: a throw during
+   * child admin-message consumption ({@code VeniceHelixAdmin.addVersion}) would wedge the admin
+   * channel.
    *
-   * <p>Matches {@code ROLLED_BACK} only: a per-region rollback is binary, so a child is never
-   * rollback-{@code PARTIALLY_ONLINE} (that is a parent-only aggregate); a child
+   * <p>Rollback matches {@code ROLLED_BACK} only: a per-region rollback is binary, so a child is
+   * never rollback-{@code PARTIALLY_ONLINE} (that is a parent-only aggregate); a child
    * {@code PARTIALLY_ONLINE} is a degraded-mode forward push and must not block. A partial rollback
    * is still caught because its rolled-back region reports {@code ROLLED_BACK}.
    *
-   * <p>Unreachable/errored regions are skipped (and logged); with no reachable rolled-back child the
-   * push is allowed.
+   * <p>Unreachable/errored/malformed regions are skipped (and logged); with no reachable child that
+   * violates either guard the push is allowed. A genuine violation throws to reject the push.
    */
-  void checkRollbackOriginVersionCapacityFromChildren(String clusterName, String storeName) {
+  void checkNewPushCapacityFromChildren(String clusterName, String storeName) {
     long rolledBackVersionRetentionMs =
         getMultiClusterConfigs().getControllerConfig(clusterName).getRolledBackVersionRetentionMs();
+    int minNumberOfStoreVersionsToPreserve = getMultiClusterConfigs().getMinNumberOfStoreVersionsToPreserve();
+    long minBackupVersionCleanupDelayMs =
+        getMultiClusterConfigs().getControllerConfig(clusterName).getBackupVersionMinCleanupDelayMs();
     long currentTimeMs = System.currentTimeMillis();
 
     Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
     if (controllerClients.isEmpty()) {
       // No children to verify against; parent metadata can be stale, so skip rather than block.
       LOGGER.warn(
-          "No child controller clients for cluster {}; skipping rollback-origin retention check for store {}",
+          "No child controller clients for cluster {}; skipping new-push capacity checks for store {}",
           clusterName,
           storeName);
       return;
@@ -2468,7 +2471,7 @@ public class VeniceParentHelixAdmin implements Admin {
         storeResponse = entry.getValue().getStore(storeName, CONTROLLER_STORE_POLL_TIMEOUT);
       } catch (Exception e) {
         LOGGER.warn(
-            "Could not get store {} from region {} for rollback-origin retention check; skipping region",
+            "Could not get store {} from region {} for new-push capacity checks; skipping region",
             storeName,
             region,
             e);
@@ -2476,16 +2479,17 @@ public class VeniceParentHelixAdmin implements Admin {
       }
       if (storeResponse == null || storeResponse.isError()) {
         LOGGER.warn(
-            "Could not get store {} from region {} for rollback-origin retention check ({}); skipping region",
+            "Could not get store {} from region {} for new-push capacity checks ({}); skipping region",
             storeName,
             region,
             storeResponse == null ? "null response" : storeResponse.getError());
         continue;
       }
       StoreInfo childStore = storeResponse.getStore();
-      if (childStore == null) {
+      if (childStore == null || childStore.getVersions() == null) {
+        // StoreInfo defaults versions to null; treat a missing snapshot like any other bad response.
         LOGGER.warn(
-            "Null store payload for {} from region {} during rollback-origin retention check; skipping region",
+            "Missing store/version payload for {} from region {} during new-push capacity checks; skipping region",
             storeName,
             region);
         continue;
@@ -2499,61 +2503,6 @@ public class VeniceParentHelixAdmin implements Admin {
           childStore.getLatestVersionPromoteToCurrentTimestamp(),
           rolledBackVersionRetentionMs,
           currentTimeMs);
-    }
-  }
-
-  /**
-   * Blocks a new push if any reachable child region still has backup versions pending deletion but
-   * within the min cleanup delay, using LIVE child status. Mirrors
-   * {@link #checkRollbackOriginVersionCapacityFromChildren} — it runs once per new-push start on the
-   * parent only, because a throw during child admin-message consumption
-   * ({@code VeniceHelixAdmin.addVersion}) would wedge the admin channel. Unreachable/errored regions
-   * are skipped (and logged).
-   */
-  void checkBackupVersionCleanupCapacityFromChildren(String clusterName, String storeName) {
-    int minNumberOfStoreVersionsToPreserve = getMultiClusterConfigs().getMinNumberOfStoreVersionsToPreserve();
-    long minBackupVersionCleanupDelayMs =
-        getMultiClusterConfigs().getControllerConfig(clusterName).getBackupVersionMinCleanupDelayMs();
-    long currentTimeMs = System.currentTimeMillis();
-
-    Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
-    if (controllerClients.isEmpty()) {
-      // No children to verify against; parent metadata can be stale, so skip rather than block.
-      LOGGER.warn(
-          "No child controller clients for cluster {}; skipping backup-version cleanup check for store {}",
-          clusterName,
-          storeName);
-      return;
-    }
-    for (Map.Entry<String, ControllerClient> entry: controllerClients.entrySet()) {
-      String region = entry.getKey();
-      StoreResponse storeResponse;
-      try {
-        storeResponse = entry.getValue().getStore(storeName, CONTROLLER_STORE_POLL_TIMEOUT);
-      } catch (Exception e) {
-        LOGGER.warn(
-            "Could not get store {} from region {} for backup-version cleanup check; skipping region",
-            storeName,
-            region,
-            e);
-        continue;
-      }
-      if (storeResponse == null || storeResponse.isError()) {
-        LOGGER.warn(
-            "Could not get store {} from region {} for backup-version cleanup check ({}); skipping region",
-            storeName,
-            region,
-            storeResponse == null ? "null response" : storeResponse.getError());
-        continue;
-      }
-      StoreInfo childStore = storeResponse.getStore();
-      if (childStore == null) {
-        LOGGER.warn(
-            "Null store payload for {} from region {} during backup-version cleanup check; skipping region",
-            storeName,
-            region);
-        continue;
-      }
       VersionLifecyclePolicy.checkBackupVersionCleanupCapacityForNewPush(
           clusterName,
           storeName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2463,7 +2463,17 @@ public class VeniceParentHelixAdmin implements Admin {
     }
     for (Map.Entry<String, ControllerClient> entry: controllerClients.entrySet()) {
       String region = entry.getKey();
-      StoreResponse storeResponse = entry.getValue().getStore(storeName, CONTROLLER_STORE_POLL_TIMEOUT);
+      StoreResponse storeResponse;
+      try {
+        storeResponse = entry.getValue().getStore(storeName, CONTROLLER_STORE_POLL_TIMEOUT);
+      } catch (Exception e) {
+        LOGGER.warn(
+            "Could not get store {} from region {} for rollback-origin retention check; skipping region",
+            storeName,
+            region,
+            e);
+        continue;
+      }
       if (storeResponse == null || storeResponse.isError()) {
         LOGGER.warn(
             "Could not get store {} from region {} for rollback-origin retention check ({}); skipping region",
@@ -2517,7 +2527,17 @@ public class VeniceParentHelixAdmin implements Admin {
     }
     for (Map.Entry<String, ControllerClient> entry: controllerClients.entrySet()) {
       String region = entry.getKey();
-      StoreResponse storeResponse = entry.getValue().getStore(storeName, CONTROLLER_STORE_POLL_TIMEOUT);
+      StoreResponse storeResponse;
+      try {
+        storeResponse = entry.getValue().getStore(storeName, CONTROLLER_STORE_POLL_TIMEOUT);
+      } catch (Exception e) {
+        LOGGER.warn(
+            "Could not get store {} from region {} for backup-version cleanup check; skipping region",
+            storeName,
+            region,
+            e);
+        continue;
+      }
       if (storeResponse == null || storeResponse.isError()) {
         LOGGER.warn(
             "Could not get store {} from region {} for backup-version cleanup check ({}); skipping region",

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1781,10 +1781,12 @@ public class VeniceParentHelixAdmin implements Admin {
             ErrorType.BAD_REQUEST);
       }
 
-      // Block on the parent if a child still has a ROLLED_BACK version within retention (verified
-      // from LIVE child status, not stale parent metadata). See the method javadoc for rationale.
+      // Block on the parent if a child still has a ROLLED_BACK version within retention, or backup
+      // versions pending deletion within the min cleanup delay — verified from LIVE child status,
+      // not stale parent metadata. See each method's javadoc for rationale.
       if (VeniceSystemStoreType.getSystemStoreType(storeName) == null) {
         checkRollbackOriginVersionCapacityFromChildren(clusterName, storeName);
+        checkBackupVersionCleanupCapacityFromChildren(clusterName, storeName);
       }
     }
 
@@ -2486,6 +2488,64 @@ public class VeniceParentHelixAdmin implements Admin {
           childStore.getCurrentVersion(),
           childStore.getLatestVersionPromoteToCurrentTimestamp(),
           rolledBackVersionRetentionMs,
+          currentTimeMs);
+    }
+  }
+
+  /**
+   * Blocks a new push if any reachable child region still has backup versions pending deletion but
+   * within the min cleanup delay, using LIVE child status. Mirrors
+   * {@link #checkRollbackOriginVersionCapacityFromChildren} — it runs once per new-push start on the
+   * parent only, because a throw during child admin-message consumption
+   * ({@code VeniceHelixAdmin.addVersion}) would wedge the admin channel. Unreachable/errored regions
+   * are skipped (and logged).
+   */
+  void checkBackupVersionCleanupCapacityFromChildren(String clusterName, String storeName) {
+    int minNumberOfStoreVersionsToPreserve = getMultiClusterConfigs().getMinNumberOfStoreVersionsToPreserve();
+    long minBackupVersionCleanupDelayMs =
+        getMultiClusterConfigs().getControllerConfig(clusterName).getBackupVersionMinCleanupDelayMs();
+    long currentTimeMs = System.currentTimeMillis();
+
+    Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
+    if (controllerClients.isEmpty()) {
+      // No children to verify against; parent metadata can be stale, so skip rather than block.
+      LOGGER.warn(
+          "No child controller clients for cluster {}; skipping backup-version cleanup check for store {}",
+          clusterName,
+          storeName);
+      return;
+    }
+    for (Map.Entry<String, ControllerClient> entry: controllerClients.entrySet()) {
+      String region = entry.getKey();
+      StoreResponse storeResponse = entry.getValue().getStore(storeName, CONTROLLER_STORE_POLL_TIMEOUT);
+      if (storeResponse == null || storeResponse.isError()) {
+        LOGGER.warn(
+            "Could not get store {} from region {} for backup-version cleanup check ({}); skipping region",
+            storeName,
+            region,
+            storeResponse == null ? "null response" : storeResponse.getError());
+        continue;
+      }
+      StoreInfo childStore = storeResponse.getStore();
+      if (childStore == null) {
+        LOGGER.warn(
+            "Null store payload for {} from region {} during backup-version cleanup check; skipping region",
+            storeName,
+            region);
+        continue;
+      }
+      VersionLifecyclePolicy.checkBackupVersionCleanupCapacityForNewPush(
+          clusterName,
+          storeName,
+          region,
+          childStore.getVersions(),
+          childStore.getCurrentVersion(),
+          childStore.getNumVersionsToPreserve(),
+          childStore.isMigrating(),
+          childStore.getBackupStrategy(),
+          minNumberOfStoreVersionsToPreserve,
+          childStore.getLatestVersionPromoteToCurrentTimestamp(),
+          minBackupVersionCleanupDelayMs,
           currentTimeMs);
     }
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1490,22 +1490,15 @@ public class VeniceParentHelixAdmin implements Admin {
       return Optional.empty();
     }
 
-    // Statuses for the latest version that mean there is no in-flight push to wait on, so the
-    // next push may proceed:
-    // - KILLED / ERROR: failed/aborted push, version not serving.
-    // - ROLLED_BACK: operator rolled back to a previous version; this version is preserved by
-    // the rolled-back retention window, enforced separately by
-    // checkRollbackOriginVersionCapacityForNewPush.
-    // - PARTIALLY_ONLINE: parent-only terminal state from a region-filtered rollback (some
-    // regions rolled back, some didn't); same retention window applies via the same guard.
-    // - ONLINE: the push already completed (a version only reaches ONLINE after its push finishes),
-    // so there is no in-flight push to protect. Any remaining deferred-swap roll-forward is
-    // orchestrated separately by DeferredVersionSwapService and does not require serializing new
-    // pushes behind it; a subsequent push simply supersedes the pending swap. Critically, this
-    // must NOT depend on the parent version topic existing: PARENT_VERSION_STATUS_ONLY is the
-    // parent-VT-deprecation strategy (topicWriteNeeded=false), so the parent VT may never exist,
-    // and keying off ZK version status alone is what keeps this correct.
-    // Non-terminal statuses fall through to the polling branch below to wait on the in-flight push.
+    // Terminal statuses for the latest version — no in-flight push to wait on, so the next push may
+    // proceed:
+    // - KILLED / ERROR: failed/aborted push, not serving.
+    // - ROLLED_BACK / PARTIALLY_ONLINE: rollback (PARTIALLY_ONLINE = region-filtered); the
+    // rolled-back retention window is enforced separately by checkRollbackOriginVersionCapacityForNewPush.
+    // - ONLINE: push already completed; any pending deferred-swap roll-forward is orchestrated by
+    // DeferredVersionSwapService and a subsequent push simply supersedes it. Keys off ZK version
+    // status alone (not the parent VT, which may never exist under PARENT_VERSION_STATUS_ONLY).
+    // Non-terminal statuses fall through to the polling branch below.
     switch (lastVersion.getStatus()) {
       case KILLED:
       case ERROR:
@@ -1788,12 +1781,8 @@ public class VeniceParentHelixAdmin implements Admin {
             ErrorType.BAD_REQUEST);
       }
 
-      // Block the push on the parent if any child region still has a ROLLED_BACK version within its
-      // retention window. We derive this from LIVE child-region status rather than parent metadata,
-      // which can go stale (a ROLLED_BACK record left behind after children moved on) and otherwise
-      // falsely block new pushes for the entire retention window. The parent is the sole synchronous
-      // gate — the equivalent check is NOT run during child admin-message consumption, where a throw
-      // would fail the message and wedge the admin channel.
+      // Block on the parent if a child still has a ROLLED_BACK version within retention (verified
+      // from LIVE child status, not stale parent metadata). See the method javadoc for rationale.
       if (VeniceSystemStoreType.getSystemStoreType(storeName) == null) {
         checkRollbackOriginVersionCapacityFromChildren(clusterName, storeName);
       }
@@ -2442,31 +2431,19 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   /**
-   * Enforces the rollback-origin retention block for a new push using LIVE child-region status,
-   * rather than (potentially stale) parent metadata. Parent version status can retain a
-   * {@code ROLLED_BACK}/{@code PARTIALLY_ONLINE} record after the children have moved on, which
-   * would otherwise falsely block new pushes for the entire retention window (the same class of
-   * stale-parent-metadata bug as a lingering ONLINE deferred-swap record).
+   * Blocks a new push if any reachable child region still has a {@code ROLLED_BACK} version within
+   * its retention window, using LIVE child status. We do NOT consult parent metadata, which can go
+   * stale and either falsely block or falsely allow. This runs once per new-push start, so querying
+   * every child is negligible. It runs only on the parent — a throw during child admin-message
+   * consumption ({@code VeniceHelixAdmin.addVersion}) would wedge the admin channel.
    *
-   * <p>Children are the authoritative source, so we query each child controller directly and block
-   * solely if a reachable child still has a {@code ROLLED_BACK} version within its retention window.
-   * We deliberately do NOT consult parent metadata (not even as a pre-filter): a stale parent record
-   * could either falsely block or falsely allow. This runs once per new-push start, so the handful
-   * of child RPCs is negligible. The equivalent check is intentionally NOT run during child
-   * admin-message consumption ({@code VeniceHelixAdmin.addVersion}): a throw there fails
-   * admin-message consumption and wedges the admin channel, so the parent is the sole synchronous
-   * gate.
+   * <p>Matches {@code ROLLED_BACK} only: a per-region rollback is binary, so a child is never
+   * rollback-{@code PARTIALLY_ONLINE} (that is a parent-only aggregate); a child
+   * {@code PARTIALLY_ONLINE} is a degraded-mode forward push and must not block. A partial rollback
+   * is still caught because its rolled-back region reports {@code ROLLED_BACK}.
    *
-   * <p>A per-region rollback is binary — a child region is either {@code ROLLED_BACK} or not — so a
-   * rollback never leaves a child {@code PARTIALLY_ONLINE} (that is a parent-only aggregate of a
-   * partial rollback). A child {@code PARTIALLY_ONLINE} only arises from a degraded-mode forward
-   * push, which is not a rollback-origin and must not block; hence we match {@code ROLLED_BACK}
-   * only. A partial rollback is still caught here because its rolled-back region reports
-   * {@code ROLLED_BACK}.
-   *
-   * <p>Unreachable/errored child regions are skipped (and logged) rather than blocking, so a
-   * transient child query failure cannot wedge pushes. If there are no reachable rolled-back
-   * children, the push is allowed.
+   * <p>Unreachable/errored regions are skipped (and logged); with no reachable rolled-back child the
+   * push is allowed.
    */
   void checkRollbackOriginVersionCapacityFromChildren(String clusterName, String storeName) {
     long rolledBackVersionRetentionMs =
@@ -2475,8 +2452,7 @@ public class VeniceParentHelixAdmin implements Admin {
 
     Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
     if (controllerClients.isEmpty()) {
-      // No children to consult. Parent metadata can be stale, so we do not fall back to enforcing
-      // against it — that is the false-block this check exists to avoid. Skip the block instead.
+      // No children to verify against; parent metadata can be stale, so skip rather than block.
       LOGGER.warn(
           "No child controller clients for cluster {}; skipping rollback-origin retention check for store {}",
           clusterName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1490,22 +1490,30 @@ public class VeniceParentHelixAdmin implements Admin {
       return Optional.empty();
     }
 
-    // Terminal statuses for the latest version mean there is no in-flight push to wait on, so
-    // the next push may proceed:
+    // Statuses for the latest version that mean there is no in-flight push to wait on, so the
+    // next push may proceed:
     // - KILLED / ERROR: failed/aborted push, version not serving.
     // - ROLLED_BACK: operator rolled back to a previous version; this version is preserved by
     // the rolled-back retention window, enforced separately by
     // checkRollbackOriginVersionCapacityForNewPush.
     // - PARTIALLY_ONLINE: parent-only terminal state from a region-filtered rollback (some
     // regions rolled back, some didn't); same retention window applies via the same guard.
+    // - ONLINE: the push already completed (a version only reaches ONLINE after its push finishes),
+    // so there is no in-flight push to protect. Any remaining deferred-swap roll-forward is
+    // orchestrated separately by DeferredVersionSwapService and does not require serializing new
+    // pushes behind it; a subsequent push simply supersedes the pending swap. Critically, this
+    // must NOT depend on the parent version topic existing: PARENT_VERSION_STATUS_ONLY is the
+    // parent-VT-deprecation strategy (topicWriteNeeded=false), so the parent VT may never exist,
+    // and keying off ZK version status alone is what keeps this correct.
     // Non-terminal statuses fall through to the polling branch below to wait on the in-flight push.
     switch (lastVersion.getStatus()) {
       case KILLED:
       case ERROR:
       case ROLLED_BACK:
       case PARTIALLY_ONLINE:
+      case ONLINE:
         LOGGER.info(
-            "Store {} version {} is in terminal status {} (no ongoing push); allowing the next push to proceed",
+            "Store {} version {} is in status {} (no ongoing push); allowing the next push to proceed",
             storeName,
             lastVersionNum,
             lastVersion.getStatus());
@@ -1520,8 +1528,6 @@ public class VeniceParentHelixAdmin implements Admin {
         storeName,
         lastVersionNum);
     Optional<String> latestTopic = Optional.of(Version.composeKafkaTopic(storeName, lastVersionNum));
-    boolean onlyDeferredSwap =
-        lastVersion.isVersionSwapDeferred() && StringUtils.isEmpty(lastVersion.getTargetSwapRegion());
 
     if ((lastVersion.getStatus() == STARTED || lastVersion.getStatus() == PUSHED
         || lastVersion.getStatus() == CREATED)) {
@@ -1530,12 +1536,6 @@ public class VeniceParentHelixAdmin implements Admin {
           lastVersionNum,
           storeName);
       return latestTopic;
-    } else if (onlyDeferredSwap && lastVersion.getStatus() == ONLINE) {
-      // for only deferred swap, users need to rollforward to mark it current for online status
-      boolean validateChildCurrentVersions = validateChildCurrentVersions(clusterName, storeName, lastVersionNum);
-      if (!validateChildCurrentVersions) {
-        return latestTopic;
-      }
     }
 
     /**
@@ -1789,16 +1789,14 @@ public class VeniceParentHelixAdmin implements Admin {
       }
 
       // Block the push on the parent if any rollback-origin version (ROLLED_BACK, or rollback-origin
-      // PARTIALLY_ONLINE on the parent) is still within its retention window. The same check runs on
-      // the child via VeniceHelixAdmin.addVersion; running it here surfaces the rejection to the push
-      // job synchronously instead of only failing the child admin-consumption asynchronously.
+      // PARTIALLY_ONLINE) is still within its retention window. We derive this from LIVE child-region
+      // status rather than parent metadata, which can go stale (a ROLLED_BACK/PARTIALLY_ONLINE record
+      // left behind after children moved on) and otherwise falsely block new pushes for the entire
+      // retention window. The parent is the sole synchronous gate — the equivalent check is NOT run
+      // during child admin-message consumption, where a throw would fail the message and wedge the
+      // admin channel.
       if (VeniceSystemStoreType.getSystemStoreType(storeName) == null) {
-        VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
-            clusterName,
-            storeName,
-            store,
-            getMultiClusterConfigs().getControllerConfig(clusterName).getRolledBackVersionRetentionMs(),
-            System.currentTimeMillis());
+        checkRollbackOriginVersionCapacityFromChildren(clusterName, storeName, store);
       }
     }
 
@@ -2441,6 +2439,89 @@ public class VeniceParentHelixAdmin implements Admin {
     // admin operations during the exponential-backoff polling of child regions.
     if (rolledBackVersionNum != NON_EXISTING_VERSION) {
       updateParentVersionStatusAfterRollback(clusterName, storeName, rolledBackVersionNum, regionFilter);
+    }
+  }
+
+  /**
+   * Enforces the rollback-origin retention block for a new push using LIVE child-region status,
+   * rather than (potentially stale) parent metadata. Parent version status can retain a
+   * {@code ROLLED_BACK}/{@code PARTIALLY_ONLINE} record after the children have moved on, which
+   * would otherwise falsely block new pushes for the entire retention window (the same class of
+   * stale-parent-metadata bug as a lingering ONLINE deferred-swap record).
+   *
+   * <p>A cheap parent-metadata pre-check runs first: if the parent itself sees no rollback-origin
+   * version within its retention window there is nothing to block on, so we skip the child RPCs
+   * entirely (the common case). Only when the parent metadata WOULD block do we query each child
+   * controller and block solely if a reachable child still has a rollback-origin version within its
+   * retention window. The equivalent check is intentionally NOT run during child admin-message
+   * consumption ({@code VeniceHelixAdmin.addVersion}): a throw there fails admin-message consumption
+   * and wedges the admin channel, so the parent is the sole synchronous gate.
+   *
+   * <p>Unreachable/errored child regions are skipped (and logged) rather than blocking, so a
+   * transient child query failure cannot wedge pushes. If there are no child controllers to consult,
+   * we fall back to the parent-metadata decision to stay safe. A genuinely rolled-back, reachable
+   * child still blocks via {@link VersionLifecyclePolicy#checkRollbackOriginVersionCapacityForNewPush}.
+   */
+  void checkRollbackOriginVersionCapacityFromChildren(String clusterName, String storeName, Store parentStore) {
+    long rolledBackVersionRetentionMs =
+        getMultiClusterConfigs().getControllerConfig(clusterName).getRolledBackVersionRetentionMs();
+    long currentTimeMs = System.currentTimeMillis();
+
+    // Cheap parent-metadata pre-check: if the parent itself sees no rollback-origin version within
+    // its retention window, there is nothing to block on — skip the child RPCs (the common case).
+    if (!VersionLifecyclePolicy.hasRollbackOriginVersionWithinRetention(
+        parentStore.getVersions(),
+        parentStore.getCurrentVersion(),
+        parentStore.getLatestVersionPromoteToCurrentTimestamp(),
+        rolledBackVersionRetentionMs,
+        currentTimeMs)) {
+      return;
+    }
+
+    Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
+    if (controllerClients.isEmpty()) {
+      // No children to consult — fall back to the parent-metadata decision to stay safe.
+      LOGGER.warn(
+          "No child controller clients for cluster {}; falling back to parent metadata for the "
+              + "rollback-origin retention check of store {}",
+          clusterName,
+          storeName);
+      VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
+          clusterName,
+          storeName,
+          parentStore,
+          rolledBackVersionRetentionMs,
+          currentTimeMs);
+      return;
+    }
+    for (Map.Entry<String, ControllerClient> entry: controllerClients.entrySet()) {
+      String region = entry.getKey();
+      StoreResponse storeResponse = entry.getValue().getStore(storeName, CONTROLLER_STORE_POLL_TIMEOUT);
+      if (storeResponse == null || storeResponse.isError()) {
+        LOGGER.warn(
+            "Could not get store {} from region {} for rollback-origin retention check ({}); skipping region",
+            storeName,
+            region,
+            storeResponse == null ? "null response" : storeResponse.getError());
+        continue;
+      }
+      StoreInfo childStore = storeResponse.getStore();
+      if (childStore == null) {
+        LOGGER.warn(
+            "Null store payload for {} from region {} during rollback-origin retention check; skipping region",
+            storeName,
+            region);
+        continue;
+      }
+      VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
+          clusterName,
+          storeName,
+          region,
+          childStore.getVersions(),
+          childStore.getCurrentVersion(),
+          childStore.getLatestVersionPromoteToCurrentTimestamp(),
+          rolledBackVersionRetentionMs,
+          currentTimeMs);
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2480,18 +2480,12 @@ public class VeniceParentHelixAdmin implements Admin {
 
     Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
     if (controllerClients.isEmpty()) {
-      // No children to consult — fall back to the parent-metadata decision to stay safe.
+      // No children to consult. Parent metadata can be stale, so we do not fall back to enforcing
+      // against it — that is the false-block this check exists to avoid. Skip the block instead.
       LOGGER.warn(
-          "No child controller clients for cluster {}; falling back to parent metadata for the "
-              + "rollback-origin retention check of store {}",
+          "No child controller clients for cluster {}; skipping rollback-origin retention check for store {}",
           clusterName,
           storeName);
-      VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
-          clusterName,
-          storeName,
-          parentStore,
-          rolledBackVersionRetentionMs,
-          currentTimeMs);
       return;
     }
     for (Map.Entry<String, ControllerClient> entry: controllerClients.entrySet()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1788,15 +1788,14 @@ public class VeniceParentHelixAdmin implements Admin {
             ErrorType.BAD_REQUEST);
       }
 
-      // Block the push on the parent if any rollback-origin version (ROLLED_BACK, or rollback-origin
-      // PARTIALLY_ONLINE) is still within its retention window. We derive this from LIVE child-region
-      // status rather than parent metadata, which can go stale (a ROLLED_BACK/PARTIALLY_ONLINE record
-      // left behind after children moved on) and otherwise falsely block new pushes for the entire
-      // retention window. The parent is the sole synchronous gate — the equivalent check is NOT run
-      // during child admin-message consumption, where a throw would fail the message and wedge the
-      // admin channel.
+      // Block the push on the parent if any child region still has a ROLLED_BACK version within its
+      // retention window. We derive this from LIVE child-region status rather than parent metadata,
+      // which can go stale (a ROLLED_BACK record left behind after children moved on) and otherwise
+      // falsely block new pushes for the entire retention window. The parent is the sole synchronous
+      // gate — the equivalent check is NOT run during child admin-message consumption, where a throw
+      // would fail the message and wedge the admin channel.
       if (VeniceSystemStoreType.getSystemStoreType(storeName) == null) {
-        checkRollbackOriginVersionCapacityFromChildren(clusterName, storeName, store);
+        checkRollbackOriginVersionCapacityFromChildren(clusterName, storeName);
       }
     }
 
@@ -2449,34 +2448,30 @@ public class VeniceParentHelixAdmin implements Admin {
    * would otherwise falsely block new pushes for the entire retention window (the same class of
    * stale-parent-metadata bug as a lingering ONLINE deferred-swap record).
    *
-   * <p>A cheap parent-metadata pre-check runs first: if the parent itself sees no rollback-origin
-   * version within its retention window there is nothing to block on, so we skip the child RPCs
-   * entirely (the common case). Only when the parent metadata WOULD block do we query each child
-   * controller and block solely if a reachable child still has a rollback-origin version within its
-   * retention window. The equivalent check is intentionally NOT run during child admin-message
-   * consumption ({@code VeniceHelixAdmin.addVersion}): a throw there fails admin-message consumption
-   * and wedges the admin channel, so the parent is the sole synchronous gate.
+   * <p>Children are the authoritative source, so we query each child controller directly and block
+   * solely if a reachable child still has a {@code ROLLED_BACK} version within its retention window.
+   * We deliberately do NOT consult parent metadata (not even as a pre-filter): a stale parent record
+   * could either falsely block or falsely allow. This runs once per new-push start, so the handful
+   * of child RPCs is negligible. The equivalent check is intentionally NOT run during child
+   * admin-message consumption ({@code VeniceHelixAdmin.addVersion}): a throw there fails
+   * admin-message consumption and wedges the admin channel, so the parent is the sole synchronous
+   * gate.
+   *
+   * <p>A per-region rollback is binary — a child region is either {@code ROLLED_BACK} or not — so a
+   * rollback never leaves a child {@code PARTIALLY_ONLINE} (that is a parent-only aggregate of a
+   * partial rollback). A child {@code PARTIALLY_ONLINE} only arises from a degraded-mode forward
+   * push, which is not a rollback-origin and must not block; hence we match {@code ROLLED_BACK}
+   * only. A partial rollback is still caught here because its rolled-back region reports
+   * {@code ROLLED_BACK}.
    *
    * <p>Unreachable/errored child regions are skipped (and logged) rather than blocking, so a
-   * transient child query failure cannot wedge pushes. If there are no child controllers to consult,
-   * we fall back to the parent-metadata decision to stay safe. A genuinely rolled-back, reachable
-   * child still blocks via {@link VersionLifecyclePolicy#checkRollbackOriginVersionCapacityForNewPush}.
+   * transient child query failure cannot wedge pushes. If there are no reachable rolled-back
+   * children, the push is allowed.
    */
-  void checkRollbackOriginVersionCapacityFromChildren(String clusterName, String storeName, Store parentStore) {
+  void checkRollbackOriginVersionCapacityFromChildren(String clusterName, String storeName) {
     long rolledBackVersionRetentionMs =
         getMultiClusterConfigs().getControllerConfig(clusterName).getRolledBackVersionRetentionMs();
     long currentTimeMs = System.currentTimeMillis();
-
-    // Cheap parent-metadata pre-check: if the parent itself sees no rollback-origin version within
-    // its retention window, there is nothing to block on — skip the child RPCs (the common case).
-    if (!VersionLifecyclePolicy.hasRollbackOriginVersionWithinRetention(
-        parentStore.getVersions(),
-        parentStore.getCurrentVersion(),
-        parentStore.getLatestVersionPromoteToCurrentTimestamp(),
-        rolledBackVersionRetentionMs,
-        currentTimeMs)) {
-      return;
-    }
 
     Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
     if (controllerClients.isEmpty()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/versionlifecycle/VersionLifecyclePolicy.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/versionlifecycle/VersionLifecyclePolicy.java
@@ -102,29 +102,23 @@ public final class VersionLifecyclePolicy {
   }
 
   /**
-   * Throws if starting a new push would violate the retention window for a rolled-back version in a
-   * single child region. Blocks when a {@code ROLLED_BACK} version sits strictly above the current
-   * version — the rollback-origin invariant, since rollback decrements currentVersion below the
-   * rolled-back-from version's number. Stale entries lingering below currentVersion (e.g., after a
-   * subsequent push promoted higher) are skipped. The block also lifts once
-   * {@code latestVersionPromoteToCurrentTimestamp + rolledBackVersionRetentionMs} elapses; past that
-   * point, the version will be swept on the next SOP deletion pass.
+   * Throws if a new push would violate the retention window for a rolled-back version in a single
+   * child region. Blocks a {@code ROLLED_BACK} version above currentVersion (rollback decrements
+   * currentVersion, so number > currentVersion is the rollback-origin invariant); entries below
+   * currentVersion are stale and skipped. The block lifts once
+   * {@code latestVersionPromoteToCurrentTimestamp + rolledBackVersionRetentionMs} elapses.
    *
-   * <p>This evaluates a single region's store snapshot. The parent controller drives the block from
-   * LIVE child-region snapshots rather than its own metadata (see
-   * {@code VeniceParentHelixAdmin.checkRollbackOriginVersionCapacityFromChildren}), because parent
-   * version status can go stale and falsely block pushes for the whole retention window. The
-   * enforcement runs only on the parent; running it during child admin-message consumption would
-   * fail the message and wedge the admin channel.
+   * <p>The parent drives this from LIVE child snapshots, not its own metadata (see
+   * {@code VeniceParentHelixAdmin.checkRollbackOriginVersionCapacityFromChildren}), which can go
+   * stale and falsely block for the whole window. It runs only on the parent — a throw during child
+   * admin-message consumption would wedge the admin channel.
    *
-   * <p>Only {@code ROLLED_BACK} counts. A per-region rollback is binary, so a rollback never leaves a
-   * child {@code PARTIALLY_ONLINE} (that is a parent-only aggregate of a partial rollback); the only
-   * child {@code PARTIALLY_ONLINE} comes from a degraded-mode forward push, which is not a
-   * rollback-origin and must not block.
+   * <p>Only {@code ROLLED_BACK} counts: a per-region rollback is binary, so a child is never
+   * rollback-{@code PARTIALLY_ONLINE} (that is a parent-only aggregate). A child
+   * {@code PARTIALLY_ONLINE} is a degraded-mode forward push and must not block.
    *
-   * <p>Evaluates the raw fields of a single snapshot so callers can pass a child {@code StoreInfo}
-   * (which is not a {@link Store}) without a conversion. {@code regionName} enriches the rejection
-   * message; pass {@code null} for a region-agnostic evaluation.
+   * <p>Takes raw fields so callers can pass a child {@code StoreInfo} (not a {@link Store}) directly.
+   * {@code regionName} enriches the rejection message; pass {@code null} to omit it.
    */
   public static void checkRollbackOriginVersionCapacityForNewPush(
       String clusterName,
@@ -137,15 +131,10 @@ public final class VersionLifecyclePolicy {
       long currentTimeMs) {
     long retentionExpiresAt = latestVersionPromoteToCurrentTimestamp + rolledBackVersionRetentionMs;
     if (currentTimeMs > retentionExpiresAt) {
-      // Past retention — SOP deletion will clean up any rolled-back versions.
+      // Past retention — SOP deletion reclaims it.
       return;
     }
     for (Version v: versions) {
-      // A rollback-origin version is one that was promoted then rolled back to a lower version, so
-      // number > currentVersion holds (rollback decrements currentVersion). Once a subsequent push
-      // promotes higher than the rolled-back version, the retention contract is satisfied/superseded
-      // and the entry — which can linger in a store snapshot that retains more versions — is
-      // correctly aged out by this filter.
       boolean isRollbackOrigin = v.getStatus() == ROLLED_BACK && v.getNumber() > currentVersion;
       if (isRollbackOrigin) {
         throw new VeniceException(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/versionlifecycle/VersionLifecyclePolicy.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/versionlifecycle/VersionLifecyclePolicy.java
@@ -118,29 +118,10 @@ public final class VersionLifecyclePolicy {
    * version status can go stale and falsely block pushes for the whole retention window. The
    * enforcement runs only on the parent; running it during child admin-message consumption would
    * fail the message and wedge the admin channel.
-   */
-  public static void checkRollbackOriginVersionCapacityForNewPush(
-      String clusterName,
-      String storeName,
-      Store store,
-      long rolledBackVersionRetentionMs,
-      long currentTimeMs) {
-    checkRollbackOriginVersionCapacityForNewPush(
-        clusterName,
-        storeName,
-        null,
-        store.getVersions(),
-        store.getCurrentVersion(),
-        store.getLatestVersionPromoteToCurrentTimestamp(),
-        rolledBackVersionRetentionMs,
-        currentTimeMs);
-  }
-
-  /**
-   * Field-level overload of {@link #checkRollbackOriginVersionCapacityForNewPush(String, String, Store, long, long)}
-   * so callers can evaluate a child {@code StoreInfo} snapshot (which is not a {@link Store}) without
-   * a conversion. {@code regionName} is used only to enrich the rejection message; pass {@code null}
-   * for a region-agnostic (parent-metadata) evaluation.
+   *
+   * <p>Evaluates the raw fields of a single snapshot so callers can pass a child {@code StoreInfo}
+   * (which is not a {@link Store}) without a conversion. {@code regionName} enriches the rejection
+   * message; pass {@code null} for a region-agnostic evaluation.
    */
   public static void checkRollbackOriginVersionCapacityForNewPush(
       String clusterName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/versionlifecycle/VersionLifecyclePolicy.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/versionlifecycle/VersionLifecyclePolicy.java
@@ -7,6 +7,7 @@ import static com.linkedin.venice.meta.VersionStatus.ROLLED_BACK;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
+import com.linkedin.venice.meta.AbstractStore;
 import com.linkedin.venice.meta.BackupStrategy;
 import com.linkedin.venice.meta.ReadWriteStoreRepository;
 import com.linkedin.venice.meta.Store;
@@ -66,36 +67,55 @@ public final class VersionLifecyclePolicy {
 
   /**
    * Throws if starting a new push would exceed the store's version budget because existing backup
-   * versions are pending deletion but still within the min cleanup delay (e.g., after a rollback).
-   * Preserve count is {@code N-1} for {@code DELETE_ON_NEW_PUSH_START}, {@code N} otherwise.
-   * Clamps to 1 because {@link Store#retrieveVersionsToDelete(int)} rejects values below 1.
+   * versions are pending deletion but still within the min cleanup delay (e.g. after a killed push).
+   * Preserve count is {@code N-1} for {@code DELETE_ON_NEW_PUSH_START}, {@code N} otherwise, clamped
+   * to 1 because {@link AbstractStore#computeVersionsToDelete} rejects values below 1.
+   *
+   * <p>The parent drives this from LIVE child snapshots (see
+   * {@code VeniceParentHelixAdmin.checkBackupVersionCleanupCapacityFromChildren}), not its own
+   * metadata which can go stale. It runs only on the parent — a throw during child admin-message
+   * consumption ({@code VeniceHelixAdmin.addVersion}) would wedge the admin channel.
+   *
+   * <p>Takes raw fields so callers can pass a child {@code StoreInfo} (not a {@link Store}) directly.
+   * {@code regionName} enriches the rejection message; pass {@code null} to omit it.
    */
   public static void checkBackupVersionCleanupCapacityForNewPush(
       String clusterName,
       String storeName,
-      Store store,
+      String regionName,
+      List<Version> versions,
+      int currentVersion,
+      int storeNumVersionsToPreserve,
+      boolean isMigrating,
       BackupStrategy backupStrategy,
       int minNumberOfStoreVersionsToPreserve,
+      long latestVersionPromoteToCurrentTimestamp,
       long minBackupVersionCleanupDelay,
       long currentTimeMs) {
-    int numVersionToPreserve = Math.max(
+    int clusterNumVersionsToPreserve = Math.max(
         1,
         backupStrategy == BackupStrategy.DELETE_ON_NEW_PUSH_START
             ? minNumberOfStoreVersionsToPreserve - 1
             : minNumberOfStoreVersionsToPreserve);
-    List<Version> versionsToDelete = store.retrieveVersionsToDelete(numVersionToPreserve);
+    List<Version> versionsToDelete = AbstractStore.computeVersionsToDelete(
+        versions,
+        currentVersion,
+        clusterNumVersionsToPreserve,
+        storeNumVersionsToPreserve,
+        isMigrating);
     if (versionsToDelete.isEmpty()) {
       return;
     }
-    long minRetentionThreshold = store.getLatestVersionPromoteToCurrentTimestamp() + minBackupVersionCleanupDelay;
+    long minRetentionThreshold = latestVersionPromoteToCurrentTimestamp + minBackupVersionCleanupDelay;
     if (currentTimeMs <= minRetentionThreshold) {
       throw new VeniceException(
           String.format(
-              "Cannot start new push for store %s in cluster %s: %d backup version(s) pending deletion "
+              "Cannot start new push for store %s in cluster %s%s: %d backup version(s) pending deletion "
                   + "but still within min cleanup delay (%dms) of latest version promotion. "
                   + "Retry after min delay has elapsed.",
               storeName,
               clusterName,
+              regionName == null ? "" : " (region " + regionName + ")",
               versionsToDelete.size(),
               minBackupVersionCleanupDelay));
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/versionlifecycle/VersionLifecyclePolicy.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/versionlifecycle/VersionLifecyclePolicy.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.controller.versionlifecycle;
 
 import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 import static com.linkedin.venice.meta.VersionStatus.ONLINE;
-import static com.linkedin.venice.meta.VersionStatus.PARTIALLY_ONLINE;
 import static com.linkedin.venice.meta.VersionStatus.ROLLED_BACK;
 
 import com.linkedin.venice.exceptions.VeniceException;
@@ -12,7 +11,6 @@ import com.linkedin.venice.meta.BackupStrategy;
 import com.linkedin.venice.meta.ReadWriteStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushmonitor.OfflinePushStatus;
 import com.linkedin.venice.pushmonitor.PushMonitor;
@@ -104,20 +102,25 @@ public final class VersionLifecyclePolicy {
   }
 
   /**
-   * Throws if starting a new push would violate the retention window for a rollback-origin version.
-   * Blocks when a {@code ROLLED_BACK} or {@code PARTIALLY_ONLINE} version sits strictly above the
-   * current version — the rollback-origin invariant, since rollback decrements currentVersion below
-   * the rolled-back-from version's number on both parent and child controllers. Stale entries
-   * lingering below currentVersion (e.g., after a subsequent push promoted higher) are skipped.
-   * The block also lifts once {@code latestVersionPromoteToCurrentTimestamp + rolledBackVersionRetentionMs}
-   * elapses; past that point, the version will be swept on the next SOP deletion pass.
+   * Throws if starting a new push would violate the retention window for a rolled-back version in a
+   * single child region. Blocks when a {@code ROLLED_BACK} version sits strictly above the current
+   * version — the rollback-origin invariant, since rollback decrements currentVersion below the
+   * rolled-back-from version's number. Stale entries lingering below currentVersion (e.g., after a
+   * subsequent push promoted higher) are skipped. The block also lifts once
+   * {@code latestVersionPromoteToCurrentTimestamp + rolledBackVersionRetentionMs} elapses; past that
+   * point, the version will be swept on the next SOP deletion pass.
    *
-   * <p>This evaluates a single store snapshot (one region). The parent controller drives the block
-   * from LIVE child-region snapshots rather than its own metadata (see
+   * <p>This evaluates a single region's store snapshot. The parent controller drives the block from
+   * LIVE child-region snapshots rather than its own metadata (see
    * {@code VeniceParentHelixAdmin.checkRollbackOriginVersionCapacityFromChildren}), because parent
    * version status can go stale and falsely block pushes for the whole retention window. The
    * enforcement runs only on the parent; running it during child admin-message consumption would
    * fail the message and wedge the admin channel.
+   *
+   * <p>Only {@code ROLLED_BACK} counts. A per-region rollback is binary, so a rollback never leaves a
+   * child {@code PARTIALLY_ONLINE} (that is a parent-only aggregate of a partial rollback); the only
+   * child {@code PARTIALLY_ONLINE} comes from a degraded-mode forward push, which is not a
+   * rollback-origin and must not block.
    *
    * <p>Evaluates the raw fields of a single snapshot so callers can pass a child {@code StoreInfo}
    * (which is not a {@link Store}) without a conversion. {@code regionName} enriches the rejection
@@ -134,19 +137,16 @@ public final class VersionLifecyclePolicy {
       long currentTimeMs) {
     long retentionExpiresAt = latestVersionPromoteToCurrentTimestamp + rolledBackVersionRetentionMs;
     if (currentTimeMs > retentionExpiresAt) {
-      // Past retention — SOP deletion will clean up any rollback-origin versions.
+      // Past retention — SOP deletion will clean up any rolled-back versions.
       return;
     }
     for (Version v: versions) {
-      VersionStatus status = v.getStatus();
-      // A rollback-origin version is one that was promoted then rolled back to a lower version,
-      // so number > currentVersion holds (rollback decrements currentVersion on both parent and
-      // child controllers). Once a subsequent push promotes higher than the rolled-back version,
-      // the retention contract is satisfied/superseded and the entry — which can linger in a store
-      // snapshot that retains more versions — is correctly aged out by this filter.
-      // Push-origin PARTIALLY_ONLINE (number == currentVersion) is correctly excluded.
-      boolean isRollbackOrigin =
-          (status == ROLLED_BACK || status == PARTIALLY_ONLINE) && v.getNumber() > currentVersion;
+      // A rollback-origin version is one that was promoted then rolled back to a lower version, so
+      // number > currentVersion holds (rollback decrements currentVersion). Once a subsequent push
+      // promotes higher than the rolled-back version, the retention contract is satisfied/superseded
+      // and the entry — which can linger in a store snapshot that retains more versions — is
+      // correctly aged out by this filter.
+      boolean isRollbackOrigin = v.getStatus() == ROLLED_BACK && v.getNumber() > currentVersion;
       if (isRollbackOrigin) {
         throw new VeniceException(
             String.format(
@@ -155,39 +155,12 @@ public final class VersionLifecyclePolicy {
                 storeName,
                 clusterName,
                 v.getNumber(),
-                status,
+                v.getStatus(),
                 regionName == null ? "" : " in region " + regionName,
                 retentionExpiresAt - currentTimeMs));
       }
     }
-  }
-
-  /**
-   * Cheap boolean pre-check mirroring {@link #checkRollbackOriginVersionCapacityForNewPush} without
-   * throwing: returns {@code true} if the given store snapshot has a rollback-origin version
-   * ({@code ROLLED_BACK}/{@code PARTIALLY_ONLINE} above {@code currentVersion}) still within its
-   * retention window. The parent uses this against its own metadata to decide whether it is even
-   * worth paying for live child verification before enforcing the block.
-   */
-  public static boolean hasRollbackOriginVersionWithinRetention(
-      List<Version> versions,
-      int currentVersion,
-      long latestVersionPromoteToCurrentTimestamp,
-      long rolledBackVersionRetentionMs,
-      long currentTimeMs) {
-    if (currentTimeMs > latestVersionPromoteToCurrentTimestamp + rolledBackVersionRetentionMs) {
-      return false;
-    }
-    for (Version v: versions) {
-      VersionStatus status = v.getStatus();
-      if ((status == ROLLED_BACK || status == PARTIALLY_ONLINE) && v.getNumber() > currentVersion) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  // ---------- Version selection ----------
+  } // ---------- Version selection ----------
 
   /**
    * Largest {@code ONLINE} version number strictly less than {@code currentVersion}, or

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/versionlifecycle/VersionLifecyclePolicy.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/versionlifecycle/VersionLifecyclePolicy.java
@@ -72,7 +72,7 @@ public final class VersionLifecyclePolicy {
    * to 1 because {@link AbstractStore#computeVersionsToDelete} rejects values below 1.
    *
    * <p>The parent drives this from LIVE child snapshots (see
-   * {@code VeniceParentHelixAdmin.checkBackupVersionCleanupCapacityFromChildren}), not its own
+   * {@code VeniceParentHelixAdmin.checkNewPushCapacityFromChildren}), not its own
    * metadata which can go stale. It runs only on the parent — a throw during child admin-message
    * consumption ({@code VeniceHelixAdmin.addVersion}) would wedge the admin channel.
    *
@@ -129,7 +129,7 @@ public final class VersionLifecyclePolicy {
    * {@code latestVersionPromoteToCurrentTimestamp + rolledBackVersionRetentionMs} elapses.
    *
    * <p>The parent drives this from LIVE child snapshots, not its own metadata (see
-   * {@code VeniceParentHelixAdmin.checkRollbackOriginVersionCapacityFromChildren}), which can go
+   * {@code VeniceParentHelixAdmin.checkNewPushCapacityFromChildren}), which can go
    * stale and falsely block for the whole window. It runs only on the parent — a throw during child
    * admin-message consumption would wedge the admin channel.
    *

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/versionlifecycle/VersionLifecyclePolicy.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/versionlifecycle/VersionLifecyclePolicy.java
@@ -111,6 +111,13 @@ public final class VersionLifecyclePolicy {
    * lingering below currentVersion (e.g., after a subsequent push promoted higher) are skipped.
    * The block also lifts once {@code latestVersionPromoteToCurrentTimestamp + rolledBackVersionRetentionMs}
    * elapses; past that point, the version will be swept on the next SOP deletion pass.
+   *
+   * <p>This evaluates a single store snapshot (one region). The parent controller drives the block
+   * from LIVE child-region snapshots rather than its own metadata (see
+   * {@code VeniceParentHelixAdmin.checkRollbackOriginVersionCapacityFromChildren}), because parent
+   * version status can go stale and falsely block pushes for the whole retention window. The
+   * enforcement runs only on the parent; running it during child admin-message consumption would
+   * fail the message and wedge the admin channel.
    */
   public static void checkRollbackOriginVersionCapacityForNewPush(
       String clusterName,
@@ -118,35 +125,85 @@ public final class VersionLifecyclePolicy {
       Store store,
       long rolledBackVersionRetentionMs,
       long currentTimeMs) {
-    long retentionExpiresAt = store.getLatestVersionPromoteToCurrentTimestamp() + rolledBackVersionRetentionMs;
+    checkRollbackOriginVersionCapacityForNewPush(
+        clusterName,
+        storeName,
+        null,
+        store.getVersions(),
+        store.getCurrentVersion(),
+        store.getLatestVersionPromoteToCurrentTimestamp(),
+        rolledBackVersionRetentionMs,
+        currentTimeMs);
+  }
+
+  /**
+   * Field-level overload of {@link #checkRollbackOriginVersionCapacityForNewPush(String, String, Store, long, long)}
+   * so callers can evaluate a child {@code StoreInfo} snapshot (which is not a {@link Store}) without
+   * a conversion. {@code regionName} is used only to enrich the rejection message; pass {@code null}
+   * for a region-agnostic (parent-metadata) evaluation.
+   */
+  public static void checkRollbackOriginVersionCapacityForNewPush(
+      String clusterName,
+      String storeName,
+      String regionName,
+      List<Version> versions,
+      int currentVersion,
+      long latestVersionPromoteToCurrentTimestamp,
+      long rolledBackVersionRetentionMs,
+      long currentTimeMs) {
+    long retentionExpiresAt = latestVersionPromoteToCurrentTimestamp + rolledBackVersionRetentionMs;
     if (currentTimeMs > retentionExpiresAt) {
       // Past retention — SOP deletion will clean up any rollback-origin versions.
       return;
     }
-    int currentVersion = store.getCurrentVersion();
-    for (Version v: store.getVersions()) {
+    for (Version v: versions) {
       VersionStatus status = v.getStatus();
       // A rollback-origin version is one that was promoted then rolled back to a lower version,
-      // so number > currentVersion holds (parent decrements currentVersion on rollback to mirror
-      // children, see VeniceParentHelixAdmin.updateParentVersionStatusAfterRollback). Once a
-      // subsequent push promotes higher than the rolled-back version, the retention contract is
-      // satisfied/superseded and the entry — which can linger in parent metadata since parent
-      // retains more versions than children — is correctly aged out by this filter.
+      // so number > currentVersion holds (rollback decrements currentVersion on both parent and
+      // child controllers). Once a subsequent push promotes higher than the rolled-back version,
+      // the retention contract is satisfied/superseded and the entry — which can linger in a store
+      // snapshot that retains more versions — is correctly aged out by this filter.
       // Push-origin PARTIALLY_ONLINE (number == currentVersion) is correctly excluded.
       boolean isRollbackOrigin =
           (status == ROLLED_BACK || status == PARTIALLY_ONLINE) && v.getNumber() > currentVersion;
       if (isRollbackOrigin) {
         throw new VeniceException(
             String.format(
-                "Cannot start new push for store %s in cluster %s: version %d is %s from a rollback; "
+                "Cannot start new push for store %s in cluster %s: version %d is %s from a rollback%s; "
                     + "retention expires in %dms. Retry after the rolled-back version is cleaned up.",
                 storeName,
                 clusterName,
                 v.getNumber(),
                 status,
+                regionName == null ? "" : " in region " + regionName,
                 retentionExpiresAt - currentTimeMs));
       }
     }
+  }
+
+  /**
+   * Cheap boolean pre-check mirroring {@link #checkRollbackOriginVersionCapacityForNewPush} without
+   * throwing: returns {@code true} if the given store snapshot has a rollback-origin version
+   * ({@code ROLLED_BACK}/{@code PARTIALLY_ONLINE} above {@code currentVersion}) still within its
+   * retention window. The parent uses this against its own metadata to decide whether it is even
+   * worth paying for live child verification before enforcing the block.
+   */
+  public static boolean hasRollbackOriginVersionWithinRetention(
+      List<Version> versions,
+      int currentVersion,
+      long latestVersionPromoteToCurrentTimestamp,
+      long rolledBackVersionRetentionMs,
+      long currentTimeMs) {
+    if (currentTimeMs > latestVersionPromoteToCurrentTimestamp + rolledBackVersionRetentionMs) {
+      return false;
+    }
+    for (Version v: versions) {
+      VersionStatus status = v.getStatus();
+      if ((status == ROLLED_BACK || status == PARTIALLY_ONLINE) && v.getNumber() > currentVersion) {
+        return true;
+      }
+    }
+    return false;
   }
 
   // ---------- Version selection ----------

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2768,62 +2768,46 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
     mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
-    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any(), any());
+    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any());
 
-    // Parent metadata WOULD block (rollback-origin v2 within retention), and child dc-0 still holds
-    // the rollback-origin version too -> the parent must block the new push.
+    // Child dc-0 still holds a ROLLED_BACK version within retention -> the parent must block the push.
     Map<String, ControllerClient> map = new HashMap<>();
     map.put("dc-0", childClient(rolledBackOriginStore(store)));
     doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
 
     assertThrows(
         VeniceException.class,
-        () -> mockParentAdmin
-            .checkRollbackOriginVersionCapacityFromChildren(clusterName, store, rolledBackOriginStore(store)));
+        () -> mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store));
   }
 
   @Test
   public void checkRollbackOriginFromChildrenAllowsWhenChildrenNotRolledBack() {
-    // The core fix: parent metadata carries a stale rollback-origin record (so the pre-check fires),
-    // but the LIVE child status shows no rollback-origin version -> the push must be allowed instead
-    // of being falsely blocked for the full retention window.
+    // The core fix: LIVE child status shows no rolled-back version, so the push must be allowed
+    // rather than blocked on (potentially stale) parent metadata.
     String store = "rb_from_children_allow";
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
     mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
-    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any(), any());
+    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any());
 
     Map<String, ControllerClient> map = new HashMap<>();
     map.put("dc-0", childClient(onlineOnlyStore(store)));
     map.put("dc-1", childClient(onlineOnlyStore(store)));
     doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
 
-    // Should not throw despite the stale parent rollback-origin record.
-    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store, rolledBackOriginStore(store));
-  }
-
-  @Test
-  public void checkRollbackOriginFromChildrenSkipsFastWhenParentHasNoRollbackOrigin() {
-    // Fast path: parent metadata shows no rollback-origin version, so children are never queried.
-    String store = "rb_from_children_fastpath";
-    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
-    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
-    mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
-    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any(), any());
-
-    // Should not throw, and the fast path must not enforce a block.
-    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store, onlineOnlyStore(store));
+    // Should not throw — all children are clean.
+    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store);
   }
 
   @Test
   public void checkRollbackOriginFromChildrenSkipsErroredRegion() {
     // A transient child-query failure must not wedge pushes: the errored region is skipped, and
-    // with no reachable rollback-origin child the push is allowed.
+    // with no reachable rolled-back child the push is allowed.
     String store = "rb_from_children_error";
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
     mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
-    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any(), any());
+    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any());
 
     ControllerClient errorClient = mock(ControllerClient.class);
     StoreResponse errorResponse = new StoreResponse();
@@ -2834,7 +2818,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
 
     // Should not throw.
-    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store, rolledBackOriginStore(store));
+    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store);
   }
 
   @Test
@@ -2845,11 +2829,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
     mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
-    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any(), any());
+    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any());
     doReturn(new HashMap<String, ControllerClient>()).when(internalAdmin).getControllerClientMap(anyString());
 
-    // Should not throw even though parent metadata shows a rollback-origin version within retention.
-    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store, rolledBackOriginStore(store));
+    // Should not throw.
+    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store);
   }
 
   private void mockRolledBackRetentionConfig(VeniceParentHelixAdmin admin, long retentionMs) {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2763,175 +2763,101 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   @Test
-  public void checkRollbackOriginFromChildrenBlocksWhenChildRolledBackWithinRetention() {
-    String store = "rb_from_children_block";
+  public void checkNewPushCapacityFromChildrenBlocksWhenChildRolledBackWithinRetention() {
+    String store = "npc_from_children_rollback_block";
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
-    mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
-    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any());
+    mockNewPushCapacityConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24), 2, TimeUnit.HOURS.toMillis(1));
+    doCallRealMethod().when(mockParentAdmin).checkNewPushCapacityFromChildren(any(), any());
 
     // Child dc-0 still holds a ROLLED_BACK version within retention -> the parent must block the push.
     Map<String, ControllerClient> map = new HashMap<>();
     map.put("dc-0", childClient(rolledBackOriginStore(store)));
     doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
 
-    assertThrows(
-        VeniceException.class,
-        () -> mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store));
+    assertThrows(VeniceException.class, () -> mockParentAdmin.checkNewPushCapacityFromChildren(clusterName, store));
   }
 
   @Test
-  public void checkRollbackOriginFromChildrenAllowsWhenChildrenNotRolledBack() {
-    // The core fix: LIVE child status shows no rolled-back version, so the push must be allowed
-    // rather than blocked on (potentially stale) parent metadata.
-    String store = "rb_from_children_allow";
+  public void checkNewPushCapacityFromChildrenBlocksWhenChildHasPendingBackupWithinDelay() {
+    String store = "npc_from_children_backup_block";
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
-    mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
-    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any());
+    mockNewPushCapacityConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24), 2, TimeUnit.HOURS.toMillis(1));
+    doCallRealMethod().when(mockParentAdmin).checkNewPushCapacityFromChildren(any(), any());
 
-    Map<String, ControllerClient> map = new HashMap<>();
-    map.put("dc-0", childClient(onlineOnlyStore(store)));
-    map.put("dc-1", childClient(onlineOnlyStore(store)));
-    doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
-
-    // Should not throw — all children are clean.
-    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store);
-  }
-
-  @Test
-  public void checkRollbackOriginFromChildrenSkipsErroredRegion() {
-    // A transient child-query failure must not wedge pushes: the errored region is skipped, and
-    // with no reachable rolled-back child the push is allowed.
-    String store = "rb_from_children_error";
-    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
-    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
-    mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
-    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any());
-
-    ControllerClient errorClient = mock(ControllerClient.class);
-    StoreResponse errorResponse = new StoreResponse();
-    errorResponse.setError("Simulated error fetching store for rollback-origin retention check.");
-    doReturn(errorResponse).when(errorClient).getStore(anyString(), anyInt());
-    Map<String, ControllerClient> map = new HashMap<>();
-    map.put("dc-0", errorClient);
-    doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
-
-    // Should not throw.
-    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store);
-  }
-
-  @Test
-  public void checkRollbackOriginFromChildrenSkipsWhenNoChildClients() {
-    // No children to verify against. Parent metadata can be stale, so we must NOT fall back to
-    // enforcing against it (that is the false-block this check exists to avoid) -> allow the push.
-    String store = "rb_from_children_no_clients";
-    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
-    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
-    mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
-    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any());
-    doReturn(new HashMap<String, ControllerClient>()).when(internalAdmin).getControllerClientMap(anyString());
-
-    // Should not throw.
-    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store);
-  }
-
-  @Test
-  public void checkRollbackOriginFromChildrenSkipsRegionWhenGetStoreThrows() {
-    // ControllerClient#getStore can throw (e.g. VeniceHttpException/leader-discovery); a throw must
-    // be treated as a skipped region, not abort push-start.
-    String store = "rb_from_children_throws";
-    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
-    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
-    mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
-    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any());
-
-    ControllerClient throwingClient = mock(ControllerClient.class);
-    doThrow(new VeniceException("Simulated getStore failure")).when(throwingClient).getStore(anyString(), anyInt());
-    Map<String, ControllerClient> map = new HashMap<>();
-    map.put("dc-0", throwingClient);
-    doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
-
-    // Should not throw — the region is skipped.
-    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store);
-  }
-
-  @Test
-  public void checkBackupCleanupFromChildrenBlocksWhenChildHasPendingBackupWithinDelay() {
-    String store = "backup_from_children_block";
-    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
-    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
-    mockBackupCleanupConfig(mockParentAdmin, 2, TimeUnit.HOURS.toMillis(1));
-    doCallRealMethod().when(mockParentAdmin).checkBackupVersionCleanupCapacityFromChildren(any(), any());
-
-    // Child dc-0 still has a KILLED backup pending deletion, promoted just now -> parent must block.
+    // Child dc-0 has a KILLED backup pending deletion, promoted just now -> parent must block.
     Map<String, ControllerClient> map = new HashMap<>();
     map.put("dc-0", childClient(backupPendingStore(store)));
     doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
 
-    assertThrows(
-        VeniceException.class,
-        () -> mockParentAdmin.checkBackupVersionCleanupCapacityFromChildren(clusterName, store));
+    assertThrows(VeniceException.class, () -> mockParentAdmin.checkNewPushCapacityFromChildren(clusterName, store));
   }
 
   @Test
-  public void checkBackupCleanupFromChildrenAllowsWhenChildrenHaveNoPendingBackup() {
-    String store = "backup_from_children_allow";
+  public void checkNewPushCapacityFromChildrenAllowsWhenChildrenClean() {
+    // LIVE child status shows neither a rolled-back version nor a backup pending deletion, so the
+    // push must be allowed rather than blocked on (potentially stale) parent metadata.
+    String store = "npc_from_children_allow";
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
-    mockBackupCleanupConfig(mockParentAdmin, 2, TimeUnit.HOURS.toMillis(1));
-    doCallRealMethod().when(mockParentAdmin).checkBackupVersionCleanupCapacityFromChildren(any(), any());
+    mockNewPushCapacityConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24), 2, TimeUnit.HOURS.toMillis(1));
+    doCallRealMethod().when(mockParentAdmin).checkNewPushCapacityFromChildren(any(), any());
 
     Map<String, ControllerClient> map = new HashMap<>();
     map.put("dc-0", childClient(noBackupPendingStore(store)));
     map.put("dc-1", childClient(noBackupPendingStore(store)));
     doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
 
-    // Should not throw — no child has a backup pending deletion.
-    mockParentAdmin.checkBackupVersionCleanupCapacityFromChildren(clusterName, store);
+    // Should not throw — all children are clean for both guards.
+    mockParentAdmin.checkNewPushCapacityFromChildren(clusterName, store);
   }
 
   @Test
-  public void checkBackupCleanupFromChildrenSkipsErroredRegion() {
-    String store = "backup_from_children_error";
+  public void checkNewPushCapacityFromChildrenSkipsErroredRegion() {
+    // A transient child-query failure must not wedge pushes: the errored region is skipped.
+    String store = "npc_from_children_error";
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
-    mockBackupCleanupConfig(mockParentAdmin, 2, TimeUnit.HOURS.toMillis(1));
-    doCallRealMethod().when(mockParentAdmin).checkBackupVersionCleanupCapacityFromChildren(any(), any());
+    mockNewPushCapacityConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24), 2, TimeUnit.HOURS.toMillis(1));
+    doCallRealMethod().when(mockParentAdmin).checkNewPushCapacityFromChildren(any(), any());
 
     ControllerClient errorClient = mock(ControllerClient.class);
     StoreResponse errorResponse = new StoreResponse();
-    errorResponse.setError("Simulated error fetching store for backup-version cleanup check.");
+    errorResponse.setError("Simulated error fetching store for new-push capacity checks.");
     doReturn(errorResponse).when(errorClient).getStore(anyString(), anyInt());
     Map<String, ControllerClient> map = new HashMap<>();
     map.put("dc-0", errorClient);
     doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
 
     // Should not throw — the errored region is skipped.
-    mockParentAdmin.checkBackupVersionCleanupCapacityFromChildren(clusterName, store);
+    mockParentAdmin.checkNewPushCapacityFromChildren(clusterName, store);
   }
 
   @Test
-  public void checkBackupCleanupFromChildrenSkipsWhenNoChildClients() {
-    String store = "backup_from_children_no_clients";
+  public void checkNewPushCapacityFromChildrenSkipsWhenNoChildClients() {
+    // No children to verify against. Parent metadata can be stale, so we must NOT fall back to
+    // enforcing against it (that is the false-block this check exists to avoid) -> allow the push.
+    String store = "npc_from_children_no_clients";
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
-    mockBackupCleanupConfig(mockParentAdmin, 2, TimeUnit.HOURS.toMillis(1));
-    doCallRealMethod().when(mockParentAdmin).checkBackupVersionCleanupCapacityFromChildren(any(), any());
+    mockNewPushCapacityConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24), 2, TimeUnit.HOURS.toMillis(1));
+    doCallRealMethod().when(mockParentAdmin).checkNewPushCapacityFromChildren(any(), any());
     doReturn(new HashMap<String, ControllerClient>()).when(internalAdmin).getControllerClientMap(anyString());
 
-    // Should not throw — no children to verify against.
-    mockParentAdmin.checkBackupVersionCleanupCapacityFromChildren(clusterName, store);
+    // Should not throw.
+    mockParentAdmin.checkNewPushCapacityFromChildren(clusterName, store);
   }
 
   @Test
-  public void checkBackupCleanupFromChildrenSkipsRegionWhenGetStoreThrows() {
-    // Same contract as the rollback gate: a getStore throw is a skipped region, not a push abort.
-    String store = "backup_from_children_throws";
+  public void checkNewPushCapacityFromChildrenSkipsRegionWhenGetStoreThrows() {
+    // ControllerClient#getStore can throw (e.g. VeniceHttpException/leader-discovery); a throw must
+    // be treated as a skipped region, not abort push-start.
+    String store = "npc_from_children_throws";
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
-    mockBackupCleanupConfig(mockParentAdmin, 2, TimeUnit.HOURS.toMillis(1));
-    doCallRealMethod().when(mockParentAdmin).checkBackupVersionCleanupCapacityFromChildren(any(), any());
+    mockNewPushCapacityConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24), 2, TimeUnit.HOURS.toMillis(1));
+    doCallRealMethod().when(mockParentAdmin).checkNewPushCapacityFromChildren(any(), any());
 
     ControllerClient throwingClient = mock(ControllerClient.class);
     doThrow(new VeniceException("Simulated getStore failure")).when(throwingClient).getStore(anyString(), anyInt());
@@ -2940,11 +2866,38 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
 
     // Should not throw — the region is skipped.
-    mockParentAdmin.checkBackupVersionCleanupCapacityFromChildren(clusterName, store);
+    mockParentAdmin.checkNewPushCapacityFromChildren(clusterName, store);
   }
 
-  private void mockBackupCleanupConfig(VeniceParentHelixAdmin admin, int minVersions, long cleanupDelayMs) {
+  @Test
+  public void checkNewPushCapacityFromChildrenSkipsRegionWhenChildVersionsNull() {
+    // StoreInfo defaults versions to null; a null-versions payload must be skipped, not NPE and
+    // abort push-start.
+    String store = "npc_from_children_null_versions";
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    mockNewPushCapacityConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24), 2, TimeUnit.HOURS.toMillis(1));
+    doCallRealMethod().when(mockParentAdmin).checkNewPushCapacityFromChildren(any(), any());
+
+    ControllerClient nullVersionsClient = mock(ControllerClient.class);
+    StoreResponse response = new StoreResponse();
+    response.setStore(new StoreInfo()); // versions default to null
+    doReturn(response).when(nullVersionsClient).getStore(anyString(), anyInt());
+    Map<String, ControllerClient> map = new HashMap<>();
+    map.put("dc-0", nullVersionsClient);
+    doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
+
+    // Should not throw — the region is skipped.
+    mockParentAdmin.checkNewPushCapacityFromChildren(clusterName, store);
+  }
+
+  private void mockNewPushCapacityConfig(
+      VeniceParentHelixAdmin admin,
+      long retentionMs,
+      int minVersions,
+      long cleanupDelayMs) {
     VeniceControllerClusterConfig clusterConfig = mock(VeniceControllerClusterConfig.class);
+    doReturn(retentionMs).when(clusterConfig).getRolledBackVersionRetentionMs();
     doReturn(cleanupDelayMs).when(clusterConfig).getBackupVersionMinCleanupDelayMs();
     VeniceControllerMultiClusterConfig multiConfig = mock(VeniceControllerMultiClusterConfig.class);
     doReturn(clusterConfig).when(multiConfig).getControllerConfig(anyString());
@@ -2974,14 +2927,6 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     return store;
   }
 
-  private void mockRolledBackRetentionConfig(VeniceParentHelixAdmin admin, long retentionMs) {
-    VeniceControllerClusterConfig clusterConfig = mock(VeniceControllerClusterConfig.class);
-    doReturn(retentionMs).when(clusterConfig).getRolledBackVersionRetentionMs();
-    VeniceControllerMultiClusterConfig multiConfig = mock(VeniceControllerMultiClusterConfig.class);
-    doReturn(clusterConfig).when(multiConfig).getControllerConfig(anyString());
-    doReturn(multiConfig).when(admin).getMultiClusterConfigs();
-  }
-
   private static ControllerClient childClient(Store store) {
     ControllerClient client = mock(ControllerClient.class);
     StoreResponse response = new StoreResponse();
@@ -2997,17 +2942,6 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     store.updateVersionStatus(1, VersionStatus.ONLINE);
     store.updateVersionStatus(2, VersionStatus.ROLLED_BACK);
     store.setCurrentVersion(1);
-    store.setLatestVersionPromoteToCurrentTimestamp(System.currentTimeMillis());
-    return store;
-  }
-
-  private static Store onlineOnlyStore(String storeName) {
-    Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
-    store.addVersion(new VersionImpl(storeName, 1, "push1"));
-    store.addVersion(new VersionImpl(storeName, 2, "push2"));
-    store.updateVersionStatus(1, VersionStatus.ONLINE);
-    store.updateVersionStatus(2, VersionStatus.ONLINE);
-    store.setCurrentVersion(2);
     store.setLatestVersionPromoteToCurrentTimestamp(System.currentTimeMillis());
     return store;
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2836,6 +2836,105 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store);
   }
 
+  @Test
+  public void checkBackupCleanupFromChildrenBlocksWhenChildHasPendingBackupWithinDelay() {
+    String store = "backup_from_children_block";
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    mockBackupCleanupConfig(mockParentAdmin, 2, TimeUnit.HOURS.toMillis(1));
+    doCallRealMethod().when(mockParentAdmin).checkBackupVersionCleanupCapacityFromChildren(any(), any());
+
+    // Child dc-0 still has a KILLED backup pending deletion, promoted just now -> parent must block.
+    Map<String, ControllerClient> map = new HashMap<>();
+    map.put("dc-0", childClient(backupPendingStore(store)));
+    doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
+
+    assertThrows(
+        VeniceException.class,
+        () -> mockParentAdmin.checkBackupVersionCleanupCapacityFromChildren(clusterName, store));
+  }
+
+  @Test
+  public void checkBackupCleanupFromChildrenAllowsWhenChildrenHaveNoPendingBackup() {
+    String store = "backup_from_children_allow";
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    mockBackupCleanupConfig(mockParentAdmin, 2, TimeUnit.HOURS.toMillis(1));
+    doCallRealMethod().when(mockParentAdmin).checkBackupVersionCleanupCapacityFromChildren(any(), any());
+
+    Map<String, ControllerClient> map = new HashMap<>();
+    map.put("dc-0", childClient(noBackupPendingStore(store)));
+    map.put("dc-1", childClient(noBackupPendingStore(store)));
+    doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
+
+    // Should not throw — no child has a backup pending deletion.
+    mockParentAdmin.checkBackupVersionCleanupCapacityFromChildren(clusterName, store);
+  }
+
+  @Test
+  public void checkBackupCleanupFromChildrenSkipsErroredRegion() {
+    String store = "backup_from_children_error";
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    mockBackupCleanupConfig(mockParentAdmin, 2, TimeUnit.HOURS.toMillis(1));
+    doCallRealMethod().when(mockParentAdmin).checkBackupVersionCleanupCapacityFromChildren(any(), any());
+
+    ControllerClient errorClient = mock(ControllerClient.class);
+    StoreResponse errorResponse = new StoreResponse();
+    errorResponse.setError("Simulated error fetching store for backup-version cleanup check.");
+    doReturn(errorResponse).when(errorClient).getStore(anyString(), anyInt());
+    Map<String, ControllerClient> map = new HashMap<>();
+    map.put("dc-0", errorClient);
+    doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
+
+    // Should not throw — the errored region is skipped.
+    mockParentAdmin.checkBackupVersionCleanupCapacityFromChildren(clusterName, store);
+  }
+
+  @Test
+  public void checkBackupCleanupFromChildrenSkipsWhenNoChildClients() {
+    String store = "backup_from_children_no_clients";
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    mockBackupCleanupConfig(mockParentAdmin, 2, TimeUnit.HOURS.toMillis(1));
+    doCallRealMethod().when(mockParentAdmin).checkBackupVersionCleanupCapacityFromChildren(any(), any());
+    doReturn(new HashMap<String, ControllerClient>()).when(internalAdmin).getControllerClientMap(anyString());
+
+    // Should not throw — no children to verify against.
+    mockParentAdmin.checkBackupVersionCleanupCapacityFromChildren(clusterName, store);
+  }
+
+  private void mockBackupCleanupConfig(VeniceParentHelixAdmin admin, int minVersions, long cleanupDelayMs) {
+    VeniceControllerClusterConfig clusterConfig = mock(VeniceControllerClusterConfig.class);
+    doReturn(cleanupDelayMs).when(clusterConfig).getBackupVersionMinCleanupDelayMs();
+    VeniceControllerMultiClusterConfig multiConfig = mock(VeniceControllerMultiClusterConfig.class);
+    doReturn(clusterConfig).when(multiConfig).getControllerConfig(anyString());
+    doReturn(minVersions).when(multiConfig).getMinNumberOfStoreVersionsToPreserve();
+    doReturn(multiConfig).when(admin).getMultiClusterConfigs();
+  }
+
+  private static Store backupPendingStore(String storeName) {
+    Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
+    store.addVersion(new VersionImpl(storeName, 1, "push1"));
+    store.addVersion(new VersionImpl(storeName, 2, "push2"));
+    // v1 KILLED is always pending deletion (canDelete); v2 was just promoted -> within cleanup delay.
+    store.updateVersionStatus(1, VersionStatus.KILLED);
+    store.updateVersionStatus(2, VersionStatus.ONLINE);
+    store.setCurrentVersion(2);
+    store.setLatestVersionPromoteToCurrentTimestamp(System.currentTimeMillis());
+    return store;
+  }
+
+  private static Store noBackupPendingStore(String storeName) {
+    Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
+    store.addVersion(new VersionImpl(storeName, 1, "push1"));
+    // Only the current version exists, so nothing is pending deletion.
+    store.updateVersionStatus(1, VersionStatus.ONLINE);
+    store.setCurrentVersion(1);
+    store.setLatestVersionPromoteToCurrentTimestamp(System.currentTimeMillis());
+    return store;
+  }
+
   private void mockRolledBackRetentionConfig(VeniceParentHelixAdmin admin, long retentionMs) {
     VeniceControllerClusterConfig clusterConfig = mock(VeniceControllerClusterConfig.class);
     doReturn(retentionMs).when(clusterConfig).getRolledBackVersionRetentionMs();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2837,6 +2837,26 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   @Test
+  public void checkRollbackOriginFromChildrenSkipsRegionWhenGetStoreThrows() {
+    // ControllerClient#getStore can throw (e.g. VeniceHttpException/leader-discovery); a throw must
+    // be treated as a skipped region, not abort push-start.
+    String store = "rb_from_children_throws";
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
+    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any());
+
+    ControllerClient throwingClient = mock(ControllerClient.class);
+    doThrow(new VeniceException("Simulated getStore failure")).when(throwingClient).getStore(anyString(), anyInt());
+    Map<String, ControllerClient> map = new HashMap<>();
+    map.put("dc-0", throwingClient);
+    doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
+
+    // Should not throw — the region is skipped.
+    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store);
+  }
+
+  @Test
   public void checkBackupCleanupFromChildrenBlocksWhenChildHasPendingBackupWithinDelay() {
     String store = "backup_from_children_block";
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
@@ -2901,6 +2921,25 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(new HashMap<String, ControllerClient>()).when(internalAdmin).getControllerClientMap(anyString());
 
     // Should not throw — no children to verify against.
+    mockParentAdmin.checkBackupVersionCleanupCapacityFromChildren(clusterName, store);
+  }
+
+  @Test
+  public void checkBackupCleanupFromChildrenSkipsRegionWhenGetStoreThrows() {
+    // Same contract as the rollback gate: a getStore throw is a skipped region, not a push abort.
+    String store = "backup_from_children_throws";
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    mockBackupCleanupConfig(mockParentAdmin, 2, TimeUnit.HOURS.toMillis(1));
+    doCallRealMethod().when(mockParentAdmin).checkBackupVersionCleanupCapacityFromChildren(any(), any());
+
+    ControllerClient throwingClient = mock(ControllerClient.class);
+    doThrow(new VeniceException("Simulated getStore failure")).when(throwingClient).getStore(anyString(), anyInt());
+    Map<String, ControllerClient> map = new HashMap<>();
+    map.put("dc-0", throwingClient);
+    doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
+
+    // Should not throw — the region is skipped.
     mockParentAdmin.checkBackupVersionCleanupCapacityFromChildren(clusterName, store);
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2763,6 +2763,136 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   @Test
+  public void checkRollbackOriginFromChildrenBlocksWhenChildRolledBackWithinRetention() {
+    String store = "rb_from_children_block";
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
+    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any(), any());
+
+    // Parent metadata WOULD block (rollback-origin v2 within retention), and child dc-0 still holds
+    // the rollback-origin version too -> the parent must block the new push.
+    Map<String, ControllerClient> map = new HashMap<>();
+    map.put("dc-0", childClient(rolledBackOriginStore(store)));
+    doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
+
+    assertThrows(
+        VeniceException.class,
+        () -> mockParentAdmin
+            .checkRollbackOriginVersionCapacityFromChildren(clusterName, store, rolledBackOriginStore(store)));
+  }
+
+  @Test
+  public void checkRollbackOriginFromChildrenAllowsWhenChildrenNotRolledBack() {
+    // The core fix: parent metadata carries a stale rollback-origin record (so the pre-check fires),
+    // but the LIVE child status shows no rollback-origin version -> the push must be allowed instead
+    // of being falsely blocked for the full retention window.
+    String store = "rb_from_children_allow";
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
+    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any(), any());
+
+    Map<String, ControllerClient> map = new HashMap<>();
+    map.put("dc-0", childClient(onlineOnlyStore(store)));
+    map.put("dc-1", childClient(onlineOnlyStore(store)));
+    doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
+
+    // Should not throw despite the stale parent rollback-origin record.
+    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store, rolledBackOriginStore(store));
+  }
+
+  @Test
+  public void checkRollbackOriginFromChildrenSkipsFastWhenParentHasNoRollbackOrigin() {
+    // Fast path: parent metadata shows no rollback-origin version, so children are never queried.
+    String store = "rb_from_children_fastpath";
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
+    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any(), any());
+
+    // Should not throw, and the fast path must not enforce a block.
+    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store, onlineOnlyStore(store));
+  }
+
+  @Test
+  public void checkRollbackOriginFromChildrenSkipsErroredRegion() {
+    // A transient child-query failure must not wedge pushes: the errored region is skipped, and
+    // with no reachable rollback-origin child the push is allowed.
+    String store = "rb_from_children_error";
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
+    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any(), any());
+
+    ControllerClient errorClient = mock(ControllerClient.class);
+    StoreResponse errorResponse = new StoreResponse();
+    errorResponse.setError("Simulated error fetching store for rollback-origin retention check.");
+    doReturn(errorResponse).when(errorClient).getStore(anyString(), anyInt());
+    Map<String, ControllerClient> map = new HashMap<>();
+    map.put("dc-0", errorClient);
+    doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
+
+    // Should not throw.
+    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store, rolledBackOriginStore(store));
+  }
+
+  @Test
+  public void checkRollbackOriginFromChildrenFallsBackToParentWhenNoChildClients() {
+    // Degenerate config: parent would block and there are no children to verify against -> fall back
+    // to the parent-metadata decision (block) to stay safe.
+    String store = "rb_from_children_no_clients";
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    mockRolledBackRetentionConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24));
+    doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any(), any());
+    doReturn(new HashMap<String, ControllerClient>()).when(internalAdmin).getControllerClientMap(anyString());
+
+    assertThrows(
+        VeniceException.class,
+        () -> mockParentAdmin
+            .checkRollbackOriginVersionCapacityFromChildren(clusterName, store, rolledBackOriginStore(store)));
+  }
+
+  private void mockRolledBackRetentionConfig(VeniceParentHelixAdmin admin, long retentionMs) {
+    VeniceControllerClusterConfig clusterConfig = mock(VeniceControllerClusterConfig.class);
+    doReturn(retentionMs).when(clusterConfig).getRolledBackVersionRetentionMs();
+    VeniceControllerMultiClusterConfig multiConfig = mock(VeniceControllerMultiClusterConfig.class);
+    doReturn(clusterConfig).when(multiConfig).getControllerConfig(anyString());
+    doReturn(multiConfig).when(admin).getMultiClusterConfigs();
+  }
+
+  private static ControllerClient childClient(Store store) {
+    ControllerClient client = mock(ControllerClient.class);
+    StoreResponse response = new StoreResponse();
+    response.setStore(StoreInfo.fromStore(store));
+    doReturn(response).when(client).getStore(anyString(), anyInt());
+    return client;
+  }
+
+  private static Store rolledBackOriginStore(String storeName) {
+    Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
+    store.addVersion(new VersionImpl(storeName, 1, "push1"));
+    store.addVersion(new VersionImpl(storeName, 2, "push2"));
+    store.updateVersionStatus(1, VersionStatus.ONLINE);
+    store.updateVersionStatus(2, VersionStatus.ROLLED_BACK);
+    store.setCurrentVersion(1);
+    store.setLatestVersionPromoteToCurrentTimestamp(System.currentTimeMillis());
+    return store;
+  }
+
+  private static Store onlineOnlyStore(String storeName) {
+    Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
+    store.addVersion(new VersionImpl(storeName, 1, "push1"));
+    store.addVersion(new VersionImpl(storeName, 2, "push2"));
+    store.updateVersionStatus(1, VersionStatus.ONLINE);
+    store.updateVersionStatus(2, VersionStatus.ONLINE);
+    store.setCurrentVersion(2);
+    store.setLatestVersionPromoteToCurrentTimestamp(System.currentTimeMillis());
+    return store;
+  }
+
+  @Test
   public void testGetCurrentVersionForMultiRegionsWithError() {
     int regionCount = 4;
     Map<String, ControllerClient> controllerClientMap = prepareForCurrentVersionTest(regionCount - 1);
@@ -2858,53 +2988,13 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(new StoreVersionInfo(store, store.getVersion(1))).when(internalAdmin)
         .waitVersion(eq(clusterName), eq(storeName), eq(1), any());
 
-    String latestTopic = storeName + "_v1";
-
-    // When there is a regular topic and the job status is terminal
-    doReturn(new Admin.OfflinePushStatusInfo(ExecutionStatus.COMPLETED)).when(mockParentAdmin)
-        .getOffLinePushStatus(clusterName, latestTopic);
-    doReturn(false).when(mockParentAdmin).isTopicTruncated(latestTopic);
+    // Latest version ONLINE: the push already completed, so the parent allows the next push through
+    // (returns empty) WITHOUT polling offline push status. This is the fix that unblocks a stuck
+    // deferred-swap ONLINE version whose push-status resource no longer exists.
     Assert.assertFalse(mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false).isPresent());
-    // When there is a regular topic and the job status is not terminal
-    doReturn(new Admin.OfflinePushStatusInfo(ExecutionStatus.PROGRESS)).when(mockParentAdmin)
-        .getOffLinePushStatus(clusterName, latestTopic);
-    Optional<String> currentPush = mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false);
-    Assert.assertTrue(currentPush.isPresent());
-    assertEquals(currentPush.get(), latestTopic);
-    verify(mockParentAdmin, times(2)).getOffLinePushStatus(clusterName, latestTopic);
+    verify(mockParentAdmin, never()).getOffLinePushStatus(eq(clusterName), anyString());
 
-    // When there is a regular topic and the job status is 'UNKNOWN' in some region,
-    // but overall status is 'COMPLETED'
-    Map<String, String> extraInfo = new HashMap<>();
-    extraInfo.put("cluster1", ExecutionStatus.UNKNOWN.toString());
-    doReturn(new Admin.OfflinePushStatusInfo(ExecutionStatus.COMPLETED, extraInfo)).when(mockParentAdmin)
-        .getOffLinePushStatus(clusterName, latestTopic);
-    doCallRealMethod().when(mockParentAdmin).setTimer(any());
-    mockParentAdmin.setTimer(new TestMockTime());
-    currentPush = mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false);
-    Assert.assertFalse(currentPush.isPresent());
-    verify(mockParentAdmin, times(7)).getOffLinePushStatus(clusterName, latestTopic);
-
-    // When there is a regular topic and the job status is 'UNKNOWN' in some region,
-    // but overall status is 'PROGRESS'
-    doReturn(new Admin.OfflinePushStatusInfo(ExecutionStatus.PROGRESS, extraInfo)).when(mockParentAdmin)
-        .getOffLinePushStatus(clusterName, latestTopic);
-    currentPush = mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false);
-    Assert.assertTrue(currentPush.isPresent());
-    assertEquals(currentPush.get(), latestTopic);
-    verify(mockParentAdmin, times(12)).getOffLinePushStatus(clusterName, latestTopic);
-
-    // When there is a regular topic and the job status is 'UNKNOWN' in some region for the first time,
-    // but overall status is 'PROGRESS'
-    doReturn(new Admin.OfflinePushStatusInfo(ExecutionStatus.PROGRESS, extraInfo)).when(mockParentAdmin)
-        .getOffLinePushStatus(clusterName, latestTopic);
-    when(mockParentAdmin.getOffLinePushStatus(clusterName, latestTopic))
-        .thenReturn(new Admin.OfflinePushStatusInfo(ExecutionStatus.PROGRESS, extraInfo))
-        .thenReturn(new Admin.OfflinePushStatusInfo(ExecutionStatus.PROGRESS));
-    currentPush = mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false);
-    Assert.assertTrue(currentPush.isPresent());
-    assertEquals(currentPush.get(), latestTopic);
-    verify(mockParentAdmin, times(14)).getOffLinePushStatus(clusterName, latestTopic);
+    Optional<String> currentPush;
 
     version = new VersionImpl(storeName, 2, "test_push_id");
     version.setStatus(VersionStatus.KILLED);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -3028,6 +3028,77 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   @Test
+  public void testGetTopicForCurrentPushJobBlocksInProgressVersion() {
+    // Regression coverage for the in-progress/polling branch of
+    // getTopicForCurrentPushJobParentVersionStatusBasedTracking. Terminal statuses early-exit (see
+    // testGetTopicForCurrentPushJob); a non-terminal latest version must instead block the next push -
+    // either immediately (STARTED/PUSHED/CREATED) or by polling getOffLinePushStatus until the offline
+    // job status is terminal. This guards the stuck-push prevention behavior.
+    String storeName = Utils.getUniqueString("test-store");
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    doReturn(new ArrayList<String>()).when(mockParentAdmin).getKafkaTopicsByAge(any());
+    ControllerClient client = mock(ControllerClient.class);
+    Map<String, ControllerClient> map = new HashMap<>();
+    map.put("dc-0", client);
+    doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
+    Map<String, VeniceControllerClusterConfig> configMap = new HashMap<>();
+    configMap.put(clusterName, config);
+    doReturn(new VeniceControllerMultiClusterConfig(configMap)).when(mockParentAdmin).getMultiClusterConfigs();
+    HelixVeniceClusterResources clusterResources = internalAdmin.getHelixVeniceClusterResources(clusterName);
+    doReturn(clusterResources).when(internalAdmin).getHelixVeniceClusterResources(clusterName);
+    doCallRealMethod().when(mockParentAdmin).getTopicForCurrentPushJob(clusterName, storeName, false, false);
+    doCallRealMethod().when(mockParentAdmin)
+        .getTopicForCurrentPushJobParentVersionStatusBasedTracking(clusterName, storeName);
+    doCallRealMethod().when(mockParentAdmin).setTimer(any());
+    mockParentAdmin.setTimer(new TestMockTime());
+
+    String latestTopic = storeName + "_v1";
+
+    // STARTED: push still running -> blocked immediately, without polling offline push status.
+    doReturn(inProgressStore(storeName, VersionStatus.STARTED)).when(mockParentAdmin).getStore(clusterName, storeName);
+    Optional<String> currentPush = mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false);
+    Assert.assertTrue(currentPush.isPresent());
+    assertEquals(currentPush.get(), latestTopic);
+    verify(mockParentAdmin, never()).getOffLinePushStatus(eq(clusterName), anyString());
+
+    // Non-terminal latest version reaches the polling branch. PROGRESS offline status is non-terminal,
+    // so the parent blocks the next push and returns the in-flight topic.
+    doReturn(inProgressStore(storeName, VersionStatus.NOT_CREATED)).when(mockParentAdmin)
+        .getStore(clusterName, storeName);
+    doReturn(new Admin.OfflinePushStatusInfo(ExecutionStatus.PROGRESS)).when(mockParentAdmin)
+        .getOffLinePushStatus(clusterName, latestTopic);
+    currentPush = mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false);
+    Assert.assertTrue(currentPush.isPresent());
+    assertEquals(currentPush.get(), latestTopic);
+    verify(mockParentAdmin, atLeast(1)).getOffLinePushStatus(clusterName, latestTopic);
+
+    // UNKNOWN in a region triggers retries; once the overall status is terminal (COMPLETED) the parent
+    // stops blocking and allows the next push (returns empty).
+    Map<String, String> extraInfo = new HashMap<>();
+    extraInfo.put("dc-0", ExecutionStatus.UNKNOWN.toString());
+    doReturn(new Admin.OfflinePushStatusInfo(ExecutionStatus.COMPLETED, extraInfo)).when(mockParentAdmin)
+        .getOffLinePushStatus(clusterName, latestTopic);
+    Assert.assertFalse(mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false).isPresent());
+  }
+
+  private Store inProgressStore(String storeName, VersionStatus status) {
+    Store store = new ZKStore(
+        storeName,
+        "test_owner",
+        1,
+        PersistenceType.ROCKS_DB,
+        RoutingStrategy.CONSISTENT_HASH,
+        ReadStrategy.ANY_OF_ONLINE,
+        OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION,
+        1);
+    VersionImpl version = new VersionImpl(storeName, 1, "test_push_id");
+    version.setStatus(status);
+    store.addVersion(version);
+    return store;
+  }
+
+  @Test
   public void testTruncateTopicsBasedOnMaxErroredTopicNumToKeep() {
     String storeName = Utils.getUniqueString("test-store");
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2838,9 +2838,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   @Test
-  public void checkRollbackOriginFromChildrenFallsBackToParentWhenNoChildClients() {
-    // Degenerate config: parent would block and there are no children to verify against -> fall back
-    // to the parent-metadata decision (block) to stay safe.
+  public void checkRollbackOriginFromChildrenSkipsWhenNoChildClients() {
+    // No children to verify against. Parent metadata can be stale, so we must NOT fall back to
+    // enforcing against it (that is the false-block this check exists to avoid) -> allow the push.
     String store = "rb_from_children_no_clients";
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
@@ -2848,10 +2848,8 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doCallRealMethod().when(mockParentAdmin).checkRollbackOriginVersionCapacityFromChildren(any(), any(), any());
     doReturn(new HashMap<String, ControllerClient>()).when(internalAdmin).getControllerClientMap(anyString());
 
-    assertThrows(
-        VeniceException.class,
-        () -> mockParentAdmin
-            .checkRollbackOriginVersionCapacityFromChildren(clusterName, store, rolledBackOriginStore(store)));
+    // Should not throw even though parent metadata shows a rollback-origin version within retention.
+    mockParentAdmin.checkRollbackOriginVersionCapacityFromChildren(clusterName, store, rolledBackOriginStore(store));
   }
 
   private void mockRolledBackRetentionConfig(VeniceParentHelixAdmin admin, long retentionMs) {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/versionlifecycle/NewPushCapacityGuardsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/versionlifecycle/NewPushCapacityGuardsTest.java
@@ -412,4 +412,41 @@ public class NewPushCapacityGuardsTest {
         () -> VersionLifecyclePolicy
             .checkRollbackOriginVersionCapacityForNewPush(CLUSTER_NAME, STORE_NAME, store, retention, now));
   }
+
+  @Test
+  public void rollbackOriginFieldOverloadBlocksAndIncludesRegionNameInMessage() {
+    // The child-snapshot overload evaluates raw fields (as fed from a child StoreInfo) and enriches
+    // the rejection message with the region name so operators can see which child is blocking.
+    long now = System.currentTimeMillis();
+    VeniceException e = expectThrows(
+        VeniceException.class,
+        () -> VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
+            CLUSTER_NAME,
+            STORE_NAME,
+            "dc-0",
+            Arrays.asList(mockVersion(4, VersionStatus.ONLINE), mockVersion(5, VersionStatus.ROLLED_BACK)),
+            /* currentVersion */ 4,
+            /* latestVersionPromoteToCurrentTimestamp */ now - TimeUnit.HOURS.toMillis(1),
+            ROLLED_BACK_RETENTION_MS,
+            now));
+    assertTrue(e.getMessage().contains("in region dc-0"), "message should include region: " + e.getMessage());
+    assertTrue(e.getMessage().contains("version 5"), "message should include version number: " + e.getMessage());
+    assertTrue(e.getMessage().contains("ROLLED_BACK"), "message should include status: " + e.getMessage());
+  }
+
+  @Test
+  public void rollbackOriginFieldOverloadPassesWhenNoRollbackOriginVersion() {
+    // Live child snapshot shows no rollback-origin version -> no block, even within the retention
+    // window. This is the parent-side allow path when parent metadata is stale but children are clean.
+    long now = System.currentTimeMillis();
+    VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
+        CLUSTER_NAME,
+        STORE_NAME,
+        "dc-0",
+        Arrays.asList(mockVersion(4, VersionStatus.ONLINE), mockVersion(5, VersionStatus.ONLINE)),
+        /* currentVersion */ 5,
+        /* latestVersionPromoteToCurrentTimestamp */ now,
+        ROLLED_BACK_RETENTION_MS,
+        now);
+  }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/versionlifecycle/NewPushCapacityGuardsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/versionlifecycle/NewPushCapacityGuardsTest.java
@@ -220,6 +220,20 @@ public class NewPushCapacityGuardsTest {
 
   // ---------- checkRollbackOriginVersionCapacityForNewPush ----------
 
+  // Repoints the Store-based scenarios at the field overload (the only surviving signature),
+  // unpacking the Store snapshot exactly as the parent does for a child StoreInfo.
+  private static void checkRollbackOrigin(Store store, long rolledBackVersionRetentionMs, long currentTimeMs) {
+    VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
+        CLUSTER_NAME,
+        STORE_NAME,
+        null,
+        store.getVersions(),
+        store.getCurrentVersion(),
+        store.getLatestVersionPromoteToCurrentTimestamp(),
+        rolledBackVersionRetentionMs,
+        currentTimeMs);
+  }
+
   @Test
   public void rollbackOriginPassesWhenNoRollbackOriginVersions() {
     Store store = mockStoreWithVersions(
@@ -228,12 +242,7 @@ public class NewPushCapacityGuardsTest {
         mockVersion(1, VersionStatus.ONLINE),
         mockVersion(2, VersionStatus.ONLINE));
 
-    VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
-        CLUSTER_NAME,
-        STORE_NAME,
-        store,
-        ROLLED_BACK_RETENTION_MS,
-        System.currentTimeMillis());
+    checkRollbackOrigin(store, ROLLED_BACK_RETENTION_MS, System.currentTimeMillis());
   }
 
   @Test
@@ -245,14 +254,8 @@ public class NewPushCapacityGuardsTest {
         mockVersion(4, VersionStatus.ONLINE),
         mockVersion(5, VersionStatus.ROLLED_BACK));
 
-    VeniceException e = expectThrows(
-        VeniceException.class,
-        () -> VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
-            CLUSTER_NAME,
-            STORE_NAME,
-            store,
-            ROLLED_BACK_RETENTION_MS,
-            now));
+    VeniceException e =
+        expectThrows(VeniceException.class, () -> checkRollbackOrigin(store, ROLLED_BACK_RETENTION_MS, now));
     assertTrue(e.getMessage().contains(STORE_NAME), "message should include store name: " + e.getMessage());
     assertTrue(e.getMessage().contains("ROLLED_BACK"), "message should include status: " + e.getMessage());
     assertTrue(e.getMessage().contains("version 5"), "message should include version number: " + e.getMessage());
@@ -267,8 +270,7 @@ public class NewPushCapacityGuardsTest {
         mockVersion(4, VersionStatus.ONLINE),
         mockVersion(5, VersionStatus.ROLLED_BACK));
 
-    VersionLifecyclePolicy
-        .checkRollbackOriginVersionCapacityForNewPush(CLUSTER_NAME, STORE_NAME, store, ROLLED_BACK_RETENTION_MS, now);
+    checkRollbackOrigin(store, ROLLED_BACK_RETENTION_MS, now);
   }
 
   @Test
@@ -281,14 +283,8 @@ public class NewPushCapacityGuardsTest {
         mockVersion(4, VersionStatus.ONLINE),
         mockVersion(5, VersionStatus.PARTIALLY_ONLINE));
 
-    VeniceException e = expectThrows(
-        VeniceException.class,
-        () -> VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
-            CLUSTER_NAME,
-            STORE_NAME,
-            store,
-            ROLLED_BACK_RETENTION_MS,
-            now));
+    VeniceException e =
+        expectThrows(VeniceException.class, () -> checkRollbackOrigin(store, ROLLED_BACK_RETENTION_MS, now));
     assertTrue(e.getMessage().contains("PARTIALLY_ONLINE"), "message should include status: " + e.getMessage());
   }
 
@@ -305,8 +301,7 @@ public class NewPushCapacityGuardsTest {
         mockVersion(2, VersionStatus.ROLLED_BACK),
         mockVersion(3, VersionStatus.ONLINE));
 
-    VersionLifecyclePolicy
-        .checkRollbackOriginVersionCapacityForNewPush(CLUSTER_NAME, STORE_NAME, store, ROLLED_BACK_RETENTION_MS, now);
+    checkRollbackOrigin(store, ROLLED_BACK_RETENTION_MS, now);
   }
 
   @Test
@@ -323,14 +318,8 @@ public class NewPushCapacityGuardsTest {
         mockVersion(4, VersionStatus.ONLINE),
         mockVersion(5, VersionStatus.ROLLED_BACK));
 
-    VeniceException e = expectThrows(
-        VeniceException.class,
-        () -> VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
-            CLUSTER_NAME,
-            STORE_NAME,
-            store,
-            ROLLED_BACK_RETENTION_MS,
-            now));
+    VeniceException e =
+        expectThrows(VeniceException.class, () -> checkRollbackOrigin(store, ROLLED_BACK_RETENTION_MS, now));
     assertTrue(
         e.getMessage().contains("version 5"),
         "should block on v5 (above current), not stale v2: " + e.getMessage());
@@ -346,8 +335,7 @@ public class NewPushCapacityGuardsTest {
         mockVersion(3, VersionStatus.ONLINE),
         mockVersion(4, VersionStatus.PARTIALLY_ONLINE));
 
-    VersionLifecyclePolicy
-        .checkRollbackOriginVersionCapacityForNewPush(CLUSTER_NAME, STORE_NAME, store, ROLLED_BACK_RETENTION_MS, now);
+    checkRollbackOrigin(store, ROLLED_BACK_RETENTION_MS, now);
   }
 
   @Test
@@ -360,8 +348,7 @@ public class NewPushCapacityGuardsTest {
         mockVersion(4, VersionStatus.PARTIALLY_ONLINE),
         mockVersion(5, VersionStatus.ONLINE));
 
-    VersionLifecyclePolicy
-        .checkRollbackOriginVersionCapacityForNewPush(CLUSTER_NAME, STORE_NAME, store, ROLLED_BACK_RETENTION_MS, now);
+    checkRollbackOrigin(store, ROLLED_BACK_RETENTION_MS, now);
   }
 
   @Test
@@ -376,8 +363,7 @@ public class NewPushCapacityGuardsTest {
         mockVersion(4, VersionStatus.ONLINE),
         mockVersion(5, VersionStatus.ROLLED_BACK));
 
-    VersionLifecyclePolicy
-        .checkRollbackOriginVersionCapacityForNewPush(CLUSTER_NAME, STORE_NAME, store, retention, now);
+    checkRollbackOrigin(store, retention, now);
   }
 
   @Test
@@ -390,10 +376,7 @@ public class NewPushCapacityGuardsTest {
         mockVersion(4, VersionStatus.ONLINE),
         mockVersion(5, VersionStatus.ROLLED_BACK));
 
-    expectThrows(
-        VeniceException.class,
-        () -> VersionLifecyclePolicy
-            .checkRollbackOriginVersionCapacityForNewPush(CLUSTER_NAME, STORE_NAME, store, retention, now));
+    expectThrows(VeniceException.class, () -> checkRollbackOrigin(store, retention, now));
   }
 
   @Test
@@ -407,10 +390,7 @@ public class NewPushCapacityGuardsTest {
         mockVersion(4, VersionStatus.ONLINE),
         mockVersion(5, VersionStatus.ROLLED_BACK));
 
-    expectThrows(
-        VeniceException.class,
-        () -> VersionLifecyclePolicy
-            .checkRollbackOriginVersionCapacityForNewPush(CLUSTER_NAME, STORE_NAME, store, retention, now));
+    expectThrows(VeniceException.class, () -> checkRollbackOrigin(store, retention, now));
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/versionlifecycle/NewPushCapacityGuardsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/versionlifecycle/NewPushCapacityGuardsTest.java
@@ -274,8 +274,10 @@ public class NewPushCapacityGuardsTest {
   }
 
   @Test
-  public void rollbackOriginBlocksPushWhenPartiallyOnlineVersionAboveCurrentExistsWithinRetention() {
-    // Parent-side partial rollback: v5 is PARTIALLY_ONLINE with number > currentVersion (v4)
+  public void rollbackOriginPassesWhenPartiallyOnlineVersionAboveCurrentExists() {
+    // A child region's rollback is binary (ROLLED_BACK), so a rollback never leaves a child
+    // PARTIALLY_ONLINE. A child PARTIALLY_ONLINE above currentVersion comes only from a degraded-mode
+    // forward push, which is NOT a rollback-origin and must not block a new push.
     long now = System.currentTimeMillis();
     Store store = mockStoreWithVersions(
         4,
@@ -283,9 +285,7 @@ public class NewPushCapacityGuardsTest {
         mockVersion(4, VersionStatus.ONLINE),
         mockVersion(5, VersionStatus.PARTIALLY_ONLINE));
 
-    VeniceException e =
-        expectThrows(VeniceException.class, () -> checkRollbackOrigin(store, ROLLED_BACK_RETENTION_MS, now));
-    assertTrue(e.getMessage().contains("PARTIALLY_ONLINE"), "message should include status: " + e.getMessage());
+    checkRollbackOrigin(store, ROLLED_BACK_RETENTION_MS, now);
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/versionlifecycle/NewPushCapacityGuardsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/versionlifecycle/NewPushCapacityGuardsTest.java
@@ -8,10 +8,6 @@ import static com.linkedin.venice.controller.versionlifecycle.VersionLifecycleTe
 import static com.linkedin.venice.controller.versionlifecycle.VersionLifecycleTestSupport.mockStoreWithPromoteTimestamp;
 import static com.linkedin.venice.controller.versionlifecycle.VersionLifecycleTestSupport.mockStoreWithVersions;
 import static com.linkedin.venice.controller.versionlifecycle.VersionLifecycleTestSupport.mockVersion;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
@@ -19,10 +15,8 @@ import static org.testng.Assert.expectThrows;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.BackupStrategy;
 import com.linkedin.venice.meta.Store;
-import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.testng.annotations.Test;
 
@@ -34,85 +28,54 @@ import org.testng.annotations.Test;
  */
 public class NewPushCapacityGuardsTest {
   // ---------- checkBackupVersionCleanupCapacityForNewPush ----------
-  @Test
-  public void deleteOnNewPushStartUsesNMinusOnePreserveCountAndPassesWhenNoVersionsPending() {
-    // DELETE_ON_NEW_PUSH_START: after SOP cleanup we expect only current + new push.
-    // Preserve count passed to retrieveVersionsToDelete should be N-1 (= 1).
-    Store store = mock(Store.class);
-    doReturn(Collections.emptyList()).when(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
 
+  // Unpacks a Store snapshot into the field overload, as the parent does for a child StoreInfo.
+  private static void checkBackupCleanup(
+      Store store,
+      BackupStrategy backupStrategy,
+      int minVersionsToPreserve,
+      long minCleanupDelayMs,
+      long currentTimeMs) {
     VersionLifecyclePolicy.checkBackupVersionCleanupCapacityForNewPush(
         CLUSTER_NAME,
         STORE_NAME,
+        null,
+        store.getVersions(),
+        store.getCurrentVersion(),
+        store.getNumVersionsToPreserve(),
+        store.isMigrating(),
+        backupStrategy,
+        minVersionsToPreserve,
+        store.getLatestVersionPromoteToCurrentTimestamp(),
+        minCleanupDelayMs,
+        currentTimeMs);
+  }
+
+  @Test
+  public void backupCleanupPassesWhenNoDeletableVersions() {
+    // Only the current version exists, so nothing is pending deletion regardless of the delay.
+    Store store = mockStoreWithVersions(2, /* promotedMsAgo */ 0, mockVersion(2, VersionStatus.ONLINE));
+    checkBackupCleanup(
         store,
         BackupStrategy.DELETE_ON_NEW_PUSH_START,
         MIN_VERSIONS_TO_PRESERVE,
         MIN_CLEANUP_DELAY_MS,
         System.currentTimeMillis());
-
-    verify(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
-    verify(store, never()).getLatestVersionPromoteToCurrentTimestamp();
   }
 
   @Test
-  public void keepMinVersionsUsesNPreserveCountAndPassesWhenNoVersionsPending() {
-    // KEEP_MIN_VERSIONS: preserve N at steady state, N+1 during push.
-    // Preserve count passed to retrieveVersionsToDelete should be N (= 2), not N-1.
-    Store store = mock(Store.class);
-    doReturn(Collections.emptyList()).when(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE);
-
-    VersionLifecyclePolicy.checkBackupVersionCleanupCapacityForNewPush(
-        CLUSTER_NAME,
-        STORE_NAME,
-        store,
-        BackupStrategy.KEEP_MIN_VERSIONS,
-        MIN_VERSIONS_TO_PRESERVE,
-        MIN_CLEANUP_DELAY_MS,
-        System.currentTimeMillis());
-
-    verify(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE);
-    verify(store, never()).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
-    verify(store, never()).getLatestVersionPromoteToCurrentTimestamp();
-  }
-
-  @Test
-  public void backupCleanupPassesWhenPastMinCleanupDelayEvenWithPendingVersions() {
-    Store store = mock(Store.class);
-    Version pendingVersion = mock(Version.class);
-    doReturn(Collections.singletonList(pendingVersion)).when(store)
-        .retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
+  public void deleteOnNewPushStartBlocksWhenKilledBackupWithinMinCleanupDelay() {
+    // v1 KILLED is pending deletion (canDelete) and v2 was just promoted, so the push is blocked.
     long now = System.currentTimeMillis();
-    long promotionTime = now - MIN_CLEANUP_DELAY_MS - 1;
-    doReturn(promotionTime).when(store).getLatestVersionPromoteToCurrentTimestamp();
-
-    VersionLifecyclePolicy.checkBackupVersionCleanupCapacityForNewPush(
-        CLUSTER_NAME,
-        STORE_NAME,
-        store,
-        BackupStrategy.DELETE_ON_NEW_PUSH_START,
-        MIN_VERSIONS_TO_PRESERVE,
-        MIN_CLEANUP_DELAY_MS,
-        now);
-
-    verify(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
-    verify(store).getLatestVersionPromoteToCurrentTimestamp();
-  }
-
-  @Test
-  public void deleteOnNewPushStartBlocksPushWhenWithinMinCleanupDelay() {
-    // Rollback scenario: versions pending AND promotion was 30min ago (< 1h min delay).
-    Store store = mock(Store.class);
-    Version pendingVersion = mock(Version.class);
-    doReturn(Collections.singletonList(pendingVersion)).when(store)
-        .retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
-    long now = System.currentTimeMillis();
-    doReturn(now - TimeUnit.MINUTES.toMillis(30)).when(store).getLatestVersionPromoteToCurrentTimestamp();
+    Store store = mockStoreWithVersions(
+        2,
+        /* promotedMsAgo */ TimeUnit.MINUTES.toMillis(30),
+        mockVersion(1, VersionStatus.KILLED),
+        mockVersion(2, VersionStatus.ONLINE));
 
     VeniceException e = expectThrows(
         VeniceException.class,
-        () -> VersionLifecyclePolicy.checkBackupVersionCleanupCapacityForNewPush(
-            CLUSTER_NAME,
-            STORE_NAME,
+        () -> checkBackupCleanup(
             store,
             BackupStrategy.DELETE_ON_NEW_PUSH_START,
             MIN_VERSIONS_TO_PRESERVE,
@@ -120,55 +83,44 @@ public class NewPushCapacityGuardsTest {
             now));
     assertTrue(e.getMessage().contains(STORE_NAME), "Error should include store name: " + e.getMessage());
     assertTrue(e.getMessage().contains(CLUSTER_NAME), "Error should include cluster name: " + e.getMessage());
-    // Anchor on "1 backup version(s)" to avoid matching the digit 1 that could appear elsewhere in the message.
+    assertTrue(e.getMessage().contains("1 backup version(s)"), "Error should include pending count: " + e.getMessage());
+    assertTrue(e.getMessage().contains("pending deletion"), "Error should mention pending deletion: " + e.getMessage());
     assertTrue(
-        e.getMessage().contains("1 backup version(s)"),
-        "Error should include pending version count: " + e.getMessage());
+        e.getMessage().contains("min cleanup delay"),
+        "Error should mention min cleanup delay: " + e.getMessage());
     assertTrue(
         e.getMessage().contains(String.valueOf(MIN_CLEANUP_DELAY_MS)),
         "Error should include the min cleanup delay value: " + e.getMessage());
   }
 
   @Test
-  public void keepMinVersionsBlocksPushWhenWithinMinCleanupDelay() {
-    Store store = mock(Store.class);
-    Version v1 = mock(Version.class);
-    Version v2 = mock(Version.class);
-    doReturn(Arrays.asList(v1, v2)).when(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE);
+  public void backupCleanupPassesWhenPastMinCleanupDelayEvenWithPendingVersions() {
     long now = System.currentTimeMillis();
-    doReturn(now - TimeUnit.MINUTES.toMillis(30)).when(store).getLatestVersionPromoteToCurrentTimestamp();
-
-    VeniceException e = expectThrows(
-        VeniceException.class,
-        () -> VersionLifecyclePolicy.checkBackupVersionCleanupCapacityForNewPush(
-            CLUSTER_NAME,
-            STORE_NAME,
-            store,
-            BackupStrategy.KEEP_MIN_VERSIONS,
-            MIN_VERSIONS_TO_PRESERVE,
-            MIN_CLEANUP_DELAY_MS,
-            now));
-    assertTrue(e.getMessage().contains(STORE_NAME));
-    assertTrue(
-        e.getMessage().contains("2 backup version(s)"),
-        "Error should report the 2 pending versions: " + e.getMessage());
+    Store store = mockStoreWithPromoteTimestamp(
+        2,
+        now - MIN_CLEANUP_DELAY_MS - 1,
+        mockVersion(1, VersionStatus.KILLED),
+        mockVersion(2, VersionStatus.ONLINE));
+    checkBackupCleanup(
+        store,
+        BackupStrategy.DELETE_ON_NEW_PUSH_START,
+        MIN_VERSIONS_TO_PRESERVE,
+        MIN_CLEANUP_DELAY_MS,
+        now);
   }
 
   @Test
   public void backupCleanupBlocksExactlyAtMinCleanupDelayBoundary() {
-    // At the boundary (currentTime == promotionTime + minDelay), the check is <= so it blocks.
-    Store store = mock(Store.class);
-    Version pendingVersion = mock(Version.class);
-    doReturn(Collections.singletonList(pendingVersion)).when(store)
-        .retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
+    // At the boundary (currentTime == promotionTime + minDelay) the check is <=, so it blocks.
     long now = System.currentTimeMillis();
-    doReturn(now - MIN_CLEANUP_DELAY_MS).when(store).getLatestVersionPromoteToCurrentTimestamp();
-
+    Store store = mockStoreWithPromoteTimestamp(
+        2,
+        now - MIN_CLEANUP_DELAY_MS,
+        mockVersion(1, VersionStatus.KILLED),
+        mockVersion(2, VersionStatus.ONLINE));
     assertThrows(
         VeniceException.class,
-        () -> VersionLifecyclePolicy.checkBackupVersionCleanupCapacityForNewPush(
-            CLUSTER_NAME,
-            STORE_NAME,
+        () -> checkBackupCleanup(
             store,
             BackupStrategy.DELETE_ON_NEW_PUSH_START,
             MIN_VERSIONS_TO_PRESERVE,
@@ -177,51 +129,77 @@ public class NewPushCapacityGuardsTest {
   }
 
   @Test
-  public void backupCleanupJustPastBoundaryAllowsPush() {
-    Store store = mock(Store.class);
-    Version pendingVersion = mock(Version.class);
-    doReturn(Collections.singletonList(pendingVersion)).when(store)
-        .retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
+  public void preserveCountDiffersBetweenBackupStrategies() {
+    // An ONLINE backup (v1) below current (v2), just promoted. DELETE_ON_NEW_PUSH_START preserves
+    // N-1 (= 1: just the current), so v1 is deletable -> blocked. KEEP_MIN_VERSIONS preserves N
+    // (= 2), so v1 is kept -> allowed.
     long now = System.currentTimeMillis();
-    doReturn(now - MIN_CLEANUP_DELAY_MS - 1).when(store).getLatestVersionPromoteToCurrentTimestamp();
+    Store store = mockStoreWithVersions(
+        2,
+        /* promotedMsAgo */ TimeUnit.MINUTES.toMillis(30),
+        mockVersion(1, VersionStatus.ONLINE),
+        mockVersion(2, VersionStatus.ONLINE));
 
-    VersionLifecyclePolicy.checkBackupVersionCleanupCapacityForNewPush(
-        CLUSTER_NAME,
-        STORE_NAME,
-        store,
-        BackupStrategy.DELETE_ON_NEW_PUSH_START,
-        MIN_VERSIONS_TO_PRESERVE,
-        MIN_CLEANUP_DELAY_MS,
-        now);
-    verify(store).retrieveVersionsToDelete(MIN_VERSIONS_TO_PRESERVE - 1);
-    verify(store).getLatestVersionPromoteToCurrentTimestamp();
+    assertThrows(
+        VeniceException.class,
+        () -> checkBackupCleanup(
+            store,
+            BackupStrategy.DELETE_ON_NEW_PUSH_START,
+            MIN_VERSIONS_TO_PRESERVE,
+            MIN_CLEANUP_DELAY_MS,
+            now));
+    checkBackupCleanup(store, BackupStrategy.KEEP_MIN_VERSIONS, MIN_VERSIONS_TO_PRESERVE, MIN_CLEANUP_DELAY_MS, now);
   }
 
   @Test
   public void deleteOnNewPushStartClampsPreserveCountToAtLeastOneWhenMinIsOne() {
-    // If cluster config sets minNumberOfStoreVersionsToPreserve == 1, the DELETE_ON_NEW_PUSH_START branch
-    // would compute N-1 = 0, which Store.retrieveVersionsToDelete rejects with IllegalArgumentException.
-    // Verify the check clamps to 1 so the push path doesn't break.
-    Store store = mock(Store.class);
-    doReturn(Collections.emptyList()).when(store).retrieveVersionsToDelete(1);
+    // min == 1 would compute N-1 = 0, which computeVersionsToDelete rejects with
+    // IllegalArgumentException. The clamp to 1 keeps it a normal VeniceException capacity block.
+    long now = System.currentTimeMillis();
+    Store store = mockStoreWithVersions(
+        2,
+        /* promotedMsAgo */ TimeUnit.MINUTES.toMillis(30),
+        mockVersion(1, VersionStatus.ONLINE),
+        mockVersion(2, VersionStatus.ONLINE));
+    assertThrows(
+        VeniceException.class,
+        () -> checkBackupCleanup(
+            store,
+            BackupStrategy.DELETE_ON_NEW_PUSH_START,
+            /* min */ 1,
+            MIN_CLEANUP_DELAY_MS,
+            now));
+  }
 
-    VersionLifecyclePolicy.checkBackupVersionCleanupCapacityForNewPush(
-        CLUSTER_NAME,
-        STORE_NAME,
-        store,
-        BackupStrategy.DELETE_ON_NEW_PUSH_START,
-        1, // cluster config edge case
-        MIN_CLEANUP_DELAY_MS,
-        System.currentTimeMillis());
-
-    verify(store).retrieveVersionsToDelete(1);
-    verify(store, never()).retrieveVersionsToDelete(0);
+  @Test
+  public void backupCleanupIncludesRegionNameInMessage() {
+    long now = System.currentTimeMillis();
+    Store store = mockStoreWithVersions(
+        2,
+        /* promotedMsAgo */ TimeUnit.MINUTES.toMillis(30),
+        mockVersion(1, VersionStatus.KILLED),
+        mockVersion(2, VersionStatus.ONLINE));
+    VeniceException e = expectThrows(
+        VeniceException.class,
+        () -> VersionLifecyclePolicy.checkBackupVersionCleanupCapacityForNewPush(
+            CLUSTER_NAME,
+            STORE_NAME,
+            "dc-1",
+            store.getVersions(),
+            store.getCurrentVersion(),
+            store.getNumVersionsToPreserve(),
+            store.isMigrating(),
+            BackupStrategy.DELETE_ON_NEW_PUSH_START,
+            MIN_VERSIONS_TO_PRESERVE,
+            store.getLatestVersionPromoteToCurrentTimestamp(),
+            MIN_CLEANUP_DELAY_MS,
+            now));
+    assertTrue(e.getMessage().contains("region dc-1"), "Error should include region name: " + e.getMessage());
   }
 
   // ---------- checkRollbackOriginVersionCapacityForNewPush ----------
 
-  // Repoints the Store-based scenarios at the field overload (the only surviving signature),
-  // unpacking the Store snapshot exactly as the parent does for a child StoreInfo.
+  // Unpacks a Store snapshot into the field overload, as the parent does for a child StoreInfo.
   private static void checkRollbackOrigin(Store store, long rolledBackVersionRetentionMs, long currentTimeMs) {
     VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
         CLUSTER_NAME,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/versionlifecycle/NewPushCapacityGuardsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/versionlifecycle/NewPushCapacityGuardsTest.java
@@ -290,10 +290,8 @@ public class NewPushCapacityGuardsTest {
 
   @Test
   public void rollbackOriginPassesWhenRolledBackVersionBelowCurrentVersion() {
-    // Stale ROLLED_BACK entry on parent: a rollback happened, then a subsequent push promoted higher.
-    // Parent retains more versions than children, so the ROLLED_BACK entry can linger after parent's
-    // currentVersion has moved past it. The filter must skip such entries — otherwise every fresh
-    // promotion's retention window would re-trigger the guard against the stale entry forever.
+    // Stale ROLLED_BACK entry below currentVersion (a later push promoted higher) must be skipped —
+    // otherwise every fresh promotion's retention window would re-trigger the guard forever.
     long now = System.currentTimeMillis();
     Store store = mockStoreWithVersions(
         3,
@@ -306,10 +304,7 @@ public class NewPushCapacityGuardsTest {
 
   @Test
   public void rollbackOriginBlocksOnlyRolledBackEntryAboveCurrentVersion() {
-    // Multi-rollback on parent: stale ROLLED_BACK v2 lingers below currentVersion=4 (aged out by a
-    // subsequent push), while v5 is the active rollback-origin above current. The filter must skip
-    // v2 and block on v5 — pre-PR filter (status==ROLLED_BACK alone) would have matched v2 first
-    // and misattributed the block.
+    // Stale ROLLED_BACK v2 below current is skipped; the active v5 above current blocks.
     long now = System.currentTimeMillis();
     Store store = mockStoreWithVersions(
         4,
@@ -327,7 +322,7 @@ public class NewPushCapacityGuardsTest {
 
   @Test
   public void rollbackOriginPassesWhenPartiallyOnlineVersionEqualsCurrentVersion() {
-    // Push-origin PARTIALLY_ONLINE: v4 is PARTIALLY_ONLINE and IS the current version → not rollback-origin
+    // PARTIALLY_ONLINE at currentVersion is a push, not a rollback-origin.
     long now = System.currentTimeMillis();
     Store store = mockStoreWithVersions(
         4,
@@ -340,7 +335,7 @@ public class NewPushCapacityGuardsTest {
 
   @Test
   public void rollbackOriginPassesWhenPartiallyOnlineBelowCurrentVersion() {
-    // Push-origin PARTIALLY_ONLINE on an older version (current was promoted past it) → not rollback-origin
+    // PARTIALLY_ONLINE below currentVersion is a superseded push, not a rollback-origin.
     long now = System.currentTimeMillis();
     Store store = mockStoreWithVersions(
         5,
@@ -353,8 +348,8 @@ public class NewPushCapacityGuardsTest {
 
   @Test
   public void rollbackOriginPassesJustPastRetention() {
-    // Past retention → check short-circuits, no block.
-    // Mock promoteTimestamp explicitly so wall-clock jitter doesn't disturb the boundary.
+    // Past retention → short-circuits, no block. Mock promoteTimestamp so wall-clock jitter can't
+    // disturb the boundary.
     long now = 1_000_000L;
     long retention = ROLLED_BACK_RETENTION_MS;
     Store store = mockStoreWithPromoteTimestamp(
@@ -395,8 +390,7 @@ public class NewPushCapacityGuardsTest {
 
   @Test
   public void rollbackOriginFieldOverloadBlocksAndIncludesRegionNameInMessage() {
-    // The child-snapshot overload evaluates raw fields (as fed from a child StoreInfo) and enriches
-    // the rejection message with the region name so operators can see which child is blocking.
+    // The region-named overload enriches the rejection message so operators see which child blocks.
     long now = System.currentTimeMillis();
     VeniceException e = expectThrows(
         VeniceException.class,
@@ -416,8 +410,7 @@ public class NewPushCapacityGuardsTest {
 
   @Test
   public void rollbackOriginFieldOverloadPassesWhenNoRollbackOriginVersion() {
-    // Live child snapshot shows no rollback-origin version -> no block, even within the retention
-    // window. This is the parent-side allow path when parent metadata is stale but children are clean.
+    // Clean child snapshot within the retention window → no block.
     long now = System.currentTimeMillis();
     VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
         CLUSTER_NAME,


### PR DESCRIPTION
## Problem Statement

`VeniceParentHelixAdmin.getTopicForCurrentPushJobParentVersionStatusBasedTracking()`
could permanently block a new push. When the parent version status was `ONLINE`
and a target swap region was set, `onlyDeferredSwap` evaluated to `false`, so the
method fell through to the `getOffLinePushStatus` polling loop. Once the
push-status resource for the completed version is gone, that poll never reaches a
terminal state, so the concurrent-push check never terminates and the new push is
blocked indefinitely (observed in production: a completed `ONLINE` version wedged
a subsequent push).

Separately, the `ROLLED_BACK` rollback-retention capacity guard
(`checkRollbackOriginVersionCapacityForNewPush`) also ran on the **child**
controller inside `VeniceHelixAdmin.addVersion`. Throwing there happens during
admin-message consumption, which fails the admin message and wedges the admin
channel.

## Solution

**Change 1 — ONLINE early-exit.** Treat a parent version status of `ONLINE` as
"push already complete" and allow the new push through (`Optional.empty()`)
instead of polling. This reads only the ZK version status, so it is
parent-VT-independent and robust under parent-VT deprecation. `ONLINE` joins the
existing terminal statuses (`KILLED` / `ERROR` / `ROLLED_BACK` /
`PARTIALLY_ONLINE`) in the early-exit switch; the now-dead
`onlyDeferredSwap && ONLINE` branch and the unused `onlyDeferredSwap` local are
removed. Non-terminal statuses still fall through to the in-progress /
`getOffLinePushStatus` polling branch that blocks the next push.

**Change 2 — child-verified rollback retention.** The rollback-retention guard is
now the parent's sole synchronous gate, and it runs only at push-start (a cold
path). It always queries live child controllers — there is no parent-metadata
pre-check and no fallback to parent metadata, both of which reintroduced a
stale-parent dependency. It blocks the new push only when a reachable child still
has a `ROLLED_BACK`-origin version inside the retention window. Matching is
`ROLLED_BACK`-only: `PARTIALLY_ONLINE` is a parent-only aggregate and never a
child rollback origin, so it is not treated as one. Unreachable / errored / null
regions are skipped, and when there are no child clients at all the check skips
(allows) rather than blocking on possibly-stale parent state. The child-side check
in `VeniceHelixAdmin.addVersion` is removed so a capacity rejection can no longer
wedge the admin channel.

No new configs and no new user-facing API. The only new log lines are `WARN`
"skipping" messages on the parent gate when child clients are unavailable or a
region cannot be read.

## How was this PR tested?

- [x] Modified or extended existing tests.
- [x] New unit tests added.
- [x] Local code review completed.

Targeted suites (all green):
- `NewPushCapacityGuardsTest` (21/21) — added a region-name-in-message block case
  and a no-rollback-origin pass case for the primitives overload.
- `TestVeniceParentHelixAdmin` — added 4 tests for
  `checkRollbackOriginVersionCapacityFromChildren` (block / allow-when-children-clean
  / errored-region skip / no-child-clients skip); added
  `testGetTopicForCurrentPushJobBlocksInProgressVersion`, a regression test for the
  in-progress / polling branch (STARTED blocks without polling; a non-terminal
  version polls `getOffLinePushStatus`, blocking on `PROGRESS` and allowing once
  the status is terminal after an `UNKNOWN`-region retry); and updated
  `testGetTopicForCurrentPushJob` to assert `ONLINE` allows the push through
  without polling (`verify(never()).getOffLinePushStatus(...)`).

## Does this PR introduce any user-facing or breaking changes?

No user-facing API change. Behavioral change: a completed (`ONLINE`) parent
version no longer blocks a subsequent push, and the rollback-retention guard is
enforced only on the parent (verified against live child status) rather than on
the child admin-message path.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
