### PR TITLE
[schema] Gate RMD schema registration on any retained A/A version

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadOnlySchemaRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadOnlySchemaRepository.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.schema.GeneratedSchemaID;
 import com.linkedin.venice.schema.SchemaData;
 import com.linkedin.venice.schema.SchemaEntry;
@@ -158,11 +159,36 @@ public class HelixReadOnlySchemaRepository implements ReadOnlySchemaRepository, 
    * @return true if the subscription was established (only if AA is enabled)
    */
   boolean maybeRegisterAndPopulateRmdSchema(Store store, SchemaData schemaData) {
-    if (store.isActiveActiveReplicationEnabled()) {
+    if (isActiveActiveReplicationEnabled(store)) {
       String storeName = store.getName();
       getAccessor().subscribeReplicationMetadataSchemaCreationChange(storeName, replicationMetadataSchemaChildListener);
       getAccessor().getAllReplicationMetadataSchemas(storeName).forEach(schemaData::addReplicationMetadataSchema);
       return true;
+    }
+    return false;
+  }
+
+  /**
+   * Determine whether RMD (replication metadata) schemas should be subscribed/fetched/served for a store.
+   *
+   * The store-level {@link Store#isActiveActiveReplicationEnabled()} flag alone is not sufficient: it is possible
+   * for a store to have A/A replication disabled at the store level while one or more retained {@link Version}s
+   * (e.g. the current serving version, or a retained backup version) still have A/A replication enabled. This can
+   * happen, for instance, when A/A is disabled on a store after a version with A/A enabled has already been
+   * created/retained. If we only checked the store-level flag, a cold server bootstrap could skip subscribing to
+   * and populating RMD schemas entirely, which would then cause ingestion (SITs) to fail for any retained
+   * A/A-enabled version once it needs to deserialize/produce RMD records.
+   *
+   * @return true if the store itself has A/A replication enabled, or if any of its retained versions do.
+   */
+  static boolean isActiveActiveReplicationEnabled(Store store) {
+    if (store.isActiveActiveReplicationEnabled()) {
+      return true;
+    }
+    for (Version version: store.getVersions()) {
+      if (version.isActiveActiveReplicationEnabled()) {
+        return true;
+      }
     }
     return false;
   }
@@ -222,7 +248,7 @@ public class HelixReadOnlySchemaRepository implements ReadOnlySchemaRepository, 
           store.getName());
       return false;
     }
-    if (store.isActiveActiveReplicationEnabled() && !schemaData.hasRmdSchema(supersetSchemaId)) {
+    if (isActiveActiveReplicationEnabled(store) && !schemaData.hasRmdSchema(supersetSchemaId)) {
       logger.warn(
           "RMD schema of superset schema ID: {} for store: {} not found in schema cache.",
           supersetSchemaId,
@@ -238,7 +264,7 @@ public class HelixReadOnlySchemaRepository implements ReadOnlySchemaRepository, 
     if (store.isWriteComputationEnabled()) {
       getAccessor().getAllDerivedSchemas(storeName).forEach(schemaData::addDerivedSchema);
     }
-    if (store.isActiveActiveReplicationEnabled()) {
+    if (isActiveActiveReplicationEnabled(store)) {
       getAccessor().getAllReplicationMetadataSchemas(storeName).forEach(schemaData::addReplicationMetadataSchema);
     }
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/HelixReadOnlySchemaRepositoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/HelixReadOnlySchemaRepositoryTest.java
@@ -184,6 +184,7 @@ public class HelixReadOnlySchemaRepositoryTest {
     RmdSchemaEntry rmdSchemaEntry = new RmdSchemaEntry(1, 1, UPDATE_SCHEMA.toString());
     HelixSchemaAccessor schemaAccessor = mock(HelixSchemaAccessor.class);
     when(schemaRepository.getAccessor()).thenReturn(schemaAccessor);
+    when(schemaAccessor.getAllValueSchemas(storeName)).thenReturn(Collections.emptyList());
     when(schemaAccessor.getAllReplicationMetadataSchemas(storeName))
         .thenReturn(Collections.singletonList(rmdSchemaEntry));
     SchemaData schemaData = new SchemaData(storeName, null);
@@ -219,6 +220,7 @@ public class HelixReadOnlySchemaRepositoryTest {
     when(storeRepository.getStoreOrThrow(storeName)).thenReturn(store);
 
     RmdSchemaEntry rmdSchemaEntry = new RmdSchemaEntry(1, 1, UPDATE_SCHEMA.toString());
+    when(accessor.getAllValueSchemas(storeName)).thenReturn(Collections.emptyList());
     when(accessor.getAllReplicationMetadataSchemas(storeName)).thenReturn(Collections.singletonList(rmdSchemaEntry));
 
     verify(accessor, never()).subscribeReplicationMetadataSchemaCreationChange(anyString(), any());

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/HelixReadOnlySchemaRepositoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/HelixReadOnlySchemaRepositoryTest.java
@@ -19,6 +19,7 @@ import com.linkedin.venice.exceptions.InvalidVeniceSchemaException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.schema.GeneratedSchemaID;
 import com.linkedin.venice.schema.SchemaData;
 import com.linkedin.venice.schema.SchemaEntry;
@@ -30,6 +31,8 @@ import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -86,6 +89,147 @@ public class HelixReadOnlySchemaRepositoryTest {
     schemaRepository.maybeRegisterAndPopulateRmdSchema(store, schemaData);
     verify(schemaAccessor, times(1)).subscribeReplicationMetadataSchemaCreationChange(anyString(), any());
     Assert.assertEquals(schemaData.getReplicationMetadataSchema(1, 1).getSchema(), UPDATE_SCHEMA);
+  }
+
+  /**
+   * Builds a {@link Store} mock whose store-level A/A flag is {@code storeAAEnabled}, and which retains two
+   * {@link Version}s (mimicking a current serving version plus one retained backup version) with the given A/A
+   * flags. This models the incident scenario where a store's A/A flag was flipped to false, but a retained
+   * (e.g. backup) version was created while A/A was still enabled and is thus still A/A itself.
+   */
+  private Store mockStoreWithRetainedVersions(
+      String storeName,
+      boolean storeAAEnabled,
+      boolean currentVersionAAEnabled,
+      boolean retainedBackupVersionAAEnabled) {
+    Store store = mock(Store.class);
+    when(store.getName()).thenReturn(storeName);
+    when(store.isActiveActiveReplicationEnabled()).thenReturn(storeAAEnabled);
+
+    Version currentVersion = mock(Version.class);
+    when(currentVersion.isActiveActiveReplicationEnabled()).thenReturn(currentVersionAAEnabled);
+    Version retainedBackupVersion = mock(Version.class);
+    when(retainedBackupVersion.isActiveActiveReplicationEnabled()).thenReturn(retainedBackupVersionAAEnabled);
+    when(store.getVersions()).thenReturn(Arrays.asList(currentVersion, retainedBackupVersion));
+    return store;
+  }
+
+  /**
+   * Regression test for the incident where a store had A/A replication disabled at the store level (and its
+   * current version was also non-A/A), yet a retained backup {@link Version} still had A/A replication enabled.
+   * {@link HelixReadOnlySchemaRepository#isActiveActiveReplicationEnabled(Store)} must consider retained versions,
+   * not just the store-level flag, so that {@link HelixReadOnlySchemaRepository#maybeRegisterAndPopulateRmdSchema}
+   * still subscribes to and populates RMD schemas; otherwise a cold server bootstrap would skip RMD schemas
+   * entirely and ingestion (SITs) of the retained A/A version would fail.
+   */
+  @Test
+  public void testMaybeRegisterAndPopulateRmdSchemaForRetainedActiveActiveVersion() {
+    HelixReadOnlySchemaRepository schemaRepository = mock(HelixReadOnlySchemaRepository.class);
+    doCallRealMethod().when(schemaRepository).maybeRegisterAndPopulateRmdSchema(any(), any());
+    String storeName = "testStore";
+    // Store-level AA disabled, current version AA disabled, but a retained backup version is still AA enabled.
+    Store store = mockStoreWithRetainedVersions(storeName, false, false, true);
+
+    RmdSchemaEntry rmdSchemaEntry = new RmdSchemaEntry(1, 1, UPDATE_SCHEMA.toString());
+    HelixSchemaAccessor schemaAccessor = mock(HelixSchemaAccessor.class);
+    when(schemaRepository.getAccessor()).thenReturn(schemaAccessor);
+    when(schemaAccessor.getAllReplicationMetadataSchemas(storeName))
+        .thenReturn(Collections.singletonList(rmdSchemaEntry));
+    SchemaData schemaData = new SchemaData(storeName, null);
+
+    boolean subscribed = schemaRepository.maybeRegisterAndPopulateRmdSchema(store, schemaData);
+    Assert.assertTrue(subscribed, "RMD schema subscription must be established for retained A/A version");
+    verify(schemaAccessor, times(1)).subscribeReplicationMetadataSchemaCreationChange(anyString(), any());
+    Assert.assertEquals(schemaData.getReplicationMetadataSchema(1, 1).getSchema(), UPDATE_SCHEMA);
+  }
+
+  /**
+   * Companion regression test for {@link #testMaybeRegisterAndPopulateRmdSchemaForRetainedActiveActiveVersion()}:
+   * confirms {@link HelixReadOnlySchemaRepository#isSupersetSchemaReadyToServe} also honors retained A/A versions
+   * when deciding whether the RMD schema for the superset value schema must be present.
+   */
+  @Test
+  public void testIsSupersetSchemaReadyToServeForRetainedActiveActiveVersion() {
+    HelixReadOnlySchemaRepository schemaRepository = mock(HelixReadOnlySchemaRepository.class);
+    doCallRealMethod().when(schemaRepository).isSupersetSchemaReadyToServe(any(), any(), anyInt());
+    String storeName = "testStore";
+    Store store = mockStoreWithRetainedVersions(storeName, false, false, true);
+    when(store.isWriteComputationEnabled()).thenReturn(false);
+    int supersetSchemaId = 1;
+
+    SchemaData schemaData = new SchemaData(storeName, null);
+    schemaData.addValueSchema(new SchemaEntry(supersetSchemaId, VALUE_SCHEMA.toString()));
+
+    // RMD schema not yet populated: not ready to serve, since a retained version is still A/A.
+    Assert.assertFalse(schemaRepository.isSupersetSchemaReadyToServe(store, schemaData, supersetSchemaId));
+
+    // Once the RMD schema is populated, it should be considered ready.
+    schemaData.addReplicationMetadataSchema(new RmdSchemaEntry(supersetSchemaId, 1, UPDATE_SCHEMA.toString()));
+    Assert.assertTrue(schemaRepository.isSupersetSchemaReadyToServe(store, schemaData, supersetSchemaId));
+  }
+
+  /**
+   * Companion regression test for {@link #testMaybeRegisterAndPopulateRmdSchemaForRetainedActiveActiveVersion()}:
+   * confirms {@link HelixReadOnlySchemaRepository#forceRefreshSchemaData} also fetches RMD schemas for stores with
+   * a retained A/A version, even though neither the store nor its current version is A/A enabled.
+   */
+  @Test
+  public void testForceRefreshSchemaDataForRetainedActiveActiveVersion() {
+    HelixReadOnlySchemaRepository schemaRepository = mock(HelixReadOnlySchemaRepository.class);
+    doCallRealMethod().when(schemaRepository).forceRefreshSchemaData(any(), any());
+    String storeName = "testStore";
+    Store store = mockStoreWithRetainedVersions(storeName, false, false, true);
+    when(store.isWriteComputationEnabled()).thenReturn(false);
+
+    RmdSchemaEntry rmdSchemaEntry = new RmdSchemaEntry(1, 1, UPDATE_SCHEMA.toString());
+    HelixSchemaAccessor schemaAccessor = mock(HelixSchemaAccessor.class);
+    when(schemaRepository.getAccessor()).thenReturn(schemaAccessor);
+    when(schemaAccessor.getAllReplicationMetadataSchemas(storeName))
+        .thenReturn(Collections.singletonList(rmdSchemaEntry));
+    SchemaData schemaData = new SchemaData(storeName, null);
+
+    schemaRepository.forceRefreshSchemaData(store, schemaData);
+    verify(schemaAccessor, times(1)).getAllReplicationMetadataSchemas(storeName);
+    Assert.assertEquals(schemaData.getReplicationMetadataSchema(1, 1).getSchema(), UPDATE_SCHEMA);
+  }
+
+  /**
+   * End-to-end regression test modeling a cold Venice server bootstrap for the incident scenario: a store whose
+   * store-level A/A flag is false (and whose current version is also non-A/A) but which retains a backup
+   * {@link Version} with A/A replication enabled. Prior to the fix, {@link HelixReadOnlySchemaRepository} only
+   * consulted the store-level flag when warming up its local schema cache
+   * ({@link HelixReadOnlySchemaRepository#populateSchemaMap}), so RMD schemas were never subscribed to or fetched
+   * on bootstrap, which subsequently caused SITs for the retained A/A version to fail. This test uses a real
+   * {@link HelixReadOnlySchemaRepository} (mirroring the existing {@code getDerivedSchemaIdTest}/
+   * {@code getSupersetOrLatestValueSchemaTest} integration-style tests in this file) with a mocked store repository
+   * and schema accessor, and triggers the very first (cold) schema lookup for the store to verify that RMD schema
+   * subscription and population still occur.
+   */
+  @Test
+  public void testColdBootstrapPopulatesRmdSchemaForRetainedActiveActiveVersion() {
+    ReadOnlyStoreRepository storeRepository = mock(ReadOnlyStoreRepository.class);
+    ZkClient zkClient = mock(ZkClient.class);
+    HelixSchemaAccessor accessor = mock(HelixSchemaAccessor.class);
+    HelixReadOnlySchemaRepository schemaRepository =
+        new HelixReadOnlySchemaRepository(storeRepository, zkClient, accessor, 10, 100);
+
+    String storeName = "store";
+    Store store = mockStoreWithRetainedVersions(storeName, false, false, true);
+    when(store.isWriteComputationEnabled()).thenReturn(false);
+    when(storeRepository.getStoreOrThrow(storeName)).thenReturn(store);
+
+    RmdSchemaEntry rmdSchemaEntry = new RmdSchemaEntry(1, 1, UPDATE_SCHEMA.toString());
+    when(accessor.getAllReplicationMetadataSchemas(storeName)).thenReturn(Collections.singletonList(rmdSchemaEntry));
+
+    verify(accessor, never()).subscribeReplicationMetadataSchemaCreationChange(anyString(), any());
+
+    // The local schema cache is empty (cold bootstrap), so this first lookup for the store must populate it,
+    // including subscribing to and fetching the RMD schema for the retained A/A backup version.
+    Collection<RmdSchemaEntry> rmdSchemas = schemaRepository.getReplicationMetadataSchemas(storeName);
+
+    verify(accessor, times(1)).subscribeReplicationMetadataSchemaCreationChange(anyString(), any());
+    assertEquals(rmdSchemas.size(), 1);
+    assertEquals(rmdSchemas.iterator().next(), rmdSchemaEntry);
   }
 
   /**


### PR DESCRIPTION
## Problem

`HelixReadOnlySchemaRepository` decides whether to subscribe to, populate, and serve replication metadata (RMD) schemas for a store based on `Store#isActiveActiveReplicationEnabled()` — the store-level active/active (A/A) replication flag. This flag alone is not a sufficient signal.

A store can have A/A disabled at the store level (and on its current serving version) while a **retained** version — e.g. a backup version that was created while A/A was still enabled — still has A/A enabled. When that happens, a cold server bootstrap never subscribes to or fetches RMD schemas for the store, because only the store-level flag is consulted. Ingestion (SIT) for the retained A/A version then fails once it needs to deserialize or produce RMD records, since no RMD schema was ever cached locally.

Checking only the store's **current** version is also insufficient: retained backup versions can still be actively serving traffic or become the target of a rollback, so their A/A status needs to be honored too.

## Fix

Add a helper, `HelixReadOnlySchemaRepository#isActiveActiveReplicationEnabled(Store)`, that returns `true` if the store itself has A/A enabled **or** if any of its retained `Version`s have A/A enabled. This helper now backs all three places that previously checked the store-level flag directly:

- `maybeRegisterAndPopulateRmdSchema` — RMD schema subscription + population
- `isSupersetSchemaReadyToServe` — superset schema readiness gating
- `forceRefreshSchemaData` — forced refresh path

## Tests

- Unit tests for each of the three call sites above, confirming RMD schema handling now honors a retained A/A version even when the store-level flag (and current version) is non-A/A.
- An end-to-end cold-bootstrap regression test that models the failure scenario directly: store-level A/A disabled, current version A/A disabled, but a retained backup version still A/A enabled. It exercises the very first (cold) schema lookup for the store against a real `HelixReadOnlySchemaRepository` and asserts that RMD schema subscription/population still occurs.

Verified locally with JDK 17:
```
./gradlew :internal:venice-common:test --tests 'com.linkedin.venice.helix.HelixReadOnlySchemaRepositoryTest'
```

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (not applicable — internal implementation detail)
- [x] CI passing (targeted test suite verified locally)
- [x] No breaking changes
