### PR TITLE
[server][pubsub] PubSub health OTel metric entity

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -190,6 +190,10 @@ import static com.linkedin.venice.ConfigKeys.SERVER_PER_RECORD_OTEL_METRICS_ENAB
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_CONSUMER_POLL_RETRY_BACKOFF_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_CONSUMER_POLL_RETRY_TIMES;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_HEALTH_MONITOR_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_HEALTH_PROBE_INTERVAL_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_HEALTH_PROBE_TOPIC;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_PARTITION_PAUSE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_QUOTA_ENFORCEMENT_CAPACITY_MULTIPLE;
 import static com.linkedin.venice.ConfigKeys.SERVER_QUOTA_ENFORCEMENT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_QUOTA_ENFORCEMENT_INTERVAL_IN_MILLIS;
@@ -483,6 +487,11 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final long diskHealthCheckTimeoutInMs;
 
   private final boolean diskHealthCheckServiceEnabled;
+
+  private final boolean pubSubHealthMonitorEnabled;
+  private final boolean pubSubPartitionPauseEnabled;
+  private final int pubSubHealthProbeIntervalSeconds;
+  private final String pubSubHealthProbeTopic;
 
   private final Duration serverMaxWaitForVersionInfo;
 
@@ -964,6 +973,11 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     diskHealthCheckTimeoutInMs =
         TimeUnit.SECONDS.toMillis(serverProperties.getLong(SERVER_DISK_HEALTH_CHECK_TIMEOUT_IN_SECONDS, 30));
     diskHealthCheckServiceEnabled = serverProperties.getBoolean(SERVER_DISK_HEALTH_CHECK_SERVICE_ENABLED, true);
+    pubSubHealthMonitorEnabled = serverProperties.getBoolean(SERVER_PUBSUB_HEALTH_MONITOR_ENABLED, false);
+    pubSubPartitionPauseEnabled =
+        pubSubHealthMonitorEnabled && serverProperties.getBoolean(SERVER_PUBSUB_PARTITION_PAUSE_ENABLED, false);
+    pubSubHealthProbeIntervalSeconds = serverProperties.getInt(SERVER_PUBSUB_HEALTH_PROBE_INTERVAL_SECONDS, 30);
+    pubSubHealthProbeTopic = serverProperties.getString(SERVER_PUBSUB_HEALTH_PROBE_TOPIC, "");
     serverMaxWaitForVersionInfo =
         Duration.ofMillis(serverProperties.getLong(SERVER_MAX_WAIT_FOR_VERSION_INFO_MS_CONFIG, 5000));
     storeVersionMetadataWaitDuringStateTransitionTimeMs =
@@ -1625,6 +1639,22 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isDiskHealthCheckServiceEnabled() {
     return diskHealthCheckServiceEnabled;
+  }
+
+  public boolean isPubSubHealthMonitorEnabled() {
+    return pubSubHealthMonitorEnabled;
+  }
+
+  public boolean isPubSubPartitionPauseEnabled() {
+    return pubSubPartitionPauseEnabled;
+  }
+
+  public int getPubSubHealthProbeIntervalSeconds() {
+    return pubSubHealthProbeIntervalSeconds;
+  }
+
+  public String getPubSubHealthProbeTopic() {
+    return pubSubHealthProbeTopic;
   }
 
   public Duration getServerMaxWaitForVersionInfo() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/PubSubHealthOtelMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/PubSubHealthOtelMetricEntity.java
@@ -1,0 +1,67 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_PUBSUB_HEALTH_CATEGORY;
+import static com.linkedin.venice.utils.Utils.setOf;
+
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.metrics.MetricEntity;
+import com.linkedin.venice.stats.metrics.MetricType;
+import com.linkedin.venice.stats.metrics.MetricUnit;
+import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
+import java.util.Set;
+
+
+public enum PubSubHealthOtelMetricEntity implements ModuleMetricEntityInterface {
+  PUBSUB_HEALTH_UNHEALTHY_COUNT(
+      "pubsub.health.unhealthy_count", MetricType.ASYNC_GAUGE, MetricUnit.NUMBER,
+      "Count of unhealthy PubSub targets by category", setOf(VENICE_CLUSTER_NAME, VENICE_PUBSUB_HEALTH_CATEGORY)
+  ),
+
+  PUBSUB_HEALTH_PROBE_SUCCESS_COUNT(
+      "pubsub.health.probe.success_count", MetricType.COUNTER, MetricUnit.NUMBER,
+      "Count of successful recovery probe attempts", setOf(VENICE_CLUSTER_NAME, VENICE_PUBSUB_HEALTH_CATEGORY)
+  ),
+
+  PUBSUB_HEALTH_PROBE_FAILURE_COUNT(
+      "pubsub.health.probe.failure_count", MetricType.COUNTER, MetricUnit.NUMBER,
+      "Count of failed recovery probe attempts", setOf(VENICE_CLUSTER_NAME, VENICE_PUBSUB_HEALTH_CATEGORY)
+  ),
+
+  PUBSUB_HEALTH_STATE_TRANSITION_COUNT(
+      "pubsub.health.state_transition_count", MetricType.COUNTER, MetricUnit.NUMBER,
+      "Count of health state transitions", setOf(VENICE_CLUSTER_NAME, VENICE_PUBSUB_HEALTH_CATEGORY)
+  ),
+
+  PUBSUB_HEALTH_PAUSED_PARTITION_COUNT(
+      "pubsub.health.paused_partition_count", MetricType.ASYNC_GAUGE, MetricUnit.NUMBER,
+      "Total count of partitions paused due to PubSub health issues", setOf(VENICE_CLUSTER_NAME)
+  ),
+
+  PUBSUB_HEALTH_PROBE_LATENCY(
+      "pubsub.health.probe.latency", MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS, MetricUnit.MILLISECOND,
+      "Latency of recovery probe attempts", setOf(VENICE_CLUSTER_NAME, VENICE_PUBSUB_HEALTH_CATEGORY)
+  ),
+
+  PUBSUB_HEALTH_PROBE_ATTEMPT_COUNT(
+      "pubsub.health.probe.attempt_count", MetricType.COUNTER, MetricUnit.NUMBER,
+      "Total count of recovery probe attempts (success + failure)",
+      setOf(VENICE_CLUSTER_NAME, VENICE_PUBSUB_HEALTH_CATEGORY)
+  );
+
+  private final MetricEntity metricEntity;
+
+  PubSubHealthOtelMetricEntity(
+      String name,
+      MetricType metricType,
+      MetricUnit unit,
+      String description,
+      Set<VeniceMetricsDimensions> dimensionsList) {
+    this.metricEntity = new MetricEntity(name, metricType, unit, description, dimensionsList);
+  }
+
+  @Override
+  public MetricEntity getMetricEntity() {
+    return metricEntity;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetricEntity.java
@@ -52,7 +52,8 @@ public final class ServerMetricEntity {
         BackupVersionOptimizationOtelMetricEntity.class,
         ParticipantStateTransitionOtelMetricEntity.class,
         DaVinciRecordTransformerOtelMetricEntity.class,
-        StuckConsumerRepairOtelMetricEntity.class);
+        StuckConsumerRepairOtelMetricEntity.class,
+        PubSubHealthOtelMetricEntity.class);
   }
 
   public static final Collection<MetricEntity> SERVER_METRIC_ENTITIES =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
@@ -17,6 +17,10 @@ import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_OTEL_STATS_ENABLED
 import static com.linkedin.venice.ConfigKeys.SERVER_LEADER_HANDOVER_USE_DOL_MECHANISM_FOR_SYSTEM_STORES;
 import static com.linkedin.venice.ConfigKeys.SERVER_LEADER_HANDOVER_USE_DOL_MECHANISM_FOR_USER_STORES;
 import static com.linkedin.venice.ConfigKeys.SERVER_PARALLEL_SHUTDOWN_THREAD_POOL_SIZE;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_HEALTH_MONITOR_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_HEALTH_PROBE_INTERVAL_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_HEALTH_PROBE_TOPIC;
+import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_PARTITION_PAUSE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_READ_OTEL_STATS_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_AA_WC_LEADER;
 import static com.linkedin.venice.ConfigKeys.SERVER_THROTTLER_FACTORS_FOR_CURRENT_VERSION_NON_AA_WC_LEADER;
@@ -293,5 +297,34 @@ public class VeniceServerConfigTest {
     config = new VeniceServerConfig(new VeniceProperties(props));
     assertFalse(config.isReadOtelStatsEnabled());
     assertFalse(config.isIngestionOtelStatsEnabled());
+  }
+
+  @Test
+  public void testPubSubHealthConfigs() {
+    // Defaults: everything off, probe interval 30s, empty probe topic.
+    Properties props = populatedBasicProperties();
+    VeniceServerConfig config = new VeniceServerConfig(new VeniceProperties(props));
+    assertFalse(config.isPubSubHealthMonitorEnabled());
+    assertFalse(config.isPubSubPartitionPauseEnabled());
+    assertEquals(config.getPubSubHealthProbeIntervalSeconds(), 30);
+    assertEquals(config.getPubSubHealthProbeTopic(), "");
+
+    // Monitor enabled + pause enabled: pause honored because monitor is on.
+    props.put(SERVER_PUBSUB_HEALTH_MONITOR_ENABLED, "true");
+    props.put(SERVER_PUBSUB_PARTITION_PAUSE_ENABLED, "true");
+    props.put(SERVER_PUBSUB_HEALTH_PROBE_INTERVAL_SECONDS, "45");
+    props.put(SERVER_PUBSUB_HEALTH_PROBE_TOPIC, "health_probe_topic");
+    config = new VeniceServerConfig(new VeniceProperties(props));
+    assertTrue(config.isPubSubHealthMonitorEnabled());
+    assertTrue(config.isPubSubPartitionPauseEnabled());
+    assertEquals(config.getPubSubHealthProbeIntervalSeconds(), 45);
+    assertEquals(config.getPubSubHealthProbeTopic(), "health_probe_topic");
+
+    // Monitor disabled but pause requested: pause stays off (monitor gates it).
+    props.put(SERVER_PUBSUB_HEALTH_MONITOR_ENABLED, "false");
+    props.put(SERVER_PUBSUB_PARTITION_PAUSE_ENABLED, "true");
+    config = new VeniceServerConfig(new VeniceProperties(props));
+    assertFalse(config.isPubSubHealthMonitorEnabled());
+    assertFalse(config.isPubSubPartitionPauseEnabled());
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ServerMetricEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 public class ServerMetricEntityTest {
   @Test
   public void testServerMetricEntitiesCount() {
-    assertEquals(SERVER_METRIC_ENTITIES.size(), 185, "Expected 185 unique metric entities");
+    assertEquals(SERVER_METRIC_ENTITIES.size(), 192, "Expected 192 unique metric entities");
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -186,7 +186,10 @@ public enum VeniceMetricsDimensions {
   VENICE_RECORD_TRANSFORMER_OPERATION("venice.record_transformer.operation"),
 
   /** {@link VeniceStoreWriteType} Store write type: regular or write_compute. */
-  VENICE_STORE_WRITE_TYPE("venice.store.write_type");
+  VENICE_STORE_WRITE_TYPE("venice.store.write_type"),
+
+  /** {@link com.linkedin.venice.pubsub.PubSubHealthCategory} */
+  VENICE_PUBSUB_HEALTH_CATEGORY("venice.pubsub.health.category");
 
   private final String[] dimensionName = new String[VeniceOpenTelemetryMetricNamingFormat.SIZE];
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/PubSubHealthCategoryTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/PubSubHealthCategoryTest.java
@@ -1,0 +1,21 @@
+package com.linkedin.venice.stats.dimensions;
+
+import com.linkedin.venice.pubsub.PubSubHealthCategory;
+import com.linkedin.venice.utils.CollectionUtils;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class PubSubHealthCategoryTest {
+  @Test
+  public void testDimensionInterface() {
+    Map<PubSubHealthCategory, String> expectedValues = CollectionUtils.<PubSubHealthCategory, String>mapBuilder()
+        .put(PubSubHealthCategory.BROKER, "broker")
+        .put(PubSubHealthCategory.METADATA_SERVICE, "metadata_service")
+        .build();
+    new VeniceDimensionTestFixture<>(
+        PubSubHealthCategory.class,
+        VeniceMetricsDimensions.VENICE_PUBSUB_HEALTH_CATEGORY,
+        expectedValues).assertAll();
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -190,6 +190,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_STORE_WRITE_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.store.write_type");
           break;
+        case VENICE_PUBSUB_HEALTH_CATEGORY:
+          assertEquals(dimension.getDimensionName(format), "venice.pubsub.health.category");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -378,6 +381,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_STORE_WRITE_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.store.writeType");
           break;
+        case VENICE_PUBSUB_HEALTH_CATEGORY:
+          assertEquals(dimension.getDimensionName(format), "venice.pubsub.health.category");
+          break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);
       }
@@ -565,6 +571,9 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_STORE_WRITE_TYPE:
           assertEquals(dimension.getDimensionName(format), "Venice.Store.WriteType");
+          break;
+        case VENICE_PUBSUB_HEALTH_CATEGORY:
+          assertEquals(dimension.getDimensionName(format), "Venice.Pubsub.Health.Category");
           break;
         default:
           throw new IllegalArgumentException("Unknown dimension: " + dimension);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1059,6 +1059,33 @@ public class ConfigKeys {
       "server." + PubSubConstants.PUBSUB_CONSUMER_POLL_RETRY_BACKOFF_MS;
 
   /**
+   * Whether the PubSub health monitor is enabled. When enabled, the server tracks per-broker
+   * health and runs recovery probes for unhealthy brokers.
+   */
+  public static final String SERVER_PUBSUB_HEALTH_MONITOR_ENABLED = "server.pubsub.health.monitor.enabled";
+
+  /**
+   * Whether partition pausing on PubSub outage is enabled. Requires
+   * {@link #SERVER_PUBSUB_HEALTH_MONITOR_ENABLED} to also be enabled — if the health monitor
+   * is disabled, this config is ignored.
+   */
+  public static final String SERVER_PUBSUB_PARTITION_PAUSE_ENABLED = "server.pubsub.partition.pause.enabled";
+
+  /**
+   * The interval in seconds between recovery probe attempts for unhealthy brokers.
+   */
+  public static final String SERVER_PUBSUB_HEALTH_PROBE_INTERVAL_SECONDS =
+      "server.pubsub.health.probe.interval.seconds";
+
+  /**
+   * The PubSub topic name used for recovery probes. The probe sends a metadata request for this
+   * topic to verify broker reachability. Must be a topic that is guaranteed to exist on the broker
+   * (e.g., a store's version topic). If empty or not set, recovery probes are skipped and paused
+   * partitions will not be automatically resumed.
+   */
+  public static final String SERVER_PUBSUB_HEALTH_PROBE_TOPIC = "server.pubsub.health.probe.topic";
+
+  /**
    * Maximum duration (in milliseconds) to wait for the version information to become available in the store metadata
    * repository before skipping Heartbeat (HB) lag monitor setup activity during state transition.
    */

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthCategory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthCategory.java
@@ -1,0 +1,22 @@
+package com.linkedin.venice.pubsub;
+
+import com.linkedin.venice.stats.dimensions.VeniceDimensionInterface;
+import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+
+
+/**
+ * Categories of PubSub health tracked independently by the health monitor.
+ * A broker can be healthy while the metadata service is unhealthy, or vice versa.
+ */
+public enum PubSubHealthCategory implements VeniceDimensionInterface {
+  /** PubSub broker health — affects produce and consume operations */
+  BROKER,
+
+  /** PubSub metadata service health — affects topic creation, deletion, and metadata queries */
+  METADATA_SERVICE;
+
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VeniceMetricsDimensions.VENICE_PUBSUB_HEALTH_CATEGORY;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthChangeListener.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthChangeListener.java
@@ -1,0 +1,16 @@
+package com.linkedin.venice.pubsub;
+
+/**
+ * Listener for PubSub health status changes. Implementations are notified asynchronously
+ * when a PubSub target transitions between health states.
+ */
+public interface PubSubHealthChangeListener {
+  /**
+   * Called when a PubSub target's health status changes. Implementations must be non-blocking.
+   *
+   * @param pubSubAddress the broker or metadata service address
+   * @param category      whether this is a BROKER or METADATA_SERVICE status change
+   * @param newStatus     the new health status
+   */
+  void onHealthStatusChanged(String pubSubAddress, PubSubHealthCategory category, PubSubHealthStatus newStatus);
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthSignalProvider.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthSignalProvider.java
@@ -1,0 +1,34 @@
+package com.linkedin.venice.pubsub;
+
+/**
+ * A pluggable provider of health signals for PubSub targets. The PubSub health monitor
+ * aggregates signals from all registered providers to determine overall broker health.
+ *
+ * <p>The first implementation is exception-based (any PubSub exception marks the target unhealthy).
+ * Future implementations can detect non-exception failures such as growing heartbeat lag or
+ * elevated latency.
+ */
+public interface PubSubHealthSignalProvider {
+  /**
+   * @return a descriptive name for this provider, used in logging and metrics (e.g., "exception", "heartbeat-lag")
+   */
+  String getName();
+
+  /**
+   * @return true if this provider currently considers the given target unhealthy
+   */
+  boolean isUnhealthy(String pubSubAddress, PubSubHealthCategory category);
+
+  /**
+   * Called by the health monitor when a recovery probe succeeds for the given target.
+   * Implementations should clear any failure state for this target.
+   */
+  default void onProbeSuccess(String pubSubAddress, PubSubHealthCategory category) {
+  }
+
+  /**
+   * Called by the health monitor when a recovery probe fails for the given target.
+   */
+  default void onProbeFailure(String pubSubAddress, PubSubHealthCategory category) {
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubHealthStatus.java
@@ -1,0 +1,8 @@
+package com.linkedin.venice.pubsub;
+
+/**
+ * Health status of a PubSub target (broker or metadata service).
+ */
+public enum PubSubHealthStatus {
+  HEALTHY, UNHEALTHY
+}


### PR DESCRIPTION
## Summary

Second of the **stacked series** splitting the PubSub Health Monitoring feature (#2534). **Stacks on #2929** (foundation).

> ⚠️ **Stacked PR:** This targets `main`, so until #2929 merges its diff will also show the foundation changes. Please review #2929 first and merge it before this one. After #2929 merges, this diff narrows to just the two files below.

## What's included

- **`PubSubHealthOtelMetricEntity`** — defines the OTel metric entities for pubsub health (unhealthy count, paused partition count, probe success/failure, state transitions), keyed by the `VENICE_PUBSUB_HEALTH_CATEGORY` dimension introduced in #2929.
- Registers `PubSubHealthOtelMetricEntity` in `ServerMetricEntity` so the entities are emitted with the rest of the server metrics.

Metric entities only — the monitor that populates them lands in a later PR.

## Stack

Decomposition of #2534:
1. #2929 — foundation (types, config, dimension)
2. **This PR** — PubSub health OTel metric entity
3. Monitor core (`PubSubHealthMonitor` + signal provider + stats)
4. Ingestion integration: pause on outage
5. Resume on recovery + server wiring + integration/E2E tests

## How was this PR tested?

- Compiles independently on top of #2929 (`da-vinci-client`).

## Does this PR introduce any user-facing or breaking changes?

- [x] No.
