### PR TITLE
[vpj]: Apply Incremental push quota throttling at store level

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -129,6 +129,7 @@ import com.linkedin.venice.hadoop.mapreduce.engine.DefaultJobClientWrapper;
 import com.linkedin.venice.hadoop.schema.HDFSSchemaSource;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
 import com.linkedin.venice.hadoop.task.datawriter.ExternalStorageWriteThrottler;
+import com.linkedin.venice.hadoop.task.datawriter.IncrementalPushWriteQuotaUtils;
 import com.linkedin.venice.hadoop.utils.HadoopUtils;
 import com.linkedin.venice.hadoop.utils.VPJSSLUtils;
 import com.linkedin.venice.hadoop.validation.NoOpValidator;
@@ -891,13 +892,14 @@ public class VenicePushJob implements AutoCloseable {
           props,
           optionalCompressionDictionary);
       updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.NEW_VERSION_CREATED);
-      // Fail fast here (driver-side, before the data-writer job launches) if external-storage dual-write
-      // throttling is misconfigured for the partition count just assigned to this version.
-      validateExternalStorageDualWriteQuota(pushJobSetting);
-
       // Fetch the version config for separateRealTimeTopicEnabled after version creation,
       Version createdVersion = getStoreVersion(pushJobSetting.storeName, pushJobSetting.version);
       pushJobSetting.versionSeparateRealTimeTopicEnabled = createdVersion.isSeparateRealTimeTopicEnabled();
+
+      // Fail fast here (driver-side, before the data-writer job launches) if throttling is misconfigured for the
+      // partition count just assigned to this version.
+      validateExternalStorageDualWriteQuota(pushJobSetting);
+      validateIncrementalPushWriteQuota(pushJobSetting);
 
       // Update and send push job details with new info to the controller
       pushJobDetails.partitionCount = pushJobSetting.partitionCount;
@@ -2673,6 +2675,20 @@ public class VenicePushJob implements AutoCloseable {
         props.getLong(PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND, -1),
         props.getLong(PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND, -1),
         setting.partitionCount);
+  }
+
+  /**
+   * Fail fast on the driver — before launching the data-writer job and allocating its cluster resources — when
+   * incremental-push throttling is misconfigured for the partition count assigned to this version. Separate real-time
+   * topic incremental pushes skip this throttling in the executor path, so they skip this validation too.
+   */
+  private void validateIncrementalPushWriteQuota(PushJobSetting setting) {
+    if (!setting.isIncrementalPush
+        || (setting.pushToSeparateRealtimeTopicEnabled && setting.versionSeparateRealTimeTopicEnabled)) {
+      return;
+    }
+    IncrementalPushWriteQuotaUtils
+        .validateQuota(props.getLong(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, -1), setting.partitionCount);
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -129,7 +129,6 @@ import com.linkedin.venice.hadoop.mapreduce.engine.DefaultJobClientWrapper;
 import com.linkedin.venice.hadoop.schema.HDFSSchemaSource;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
 import com.linkedin.venice.hadoop.task.datawriter.ExternalStorageWriteThrottler;
-import com.linkedin.venice.hadoop.task.datawriter.IncrementalPushWriteQuotaUtils;
 import com.linkedin.venice.hadoop.utils.HadoopUtils;
 import com.linkedin.venice.hadoop.utils.VPJSSLUtils;
 import com.linkedin.venice.hadoop.validation.NoOpValidator;
@@ -896,10 +895,10 @@ public class VenicePushJob implements AutoCloseable {
       Version createdVersion = getStoreVersion(pushJobSetting.storeName, pushJobSetting.version);
       pushJobSetting.versionSeparateRealTimeTopicEnabled = createdVersion.isSeparateRealTimeTopicEnabled();
 
-      // Fail fast here (driver-side, before the data-writer job launches) if throttling is misconfigured for the
-      // partition count just assigned to this version.
+      // Fail fast here (driver-side, before the data-writer job launches) if external-storage dual-write
+      // throttling is misconfigured for the partition count just assigned to this version. Incremental-push write
+      // quota is validated later, when the data-writer job config is assembled (also driver-side, pre-launch).
       validateExternalStorageDualWriteQuota(pushJobSetting);
-      validateIncrementalPushWriteQuota(pushJobSetting);
 
       // Update and send push job details with new info to the controller
       pushJobDetails.partitionCount = pushJobSetting.partitionCount;
@@ -2675,20 +2674,6 @@ public class VenicePushJob implements AutoCloseable {
         props.getLong(PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND, -1),
         props.getLong(PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND, -1),
         setting.partitionCount);
-  }
-
-  /**
-   * Fail fast on the driver — before launching the data-writer job and allocating its cluster resources — when
-   * incremental-push throttling is misconfigured for the partition count assigned to this version. Separate real-time
-   * topic incremental pushes skip this throttling in the executor path, so they skip this validation too.
-   */
-  private void validateIncrementalPushWriteQuota(PushJobSetting setting) {
-    if (!setting.isIncrementalPush
-        || (setting.pushToSeparateRealtimeTopicEnabled && setting.versionSeparateRealTimeTopicEnabled)) {
-      return;
-    }
-    IncrementalPushWriteQuotaUtils
-        .validateQuota(props.getLong(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, -1), setting.partitionCount);
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
@@ -23,6 +23,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.GENERATE_PARTIAL_UP
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_RATE_LIMITER_TYPE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_TIME_WINDOW_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_COMPRESSION_STRATEGY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_TOPIC_CHUNKING_ENABLED;
@@ -33,7 +34,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.MAP_REDUCE_PARTITIO
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PARTITION_COUNT;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_DUAL_WRITE_TARGET_REGIONS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_PROP_PREFIX;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_TO_SEPARATE_REALTIME_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REDUCER_SPECULATIVE_EXECUTION_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_POLICY;
@@ -43,7 +43,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_DIR;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SCHEMA_STRING_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_PREFIX;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.STORAGE_QUOTA_PROP;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.STORE_SEPARATE_REALTIME_TOPIC_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SYSTEM_SCHEMA_READER_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TELEMETRY_MESSAGE_INTERVAL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TOPIC_PROP;
@@ -83,6 +82,7 @@ import com.linkedin.venice.hadoop.mapreduce.datawriter.partition.VeniceMRPartiti
 import com.linkedin.venice.hadoop.mapreduce.datawriter.reduce.VeniceReducer;
 import com.linkedin.venice.hadoop.mapreduce.datawriter.task.CounterBackedMapReduceDataWriterTaskTracker;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import com.linkedin.venice.hadoop.task.datawriter.IncrementalPushWriteQuotaUtils;
 import com.linkedin.venice.hadoop.utils.HadoopUtils;
 import com.linkedin.venice.jobs.DataWriterComputeJob;
 import com.linkedin.venice.pubsub.api.PubSubSecurityProtocol;
@@ -203,13 +203,18 @@ public class DataWriterMRJob extends DataWriterComputeJob {
     }
     conf.setBoolean(ENABLE_WRITE_COMPUTE, pushJobSetting.enableWriteCompute);
 
-    // Incremental push throttling configs - pass through to mapper/reducer
+    // Incremental push throttling: the driver computes the per-partition-writer quota once (validating fail-fast here,
+    // before the MR job runs) and forwards it, so the reducer consumes it directly without re-deriving the split.
     conf.setBoolean(INCREMENTAL_PUSH, pushJobSetting.isIncrementalPush);
-    conf.setBoolean(PUSH_TO_SEPARATE_REALTIME_TOPIC, pushJobSetting.pushToSeparateRealtimeTopicEnabled);
-    conf.setBoolean(STORE_SEPARATE_REALTIME_TOPIC_ENABLED, pushJobSetting.versionSeparateRealTimeTopicEnabled);
     conf.set(
-        INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND,
-        props.getString(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "-1"));
+        INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION,
+        Long.toString(
+            IncrementalPushWriteQuotaUtils.perPartitionQuotaForPush(
+                pushJobSetting.isIncrementalPush,
+                pushJobSetting.pushToSeparateRealtimeTopicEnabled,
+                pushJobSetting.versionSeparateRealTimeTopicEnabled,
+                props.getLong(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, -1),
+                pushJobSetting.partitionCount)));
     if (props.containsKey(INCREMENTAL_PUSH_RATE_LIMITER_TYPE)) {
       conf.set(INCREMENTAL_PUSH_RATE_LIMITER_TYPE, props.getString(INCREMENTAL_PUSH_RATE_LIMITER_TYPE));
     }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -13,7 +13,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_PUSH_JOB_EX
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DERIVED_SCHEMA_ID_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ENABLE_WRITE_COMPUTE;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_RATE_LIMITER_TYPE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_TIME_WINDOW_MS;
@@ -297,8 +296,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
   private final Lazy<CompressorFactory> compressorFactory = Lazy.of(CompressorFactory::new);
   private Lazy<VeniceCompressor> compressor;
 
-  // Incremental push write quota throttlers
-  private boolean isIncrementalPush = false;
+  // Incremental push write quota throttler
   private VeniceRateLimiter recordsThrottler = null;
   /**
    * Accumulated throttle time across all calls. Only accessed from the single-threaded
@@ -540,7 +538,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
 
   @VisibleForTesting
   boolean isIncrementalPushThrottlingEnabled() {
-    return isIncrementalPush && recordsThrottler != null;
+    return recordsThrottler != null;
   }
 
   @VisibleForTesting
@@ -1043,7 +1041,6 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
    * throttling and this method is a no-op.
    */
   private void initIncrementalPushThrottlers(VeniceProperties props) {
-    this.isIncrementalPush = props.getBoolean(INCREMENTAL_PUSH, false);
     long perPartitionRecordsPerSecond =
         props.getLong(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION, -1);
     if (perPartitionRecordsPerSecond <= 0) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -1039,9 +1039,10 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
   }
 
   /**
-   * Initialize throttlers for incremental push write quota enforcement.
-   * Throttlers are only created if this is an incremental push writing to the regular RT topic
-   * (not a separate real-time topic) and write quota is enabled.
+   * Initialize throttlers for incremental push write quota enforcement. Throttlers are only created if this is an
+   * incremental push writing to the regular RT topic (not a separate real-time topic) and write quota is enabled. The
+   * configured quota is the global job/store quota and is split evenly across partition-writer tasks for local
+   * enforcement.
    */
   private void initIncrementalPushThrottlers(VeniceProperties props) {
     this.isIncrementalPush = props.getBoolean(INCREMENTAL_PUSH, false);
@@ -1059,10 +1060,12 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
       return;
     }
 
-    long recordsPerSecond = props.getLong(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, -1);
-    if (recordsPerSecond <= 0) {
+    long globalRecordsPerSecond = props.getLong(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, -1);
+    if (globalRecordsPerSecond <= 0) {
       return;
     }
+    long perPartitionRecordsPerSecond =
+        IncrementalPushWriteQuotaUtils.getPerPartitionRecordsPerSecond(globalRecordsPerSecond, getPartitionCount());
 
     String storeName = Version.parseStoreFromKafkaTopicName(props.getString(TOPIC_PROP));
     String rateLimiterTypeStr = props
@@ -1082,7 +1085,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     switch (rateLimiterType) {
       case EVENT_THROTTLER_WITH_SILENT_REJECTION:
         this.recordsThrottler = new EventThrottler(
-            recordsPerSecond,
+            perPartitionRecordsPerSecond,
             storeName + "_incremental_push_records_throttler",
             true,
             EventThrottler.REJECT_STRATEGY);
@@ -1098,18 +1101,25 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
           timeWindowMs = 1000;
         }
         int capacityMultiple = rateLimiterType == VeniceRateLimiter.RateLimiterType.TOKEN_BUCKET_GREEDY_REFILL ? 5 : 2;
-        this.recordsThrottler = TokenBucket
-            .tokenBucketFromRcuPerSecond(recordsPerSecond, 1.0, timeWindowMs, capacityMultiple, Clock.systemUTC());
+        this.recordsThrottler = TokenBucket.tokenBucketFromRcuPerSecond(
+            perPartitionRecordsPerSecond,
+            1.0,
+            timeWindowMs,
+            capacityMultiple,
+            Clock.systemUTC());
         break;
       case GUAVA_RATE_LIMITER:
       default:
-        this.recordsThrottler = new GuavaRateLimiter(recordsPerSecond);
+        this.recordsThrottler = new GuavaRateLimiter(perPartitionRecordsPerSecond);
         break;
     }
     LOGGER.info(
-        "Initialized incremental push records throttler for store {}: {} records/sec, type: {}",
+        "Initialized incremental push records throttler for store {}: {} records/sec global split across {} "
+            + "partition-writer tasks => {} records/sec per task, type: {}",
         storeName,
-        recordsPerSecond,
+        globalRecordsPerSecond,
+        getPartitionCount(),
+        perPartitionRecordsPerSecond,
         rateLimiterType);
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -15,7 +15,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.DERIVED_SCHEMA_ID_P
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ENABLE_WRITE_COMPUTE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_RATE_LIMITER_TYPE;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_TIME_WINDOW_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_COMPRESSION_STRATEGY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
@@ -23,12 +23,10 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_S
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_TO_SEPARATE_REALTIME_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_DIR;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_ID_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.STORAGE_QUOTA_PROP;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.STORE_SEPARATE_REALTIME_TOPIC_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TELEMETRY_MESSAGE_INTERVAL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TOPIC_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_SCHEMA_DIR;
@@ -1039,33 +1037,18 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
   }
 
   /**
-   * Initialize throttlers for incremental push write quota enforcement. Throttlers are only created if this is an
-   * incremental push writing to the regular RT topic (not a separate real-time topic) and write quota is enabled. The
-   * configured quota is the global job/store quota and is split evenly across partition-writer tasks for local
-   * enforcement.
+   * Initialize the incremental-push write-quota throttler from the driver-computed per-partition quota. The driver
+   * already folded in the incremental-push / separate-real-time-topic / disabled decision and the global-quota split
+   * (see {@link IncrementalPushWriteQuotaUtils#perPartitionQuotaForPush}), so a forwarded value {@code <= 0} means no
+   * throttling and this method is a no-op.
    */
   private void initIncrementalPushThrottlers(VeniceProperties props) {
     this.isIncrementalPush = props.getBoolean(INCREMENTAL_PUSH, false);
-    if (!isIncrementalPush) {
-      return;
-    }
-
-    // Skip throttling for incremental pushes writing to a separate real-time topic.
-    // Both the push job config and the store config must be true for the push to actually use
-    // the separate RT topic (see CreateVersion.determineResponseTopic).
-    boolean pushToSeparateRealtimeTopic = props.getBoolean(PUSH_TO_SEPARATE_REALTIME_TOPIC, false);
-    boolean storeSeparateRealTimeTopicEnabled = props.getBoolean(STORE_SEPARATE_REALTIME_TOPIC_ENABLED, false);
-    if (pushToSeparateRealtimeTopic && storeSeparateRealTimeTopicEnabled) {
-      LOGGER.info("Incremental push write quota throttling is skipped for separate real-time topic pushes");
-      return;
-    }
-
-    long globalRecordsPerSecond = props.getLong(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, -1);
-    if (globalRecordsPerSecond <= 0) {
-      return;
-    }
     long perPartitionRecordsPerSecond =
-        IncrementalPushWriteQuotaUtils.getPerPartitionRecordsPerSecond(globalRecordsPerSecond, getPartitionCount());
+        props.getLong(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION, -1);
+    if (perPartitionRecordsPerSecond <= 0) {
+      return;
+    }
 
     String storeName = Version.parseStoreFromKafkaTopicName(props.getString(TOPIC_PROP));
     String rateLimiterTypeStr = props
@@ -1114,11 +1097,8 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
         break;
     }
     LOGGER.info(
-        "Initialized incremental push records throttler for store {}: {} records/sec global split across {} "
-            + "partition-writer tasks => {} records/sec per task, type: {}",
+        "Initialized incremental push records throttler for store {}: {} records/sec per partition-writer task, type: {}",
         storeName,
-        globalRecordsPerSecond,
-        getPartitionCount(),
         perPartitionRecordsPerSecond,
         rateLimiterType);
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/IncrementalPushWriteQuotaUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/IncrementalPushWriteQuotaUtils.java
@@ -1,0 +1,50 @@
+package com.linkedin.venice.hadoop.task.datawriter;
+
+import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND;
+
+import com.linkedin.venice.exceptions.VeniceException;
+
+
+/**
+ * Utilities for enforcing the incremental-push write quota as one global job/store budget.
+ *
+ * <p>Partition-writer tasks run independently in distributed executors, so the global quota is enforced by a static
+ * even split: every partition-writer task gets {@code globalRecordsPerSecond / partitionCount}. This keeps the
+ * aggregate write rate across all partition writers at or below the configured global quota.
+ */
+public final class IncrementalPushWriteQuotaUtils {
+  private IncrementalPushWriteQuotaUtils() {
+  }
+
+  /**
+   * Validate that a configured positive global quota can be split into at least 1 record/sec per partition-writer task.
+   * Non-positive quotas disable throttling and are considered valid.
+   */
+  public static void validateQuota(long globalRecordsPerSecond, int partitionCount) {
+    if (globalRecordsPerSecond <= 0) {
+      return;
+    }
+    if (partitionCount <= 0) {
+      throw new VeniceException(
+          "Cannot split the incremental-push write quota across a non-positive partition count " + partitionCount);
+    }
+    if (globalRecordsPerSecond / partitionCount <= 0) {
+      throw new VeniceException(
+          "Incremental-push write quota " + globalRecordsPerSecond + "/sec is smaller than the " + partitionCount
+              + " partition writers sharing it; each task would get 0/sec. Raise "
+              + INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND + " to at least the partition count.");
+    }
+  }
+
+  /**
+   * Return the local per-partition-writer quota for a configured global quota. Non-positive quotas are returned
+   * unchanged because they mean throttling is disabled.
+   */
+  public static long getPerPartitionRecordsPerSecond(long globalRecordsPerSecond, int partitionCount) {
+    validateQuota(globalRecordsPerSecond, partitionCount);
+    if (globalRecordsPerSecond <= 0) {
+      return globalRecordsPerSecond;
+    }
+    return globalRecordsPerSecond / partitionCount;
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/IncrementalPushWriteQuotaUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/IncrementalPushWriteQuotaUtils.java
@@ -6,38 +6,54 @@ import com.linkedin.venice.exceptions.VeniceException;
 
 
 /**
- * Utilities for enforcing the incremental-push write quota as one global job/store budget.
+ * Driver-side helper for the incremental-push write quota.
  *
- * <p>Partition-writer tasks run independently in distributed executors, so the global quota is enforced by a static
- * even split: every partition-writer task gets {@code globalRecordsPerSecond / partitionCount}. This keeps the
- * aggregate write rate across all partition writers at or below the configured global quota.
+ * <p>The configured quota ({@code incremental.push.write.quota.records.per.second}) is a single global job/store
+ * budget. Because partition-writer tasks run independently in distributed executors with no shared state, the budget
+ * is enforced by a static even split: each of the {@code partitionCount} tasks gets
+ * {@code globalRecordsPerSecond / partitionCount}. That division is computed once here, on the driver, and forwarded to
+ * the tasks so enforcement never re-derives (or disagrees about) the split.
  */
 public final class IncrementalPushWriteQuotaUtils {
+  /** Sentinel returned (and forwarded to tasks) when incremental-push throttling does not apply. */
+  public static final long THROTTLING_DISABLED = -1;
+
   private IncrementalPushWriteQuotaUtils() {
   }
 
   /**
-   * Validate that a configured positive global quota can be split into at least 1 record/sec per partition-writer task.
-   * Non-positive quotas disable throttling and are considered valid.
+   * Compute the per-partition-writer quota for a push, validating on the driver so a misconfiguration fails fast before
+   * the data-writer job is launched.
+   *
+   * <p>Returns {@link #THROTTLING_DISABLED} when throttling does not apply: batch pushes, incremental pushes to a
+   * separate real-time topic (both the push-job and store configs are enabled), or a non-positive global quota.
+   * Otherwise returns {@code globalRecordsPerSecond / partitionCount}.
+   *
+   * @throws VeniceException if a positive quota cannot be split into at least 1 record/sec per partition-writer task
+   *         (i.e. {@code partitionCount <= 0}, or {@code globalRecordsPerSecond < partitionCount}).
    */
-  public static void validateQuota(long globalRecordsPerSecond, int partitionCount) {
-    if (globalRecordsPerSecond <= 0) {
-      return;
+  public static long perPartitionQuotaForPush(
+      boolean isIncrementalPush,
+      boolean pushToSeparateRealtimeTopicEnabled,
+      boolean versionSeparateRealTimeTopicEnabled,
+      long globalRecordsPerSecond,
+      int partitionCount) {
+    boolean throttlingApplies =
+        isIncrementalPush && !(pushToSeparateRealtimeTopicEnabled && versionSeparateRealTimeTopicEnabled);
+    if (!throttlingApplies || globalRecordsPerSecond <= 0) {
+      return THROTTLING_DISABLED;
     }
     if (partitionCount <= 0) {
       throw new VeniceException(
           "Cannot split the incremental-push write quota across a non-positive partition count " + partitionCount);
     }
-    if (globalRecordsPerSecond / partitionCount <= 0) {
+    long perPartitionRecordsPerSecond = globalRecordsPerSecond / partitionCount;
+    if (perPartitionRecordsPerSecond <= 0) {
       throw new VeniceException(
           "Incremental-push write quota " + globalRecordsPerSecond + "/sec is smaller than the " + partitionCount
               + " partition writers sharing it; each task would get 0/sec. Raise "
               + INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND + " to at least the partition count.");
     }
-  }
-
-  /** Return the local per-partition-writer quota for an already-validated positive global quota. */
-  public static long getPerPartitionRecordsPerSecond(long globalRecordsPerSecond, int partitionCount) {
-    return globalRecordsPerSecond / partitionCount;
+    return perPartitionRecordsPerSecond;
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/IncrementalPushWriteQuotaUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/IncrementalPushWriteQuotaUtils.java
@@ -36,15 +36,8 @@ public final class IncrementalPushWriteQuotaUtils {
     }
   }
 
-  /**
-   * Return the local per-partition-writer quota for a configured global quota. Non-positive quotas are returned
-   * unchanged because they mean throttling is disabled.
-   */
+  /** Return the local per-partition-writer quota for an already-validated positive global quota. */
   public static long getPerPartitionRecordsPerSecond(long globalRecordsPerSecond, int partitionCount) {
-    validateQuota(globalRecordsPerSecond, partitionCount);
-    if (globalRecordsPerSecond <= 0) {
-      return globalRecordsPerSecond;
-    }
     return globalRecordsPerSecond / partitionCount;
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -42,6 +42,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.EXTENDED_SCHEMA_VAL
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_RATE_LIMITER_TYPE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_TIME_WINDOW_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_COMPRESSION_STRATEGY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_TOPIC_CHUNKING_ENABLED;
@@ -49,7 +50,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PARTITION_COUNT;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_DUAL_WRITE_TARGET_REGIONS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_PROP_PREFIX;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_TO_SEPARATE_REALTIME_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_POLICY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.REPUSH_TTL_START_TIMESTAMP;
@@ -62,7 +62,6 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_STORE_PROPE
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_PREFIX;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_TRUST_STORE_PROPERTY_NAME;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.STORAGE_QUOTA_PROP;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.STORE_SEPARATE_REALTIME_TOPIC_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SYSTEM_SCHEMA_READER_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TELEMETRY_MESSAGE_INTERVAL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TOPIC_PROP;
@@ -85,6 +84,7 @@ import com.linkedin.venice.hadoop.exceptions.VeniceInvalidInputException;
 import com.linkedin.venice.hadoop.input.kafka.ttl.TTLResolutionPolicy;
 import com.linkedin.venice.hadoop.ssl.TempFileSSLConfigurator;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import com.linkedin.venice.hadoop.task.datawriter.IncrementalPushWriteQuotaUtils;
 import com.linkedin.venice.jobs.DataWriterComputeJob;
 import com.linkedin.venice.jobs.StageMetricsSnapshot;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
@@ -355,13 +355,19 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     // does not live under the push.job.external.storage.* prefix.
     jobConf.set(PUSH_JOB_DUAL_WRITE_TARGET_REGIONS, String.join(",", pushJobSetting.dualWriteTargetRegions));
 
-    // Incremental push throttling configs - pass through to partition writer
+    // Incremental push throttling: the driver computes the per-partition-writer quota once (validating fail-fast here,
+    // before the Spark job runs) and forwards it, so the data-writer tasks consume it directly without re-deriving the
+    // split.
     jobConf.set(INCREMENTAL_PUSH, pushJobSetting.isIncrementalPush);
-    jobConf.set(PUSH_TO_SEPARATE_REALTIME_TOPIC, pushJobSetting.pushToSeparateRealtimeTopicEnabled);
-    jobConf.set(STORE_SEPARATE_REALTIME_TOPIC_ENABLED, pushJobSetting.versionSeparateRealTimeTopicEnabled);
     jobConf.set(
-        INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND,
-        props.getString(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "-1"));
+        INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION,
+        Long.toString(
+            IncrementalPushWriteQuotaUtils.perPartitionQuotaForPush(
+                pushJobSetting.isIncrementalPush,
+                pushJobSetting.pushToSeparateRealtimeTopicEnabled,
+                pushJobSetting.versionSeparateRealTimeTopicEnabled,
+                props.getLong(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, -1),
+                pushJobSetting.partitionCount)));
     jobConf.set(
         INCREMENTAL_PUSH_RATE_LIMITER_TYPE,
         props.getString(

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -620,11 +620,11 @@ public final class VenicePushJobConstants {
   public static final String NEWER_KME_SCHEMAS_PREFIX = "newer.kme.schemas.prefix.";
 
   /**
-   * Write quota in records per second for incremental pushes.
+   * Global write quota in records per second for incremental pushes.
    * Any value {@code <= 0} disables throttling (unlimited writes). The recommended sentinel for
    * explicitly configuring "unlimited" is {@code -1}.
-   * This quota is enforced per partition-writer task. The effective aggregate write rate across the entire
-   * job is {@code recordsPerSecond * numberOfTasks}.
+   * This quota is split evenly across partition-writer tasks for local enforcement, so the effective aggregate
+   * write rate across the job/store is at or below the configured value.
    */
   public static final String INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND =
       "incremental.push.write.quota.records.per.second";

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -630,6 +630,16 @@ public final class VenicePushJobConstants {
       "incremental.push.write.quota.records.per.second";
 
   /**
+   * Internal, driver-computed per-partition-writer slice of {@link #INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND}.
+   * The driver computes {@code globalQuota / partitionCount} once (after validating splittability) and forwards this
+   * value to the data-writer tasks, so each partition writer enforces it directly without re-deriving the split. A
+   * value {@code <= 0} means throttling does not apply (batch push, separate real-time topic push, or disabled quota).
+   * This is not a user-facing config; it is set by {@link VenicePushJob}.
+   */
+  public static final String INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION =
+      "incremental.push.write.quota.records.per.second.per.partition";
+
+  /**
    * Time window in milliseconds over which throttling is measured. Defaults to 1 second.
    * This parameter is only applicable when using TOKEN_BUCKET_INCREMENTAL_REFILL or
    * TOKEN_BUCKET_GREEDY_REFILL rate limiter types.

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriterThrottlingTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriterThrottlingTest.java
@@ -175,15 +175,7 @@ public class AbstractPartitionWriterThrottlingTest {
 
   @Test
   public void testGlobalQuotaBelowPartitionCountFailsFast() {
-    Properties props = createBaseProperties();
-    props.setProperty(INCREMENTAL_PUSH, "true");
-    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "2");
-    props.setProperty(PARTITION_COUNT, "4");
-    setupMockConfigProvider(props);
-
-    partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
-
-    assertThrows(VeniceException.class, () -> partitionWriter.configure(mockConfigProvider));
+    assertThrows(VeniceException.class, () -> IncrementalPushWriteQuotaUtils.validateQuota(2, 4));
   }
 
   // rate limiter type config, expected throttler class

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriterThrottlingTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriterThrottlingTest.java
@@ -137,6 +137,55 @@ public class AbstractPartitionWriterThrottlingTest {
     }
   }
 
+  @Test
+  public void testGlobalQuotaSplitAcrossPartitionWriters() {
+    Properties props = createBaseProperties();
+    props.setProperty(INCREMENTAL_PUSH, "true");
+    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "1000");
+    props.setProperty(PARTITION_COUNT, "4");
+    setupMockConfigProvider(props);
+
+    partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
+    partitionWriter.configure(mockConfigProvider);
+
+    assertNotNull(partitionWriter.getRecordsThrottler(), "Throttler should be initialized");
+    assertEquals(
+        partitionWriter.getRecordsThrottler().getQuota(),
+        250L,
+        "1000 records/sec global quota should be split across 4 partition-writer tasks");
+  }
+
+  @Test
+  public void testGlobalQuotaSplitUsesFloorDivisionToStayUnderGlobalQuota() {
+    Properties props = createBaseProperties();
+    props.setProperty(INCREMENTAL_PUSH, "true");
+    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "1000");
+    props.setProperty(PARTITION_COUNT, "3");
+    setupMockConfigProvider(props);
+
+    partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
+    partitionWriter.configure(mockConfigProvider);
+
+    assertNotNull(partitionWriter.getRecordsThrottler(), "Throttler should be initialized");
+    assertEquals(
+        partitionWriter.getRecordsThrottler().getQuota(),
+        333L,
+        "Non-divisible global quotas should be rounded down per task so aggregate rate does not exceed the quota");
+  }
+
+  @Test
+  public void testGlobalQuotaBelowPartitionCountFailsFast() {
+    Properties props = createBaseProperties();
+    props.setProperty(INCREMENTAL_PUSH, "true");
+    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "2");
+    props.setProperty(PARTITION_COUNT, "4");
+    setupMockConfigProvider(props);
+
+    partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
+
+    assertThrows(VeniceException.class, () -> partitionWriter.configure(mockConfigProvider));
+  }
+
   // rate limiter type config, expected throttler class
   @DataProvider(name = "rateLimiterTypes")
   public Object[][] rateLimiterTypes() {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriterThrottlingTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriterThrottlingTest.java
@@ -2,11 +2,9 @@ package com.linkedin.venice.hadoop.task.datawriter;
 
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_RATE_LIMITER_TYPE;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_WRITE_QUOTA_TIME_WINDOW_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PARTITION_COUNT;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_TO_SEPARATE_REALTIME_TOPIC;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.STORE_SEPARATE_REALTIME_TOPIC_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TELEMETRY_MESSAGE_INTERVAL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TOPIC_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_SCHEMA_ID_PROP;
@@ -54,7 +52,8 @@ public class AbstractPartitionWriterThrottlingTest {
   }
 
   @Test
-  public void testThrottlingDisabledForBatchPush() {
+  public void testThrottlingDisabledWhenNoPerPartitionQuotaForwarded() {
+    // Batch pushes and separate-RT pushes lead the driver to forward a disabled (<= 0) per-partition quota.
     Properties props = createBaseProperties();
     props.setProperty(INCREMENTAL_PUSH, "false");
     setupMockConfigProvider(props);
@@ -65,58 +64,21 @@ public class AbstractPartitionWriterThrottlingTest {
     assertEquals(
         partitionWriter.isIncrementalPushThrottlingEnabled(),
         false,
-        "Throttling should not be enabled for batch push");
-    assertNull(partitionWriter.getRecordsThrottler(), "Records throttler should not be initialized for batch push");
+        "Throttling should not be enabled when no per-partition quota is forwarded");
+    assertNull(partitionWriter.getRecordsThrottler(), "Records throttler should not be initialized");
   }
 
-  // pushToSeparateRT, storeSeparateRTEnabled, expectedThrottlingEnabled
-  @DataProvider(name = "separateRealTimeTopicCombinations")
-  public Object[][] separateRealTimeTopicCombinations() {
-    return new Object[][] { { true, true, false }, // both true: skip throttling
-        { true, false, true }, // only push config: still throttle
-        { false, true, true }, // only store config: still throttle
-        { false, false, true } // neither: still throttle
-    };
+  // forwarded per-partition quota, expected throttling enabled
+  @DataProvider(name = "perPartitionQuotaValues")
+  public Object[][] perPartitionQuotaValues() {
+    return new Object[][] { { "-1", false }, { "0", false }, { "1", true }, { "250", true }, { "1000", true } };
   }
 
-  @Test(dataProvider = "separateRealTimeTopicCombinations")
-  public void testThrottlingForSeparateRealtimeTopicCombinations(
-      boolean pushToSeparateRT,
-      boolean storeSeparateRTEnabled,
-      boolean expectedThrottlingEnabled) {
+  @Test(dataProvider = "perPartitionQuotaValues")
+  public void testThrottlingByPerPartitionQuota(String perPartitionQuota, boolean expectedEnabled) {
     Properties props = createBaseProperties();
     props.setProperty(INCREMENTAL_PUSH, "true");
-    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "1000");
-    props.setProperty(PUSH_TO_SEPARATE_REALTIME_TOPIC, String.valueOf(pushToSeparateRT));
-    props.setProperty(STORE_SEPARATE_REALTIME_TOPIC_ENABLED, String.valueOf(storeSeparateRTEnabled));
-    setupMockConfigProvider(props);
-
-    partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
-    partitionWriter.configure(mockConfigProvider);
-
-    assertEquals(
-        partitionWriter.isIncrementalPushThrottlingEnabled(),
-        expectedThrottlingEnabled,
-        "Throttling mismatch for pushToSeparateRT=" + pushToSeparateRT + ", storeSeparateRTEnabled="
-            + storeSeparateRTEnabled);
-    if (expectedThrottlingEnabled) {
-      assertNotNull(partitionWriter.getRecordsThrottler(), "Throttler should be initialized");
-    } else {
-      assertNull(partitionWriter.getRecordsThrottler(), "Throttler should not be initialized");
-    }
-  }
-
-  // quota value, expected throttling enabled
-  @DataProvider(name = "quotaValues")
-  public Object[][] quotaValues() {
-    return new Object[][] { { "-1", false }, { "0", false }, { "1", true }, { "1000", true }, { "5000", true } };
-  }
-
-  @Test(dataProvider = "quotaValues")
-  public void testThrottlingByQuotaValue(String recordsPerSecond, boolean expectedEnabled) {
-    Properties props = createBaseProperties();
-    props.setProperty(INCREMENTAL_PUSH, "true");
-    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, recordsPerSecond);
+    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION, perPartitionQuota);
     setupMockConfigProvider(props);
 
     partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
@@ -125,57 +87,20 @@ public class AbstractPartitionWriterThrottlingTest {
     assertEquals(
         partitionWriter.isIncrementalPushThrottlingEnabled(),
         expectedEnabled,
-        "Throttling enabled mismatch for recordsPerSecond=" + recordsPerSecond);
+        "Throttling enabled mismatch for perPartitionQuota=" + perPartitionQuota);
     if (expectedEnabled) {
       assertNotNull(
           partitionWriter.getRecordsThrottler(),
-          "Throttler should be initialized for quota " + recordsPerSecond);
+          "Throttler should be initialized for quota " + perPartitionQuota);
+      assertEquals(
+          partitionWriter.getRecordsThrottler().getQuota(),
+          Long.parseLong(perPartitionQuota),
+          "Throttler should enforce the forwarded per-partition quota directly (no re-derivation)");
     } else {
       assertNull(
           partitionWriter.getRecordsThrottler(),
-          "Throttler should not be initialized for quota " + recordsPerSecond);
+          "Throttler should not be initialized for quota " + perPartitionQuota);
     }
-  }
-
-  @Test
-  public void testGlobalQuotaSplitAcrossPartitionWriters() {
-    Properties props = createBaseProperties();
-    props.setProperty(INCREMENTAL_PUSH, "true");
-    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "1000");
-    props.setProperty(PARTITION_COUNT, "4");
-    setupMockConfigProvider(props);
-
-    partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
-    partitionWriter.configure(mockConfigProvider);
-
-    assertNotNull(partitionWriter.getRecordsThrottler(), "Throttler should be initialized");
-    assertEquals(
-        partitionWriter.getRecordsThrottler().getQuota(),
-        250L,
-        "1000 records/sec global quota should be split across 4 partition-writer tasks");
-  }
-
-  @Test
-  public void testGlobalQuotaSplitUsesFloorDivisionToStayUnderGlobalQuota() {
-    Properties props = createBaseProperties();
-    props.setProperty(INCREMENTAL_PUSH, "true");
-    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "1000");
-    props.setProperty(PARTITION_COUNT, "3");
-    setupMockConfigProvider(props);
-
-    partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
-    partitionWriter.configure(mockConfigProvider);
-
-    assertNotNull(partitionWriter.getRecordsThrottler(), "Throttler should be initialized");
-    assertEquals(
-        partitionWriter.getRecordsThrottler().getQuota(),
-        333L,
-        "Non-divisible global quotas should be rounded down per task so aggregate rate does not exceed the quota");
-  }
-
-  @Test
-  public void testGlobalQuotaBelowPartitionCountFailsFast() {
-    assertThrows(VeniceException.class, () -> IncrementalPushWriteQuotaUtils.validateQuota(2, 4));
   }
 
   // rate limiter type config, expected throttler class
@@ -192,7 +117,7 @@ public class AbstractPartitionWriterThrottlingTest {
   public void testRateLimiterTypeSelection(String rateLimiterType, Class<?> expectedClass) {
     Properties props = createBaseProperties();
     props.setProperty(INCREMENTAL_PUSH, "true");
-    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "1000");
+    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION, "1000");
     if (rateLimiterType != null) {
       props.setProperty(INCREMENTAL_PUSH_RATE_LIMITER_TYPE, rateLimiterType);
     }
@@ -213,7 +138,7 @@ public class AbstractPartitionWriterThrottlingTest {
   public void testThrottlingDoesNotBlockBelowQuota() {
     Properties props = createBaseProperties();
     props.setProperty(INCREMENTAL_PUSH, "true");
-    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "100000"); // Very high quota
+    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION, "100000"); // Very high quota
     setupMockConfigProvider(props);
 
     partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
@@ -239,7 +164,7 @@ public class AbstractPartitionWriterThrottlingTest {
   public void testTokenBucketWithSubSecondTimeWindow() {
     Properties props = createBaseProperties();
     props.setProperty(INCREMENTAL_PUSH, "true");
-    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "1000");
+    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION, "1000");
     props.setProperty(INCREMENTAL_PUSH_RATE_LIMITER_TYPE, "TOKEN_BUCKET_INCREMENTAL_REFILL");
     props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_TIME_WINDOW_MS, "100");
     setupMockConfigProvider(props);
@@ -263,7 +188,7 @@ public class AbstractPartitionWriterThrottlingTest {
   public void testThrottlingDisabledForZeroQuota() {
     Properties props = createBaseProperties();
     props.setProperty(INCREMENTAL_PUSH, "true");
-    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "0");
+    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION, "0");
     setupMockConfigProvider(props);
 
     partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
@@ -276,7 +201,7 @@ public class AbstractPartitionWriterThrottlingTest {
   public void testThrottlingDisabledForNegativeQuota() {
     Properties props = createBaseProperties();
     props.setProperty(INCREMENTAL_PUSH, "true");
-    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "-1");
+    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION, "-1");
     setupMockConfigProvider(props);
 
     partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
@@ -289,7 +214,7 @@ public class AbstractPartitionWriterThrottlingTest {
   public void testMinimumValidQuota() {
     Properties props = createBaseProperties();
     props.setProperty(INCREMENTAL_PUSH, "true");
-    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "1");
+    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION, "1");
     setupMockConfigProvider(props);
 
     partitionWriter = new TestablePartitionWriter(mockConfigProvider, mockVeniceWriter);
@@ -303,7 +228,7 @@ public class AbstractPartitionWriterThrottlingTest {
   public void testInvalidRateLimiterTypeFallsBackToGuava() {
     Properties props = createBaseProperties();
     props.setProperty(INCREMENTAL_PUSH, "true");
-    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "1000");
+    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION, "1000");
     props.setProperty(INCREMENTAL_PUSH_RATE_LIMITER_TYPE, "COMPLETELY_BOGUS_TYPE");
     setupMockConfigProvider(props);
 
@@ -321,7 +246,7 @@ public class AbstractPartitionWriterThrottlingTest {
   public void testTokenBucketWithInvalidTimeWindowFallsBackToDefault() {
     Properties props = createBaseProperties();
     props.setProperty(INCREMENTAL_PUSH, "true");
-    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, "1000");
+    props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND_PER_PARTITION, "1000");
     props.setProperty(INCREMENTAL_PUSH_RATE_LIMITER_TYPE, "TOKEN_BUCKET_INCREMENTAL_REFILL");
     props.setProperty(INCREMENTAL_PUSH_WRITE_QUOTA_TIME_WINDOW_MS, "0");
     setupMockConfigProvider(props);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/IncrementalPushWriteQuotaUtilsTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/IncrementalPushWriteQuotaUtilsTest.java
@@ -1,0 +1,74 @@
+package com.linkedin.venice.hadoop.task.datawriter;
+
+import static com.linkedin.venice.hadoop.task.datawriter.IncrementalPushWriteQuotaUtils.THROTTLING_DISABLED;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link IncrementalPushWriteQuotaUtils#perPartitionQuotaForPush}, the single driver-side computation
+ * that folds in the incremental-push / separate-real-time-topic / disabled decision and the global-quota split.
+ */
+public class IncrementalPushWriteQuotaUtilsTest {
+  // isIncrementalPush, pushToSeparateRT, versionSeparateRT, globalQuota, partitionCount, expectedPerPartition
+  @DataProvider(name = "disabledOrSplitCases")
+  public Object[][] disabledOrSplitCases() {
+    return new Object[][] {
+        // Batch push: throttling never applies, even with an otherwise-valid quota.
+        { false, false, false, 1000L, 4, THROTTLING_DISABLED },
+        // Separate RT (both configs true): skipped even with an otherwise-unsplittable quota.
+        { true, true, true, 2L, 4, THROTTLING_DISABLED },
+        // Only the push-job separate-RT config: still throttles to the regular RT topic.
+        { true, true, false, 1000L, 4, 250L },
+        // Only the store separate-RT config: still throttles to the regular RT topic.
+        { true, false, true, 1000L, 4, 250L },
+        // Regular RT, evenly divisible.
+        { true, false, false, 1000L, 4, 250L },
+        // Regular RT, non-divisible: floor so the aggregate stays at or below the global quota.
+        { true, false, false, 1000L, 3, 333L },
+        // Minimum valid quota: exactly one per partition writer.
+        { true, false, false, 4L, 4, 1L },
+        // Disabled quota sentinels.
+        { true, false, false, -1L, 4, THROTTLING_DISABLED }, { true, false, false, 0L, 4, THROTTLING_DISABLED } };
+  }
+
+  @Test(dataProvider = "disabledOrSplitCases")
+  public void testPerPartitionQuotaForPush(
+      boolean isIncrementalPush,
+      boolean pushToSeparateRT,
+      boolean versionSeparateRT,
+      long globalQuota,
+      int partitionCount,
+      long expectedPerPartition) {
+    assertEquals(
+        IncrementalPushWriteQuotaUtils.perPartitionQuotaForPush(
+            isIncrementalPush,
+            pushToSeparateRT,
+            versionSeparateRT,
+            globalQuota,
+            partitionCount),
+        expectedPerPartition);
+  }
+
+  @Test
+  public void testFailsFastWhenQuotaBelowPartitionCount() {
+    // 2 records/sec cannot be split across 4 partition writers without giving someone 0/sec -> fail fast.
+    assertThrows(
+        VeniceException.class,
+        () -> IncrementalPushWriteQuotaUtils.perPartitionQuotaForPush(true, false, false, 2L, 4));
+  }
+
+  @Test
+  public void testFailsFastWhenPartitionCountNonPositive() {
+    assertThrows(
+        VeniceException.class,
+        () -> IncrementalPushWriteQuotaUtils.perPartitionQuotaForPush(true, false, false, 100L, 0));
+    assertThrows(
+        VeniceException.class,
+        () -> IncrementalPushWriteQuotaUtils.perPartitionQuotaForPush(true, false, false, 100L, -3));
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestIncrementalPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestIncrementalPush.java
@@ -394,12 +394,13 @@ public class TestIncrementalPush extends AbstractMultiRegionTest {
           TimeUnit.SECONDS);
 
       // Run incremental push with throttling enabled (writing to regular RT topic).
-      // Quota of 1 rec/s ensures the throttler blocks ~1s between each record.
+      // The driver splits the global quota across partition writers, so use the actual partition count as the global
+      // quota to give each partition 1 rec/s. This keeps the test throttled while satisfying per-partition validation.
       Properties vpjProperties =
           IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
       vpjProperties.put(ENABLE_WRITE_COMPUTE, true);
       vpjProperties.put(INCREMENTAL_PUSH, true);
-      vpjProperties.put(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, 1);
+      vpjProperties.put(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, response.getPartitions());
       if (useSparkCompute) {
         vpjProperties.setProperty(DATA_WRITER_COMPUTE_JOB_CLASS, DataWriterSparkJob.class.getCanonicalName());
         vpjProperties.setProperty(SPARK_NATIVE_INPUT_FORMAT_ENABLED, String.valueOf(true));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestSeparateRealtimeTopicIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestSeparateRealtimeTopicIngestion.java
@@ -83,6 +83,7 @@ public class TestSeparateRealtimeTopicIngestion extends AbstractMultiRegionTest 
   @Test(timeOut = TEST_TIMEOUT_MS * 3)
   public void testIncrementalPushPartialUpdate() throws IOException {
     final String storeName = Utils.getUniqueString("sepRT_ingestion");
+    final int partitionCount = 1;
     String parentControllerUrl = getParentControllerUrl();
     File inputDir = getTempDataDirectory();
     Schema recordSchema = writeSimpleAvroFileWithStringToPartialUpdateOpRecordSchema(inputDir);
@@ -96,8 +97,9 @@ public class TestSeparateRealtimeTopicIngestion extends AbstractMultiRegionTest 
     // Set source region to dc-1.
     vpjProperties.put(SOURCE_GRID_FABRIC, "dc-1");
 
-    // Set quota to a small value to ensure no throttling is applied for sep RT
-    vpjProperties.put(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, 1);
+    // Use the partition count as the global quota so each partition writer gets 1 rec/s after quota splitting. This
+    // keeps the quota valid while confirming throttling is skipped for sep RT.
+    vpjProperties.put(INCREMENTAL_PUSH_WRITE_QUOTA_RECORDS_PER_SECOND, partitionCount);
 
     try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAME, parentControllerUrl)) {
       assertCommand(
@@ -107,7 +109,7 @@ public class TestSeparateRealtimeTopicIngestion extends AbstractMultiRegionTest 
           new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
               .setActiveActiveReplicationEnabled(true)
               .setCompressionStrategy(CompressionStrategy.NO_OP)
-              .setPartitionCount(1)
+              .setPartitionCount(partitionCount)
               .setWriteComputationEnabled(true)
               .setChunkingEnabled(true)
               .setIncrementalPushEnabled(true)


### PR DESCRIPTION
# [vpj] Apply Incremental push quota throttling at store level

## Problem Statement

`incremental.push.write.quota.records.per.second` was interpreted as a per-partition limit, which makes it confusing for regular users. The number should be interpreted as a full store quota and applied at that level. Partition count is an internal detail and needs to be handled automatically.

## Solution

Treat `incremental.push.write.quota.records.per.second` as a global (store-level) incremental-push write quota.

The split is computed once on the driver and forwarded to the executors, so partition count stays an internal detail:
- After the controller assigns the version's partition count, the driver computes `globalQuota / partitionCount` once, during data-writer job-config assembly (MR and Spark), via `IncrementalPushWriteQuotaUtils.perPartitionQuotaForPush(...)`.
- That single computation also folds in the skip/disable decision (batch push, separate real-time topic push, or `<= 0` quota => disabled) and validates splittability.
- The computed per-partition value is forwarded to the tasks via the internal config `incremental.push.write.quota.records.per.second.per.partition`.
- Each partition-writer task is a pure consumer: it reads the forwarded value and enforces it directly - no division, no partition-count lookup, no separate-RT logic.
- Fails fast (driver-side, before executors launch) if a positive global quota is smaller than the partition count, since that would produce a `0` records/sec local quota.
- Keeps the existing behavior where `<= 0` disables throttling.
- Keeps the existing skip behavior for separate real-time topic incremental pushes.

Example:

```text
incremental.push.write.quota.records.per.second = 1000
partition.count = 4

per partition-writer quota = 1000 / 4 = 250 records/sec
aggregate quota ~= 1000 records/sec
```

For non-divisible quotas, the per-task quota uses floor division so the aggregate enforced rate does not exceed the configured global quota.

### Code changes

- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.
  - User-facing config (unchanged): `incremental.push.write.quota.records.per.second`, default `-1`; `<= 0` still disables throttling. Its semantics changed from per-partition to global (store-level).
  - New internal config: `incremental.push.write.quota.records.per.second.per.partition`, default `-1`. Driver-computed and forwarded to tasks; not user-facing.
- [x] Introduced new **log lines**.
  - Updated the throttler initialization log to report the per-partition quota each task enforces.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.
    - The initialization log runs once when the partition writer initializes its throttler, not per record.
    - Existing per-message throttle telemetry remains gated by `telemetry.message.interval`.

### Concurrency-Specific Checks

Both reviewer and PR author to verify:

- [x] Code has **no race conditions** or **thread safety issues**.
  - The per-partition quota is computed once on the driver and forwarded; each task reads an immutable config value during initialization before record processing.
- [x] Proper **synchronization mechanisms** are used where needed.
  - No new shared mutable state or cross-thread coordination was introduced.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
  - No new critical sections were introduced.
  - Existing rate limiter blocking behavior is unchanged.
- [x] Verified **thread-safe collections** are used where needed.
  - No new collections requiring thread-safety were introduced.
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.
  - Invalid positive quotas that cannot be split across partitions throw a `VeniceException` on the driver (fail-fast) instead of silently creating an invalid local limiter.

## How was this PR tested?

- [x] New unit tests added.
  - New `IncrementalPushWriteQuotaUtilsTest` covering the single driver-side computation: global-quota split, floor division for non-divisible quotas, skip/disable decisions (batch, separate-RT, `<= 0`), and fail-fast when the quota is smaller than the partition count.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
  - Reworked `AbstractPartitionWriterThrottlingTest` to verify the executor consumes the forwarded per-partition value directly (no re-derivation).
- [x] Verified backward compatibility (if applicable).
  - `<= 0` still disables throttling.
  - Default value remains `-1`.
  - Existing rate limiter type selection behavior is unchanged.
  - Separate real-time topic incremental pushes continue to skip this throttling path.

Test commands run:

```bash
./gradlew :clients:venice-push-job:diffCoverage
./gradlew :clients:venice-push-job:test --tests com.linkedin.venice.hadoop.task.datawriter.AbstractPartitionWriterThrottlingTest --tests com.linkedin.venice.hadoop.task.datawriter.IncrementalPushWriteQuotaUtilsTest
```

The repo pre-commit hook also ran successfully during commit.

## Does this PR introduce any user-facing or breaking changes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.

Yes. This changes the behavior of `incremental.push.write.quota.records.per.second`.

Previous behavior:
- The configured quota was applied independently per partition-writer task.
- Effective aggregate rate was approximately:

```text
configuredQuota * partitionCount
```

New behavior:
- The configured quota is treated as the global incremental-push write quota.
- Each partition-writer task enforces:

```text
configuredQuota / partitionCount
```

- Effective aggregate rate is at or below the configured quota.

Impact:
- Users may observe slower incremental pushes if they previously relied on the unintended per-partition behavior.
- To preserve the previous aggregate write rate, users can increase the configured value to the desired total global rate.
- Positive quota values smaller than the partition count now fail fast because they cannot be split into at least `1` record/sec per partition writer.

