### PR TITLE
[server][da-vinci] Fix Local VT Offset Corruption due to Race Condition on Leader-Produced Records

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1912,7 +1912,15 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       // would leave the position pointing at a record that has not been durably written yet; if the write then fails,
       // a shutdown checkpoint could persist that position and the record would be skipped on restart (data loss).
       if (!dryRun) {
-        updateVersionTopicOffsetFunction.apply(consumerRecord.getPosition());
+        /*
+         * This record could be from RT / remote VT if setConsumeRemotely(false) was called during a leader-to-local
+         * transition, so check hasUpstream() to ensure that the local VT slot only holds local-VT positions.
+         */
+        if (leaderProducedRecordContext == null) {
+          updateVersionTopicOffsetFunction.apply(consumerRecord.getPosition());
+        } else if (leaderProducedRecordContext.hasCorrespondingUpstreamMessage()) {
+          updateVersionTopicOffsetFunction.apply(leaderProducedRecordContext.getProducedPosition());
+        }
       }
 
       OffsetRecord offsetRecord = partitionConsumptionState.getOffsetRecord();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1913,8 +1913,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       // a shutdown checkpoint could persist that position and the record would be skipped on restart (data loss).
       if (!dryRun) {
         /*
-         * This record could be from RT / remote VT if setConsumeRemotely(false) was called during a leader-to-local
-         * transition, so check hasUpstream() to ensure that the local VT slot only holds local-VT positions.
+         * This record may have been leader-produced to the local VT while the partition was still consuming remotely,
+         * but then drained after consumeRemotely was flipped to false. Use the immutable LeaderProducedRecordContext
+         * so the local VT slot only ever advances with a local-VT produced position.
          */
         if (leaderProducedRecordContext == null) {
           updateVersionTopicOffsetFunction.apply(consumerRecord.getPosition());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -4253,4 +4253,113 @@ public class LeaderFollowerStoreIngestionTaskTest {
           "lcs must not propagate: " + description);
     }
   }
+
+  /**
+   * Regression test for local VT offset corruption (reverted PR #2809 / #2840).
+   *
+   * <p>When a leader's {@code consumeRemotely} flag flips false (the EOP leader-to-local switch or an L->S
+   * transition) after a record has been leader-produced but before the drainer processes it, that record is
+   * handled by the local ({@code !shouldProduceToVersionTopic}) branch of
+   * {@link LeaderFollowerStoreIngestionTask#updateOffsetsFromConsumerRecord} even though it was consumed from an
+   * upstream/remote source. In that branch the local VT position must be advanced from the record's own
+   * provenance, never from {@code consumerRecord.getPosition()} which is the foreign upstream/remote-VT position
+   * (a different topicId/shard) that later crashes the local-VT subscribe with an IllegalStateException.
+   */
+  @Test
+  public void testUpdateOffsetsFromConsumerRecordLocalVtUsesProvenanceNotUpstreamPosition()
+      throws InterruptedException {
+    setUp();
+
+    // Post-flip leader state: LEADER, leaderTopic == local VT, consumeRemotely == false, so
+    // shouldProduceToVersionTopic is false and records are handled by the local (non-produce) branch.
+    OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
+    PubSubTopic versionTopicRef = leaderFollowerStoreIngestionTask.getVersionTopic();
+    doReturn(versionTopicRef).when(mockOffsetRecord).getLeaderTopic(any());
+    doReturn(mockOffsetRecord).when(mockPartitionConsumptionState).getOffsetRecord();
+    doReturn(LeaderFollowerStateType.LEADER).when(mockPartitionConsumptionState).getLeaderFollowerState();
+    doReturn(false).when(mockPartitionConsumptionState).consumeRemotely();
+    assertFalse(
+        leaderFollowerStoreIngestionTask.shouldProduceToVersionTopic(mockPartitionConsumptionState),
+        "Precondition: with leaderTopic == local VT and consumeRemotely == false the record must reach the local branch");
+
+    // A record consumed from a foreign upstream/remote source; its own position is NOT a local VT position. No
+    // leaderMetadataFooter (a batch record that raced past the flag flip), so no upstream position is filed either.
+    PubSubPosition upstreamRecordPosition = mock(PubSubPosition.class);
+    PubSubTopicPartition sourceTopicPartition = mock(PubSubTopicPartition.class);
+    PubSubTopic sourceTopic = mock(PubSubTopic.class);
+    doReturn(false).when(sourceTopic).isRealTime();
+    DefaultPubSubMessage consumerRecord = mock(DefaultPubSubMessage.class);
+    doReturn(sourceTopicPartition).when(consumerRecord).getTopicPartition();
+    doReturn(sourceTopic).when(sourceTopicPartition).getPubSubTopic();
+    doReturn(upstreamRecordPosition).when(consumerRecord).getPosition();
+    KafkaMessageEnvelope kafkaValue = new KafkaMessageEnvelope();
+    kafkaValue.producerMetadata = new ProducerMetadata();
+    kafkaValue.leaderMetadataFooter = null;
+    doReturn(kafkaValue).when(consumerRecord).getValue();
+
+    LeaderFollowerStoreIngestionTask.UpdateUpstreamTopicOffset upstreamOffsetUpdate =
+        mock(LeaderFollowerStoreIngestionTask.UpdateUpstreamTopicOffset.class);
+    LeaderFollowerStoreIngestionTask.GetLastKnownUpstreamTopicOffset lastKnownUpstream =
+        mock(LeaderFollowerStoreIngestionTask.GetLastKnownUpstreamTopicOffset.class);
+
+    // Case 1: leader-produced record that has a corresponding upstream message. The local VT slot must advance
+    // with the local-VT producedPosition, never the foreign consumerRecord position; and no upstream position is
+    // misfiled for a record without a leaderMetadataFooter.
+    PubSubPosition producedPosition = mock(PubSubPosition.class);
+    LeaderProducedRecordContext lprcWithUpstream = mock(LeaderProducedRecordContext.class);
+    doReturn(true).when(lprcWithUpstream).hasCorrespondingUpstreamMessage();
+    doReturn(producedPosition).when(lprcWithUpstream).getProducedPosition();
+    LeaderFollowerStoreIngestionTask.UpdateVersionTopicOffset vtUpdateWithUpstream =
+        mock(LeaderFollowerStoreIngestionTask.UpdateVersionTopicOffset.class);
+    leaderFollowerStoreIngestionTask.updateOffsetsFromConsumerRecord(
+        mockPartitionConsumptionState,
+        consumerRecord,
+        lprcWithUpstream,
+        vtUpdateWithUpstream,
+        upstreamOffsetUpdate,
+        lastKnownUpstream,
+        () -> "remote-broker-url",
+        false);
+    verify(vtUpdateWithUpstream, times(1)).apply(producedPosition);
+    verify(vtUpdateWithUpstream, never()).apply(upstreamRecordPosition);
+    verify(upstreamOffsetUpdate, never()).apply(any(), any(), any());
+
+    // Case 2: a leader-generated record with no corresponding upstream message (e.g. a chunk) must not advance the
+    // local VT position at all.
+    LeaderProducedRecordContext lprcChunk = mock(LeaderProducedRecordContext.class);
+    doReturn(false).when(lprcChunk).hasCorrespondingUpstreamMessage();
+    doReturn(mock(PubSubPosition.class)).when(lprcChunk).getProducedPosition();
+    LeaderFollowerStoreIngestionTask.UpdateVersionTopicOffset vtUpdateChunk =
+        mock(LeaderFollowerStoreIngestionTask.UpdateVersionTopicOffset.class);
+    leaderFollowerStoreIngestionTask.updateOffsetsFromConsumerRecord(
+        mockPartitionConsumptionState,
+        consumerRecord,
+        lprcChunk,
+        vtUpdateChunk,
+        upstreamOffsetUpdate,
+        lastKnownUpstream,
+        () -> "remote-broker-url",
+        false);
+    verify(vtUpdateChunk, never()).apply(any());
+
+    // Case 3: a record directly consumed from the local VT (no leader-produced context) advances the local VT slot
+    // with its own position, which is a valid local VT position.
+    PubSubPosition localVtPosition = mock(PubSubPosition.class);
+    DefaultPubSubMessage localVtRecord = mock(DefaultPubSubMessage.class);
+    doReturn(sourceTopicPartition).when(localVtRecord).getTopicPartition();
+    doReturn(localVtPosition).when(localVtRecord).getPosition();
+    doReturn(kafkaValue).when(localVtRecord).getValue();
+    LeaderFollowerStoreIngestionTask.UpdateVersionTopicOffset vtUpdateLocal =
+        mock(LeaderFollowerStoreIngestionTask.UpdateVersionTopicOffset.class);
+    leaderFollowerStoreIngestionTask.updateOffsetsFromConsumerRecord(
+        mockPartitionConsumptionState,
+        localVtRecord,
+        null,
+        vtUpdateLocal,
+        upstreamOffsetUpdate,
+        lastKnownUpstream,
+        () -> "remote-broker-url",
+        false);
+    verify(vtUpdateLocal, times(1)).apply(localVtPosition);
+  }
 }


### PR DESCRIPTION
## Problem Statement

Leaders were corrupting their **local Version Topic (VT) offset** (`latestProcessedVtPosition`) with an **upstream / remote-VT position**, which later crashed ingestion and put the replica into a restart loop.

`LeaderFollowerStoreIngestionTask.updateOffsetsFromConsumerRecord` decides how to advance the offset metadata by branching on the **live** `shouldProduceToVersionTopic(pcs)` flag, which reads `pcs.consumeRemotely()`. During the EOP leader-to-local switch and the L->S transition, `setConsumeRemotely(false)` can flip that flag **after** a leader-produced record's produce callback has completed but **before** the drainer processes that same in-flight record. The raced record then falls into the local (`!shouldProduceToVersionTopic`) branch, which wrote `consumerRecord.getPosition()` into the local VT slot. For a leader-produced record that position is the **upstream/remote-VT** position — a different `topicId`/`shardNumber` than the local VT.

`getLocalVtSubscribePosition()` returns that corrupted position and it is used to subscribe to the **local VT** at the EOP switch and during L->S. A foreign-shard position makes the subscribe throw:

```
java.lang.IllegalStateException: expected position: EARLIEST/LATEST/NGRangePosition,
actual [topicId=...,shardNumber=1,...]
```

which kills the ingestion task -> restart -> "client already closed" re-subscribe cascade. This was observed in **EI / cert-1** for store `cert1-histogram-hybrid` (tens of thousands of ERRORs/day).

### Relationship to the previous fix (#2809, reverted by #2840)

[#2809](https://github.com/linkedin/venice/pull/2809) diagnosed the same race but fixed it by changing the **branch dispatch** from `!shouldProduceToVersionTopic(pcs)` to `leaderProducedRecordContext == null`. That rerouted every raced (leader-produced) record into the `else` branch -> `updateOffsetsAsRemoteConsumeLeader`, which **also updates the upstream slot** using the *live* `offsetRecord.getLeaderTopic()`. During L->S, `updateLeaderTopicOnFollower` resets `leaderTopic` back to VT **before** the in-flight record drains, so #2809 filed an RT/upstream position under the **remote-VT upstream slot** — a *new* corruption that broke ingestion during L->S. It was reverted in [#2840](https://github.com/linkedin/venice/pull/2840).

## Solution

Keep the existing branch dispatch (`!shouldProduceToVersionTopic`) exactly as-is, and only correct the **value** written into the local VT slot, using each record's own immutable provenance (`LeaderProducedRecordContext`), mirroring what `updateOffsetsAsRemoteConsumeLeader` already does for the VT slot:

- `leaderProducedRecordContext == null` — record was consumed **directly from the local VT** (follower, or leader consuming local VT) -> `consumerRecord.getPosition()` (unchanged behavior).
- `leaderProducedRecordContext.hasCorrespondingUpstreamMessage()` — leader consumed from upstream and produced to local VT -> `getProducedPosition()` (the actual local-VT produce offset).
- otherwise (leader-generated chunk / TopicSwitch, no upstream) -> **do not advance** the local VT position.

### Why this is safe where #2809 was not

- It does **not** change control flow — no record is rerouted to a different branch, so all state transitions behave exactly as they do today.
- It does **not** touch the upstream-slot update path, so it cannot reintroduce #2809's remote-VT-slot corruption that broke L->S.
- It is a **no-op in steady state**: in normal operation leader-produced records take the remote branch; this only affects records that raced past the `consumeRemotely` flag flip — precisely the corruption case.

### Code changes

- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**. (Removes a race: offset provenance is now decided per-record from immutable `LeaderProducedRecordContext` rather than the mutable live `consumeRemotely` flag.)
- [x] Proper **synchronization mechanisms** are used where needed. (No new shared state introduced.)
- [x] No **blocking calls** inside critical sections.
- [x] Verified **thread-safe collections** are used. (No collection changes.)
- [x] Validated proper exception handling in multi-threaded code. (No exception-handling changes.)

## How was this PR tested?

Added regression test `testUpdateOffsetsFromConsumerRecordLocalVtUsesProvenanceNotUpstreamPosition` covering all three provenance cases:

1. Leader-produced record with a corresponding upstream message -> local VT advances with `producedPosition`, **never** `consumerRecord.getPosition()`, and no upstream position is misfiled.
2. Leader-generated chunk (no upstream) -> local VT position is **not** advanced.
3. Record consumed directly from local VT (`LPRC == null`) -> local VT advances with its own position.

The full `LeaderFollowerStoreIngestionTaskTest` class passes. Temporarily reverting the fix makes the new test **fail** (a foreign position is written), confirming it is a genuine regression guard. `ActiveActiveStoreIngestionTask` inherits this base method, so it is covered by the same fix.

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (steady-state behavior is unchanged; this is a no-op except for raced records).

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
