### PR TITLE
[changelog][da-vinci] Skip GLOBAL_RT_DIV Messages in Changelog Consumer Poll

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -829,6 +829,16 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
           List<DefaultPubSubMessage> messageList = entry.getValue();
           for (DefaultPubSubMessage message: messageList) {
             maybeUpdatePartitionToBootstrapMap(message, pubSubTopicPartition);
+            if (message.getKey().isGlobalRtDiv()) {
+              /*
+               * Global RT DIV messages carry a GlobalRtDivState payload (DIV metadata) rather than user data. Only
+               * their KafkaKey header byte marks them as GLOBAL_RT_DIV; their KafkaMessageEnvelope messageType is
+               * PUT. They must be skipped here, otherwise the DIV payload would be routed through the PUT path and
+               * deserialized with the store value schema, whose id collides with the GlobalRtDivState protocol
+               * version, corrupting the change event or failing deserialization.
+               */
+              continue;
+            }
             if (message.getKey().isControlMessage()) {
               ControlMessage controlMessage = (ControlMessage) message.getValue().getPayloadUnion();
               if (handleControlMessage(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -52,6 +52,7 @@ import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.VersionSwap;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.kafka.protocol.state.GlobalRtDivState;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
@@ -77,10 +78,12 @@ import com.linkedin.venice.schema.rmd.RmdConstants;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.serialization.StoreDeserializerCache;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
+import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
@@ -1366,6 +1369,97 @@ public class VeniceChangelogConsumerImplTest {
     // switchToNewTopic with a different topic on the same partition should return true
     PubSubTopic newVersionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName, 2));
     assertTrue(veniceChangelogConsumer.switchToNewTopic(new PubSubTopicPartitionImpl(newVersionTopic, 0)));
+  }
+
+  /**
+   * Reproduces the CDC client failure observed after Global RT DIV was enabled. A Global RT DIV message is
+   * produced into the version topic with a {@link MessageType#GLOBAL_RT_DIV} {@link KafkaKey} while its
+   * {@link KafkaMessageEnvelope} messageType stays {@link MessageType#PUT}, and its {@link Put} payload carries a
+   * serialized {@link GlobalRtDivState} tagged with the GLOBAL_RT_DIV_STATE protocol version as its schema id.
+   * Without special handling, {@link VeniceChangelogConsumerImpl#internalPoll} routes it through the PUT path and
+   * deserializes the DIV payload with the store value schema (whose id collides with the DIV protocol version),
+   * which is what surfaced as "Could not deserialize bytes back into Avro object". This test verifies the message
+   * is skipped and the surrounding data records are still returned intact.
+   */
+  @Test
+  public void testGlobalRtDivMessageIsSkippedDuringPoll() throws ExecutionException, InterruptedException {
+    prepareVersionTopicRecordsWithGlobalRtDivToBePolled(mockPubSubConsumer, oldVersionTopic, 0);
+
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceAfterImageConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer(),
+        veniceChangelogConsumerClientFactory);
+    veniceChangelogConsumer.setStoreRepository(mockRepository);
+
+    veniceChangelogConsumer.subscribe(Collections.singleton(0)).get();
+
+    List<PubSubMessage<String, ChangeEvent<Utf8>, VeniceChangeCoordinate>> pubSubMessages =
+        new ArrayList<>(veniceChangelogConsumer.poll(pollTimeoutMs));
+
+    // The Global RT DIV message must be skipped: only the two normal PUT records are returned, and polling must
+    // not choke while attempting to deserialize the DIV payload with the store value deserializer.
+    assertEquals(pubSubMessages.size(), 2);
+    assertEquals(pubSubMessages.get(0).getValue().getCurrentValue().toString(), "newValue0");
+    assertEquals(pubSubMessages.get(1).getValue().getCurrentValue().toString(), "newValue1");
+
+    veniceChangelogConsumer.close();
+  }
+
+  private void prepareVersionTopicRecordsWithGlobalRtDivToBePolled(
+      PubSubConsumerAdapter pubSubConsumerAdapter,
+      PubSubTopic versionTopic,
+      int partition) {
+    List<DefaultPubSubMessage> consumerRecordList = new ArrayList<>();
+    consumerRecordList.add(
+        constructConsumerRecord(
+            versionTopic,
+            partition,
+            "newValue0",
+            "key0",
+            Arrays.asList(0L, 0L),
+            ApacheKafkaOffsetPosition.of(0L)));
+    // Interleave a Global RT DIV message between two data records to prove it is skipped without disrupting the
+    // records around it.
+    consumerRecordList
+        .add(constructGlobalRtDivRecord(versionTopic, partition, "globalRtDivKey", ApacheKafkaOffsetPosition.of(1L)));
+    consumerRecordList.add(
+        constructConsumerRecord(
+            versionTopic,
+            partition,
+            "newValue1",
+            "key1",
+            Arrays.asList(1L, 1L),
+            ApacheKafkaOffsetPosition.of(2L)));
+    Map<PubSubTopicPartition, List<DefaultPubSubMessage>> consumerRecordsMap = new HashMap<>();
+    consumerRecordsMap.put(new PubSubTopicPartitionImpl(versionTopic, partition), consumerRecordList);
+    doReturn(consumerRecordsMap).when(pubSubConsumerAdapter).poll(pollTimeoutMs);
+  }
+
+  private DefaultPubSubMessage constructGlobalRtDivRecord(
+      PubSubTopic versionTopic,
+      int partition,
+      String key,
+      PubSubPosition pubSubPosition) {
+    // Build and serialize a GlobalRtDivState with its protocol serializer, exactly as the server's VeniceWriter
+    // does when propagating the RT DIV snapshot through the local version topic.
+    GlobalRtDivState divState = new GlobalRtDivState("localhost:9092", new HashMap<>(), ByteBuffer.wrap(new byte[0]));
+    InternalAvroSpecificSerializer<GlobalRtDivState> globalRtDivStateSerializer =
+        AvroProtocolDefinition.GLOBAL_RT_DIV_STATE.getSerializer();
+    byte[] serializedDiv = ByteUtils.extractByteArray(globalRtDivStateSerializer.serialize(divState));
+    int divSchemaId = AvroProtocolDefinition.GLOBAL_RT_DIV_STATE.getCurrentProtocolVersion();
+
+    ProducerMetadata producerMetadata = new ProducerMetadata();
+    producerMetadata.messageTimestamp = 10000L;
+    // The envelope messageType is PUT (as VeniceWriter sets it); only the KafkaKey below marks it as GLOBAL_RT_DIV.
+    KafkaMessageEnvelope kafkaMessageEnvelope = new KafkaMessageEnvelope(
+        MessageType.PUT.getValue(),
+        producerMetadata,
+        new Put(ByteBuffer.wrap(serializedDiv), divSchemaId, -1, ByteBuffer.wrap(new byte[0])),
+        null);
+    KafkaKey kafkaKey = new KafkaKey(MessageType.GLOBAL_RT_DIV, keySerializer.serialize(key));
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(versionTopic, partition);
+    return new ImmutablePubSubMessage(kafkaKey, kafkaMessageEnvelope, pubSubTopicPartition, pubSubPosition, 0, 0);
   }
 
   private ChangelogClientConfig getChangelogClientConfig() {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
@@ -595,6 +595,16 @@ public class KafkaTopicDumper implements AutoCloseable {
   }
 
   void processRecord(DefaultPubSubMessage record) {
+    if (record.getKey().isGlobalRtDiv()) {
+      /*
+       * Global RT DIV records carry Global RT DIV state (DIV metadata) rather than user data, and are only meant to be
+       * consumed by the server ingestion pipeline, which persists them to the metadata partition. Only their KafkaKey
+       * header byte marks them as GLOBAL_RT_DIV; their KafkaMessageEnvelope messageType is PUT and their Put schema id
+       * collides with a store value schema id, so routing them through the PUT path would deserialize the DIV payload
+       * with the store value schema and fail or misparse. Skip them here, as with other non-user-data records.
+       */
+      return;
+    }
     if (logTsRecord) {
       logIfTopicSwitchMessage(record, pubSubPositionDeserializer);
     } else if (logDataRecord) {

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
@@ -486,6 +486,31 @@ public class TestKafkaTopicDumper {
     verify(mockConsumer, atLeastOnce()).unSubscribe(topicPartition);
   }
 
+  @Test
+  public void testProcessRecordSkipsGlobalRtDivMessages() {
+    PubSubConsumerAdapter mockConsumer = mock(PubSubConsumerAdapter.class);
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic("test"), 0);
+    KafkaTopicDumper dumper = new KafkaTopicDumper(mockConsumer, topicPartition, 3);
+
+    // Global RT DIV records carry DIV metadata, not user data. Only the KafkaKey header marks them, while the
+    // envelope still looks like a PUT, so they must be skipped before their payload is deserialized as a user value.
+    KafkaKey globalRtDivKey = new KafkaKey(MessageType.GLOBAL_RT_DIV, Utils.getUniqueString("key-").getBytes());
+    DefaultPubSubMessage divMessage = mock(DefaultPubSubMessage.class);
+    when(divMessage.getKey()).thenReturn(globalRtDivKey);
+    when(divMessage.getPosition()).thenReturn(ApacheKafkaOffsetPosition.of(0L));
+    dumper.processRecord(divMessage);
+    // The record is skipped before its payload is ever inspected.
+    verify(divMessage, never()).getValue();
+
+    // A regular data record is not skipped: its payload is inspected for processing.
+    KafkaKey putKey = new KafkaKey(MessageType.PUT, Utils.getUniqueString("key-").getBytes());
+    DefaultPubSubMessage putMessage = mock(DefaultPubSubMessage.class);
+    when(putMessage.getKey()).thenReturn(putKey);
+    when(putMessage.getPosition()).thenReturn(ApacheKafkaOffsetPosition.of(1L));
+    dumper.processRecord(putMessage);
+    verify(putMessage, atLeastOnce()).getValue();
+  }
+
   private List<DefaultPubSubMessage> createMockMessages(int count, long startPosition) {
     List<DefaultPubSubMessage> messages = new ArrayList<>();
     for (int i = 0; i < count; i++) {


### PR DESCRIPTION
## Problem Statement
After enabling Global RT DIV, CDC (change data capture) clients crash while polling records:
```
com.linkedin.venice.serializer.VeniceSerializationException: Could not deserialize bytes back into Avro object
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -54 out of bounds for length 2
```
GLOBAL_RT_DIV messages are produced to the version topic with the envelope `KafkaMessageEnvelope.messageType = PUT` — only the `KafkaKey` header byte marks them as `GLOBAL_RT_DIV` — and with `Put.schemaId = GLOBAL_RT_DIV_STATE` protocol version, which collides with a regular store value schema id. `VeniceChangelogConsumerImpl.internalPoll()` only checked `isControlMessage()`, so a DIV message fell through to the PUT path and was deserialized with the store value schema, corrupting the change event or failing deserialization.

## Solution
Skip messages whose `KafkaKey.isGlobalRtDiv()` is true in `internalPoll()`, before the control-message / PUT dispatch. Global RT DIV state is only meant to be consumed by the main server ingestion pipeline (which persists it to the metadata partition); every other consumer must skip it. This mirrors the existing filtering in the VPJ read path (`PubSubSplitIterator`) and the explicit `case GLOBAL_RT_DIV` handling already present in `Segment.addToCheckSum` and `InstanceSizeEstimator`.

Audited all other `MessageType.valueOf(...)` / `isControlMessage()` consumer paths: the changelog consumer poll was the only unguarded production path. Framework spots (segment checksum, size estimation, server ingestion, VPJ split iterator) already handle GLOBAL_RT_DIV; other sites are admin-topic, control-message-only, or consume through the already-filtered VPJ iterator.

###  Code changes
- [ ] Added new code behind **a config**. (No.)
- [ ] Introduced new **log lines**. (No.)

## How was this PR tested?
- [x] New unit tests added — `testGlobalRtDivMessageIsSkippedDuringPoll` produces a GLOBAL_RT_DIV record into the polled batch and asserts it is skipped. It fails without the fix (`expected [2] but found [3]`) and passes with it. Full `VeniceChangelogConsumerImplTest` and `spotlessJavaCheck` pass.
- [x] Modified or extended existing tests.

## Does this PR introduce any user-facing or breaking changes?
- [x] No. (Bug fix that restores intended CDC behavior when Global RT DIV is enabled.)
