### PR TITLE
[server][pubsub] PubSub health foundation: core types, config keys, metric dimension

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -190,6 +190,10 @@ import static com.linkedin.venice.ConfigKeys.SERVER_PER_RECORD_OTEL_METRICS_ENAB
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_CONSUMER_POLL_RETRY_BACKOFF_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_CONSUMER_POLL_RETRY_TIMES;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_HEALTH_MONITOR_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_HEALTH_PROBE_INTERVAL_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_HEALTH_PROBE_TOPIC;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_PARTITION_PAUSE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_QUOTA_ENFORCEMENT_CAPACITY_MULTIPLE;
 import static com.linkedin.venice.ConfigKeys.SERVER_QUOTA_ENFORCEMENT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_QUOTA_ENFORCEMENT_INTERVAL_IN_MILLIS;
@@ -483,6 +487,11 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final long diskHealthCheckTimeoutInMs;
 
   private final boolean diskHealthCheckServiceEnabled;
+
+  private final boolean pubSubHealthMonitorEnabled;
+  private final boolean pubSubPartitionPauseEnabled;
+  private final int pubSubHealthProbeIntervalSeconds;
+  private final String pubSubHealthProbeTopic;
 
   private final Duration serverMaxWaitForVersionInfo;
 
@@ -964,6 +973,11 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     diskHealthCheckTimeoutInMs =
         TimeUnit.SECONDS.toMillis(serverProperties.getLong(SERVER_DISK_HEALTH_CHECK_TIMEOUT_IN_SECONDS, 30));
     diskHealthCheckServiceEnabled = serverProperties.getBoolean(SERVER_DISK_HEALTH_CHECK_SERVICE_ENABLED, true);
+    pubSubHealthMonitorEnabled = serverProperties.getBoolean(SERVER_PUBSUB_HEALTH_MONITOR_ENABLED, false);
+    pubSubPartitionPauseEnabled =
+        pubSubHealthMonitorEnabled && serverProperties.getBoolean(SERVER_PUBSUB_PARTITION_PAUSE_ENABLED, false);
+    pubSubHealthProbeIntervalSeconds = serverProperties.getInt(SERVER_PUBSUB_HEALTH_PROBE_INTERVAL_SECONDS, 30);
+    pubSubHealthProbeTopic = serverProperties.getString(SERVER_PUBSUB_HEALTH_PROBE_TOPIC, "");
     serverMaxWaitForVersionInfo =
         Duration.ofMillis(serverProperties.getLong(SERVER_MAX_WAIT_FOR_VERSION_INFO_MS_CONFIG, 5000));
     storeVersionMetadataWaitDuringStateTransitionTimeMs =
@@ -1625,6 +1639,22 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isDiskHealthCheckServiceEnabled() {
     return diskHealthCheckServiceEnabled;
+  }
+
+  public boolean isPubSubHealthMonitorEnabled() {
+    return pubSubHealthMonitorEnabled;
+  }
+
+  public boolean isPubSubPartitionPauseEnabled() {
+    return pubSubPartitionPauseEnabled;
+  }
+
+  public int getPubSubHealthProbeIntervalSeconds() {
+    return pubSubHealthProbeIntervalSeconds;
+  }
+
+  public String getPubSubHealthProbeTopic() {
+    return pubSubHealthProbeTopic;
   }
 
   public Duration getServerMaxWaitForVersionInfo() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
@@ -17,6 +17,10 @@ import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_OTEL_STATS_ENABLED
 import static com.linkedin.venice.ConfigKeys.SERVER_LEADER_HANDOVER_USE_DOL_MECHANISM_FOR_SYSTEM_STORES;
 import static com.linkedin.venice.ConfigKeys.SERVER_LEADER_HANDOVER_USE_DOL_MECHANISM_FOR_USER_STORES;
 import static com.linkedin.venice.ConfigKeys.SERVER_PARALLEL_SHUTDOWN_THREAD_POOL_SIZE;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_HEALTH_MONITOR_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_HEALTH_PROBE_INTERVAL_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_HEALTH_PROBE_TOPIC;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_PARTITION_PAUSE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_READ_OTEL_STATS_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER;
 import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER;
@@ -293,5 +297,34 @@ public class VeniceServerConfigTest {
     config = new VeniceServerConfig(new VeniceProperties(props));
     assertFalse(config.isReadOtelStatsEnabled());
     assertFalse(config.isIngestionOtelStatsEnabled());
+  }
+
+  @Test
+  public void testPubSubHealthConfigs() {
+    // Defaults: everything off, probe interval 30s, empty probe topic.
+    Properties props = populatedBasicProperties();
+    VeniceServerConfig config = new VeniceServerConfig(new VeniceProperties(props));
+    assertFalse(config.isPubSubHealthMonitorEnabled());
+    assertFalse(config.isPubSubPartitionPauseEnabled());
+    assertEquals(config.getPubSubHealthProbeIntervalSeconds(), 30);
+    assertEquals(config.getPubSubHealthProbeTopic(), "");
+
+    // Monitor enabled + pause enabled: pause honored because monitor is on.
+    props.put(SERVER_PUBSUB_HEALTH_MONITOR_ENABLED, "true");
+    props.put(SERVER_PUBSUB_PARTITION_PAUSE_ENABLED, "true");
+    props.put(SERVER_PUBSUB_HEALTH_PROBE_INTERVAL_SECONDS, "45");
+    props.put(SERVER_PUBSUB_HEALTH_PROBE_TOPIC, "health_probe_topic");
+    config = new VeniceServerConfig(new VeniceProperties(props));
+    assertTrue(config.isPubSubHealthMonitorEnabled());
+    assertTrue(config.isPubSubPartitionPauseEnabled());
+    assertEquals(config.getPubSubHealthProbeIntervalSeconds(), 45);
+    assertEquals(config.getPubSubHealthProbeTopic(), "health_probe_topic");
+
+    // Monitor disabled but pause requested: pause stays off (monitor gates it).
+    props.put(SERVER_PUBSUB_HEALTH_MONITOR_ENABLED, "false");
+    props.put(SERVER_PUBSUB_PARTITION_PAUSE_ENABLED, "true");
+    config = new VeniceServerConfig(new VeniceProperties(props));
+    assertFalse(config.isPubSubHealthMonitorEnabled());
+    assertFalse(config.isPubSubPartitionPauseEnabled());
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -186,7 +186,10 @@ public enum VeniceMetricsDimensions {
   VENICE_RECORD_TRANSFORMER_OPERATION("venice.record_transformer.operation"),
 
   /** {@link VeniceStoreWriteType} Store write type: regular or write_compute. */
-  VENICE_STORE_WRITE_TYPE("venice.store.write_type");
+  VENICE_STORE_WRITE_TYPE("venice.store.write_type"),
+
+  /** {@link com.linkedin.venice.pubsub.PubSubHealthCategory} */
+  VENICE_PUBSUB_HEALTH_CATEGORY("venice.pubsub.health.category");
 
   private final String[] dimensionName = new String[VeniceOpenTelemetryMetricNamingFormat.SIZE];
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/PubSubHealthCategoryTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/PubSubHealthCategoryTest.java
@@ -1,0 +1,21 @@
+package com.linkedin.venice.stats.dimensions;
+
+import com.linkedin.venice.pubsub.PubSubHealthCategory;
+import com.linkedin.venice.utils.CollectionUtils;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class PubSubHealthCategoryTest {
+  @Test
+  public void testDimensionInterface() {
+    Map<PubSubHealthCategory, String> expectedValues = CollectionUtils.<PubSubHealthCategory, String>mapBuilder()
+        .put(PubSubHealthCategory.BROKER, "broker")
+        .put(PubSubHealthCategory.METADATA_SERVICE, "metadata_service")
+        .build();
+    new VeniceDimensionTestFixture<>(
+        PubSubHealthCategory.class,
+        VeniceMetricsDimensions.VENICE_PUBSUB_HEALTH_CATEGORY,
+        expectedValues).assertAll();
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -190,6 +190,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_STORE_WRITE_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.store.write_type");
           break;
+        case VENICE_PUBSUB_HEALTH_CATEGORY:
+          assertEquals(dimension.getDimensionName(format), "venice.pubsub.health.category");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -378,6 +381,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_STORE_WRITE_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.store.writeType");
           break;
+        case VENICE_PUBSUB_HEALTH_CATEGORY:
+          assertEquals(dimension.getDimensionName(format), "venice.pubsub.health.category");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -565,6 +571,9 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_STORE_WRITE_TYPE:
           assertEquals(dimension.getDimensionName(format), "Venice.Store.WriteType");
+          break;
+        case VENICE_PUBSUB_HEALTH_CATEGORY:
+          assertEquals(dimension.getDimensionName(format), "Venice.Pubsub.Health.Category");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1059,6 +1059,33 @@ public class ConfigKeys {
       "server." + PubSubConstants.PUBSUB_CONSUMER_POLL_RETRY_BACKOFF_MS;
 
   /**
+   * Whether the PubSub health monitor is enabled. When enabled, the server tracks per-broker
+   * health and runs recovery probes for unhealthy brokers.
+   */
+  public static final String SERVER_PUBSUB_HEALTH_MONITOR_ENABLED = "server.pubsub.health.monitor.enabled";
+
+  /**
+   * Whether partition pausing on PubSub outage is enabled. Requires
+   * {@link #SERVER_PUBSUB_HEALTH_MONITOR_ENABLED} to also be enabled — if the health monitor
+   * is disabled, this config is ignored.
+   */
+  public static final String SERVER_PUBSUB_PARTITION_PAUSE_ENABLED = "server.pubsub.partition.pause.enabled";
+
+  /**
+   * The interval in seconds between recovery probe attempts for unhealthy brokers.
+   */
+  public static final String SERVER_PUBSUB_HEALTH_PROBE_INTERVAL_SECONDS =
+      "server.pubsub.health.probe.interval.seconds";
+
+  /**
+   * The PubSub topic name used for recovery probes. The probe sends a metadata request for this
+   * topic to verify broker reachability. Must be a topic that is guaranteed to exist on the broker
+   * (e.g., a store's version topic). If empty or not set, recovery probes are skipped and paused
+   * partitions will not be automatically resumed.
+   */
+  public static final String SERVER_PUBSUB_HEALTH_PROBE_TOPIC = "server.pubsub.health.probe.topic";
+
+  /**
    * Maximum duration (in milliseconds) to wait for the version information to become available in the store metadata
    * repository before skipping Heartbeat (HB) lag monitor setup activity during state transition.
    */

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthCategory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthCategory.java
@@ -1,0 +1,22 @@
+package com.linkedin.venice.pubsub;
+
+import com.linkedin.venice.stats.dimensions.VeniceDimensionInterface;
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+
+
+/**
+ * Categories of PubSub health tracked independently by the health monitor.
+ * A broker can be healthy while the metadata service is unhealthy, or vice versa.
+ */
+public enum PubSubHealthCategory implements VeniceDimensionInterface {
+  /** PubSub broker health — affects produce and consume operations */
+  BROKER,
+
+  /** PubSub metadata service health — affects topic creation, deletion, and metadata queries */
+  METADATA_SERVICE;
+
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VeniceMetricsDimensions.VENICE_PUBSUB_HEALTH_CATEGORY;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthChangeListener.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthChangeListener.java
@@ -1,0 +1,16 @@
+package com.linkedin.venice.pubsub;
+
+/**
+ * Listener for PubSub health status changes. Implementations are notified asynchronously
+ * when a PubSub target transitions between health states.
+ */
+public interface PubSubHealthChangeListener {
+  /**
+   * Called when a PubSub target's health status changes. Implementations must be non-blocking.
+   *
+   * @param pubSubAddress the broker or metadata service address
+   * @param category      whether this is a BROKER or METADATA_SERVICE status change
+   * @param newStatus     the new health status
+   */
+  void onHealthStatusChanged(String pubSubAddress, PubSubHealthCategory category, PubSubHealthStatus newStatus);
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthSignalProvider.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthSignalProvider.java
@@ -1,0 +1,34 @@
+package com.linkedin.venice.pubsub;
+
+/**
+ * A pluggable provider of health signals for PubSub targets. The PubSub health monitor
+ * aggregates signals from all registered providers to determine overall broker health.
+ *
+ * <p>The first implementation is exception-based (any PubSub exception marks the target unhealthy).
+ * Future implementations can detect non-exception failures such as growing heartbeat lag or
+ * elevated latency.
+ */
+public interface PubSubHealthSignalProvider {
+  /**
+   * @return a descriptive name for this provider, used in logging and metrics (e.g., "exception", "heartbeat-lag")
+   */
+  String getName();
+
+  /**
+   * @return true if this provider currently considers the given target unhealthy
+   */
+  boolean isUnhealthy(String pubSubAddress, PubSubHealthCategory category);
+
+  /**
+   * Called by the health monitor when a recovery probe succeeds for the given target.
+   * Implementations should clear any failure state for this target.
+   */
+  default void onProbeSuccess(String pubSubAddress, PubSubHealthCategory category) {
+  }
+
+  /**
+   * Called by the health monitor when a recovery probe fails for the given target.
+   */
+  default void onProbeFailure(String pubSubAddress, PubSubHealthCategory category) {
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthStatus.java
@@ -1,0 +1,8 @@
+package com.linkedin.venice.pubsub;
+
+/**
+ * Health status of a PubSub target (broker or metadata service).
+ */
+public enum PubSubHealthStatus {
+  HEALTHY, UNHEALTHY
+}


### PR DESCRIPTION
## Summary

First of a **stacked series** splitting the PubSub Health Monitoring feature (#2534) into smaller reviewable chunks. This PR introduces only the foundational, **behavior-free** building blocks — no wiring, no call sites, all default-off.

## What's included

**New pubsub health types** (`venice-common`):
- `PubSubHealthStatus` (HEALTHY / UNHEALTHY)
- `PubSubHealthCategory` (BROKER / METADATA_SERVICE) — also a metric dimension
- `PubSubHealthSignalProvider` — pluggable detection interface
- `PubSubHealthChangeListener` — state-transition callback interface

**New config keys** (all default-off) + `VeniceServerConfig` parsing:

| Key | Default |
|-----|---------|
| `server.pubsub.health.monitor.enabled` | `false` |
| `server.pubsub.partition.pause.enabled` | `false` |
| `server.pubsub.health.probe.interval.seconds` | `30` |
| `server.pubsub.health.probe.topic` | `""` |

**New OTel dimension** `VENICE_PUBSUB_HEALTH_CATEGORY` (required by `PubSubHealthCategory`) + dimension unit tests.

## Stack

This is **PR 1 of a series** that decomposes #2534:
1. **This PR** — foundation (types, config, dimension)
2. PubSub health OTel metric entity
3. Monitor core (`PubSubHealthMonitor` + signal provider + stats)
4. Ingestion integration: pause on outage
5. Resume on recovery + server wiring + integration/E2E tests

## How was this PR tested?

- Compiles independently (`venice-common`, `venice-client-common`, `da-vinci-client`).
- `VeniceMetricsDimensionsTest`, `PubSubHealthCategoryTest` pass.
- No call sites yet; no behavior change.

## Does this PR introduce any user-facing or breaking changes?

- [x] No.
