### PR TITLE
[vpj] Increase controller retry defaults to production values

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -409,8 +409,8 @@ public class VenicePushJob implements AutoCloseable {
     pushJobSettingToReturn.batchNumBytes = props.getInt(BATCH_NUM_BYTES_PROP, DEFAULT_BATCH_BYTES_SIZE);
     pushJobSettingToReturn.isIncrementalPush = props.getBoolean(INCREMENTAL_PUSH, false);
     pushJobSettingToReturn.isDuplicateKeyAllowed = props.getBoolean(ALLOW_DUPLICATE_KEY, false);
-    pushJobSettingToReturn.controllerRetries = props.getInt(CONTROLLER_REQUEST_RETRY_ATTEMPTS, 1);
-    pushJobSettingToReturn.controllerStatusPollRetries = props.getInt(POLL_STATUS_RETRY_ATTEMPTS, 15);
+    pushJobSettingToReturn.controllerRetries = props.getInt(CONTROLLER_REQUEST_RETRY_ATTEMPTS, 10);
+    pushJobSettingToReturn.controllerStatusPollRetries = props.getInt(POLL_STATUS_RETRY_ATTEMPTS, 100);
     pushJobSettingToReturn.pollJobStatusIntervalMs =
         props.getLong(POLL_JOB_STATUS_INTERVAL_MS, DEFAULT_POLL_STATUS_INTERVAL_MS);
     pushJobSettingToReturn.jobStatusInUnknownStateTimeoutMs =

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -26,9 +26,11 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.DATA_WRITER_COMPUTE
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_BATCH_BYTES_SIZE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_COMPRESSION_DICTIONARY_SAMPLE_SIZE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_COMPRESSION_METRIC_COLLECTION_ENABLED;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_CONTROLLER_REQUEST_RETRY_ATTEMPTS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_JOB_STATUS_IN_UNKNOWN_STATE_TIMEOUT_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_POLL_STATUS_INTERVAL_MS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_POLL_STATUS_RETRY_ATTEMPTS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_RE_PUSH_REWIND_IN_SECONDS_OVERRIDE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_SSL_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFER_VERSION_SWAP;
@@ -409,8 +411,10 @@ public class VenicePushJob implements AutoCloseable {
     pushJobSettingToReturn.batchNumBytes = props.getInt(BATCH_NUM_BYTES_PROP, DEFAULT_BATCH_BYTES_SIZE);
     pushJobSettingToReturn.isIncrementalPush = props.getBoolean(INCREMENTAL_PUSH, false);
     pushJobSettingToReturn.isDuplicateKeyAllowed = props.getBoolean(ALLOW_DUPLICATE_KEY, false);
-    pushJobSettingToReturn.controllerRetries = props.getInt(CONTROLLER_REQUEST_RETRY_ATTEMPTS, 10);
-    pushJobSettingToReturn.controllerStatusPollRetries = props.getInt(POLL_STATUS_RETRY_ATTEMPTS, 100);
+    pushJobSettingToReturn.controllerRetries =
+        props.getInt(CONTROLLER_REQUEST_RETRY_ATTEMPTS, DEFAULT_CONTROLLER_REQUEST_RETRY_ATTEMPTS);
+    pushJobSettingToReturn.controllerStatusPollRetries =
+        props.getInt(POLL_STATUS_RETRY_ATTEMPTS, DEFAULT_POLL_STATUS_RETRY_ATTEMPTS);
     pushJobSettingToReturn.pollJobStatusIntervalMs =
         props.getLong(POLL_JOB_STATUS_INTERVAL_MS, DEFAULT_POLL_STATUS_INTERVAL_MS);
     pushJobSettingToReturn.jobStatusInUnknownStateTimeoutMs =

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/heartbeat/DefaultPushJobHeartbeatSenderFactory.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/heartbeat/DefaultPushJobHeartbeatSenderFactory.java
@@ -5,6 +5,7 @@ import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_INIT
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_INTERVAL_CONFIG;
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_LAST_HEARTBEAT_IS_DELETE_CONFIG;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.CONTROLLER_REQUEST_RETRY_ATTEMPTS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_CONTROLLER_REQUEST_RETRY_ATTEMPTS;
 
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
@@ -45,7 +46,7 @@ public class DefaultPushJobHeartbeatSenderFactory implements PushJobHeartbeatSen
       Optional<Properties> sslProperties) {
     Validate.notNull(controllerClient);
     final String heartbeatStoreName = AvroProtocolDefinition.BATCH_JOB_HEARTBEAT.getSystemStoreName();
-    int retryAttempts = properties.getInt(CONTROLLER_REQUEST_RETRY_ATTEMPTS, 3);
+    int retryAttempts = properties.getInt(CONTROLLER_REQUEST_RETRY_ATTEMPTS, DEFAULT_CONTROLLER_REQUEST_RETRY_ATTEMPTS);
     StoreResponse heartBeatStoreResponse =
         ControllerClient.retryableRequest(controllerClient, retryAttempts, c -> c.getStore(heartbeatStoreName));
     if (heartBeatStoreResponse.isError()) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -78,7 +78,7 @@ public final class VenicePushJobConstants {
    *  <br><br>
    */
   public static final String COMPRESSION_METRIC_COLLECTION_ENABLED = "compression.metric.collection.enabled";
-  public static final boolean DEFAULT_COMPRESSION_METRIC_COLLECTION_ENABLED = true;
+  public static final boolean DEFAULT_COMPRESSION_METRIC_COLLECTION_ENABLED = false;
 
   /**
    * Known <a href="https://github.com/luben/zstd-jni/issues/253">zstd lib issue</a> which

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -78,7 +78,7 @@ public final class VenicePushJobConstants {
    *  <br><br>
    */
   public static final String COMPRESSION_METRIC_COLLECTION_ENABLED = "compression.metric.collection.enabled";
-  public static final boolean DEFAULT_COMPRESSION_METRIC_COLLECTION_ENABLED = false;
+  public static final boolean DEFAULT_COMPRESSION_METRIC_COLLECTION_ENABLED = true;
 
   /**
    * Known <a href="https://github.com/luben/zstd-jni/issues/253">zstd lib issue</a> which

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -57,7 +57,9 @@ public final class VenicePushJobConstants {
   public static final String PARTITION_COUNT = "partition.count";
   public static final String ALLOW_DUPLICATE_KEY = "allow.duplicate.key";
   public static final String POLL_STATUS_RETRY_ATTEMPTS = "poll.status.retry.attempts";
+  public static final int DEFAULT_POLL_STATUS_RETRY_ATTEMPTS = 100;
   public static final String CONTROLLER_REQUEST_RETRY_ATTEMPTS = "controller.request.retry.attempts";
+  public static final int DEFAULT_CONTROLLER_REQUEST_RETRY_ATTEMPTS = 10;
   public static final String POLL_JOB_STATUS_INTERVAL_MS = "poll.job.status.interval.ms";
   public static final String JOB_STATUS_IN_UNKNOWN_STATE_TIMEOUT_MS = "job.status.in.unknown.state.timeout.ms";
   public static final String PUSH_JOB_TIMEOUT_OVERRIDE_MS = "push.job.timeout.override.ms";


### PR DESCRIPTION
## Problem Statement
Two Venice Push Job resilience defaults are more fragile than the values push jobs run with in practice. `controller.request.retry.attempts` defaults to `1` and `poll.status.retry.attempts` to `15`. A single transient controller failure — a controller restart or a network blip during a long push — can fail an otherwise healthy push, or give up polling job status too early.

## Solution
Raise the defaults to `controller.request.retry.attempts = 10` and `poll.status.retry.attempts = 100`, matching the values production push jobs use, so a push tolerates transient controller unavailability instead of failing on the first hiccup. Both remain overridable per job.

### Code changes
- [x] Added new code behind **a config**. Config defaults changed:
  - `controller.request.retry.attempts`: `1` → `10`
  - `poll.status.retry.attempts`: `15` → `100`
- [ ] Introduced new **log lines**.

## How was this PR tested?
- [x] Existing unit tests pass locally (`clients:venice-push-job:test`). The retry-configured push-detail tests set these configs explicitly and are unaffected by the default change.
- [x] Verified backward compatibility: an explicitly configured value for either config is honored unchanged.

## Does this PR introduce any user-facing or breaking changes?
- [x] Yes. Push jobs now retry controller requests up to 10 times and poll status up to 100 times before failing, instead of 1 and 15. Jobs that set these explicitly are unaffected.
