### PR TITLE
[dvc][server][cc] Open RMD column family in downloaded snapshots

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/BlobTransferIngestionHelper.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/BlobTransferIngestionHelper.java
@@ -12,6 +12,7 @@ import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.davinci.store.StorageEngine;
 import com.linkedin.davinci.store.StoragePartitionAdjustmentTrigger;
 import com.linkedin.davinci.store.StoragePartitionConfig;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VenicePeersNotFoundException;
 import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
 import com.linkedin.venice.meta.Store;
@@ -420,6 +421,7 @@ public class BlobTransferIngestionHelper {
           replicaId,
           e);
       storageEngine.dropPartition(partition, false);
+      throw new VeniceException("Failed to adjust storage partition after blob transfer for replica: " + replicaId, e);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -246,6 +246,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
     this.fullPathForTempSSTFileDir = RocksDBUtils.composeTempSSTFileDir(dbDir, storeNameAndVersion, partitionId);
     this.fullPathForPartitionDBSnapshot = RocksDBUtils.composeSnapshotDir(dbDir, storeNameAndVersion, partitionId);
 
+    // For multiple column family enable atomic flush
     if (columnFamilyNamesToOpen.size() > 1 && rocksDBServerConfig.isAtomicFlushEnabled()) {
       options.setAtomicFlush(true);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -18,6 +18,7 @@ import com.linkedin.venice.utils.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -191,6 +192,8 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
     this.storeVersion = Version.parseVersionFromVersionTopicPartition(storeNameAndVersion);
     this.partitionId = storagePartitionConfig.getPartitionId();
     this.replicaId = Utils.getReplicaId(storagePartitionConfig.getStoreName(), partitionId);
+    this.fullPathForPartitionDB = RocksDBUtils.composePartitionDbDir(dbDir, storeNameAndVersion, partitionId);
+    List<byte[]> columnFamilyNamesToOpen = getColumnFamilyNamesToOpen(columnFamilyNameList);
     this.aggStatistics = factory.getAggStatistics();
 
     // If writing to offset metadata partition METADATA_PARTITION_ID enable WAL write to sync up offset on server
@@ -219,11 +222,6 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
          */
         .setBackgroundPurgeOnIteratorCleanup(true);
 
-    // For multiple column family enable atomic flush
-    if (columnFamilyNameList.size() > 1 && rocksDBServerConfig.isAtomicFlushEnabled()) {
-      options.setAtomicFlush(true);
-    }
-
     if (options.tableFormatConfig() instanceof PlainTableConfig) {
       this.deferredWrite = false;
     } else {
@@ -235,7 +233,6 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
     this.readWriteLeaderForDefaultCF = storagePartitionConfig.isReadWriteLeaderForDefaultCF();
     this.readWriteLeaderForRMDCF = storagePartitionConfig.isReadWriteLeaderForRMDCF();
     this.blobDbEnabled = storagePartitionConfig.getBlobDbEnabled();
-    this.fullPathForPartitionDB = RocksDBUtils.composePartitionDbDir(dbDir, storeNameAndVersion, partitionId);
     this.options = options;
     /**
      * TODO: check whether we should tune any config with {@link EnvOptions}.
@@ -248,6 +245,10 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
     this.rocksDBThrottler = rocksDbThrottler;
     this.fullPathForTempSSTFileDir = RocksDBUtils.composeTempSSTFileDir(dbDir, storeNameAndVersion, partitionId);
     this.fullPathForPartitionDBSnapshot = RocksDBUtils.composeSnapshotDir(dbDir, storeNameAndVersion, partitionId);
+
+    if (columnFamilyNamesToOpen.size() > 1 && rocksDBServerConfig.isAtomicFlushEnabled()) {
+      options.setAtomicFlush(true);
+    }
 
     if (deferredWrite) {
       this.rocksDBSstFileWriter = new RocksDBSstFileWriter(
@@ -266,7 +267,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
      * may be applied if we are sure replicationMetadata column family is smaller in size.
      */
     ColumnFamilyOptions columnFamilyOptions;
-    for (byte[] name: columnFamilyNameList) {
+    for (byte[] name: columnFamilyNamesToOpen) {
       if (name == REPLICATION_METADATA_COLUMN_FAMILY && !rocksDBServerConfig.isRocksDBPlainTableFormatEnabled()) {
         columnFamilyOptions = new ColumnFamilyOptions(getStoreOptions(storagePartitionConfig, true));
       } else {
@@ -303,6 +304,54 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
         replicaId,
         this.readOnly ? "read-only" : "read-write",
         this.deferredWrite ? "deferred write" : "non-deferred write");
+  }
+
+  private List<byte[]> getColumnFamilyNamesToOpen(List<byte[]> configuredColumnFamilyNames) {
+    if (!new File(fullPathForPartitionDB, "CURRENT").exists()) {
+      return configuredColumnFamilyNames;
+    }
+
+    List<byte[]> existingColumnFamilyNames;
+    try (Options columnFamilyListingOptions = new Options().setEnv(factory.getEnv())) {
+      existingColumnFamilyNames = RocksDB.listColumnFamilies(columnFamilyListingOptions, fullPathForPartitionDB);
+    } catch (RocksDBException e) {
+      throw new VeniceException("Failed to list RocksDB column families for replica: " + replicaId, e);
+    }
+
+    boolean hasDefaultColumnFamily = false;
+    boolean hasReplicationMetadataColumnFamily = false;
+    for (byte[] columnFamilyName: existingColumnFamilyNames) {
+      if (Arrays.equals(columnFamilyName, RocksDB.DEFAULT_COLUMN_FAMILY)) {
+        hasDefaultColumnFamily = true;
+      } else if (Arrays.equals(columnFamilyName, REPLICATION_METADATA_COLUMN_FAMILY)) {
+        hasReplicationMetadataColumnFamily = true;
+      } else {
+        throw new VeniceException(
+            "Unsupported RocksDB column family for replica " + replicaId + ": "
+                + new String(columnFamilyName, StandardCharsets.UTF_8));
+      }
+    }
+
+    if (!hasDefaultColumnFamily) {
+      throw new VeniceException("RocksDB default column family is missing for replica: " + replicaId);
+    }
+    if (!hasReplicationMetadataColumnFamily
+        || containsColumnFamily(configuredColumnFamilyNames, REPLICATION_METADATA_COLUMN_FAMILY)) {
+      return configuredColumnFamilyNames;
+    }
+
+    List<byte[]> columnFamilyNamesToOpen = new ArrayList<>(configuredColumnFamilyNames);
+    columnFamilyNamesToOpen.add(REPLICATION_METADATA_COLUMN_FAMILY);
+    return columnFamilyNamesToOpen;
+  }
+
+  private boolean containsColumnFamily(List<byte[]> columnFamilyNames, byte[] expectedColumnFamilyName) {
+    for (byte[] columnFamilyName: columnFamilyNames) {
+      if (Arrays.equals(columnFamilyName, expectedColumnFamilyName)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public RocksDBStoragePartition(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -268,7 +268,8 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
      */
     ColumnFamilyOptions columnFamilyOptions;
     for (byte[] name: columnFamilyNamesToOpen) {
-      if (name == REPLICATION_METADATA_COLUMN_FAMILY && !rocksDBServerConfig.isRocksDBPlainTableFormatEnabled()) {
+      if (Arrays.equals(name, REPLICATION_METADATA_COLUMN_FAMILY)
+          && !rocksDBServerConfig.isRocksDBPlainTableFormatEnabled()) {
         columnFamilyOptions = new ColumnFamilyOptions(getStoreOptions(storagePartitionConfig, true));
       } else {
         columnFamilyOptions = new ColumnFamilyOptions(options);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -319,23 +319,17 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
       throw new VeniceException("Failed to list RocksDB column families for replica: " + replicaId, e);
     }
 
-    boolean hasDefaultColumnFamily = false;
     boolean hasReplicationMetadataColumnFamily = false;
     for (byte[] columnFamilyName: existingColumnFamilyNames) {
-      if (Arrays.equals(columnFamilyName, RocksDB.DEFAULT_COLUMN_FAMILY)) {
-        hasDefaultColumnFamily = true;
-      } else if (Arrays.equals(columnFamilyName, REPLICATION_METADATA_COLUMN_FAMILY)) {
+      if (Arrays.equals(columnFamilyName, REPLICATION_METADATA_COLUMN_FAMILY)) {
         hasReplicationMetadataColumnFamily = true;
-      } else {
+      } else if (!Arrays.equals(columnFamilyName, RocksDB.DEFAULT_COLUMN_FAMILY)) {
         throw new VeniceException(
             "Unsupported RocksDB column family for replica " + replicaId + ": "
                 + new String(columnFamilyName, StandardCharsets.UTF_8));
       }
     }
 
-    if (!hasDefaultColumnFamily) {
-      throw new VeniceException("RocksDB default column family is missing for replica: " + replicaId);
-    }
     if (!hasReplicationMetadataColumnFamily
         || containsColumnFamily(configuredColumnFamilyNames, REPLICATION_METADATA_COLUMN_FAMILY)) {
       return configuredColumnFamilyNames;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -3849,6 +3849,30 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   @Test
+  public void testCompleteBlobTransferStopsRecoveryWhenStoragePartitionAdjustmentFails() throws Exception {
+    setUpWithBlobTransfer(false);
+    setUpCompleteBlobTransferMocks();
+
+    PubSubTopic versionTopic = leaderFollowerStoreIngestionTask.getVersionTopic();
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(versionTopic, 0);
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    when(pcs.getPartition()).thenReturn(0);
+    when(pcs.getReplicaId()).thenReturn(versionTopic.getName() + "-0");
+    when(pcs.getReplicaTopicPartition()).thenReturn(topicPartition);
+    when(pcs.getPendingBlobTransfer()).thenReturn(CompletableFuture.completedFuture(null));
+
+    StorageEngine storageEngine = leaderFollowerStoreIngestionTask.getStorageEngine();
+    doThrow(new VeniceException("Failed to open RocksDB")).when(storageEngine)
+        .adjustStoragePartition(eq(0), any(), any());
+
+    leaderFollowerStoreIngestionTask.completeBlobTransferAndSubscribe(pcs);
+
+    verify(storageEngine).dropPartition(0, false);
+    verify(leaderFollowerStoreIngestionTask, never()).completePostTransferPSCUpdated(pcs);
+    verify(leaderFollowerStoreIngestionTask).reportError(anyString(), eq(0), any(VeniceException.class));
+  }
+
+  @Test
   public void testTrackRecordReceivedSkipsBeforeEOP() throws Exception {
     HeartbeatMonitoringService heartbeatMonitoringService = mock(HeartbeatMonitoringService.class);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
@@ -44,6 +44,7 @@ import com.linkedin.venice.utils.VeniceProperties;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -135,6 +136,82 @@ public class RocksDBStoragePartitionTest {
     if (file.exists() && !file.delete()) {
       throw new VeniceException("Failed to remove path: " + path);
     }
+  }
+
+  @Test
+  public void testOpenDatabaseWithReplicationMetadataColumnFamily() throws RocksDBException {
+    String storeName = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
+    String storeDir = getTempDatabaseDir(storeName);
+    StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, 0);
+    VeniceProperties veniceServerProperties = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB);
+    RocksDBServerConfig rocksDBServerConfig = new RocksDBServerConfig(veniceServerProperties);
+    RocksDBStorageEngineFactory factory =
+        new RocksDBStorageEngineFactory(new VeniceServerConfig(veniceServerProperties));
+
+    byte[] key = "key".getBytes(StandardCharsets.UTF_8);
+    byte[] value = "value".getBytes(StandardCharsets.UTF_8);
+    ReplicationMetadataRocksDBStoragePartition serverPartition = new ReplicationMetadataRocksDBStoragePartition(
+        partitionConfig,
+        factory,
+        DATA_BASE_DIR,
+        null,
+        ROCKSDB_THROTTLER,
+        rocksDBServerConfig);
+    serverPartition.putWithReplicationMetadata(key, value, "replication-metadata".getBytes(StandardCharsets.UTF_8));
+    serverPartition.close();
+
+    RocksDBStoragePartition daVinciPartition = new RocksDBStoragePartition(
+        partitionConfig,
+        factory,
+        DATA_BASE_DIR,
+        null,
+        ROCKSDB_THROTTLER,
+        rocksDBServerConfig);
+    Assert.assertEquals(daVinciPartition.get(key), value);
+    Assert.assertEquals(daVinciPartition.getColumnFamilyHandleList().size(), 2);
+    Assert.assertEquals(
+        daVinciPartition.getColumnFamilyHandleList().get(1).getName(),
+        RocksDBStoragePartition.REPLICATION_METADATA_COLUMN_FAMILY);
+
+    daVinciPartition.drop();
+    removeDir(storeDir);
+  }
+
+  @Test
+  public void testRejectDatabaseWithUnknownColumnFamily() {
+    String storeName = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
+    String storeDir = getTempDatabaseDir(storeName);
+    StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, 0);
+    VeniceProperties veniceServerProperties = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB);
+    RocksDBServerConfig rocksDBServerConfig = new RocksDBServerConfig(veniceServerProperties);
+    RocksDBStorageEngineFactory factory =
+        new RocksDBStorageEngineFactory(new VeniceServerConfig(veniceServerProperties));
+    byte[] unknownColumnFamily = "unknown".getBytes(StandardCharsets.UTF_8);
+
+    RocksDBStoragePartition sourcePartition = new RocksDBStoragePartition(
+        partitionConfig,
+        factory,
+        DATA_BASE_DIR,
+        null,
+        ROCKSDB_THROTTLER,
+        rocksDBServerConfig,
+        Arrays.asList(RocksDB.DEFAULT_COLUMN_FAMILY, unknownColumnFamily));
+    sourcePartition.close();
+
+    VeniceException exception = Assert.expectThrows(
+        VeniceException.class,
+        () -> new RocksDBStoragePartition(
+            partitionConfig,
+            factory,
+            DATA_BASE_DIR,
+            null,
+            ROCKSDB_THROTTLER,
+            rocksDBServerConfig));
+    Assert.assertTrue(exception.getMessage().contains("Unsupported RocksDB column family"));
+    Assert.assertTrue(exception.getMessage().contains("unknown"));
+
+    sourcePartition.drop();
+    removeDir(storeDir);
   }
 
   @Test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientServerFallbackBlobTransferTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientServerFallbackBlobTransferTest.java
@@ -39,6 +39,8 @@ import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.davinci.client.DaVinciClient;
 import com.linkedin.davinci.client.DaVinciConfig;
 import com.linkedin.davinci.client.factory.CachingDaVinciClientFactory;
+import com.linkedin.davinci.store.StorageEngine;
+import com.linkedin.davinci.store.rocksdb.ReplicationMetadataRocksDBStoragePartition;
 import com.linkedin.venice.D2.D2ClientUtils;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
@@ -49,6 +51,8 @@ import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.PropertyBuilder;
 import com.linkedin.venice.utils.SslUtils;
@@ -167,10 +171,22 @@ public class DaVinciClientServerFallbackBlobTransferTest {
    * {@code SERVER_HTTP2_INBOUND_ENABLED} so the server's D2 service advertises https, and enables
    * {@code setStorageNodeReadQuotaEnabled(true)} on the store.
    */
-  @Test(timeOut = TEST_TIMEOUT, enabled = true)
-  public void testClientColdStartsFromServerWhenNoPeers() throws Exception {
+  @Test(timeOut = TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False", enabled = true)
+  public void testClientColdStartsFromServerWhenNoPeers(boolean activeActiveReplicationEnabled) throws Exception {
     String storeName = Utils.getUniqueString("server-fallback-store");
-    setUpStore(storeName);
+    setUpStore(storeName, activeActiveReplicationEnabled);
+
+    if (activeActiveReplicationEnabled) {
+      StorageEngine storageEngine = cluster.getVeniceServers()
+          .get(0)
+          .getVeniceServer()
+          .getStorageService()
+          .getStorageEngine(Version.composeKafkaTopic(storeName, 1));
+      Assert.assertNotNull(storageEngine);
+      Assert.assertTrue(
+          storageEngine.getPartitionOrThrow(0) instanceof ReplicationMetadataRocksDBStoragePartition,
+          "Active-active server partition should contain the replication-metadata column family");
+    }
 
     String keyStorePath = SslUtils.getPathForResource(LOCAL_KEYSTORE_JKS);
     String dvcPath = Utils.getTempDataDirectory().getAbsolutePath();
@@ -238,7 +254,7 @@ public class DaVinciClientServerFallbackBlobTransferTest {
     }
   }
 
-  private void setUpStore(String storeName) {
+  private void setUpStore(String storeName, boolean activeActiveReplicationEnabled) {
     File inputDir = getTempDataDirectory();
     try {
       writeSimpleAvroFileWithIntToStringSchema(inputDir);
@@ -252,6 +268,9 @@ public class DaVinciClientServerFallbackBlobTransferTest {
     UpdateStoreQueryParams params = new UpdateStoreQueryParams().setPartitionCount(1)
         .setBlobTransferEnabled(true)
         .setStorageNodeReadQuotaEnabled(true);
+    if (activeActiveReplicationEnabled) {
+      params.setActiveActiveReplicationEnabled(true).setHybridRewindSeconds(10).setHybridOffsetLagThreshold(10);
+    }
     try (ControllerClient controllerClient =
         createStoreForJob(cluster, DEFAULT_KEY_SCHEMA, "\"string\"", vpjProperties)) {
       cluster.createMetaSystemStore(storeName);


### PR DESCRIPTION
## Problem Statement

Da Vinci clients can download a RocksDB snapshot from an active-active Venice server that contains both the `default` and `timestamp_metadata` column families. A DVC partition without replication metadata enabled only declares `default`, so RocksDB rejects the snapshot with `Column families not opened: timestamp_metadata`.

The post-transfer error path then drops the partition but continues recovery, producing a secondary `Partition ... does not exist` failure that obscures the original incompatibility.

## Solution

Discover column families when opening an existing RocksDB database. Continue to use the configured handle order, but append and retain an unused `timestamp_metadata` handle when that family exists. Reject snapshots containing any other column family.

Propagate storage-partition adjustment failures after cleanup so blob-transfer post-processing stops and reports the original partition-open failure instead of continuing recovery against a dropped partition.

The discovery runs only when an existing RocksDB `CURRENT` file is present. New databases keep their configured column families and behavior.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] Local code review completed.
- [x] New unit tests added.
- [x] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

Ran the Da Vinci client unit test classes covering RocksDB partition behavior and blob-transfer completion, plus the
server-fallback blob-transfer integration test for both regular and active-active stores.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
