### PR TITLE
[cc] Unblock shared drainer on CDC shutdown

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/StatefulVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/StatefulVeniceChangelogConsumer.java
@@ -49,6 +49,10 @@ public interface StatefulVeniceChangelogConsumer<K, V> extends AutoCloseable {
    */
   CompletableFuture<Void> start();
 
+  /**
+   * Stops this consumer and releases its internal resources. This consumer instance cannot be restarted after this
+   * method is called. Create a new consumer from {@link VeniceChangelogConsumerClientFactory} to resume consumption.
+   */
   void stop() throws Exception;
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
@@ -225,7 +225,8 @@ public interface VeniceChangelogConsumer<K, V> extends AutoCloseable {
   Map<Integer, Long> getLastHeartbeatPerPartition();
 
   /**
-   * Release the internal resources.
+   * Releases the internal resources. This consumer instance cannot be restarted or sought after close. Create a new
+   * consumer from {@link VeniceChangelogConsumerClientFactory} to resume consumption.
    */
   void close();
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -89,8 +89,9 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
 
   private final Set<Integer> subscribedPartitions = VeniceConcurrentHashMap.newKeySet();
   private final Set<Integer> eopReceivedPartitions = VeniceConcurrentHashMap.newKeySet();
-  private final ReentrantLock bufferLock = new ReentrantLock();
-  private final Condition bufferIsFullCondition = bufferLock.newCondition();
+  // Coordinates poll waiting/draining with shutdown. ArrayBlockingQueue manages insertion locking.
+  private final ReentrantLock pubSubMessagesStateLock = new ReentrantLock();
+  private final Condition pubSubMessagesFullCondition = pubSubMessagesStateLock.newCondition();
   private volatile BackgroundReporterThread backgroundReporterThread;
   private final BasicConsumerStats changeCaptureStats;
   private final AtomicBoolean isCaughtUp = new AtomicBoolean(false);
@@ -333,14 +334,21 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
 
   @Override
   public synchronized void stop() throws Exception {
-    if (!isClosed.compareAndSet(false, true)) {
+    if (isClosed.get()) {
       return;
     }
 
     LOGGER.info("Closing VeniceChangelogConsumer with name: {}", changelogClientConfig.getConsumerName());
-    isStarted.set(false);
-    partitionToVersionToServe.clear();
-    pubSubMessages.clear();
+    pubSubMessagesStateLock.lock();
+    try {
+      isClosed.set(true);
+      isStarted.set(false);
+      partitionToVersionToServe.clear();
+      pubSubMessages.clear();
+      pubSubMessagesFullCondition.signalAll();
+    } finally {
+      pubSubMessagesStateLock.unlock();
+    }
     try {
       if (backgroundReporterThread != null) {
         backgroundReporterThread.interrupt();
@@ -472,34 +480,26 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   @Override
   public Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> poll(long timeoutInMs) {
     try {
-      if (isClosed.get()) {
-        return Collections.emptyList();
-      }
-
+      Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> drainedPubSubMessages = new ArrayList<>();
       try {
-        bufferLock.lock();
+        pubSubMessagesStateLock.lock();
 
         // Wait until pubSubMessages becomes full, or until the timeout is reached
-        if (pubSubMessages.remainingCapacity() > 0) {
-          bufferIsFullCondition.await(timeoutInMs, TimeUnit.MILLISECONDS);
+        if (!isClosed.get() && pubSubMessages.remainingCapacity() > 0) {
+          pubSubMessagesFullCondition.await(timeoutInMs, TimeUnit.MILLISECONDS);
         }
+        if (isClosed.get()) {
+          return Collections.emptyList();
+        }
+        pubSubMessages.drainTo(drainedPubSubMessages);
       } catch (InterruptedException exception) {
         LOGGER.info("Thread was interrupted", exception);
         // Restore the interrupt status
         Thread.currentThread().interrupt();
       } finally {
-        bufferLock.unlock();
+        pubSubMessagesStateLock.unlock();
       }
 
-      if (isClosed.get()) {
-        return Collections.emptyList();
-      }
-
-      Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> drainedPubSubMessages = new ArrayList<>();
-      pubSubMessages.drainTo(drainedPubSubMessages);
-      if (isClosed.get()) {
-        return Collections.emptyList();
-      }
       int messagesPolled = drainedPubSubMessages.size();
 
       if (changelogClientConfig.shouldCompactMessages()) {
@@ -835,11 +835,11 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
          * beginning of this comment block.
          */
         if (pubSubMessages.remainingCapacity() == 0) {
-          bufferLock.lock();
+          pubSubMessagesStateLock.lock();
           try {
-            bufferIsFullCondition.signal();
+            pubSubMessagesFullCondition.signal();
           } finally {
-            bufferLock.unlock();
+            pubSubMessagesStateLock.unlock();
           }
         }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -1024,6 +1024,16 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   }
 
   @VisibleForTesting
+  ExecutorService getCompletableFutureThreadPool() {
+    return completableFutureThreadPool;
+  }
+
+  @VisibleForTesting
+  Thread getBackgroundReporterThread() {
+    return backgroundReporterThread;
+  }
+
+  @VisibleForTesting
   public Set<Integer> getSubscribedPartitions() {
     return subscribedPartitions;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -1019,6 +1019,11 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   }
 
   @VisibleForTesting
+  public BlockingQueue<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> getPubSubMessages() {
+    return pubSubMessages;
+  }
+
+  @VisibleForTesting
   public Set<Integer> getSubscribedPartitions() {
     return subscribedPartitions;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -280,8 +280,15 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
           }
 
           if (changeCaptureStats != null) {
-            backgroundReporterThread = new BackgroundReporterThread();
-            backgroundReporterThread.start();
+            bufferLock.lock();
+            try {
+              if (!isClosed.get()) {
+                backgroundReporterThread = new BackgroundReporterThread();
+                backgroundReporterThread.start();
+              }
+            } finally {
+              bufferLock.unlock();
+            }
           }
         } catch (InterruptedException e) {
           LOGGER.info("Thread was interrupted", e);
@@ -345,10 +352,12 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
       isStarted.set(false);
       partitionToVersionToServe.clear();
       pubSubMessages.clear();
+      startLatch.countDown();
       bufferIsFullCondition.signalAll();
     } finally {
       bufferLock.unlock();
     }
+    completableFutureThreadPool.shutdown();
     try {
       if (backgroundReporterThread != null) {
         backgroundReporterThread.interrupt();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -209,7 +209,8 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   private void throwIfClosed() {
     if (isClosed.get()) {
       throw new VeniceClientException(
-          "Cannot start or seek a closed VeniceChangelogConsumer: " + changelogClientConfig.getConsumerName());
+          "Cannot start or seek a closed VeniceChangelogConsumer for store: " + storeName + ", consumer name: "
+              + changelogClientConfig.getConsumerName());
     }
   }
 
@@ -336,10 +337,10 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
       return;
     }
 
+    LOGGER.info("Closing VeniceChangelogConsumer with name: {}", changelogClientConfig.getConsumerName());
     isStarted.set(false);
     partitionToVersionToServe.clear();
     pubSubMessages.clear();
-    LOGGER.info("Closing Changelog Consumer with name: {}", changelogClientConfig.getConsumerName());
     try {
       if (backgroundReporterThread != null) {
         backgroundReporterThread.interrupt();
@@ -350,7 +351,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
       pubSubMessages.clear();
       veniceChangelogConsumerClientFactory.deregisterClient(changelogClientConfig.getConsumerName());
       clearPartitionState(Collections.emptySet());
-      LOGGER.info("Closed Changelog Consumer with name: {}", changelogClientConfig.getConsumerName());
+      LOGGER.info("Closed VeniceChangelogConsumer with name: {}", changelogClientConfig.getConsumerName());
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -81,6 +81,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   private final CachingDaVinciClientFactory daVinciClientFactory;
   private final SeekableDaVinciClient<K, V> daVinciClient;
   private final AtomicBoolean isStarted = new AtomicBoolean(false);
+  private final AtomicBoolean isClosed = new AtomicBoolean(false);
   private final CountDownLatch startLatch = new CountDownLatch(1);
   // Using a dedicated thread pool for CompletableFutures created by this class to avoid potential thread starvation
   // issues in the default ForkJoinPool
@@ -197,10 +198,18 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   }
 
   private synchronized void startDaVinciClient() {
+    throwIfClosed();
     // Start daVinci client if not already started
     if (!isStarted.get()) {
       daVinciClient.start();
       isStarted.set(true);
+    }
+  }
+
+  private void throwIfClosed() {
+    if (isClosed.get()) {
+      throw new VeniceClientException(
+          "Cannot start or seek a closed VeniceChangelogConsumer: " + changelogClientConfig.getConsumerName());
     }
   }
 
@@ -215,6 +224,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   private synchronized CompletableFuture<Void> initializeAndSubscribe(
       Set<Integer> partitions,
       Function<Set<Integer>, CompletableFuture<Void>> subscriptionCall) {
+    throwIfClosed();
     Set<Integer> targetPartitions = new HashSet<>();
     boolean partitionsAdded = false;
     try {
@@ -321,7 +331,14 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   }
 
   @Override
-  public void stop() throws Exception {
+  public synchronized void stop() throws Exception {
+    if (!isClosed.compareAndSet(false, true)) {
+      return;
+    }
+
+    isStarted.set(false);
+    partitionToVersionToServe.clear();
+    pubSubMessages.clear();
     LOGGER.info("Closing Changelog Consumer with name: {}", changelogClientConfig.getConsumerName());
     try {
       if (backgroundReporterThread != null) {
@@ -330,6 +347,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
       daVinciClient.close();
     } finally {
       isStarted.set(false);
+      pubSubMessages.clear();
       veniceChangelogConsumerClientFactory.deregisterClient(changelogClientConfig.getConsumerName());
       clearPartitionState(Collections.emptySet());
       LOGGER.info("Closed Changelog Consumer with name: {}", changelogClientConfig.getConsumerName());
@@ -453,6 +471,10 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   @Override
   public Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> poll(long timeoutInMs) {
     try {
+      if (isClosed.get()) {
+        return Collections.emptyList();
+      }
+
       try {
         bufferLock.lock();
 
@@ -468,8 +490,15 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
         bufferLock.unlock();
       }
 
+      if (isClosed.get()) {
+        return Collections.emptyList();
+      }
+
       Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> drainedPubSubMessages = new ArrayList<>();
       pubSubMessages.drainTo(drainedPubSubMessages);
+      if (isClosed.get()) {
+        return Collections.emptyList();
+      }
       int messagesPolled = drainedPubSubMessages.size();
 
       if (changelogClientConfig.shouldCompactMessages()) {
@@ -784,12 +813,16 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
     private void internalAddMessageToBuffer(
         int partitionId,
         ImmutableChangeCapturePubSubMessage<K, ChangeEvent<V>> pubSubMessage) {
-      if (!isServedByThisVersion(partitionId)) {
+      if (isClosed.get() || !isStarted.get() || !isServedByThisVersion(partitionId)) {
         return;
       }
 
       try {
         pubSubMessages.put(pubSubMessage);
+        if (isClosed.get() || !isStarted.get()) {
+          pubSubMessages.remove(pubSubMessage);
+          return;
+        }
         /*
          * pubSubMessages is full, signal to a poll thread awaiting on bufferFullCondition.
          * Not signaling to all threads, because if multiple poll threads try to read pubSubMessages at
@@ -968,6 +1001,11 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   @VisibleForTesting
   public boolean isStarted() {
     return isStarted.get();
+  }
+
+  @VisibleForTesting
+  public boolean isClosed() {
+    return isClosed.get();
   }
 
   @VisibleForTesting

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -89,9 +89,8 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
 
   private final Set<Integer> subscribedPartitions = VeniceConcurrentHashMap.newKeySet();
   private final Set<Integer> eopReceivedPartitions = VeniceConcurrentHashMap.newKeySet();
-  // Coordinates poll waiting/draining with shutdown. ArrayBlockingQueue manages insertion locking.
-  private final ReentrantLock pubSubMessagesStateLock = new ReentrantLock();
-  private final Condition pubSubMessagesFullCondition = pubSubMessagesStateLock.newCondition();
+  private final ReentrantLock bufferLock = new ReentrantLock();
+  private final Condition bufferIsFullCondition = bufferLock.newCondition();
   private volatile BackgroundReporterThread backgroundReporterThread;
   private final BasicConsumerStats changeCaptureStats;
   private final AtomicBoolean isCaughtUp = new AtomicBoolean(false);
@@ -340,15 +339,15 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
     }
 
     LOGGER.info("Closing VeniceChangelogConsumer with name: {}", changelogClientConfig.getConsumerName());
-    pubSubMessagesStateLock.lock();
+    bufferLock.lock();
     try {
       isClosed.set(true);
       isStarted.set(false);
       partitionToVersionToServe.clear();
       pubSubMessages.clear();
-      pubSubMessagesFullCondition.signalAll();
+      bufferIsFullCondition.signalAll();
     } finally {
-      pubSubMessagesStateLock.unlock();
+      bufferLock.unlock();
     }
     try {
       if (backgroundReporterThread != null) {
@@ -483,11 +482,11 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
     try {
       Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> drainedPubSubMessages = new ArrayList<>();
       try {
-        pubSubMessagesStateLock.lock();
+        bufferLock.lock();
 
         // Wait until pubSubMessages becomes full, or until the timeout is reached
         if (!isClosed.get() && pubSubMessages.remainingCapacity() > 0) {
-          pubSubMessagesFullCondition.await(timeoutInMs, TimeUnit.MILLISECONDS);
+          bufferIsFullCondition.await(timeoutInMs, TimeUnit.MILLISECONDS);
         }
         if (isClosed.get()) {
           return Collections.emptyList();
@@ -498,7 +497,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
         // Restore the interrupt status
         Thread.currentThread().interrupt();
       } finally {
-        pubSubMessagesStateLock.unlock();
+        bufferLock.unlock();
       }
 
       int messagesPolled = drainedPubSubMessages.size();
@@ -836,11 +835,11 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
          * beginning of this comment block.
          */
         if (pubSubMessages.remainingCapacity() == 0) {
-          pubSubMessagesStateLock.lock();
+          bufferLock.lock();
           try {
-            pubSubMessagesFullCondition.signal();
+            bufferIsFullCondition.signal();
           } finally {
-            pubSubMessagesStateLock.unlock();
+            bufferLock.unlock();
           }
         }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -210,7 +210,8 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   private void throwIfClosed() {
     if (isClosed.get()) {
       throw new VeniceClientException(
-          "Cannot start or seek a closed VeniceChangelogConsumer for store: " + storeName + ", consumer name: "
+          "This VeniceChangelogConsumer instance is closed and cannot be restarted. Create a new consumer from "
+              + "VeniceChangelogConsumerClientFactory for store: " + storeName + ", consumer name: "
               + changelogClientConfig.getConsumerName());
     }
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
@@ -604,18 +604,17 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
 
   @Test
   public void testMaxBufferSize() throws NoSuchFieldException, IllegalAccessException, InterruptedException {
-    ReentrantLock pubSubMessagesStateLock = spy(new ReentrantLock());
-    Condition pubSubMessagesFullCondition = spy(pubSubMessagesStateLock.newCondition());
+    ReentrantLock bufferLock = spy(new ReentrantLock());
+    Condition bufferIsFullCondition = spy(bufferLock.newCondition());
 
-    Field pubSubMessagesStateLockField =
-        VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField("pubSubMessagesStateLock");
-    pubSubMessagesStateLockField.setAccessible(true);
-    pubSubMessagesStateLockField.set(veniceChangelogConsumer, pubSubMessagesStateLock);
+    Field bufferLockField = VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField("bufferLock");
+    bufferLockField.setAccessible(true);
+    bufferLockField.set(veniceChangelogConsumer, bufferLock);
 
-    Field pubSubMessagesFullConditionField =
-        VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField("pubSubMessagesFullCondition");
-    pubSubMessagesFullConditionField.setAccessible(true);
-    pubSubMessagesFullConditionField.set(veniceChangelogConsumer, pubSubMessagesFullCondition);
+    Field bufferIsFullConditionField =
+        VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField("bufferIsFullCondition");
+    bufferIsFullConditionField.setAccessible(true);
+    bufferIsFullConditionField.set(veniceChangelogConsumer, bufferIsFullCondition);
 
     assertEquals(changelogClientConfig.getMaxBufferSize(), MAX_BUFFER_SIZE);
 
@@ -633,9 +632,9 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
     }
 
     // Buffer is full signal should be hit
-    verify(pubSubMessagesStateLock, timeout(1000).atLeastOnce()).lock();
-    verify(pubSubMessagesStateLock, timeout(1000L).atLeastOnce()).unlock();
-    verify(pubSubMessagesFullCondition, atLeastOnce()).signal();
+    verify(bufferLock, timeout(1000).atLeastOnce()).lock();
+    verify(bufferLock, timeout(1000L).atLeastOnce()).unlock();
+    verify(bufferIsFullCondition, atLeastOnce()).signal();
 
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
       // Verify every CompletableFuture in completableFutureList is completed besides one
@@ -652,30 +651,30 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
       assertEquals(uncompletedFutures, 1);
     });
 
-    reset(pubSubMessagesStateLock);
-    reset(pubSubMessagesFullCondition);
+    reset(bufferLock);
+    reset(bufferIsFullCondition);
 
     // Buffer is full, so poll shouldn't await on the buffer full condition
     int timeoutInMs = 100;
     veniceChangelogConsumer.poll(timeoutInMs);
-    verify(pubSubMessagesFullCondition, never()).await(timeoutInMs, TimeUnit.MILLISECONDS);
+    verify(bufferIsFullCondition, never()).await(timeoutInMs, TimeUnit.MILLISECONDS);
 
-    reset(pubSubMessagesStateLock);
-    reset(pubSubMessagesFullCondition);
+    reset(bufferLock);
+    reset(bufferIsFullCondition);
 
     // Empty the buffer and verify that all CompletableFutures are done
     veniceChangelogConsumer.poll(timeoutInMs);
-    verify(pubSubMessagesStateLock).lock();
-    verify(pubSubMessagesStateLock).unlock();
+    verify(bufferLock).lock();
+    verify(bufferLock).unlock();
     // Buffer isn't full, so poll should await on the buffer is full condition and timeout
-    verify(pubSubMessagesFullCondition).await(timeoutInMs, TimeUnit.MILLISECONDS);
+    verify(bufferIsFullCondition).await(timeoutInMs, TimeUnit.MILLISECONDS);
 
     for (int i = 0; i <= MAX_BUFFER_SIZE; i++) {
       assertTrue(completableFutureList.get(i).isDone());
     }
 
-    reset(pubSubMessagesStateLock);
-    reset(pubSubMessagesFullCondition);
+    reset(bufferLock);
+    reset(bufferIsFullCondition);
 
     /*
      * Test the case where the buffer isn't full initially, so poll awaits on the condition and doesn't hit the timeout
@@ -687,7 +686,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
     });
 
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
-      verify(pubSubMessagesFullCondition).await(timeoutInMs, TimeUnit.MILLISECONDS);
+      verify(bufferIsFullCondition).await(timeoutInMs, TimeUnit.MILLISECONDS);
     });
 
     for (int i = 0; i < MAX_BUFFER_SIZE; i++) {
@@ -698,7 +697,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
     }
 
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
-      verify(pubSubMessagesFullCondition, atLeastOnce()).signal();
+      verify(bufferIsFullCondition, atLeastOnce()).signal();
     });
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
@@ -62,9 +62,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.avro.Schema;
@@ -268,7 +267,6 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
     veniceChangelogConsumer.start();
     onStartVersionIngestionHelper(true, true);
 
-    int blockedProducerCount = MAX_BUFFER_SIZE + 3;
     BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> outputQueue = getOutputQueue();
 
     for (int i = 0; i < MAX_BUFFER_SIZE; i++) {
@@ -277,14 +275,22 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
     }
     assertEquals(outputQueue.size(), MAX_BUFFER_SIZE, "Output queue should be full before producers block");
 
-    CountDownLatch producersStarted = new CountDownLatch(blockedProducerCount);
+    int blockedProducerCount = outputQueue.size() + 1;
+    AtomicReference<Throwable> threadFailure = new AtomicReference<>();
     List<Thread> producerThreads = new ArrayList<>();
-    ExecutorService producerExecutor = Executors.newFixedThreadPool(blockedProducerCount, runnable -> {
-      Thread thread = new Thread(runnable, "blocked-cdc-producer-" + producerThreads.size());
-      producerThreads.add(thread);
-      return thread;
-    });
-    List<Future<?>> producerFutures = new ArrayList<>();
+    for (int i = 0; i < blockedProducerCount; i++) {
+      int key = MAX_BUFFER_SIZE + i;
+      Thread producerThread = new Thread(() -> {
+        try {
+          recordTransformer.processPut(Lazy.of(() -> key), lazyValue, 0, recordMetadata);
+        } catch (Throwable throwable) {
+          threadFailure.compareAndSet(null, throwable);
+        }
+      }, "blocked-cdc-producer-" + i);
+      producerThreads.add(producerThread);
+      producerThread.start();
+    }
+
     CountDownLatch daVinciCloseStarted = new CountDownLatch(1);
     CountDownLatch allowDaVinciClose = new CountDownLatch(1);
     doAnswer(invocation -> {
@@ -292,52 +298,48 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
       assertTrue(allowDaVinciClose.await(30, TimeUnit.SECONDS), "Test should release DaVinci close");
       return null;
     }).when(mockDaVinciClient).close();
-    CompletableFuture<Void> stopFuture = null;
-    try {
-      for (int i = 0; i < blockedProducerCount; i++) {
-        int key = MAX_BUFFER_SIZE + i;
-        producerFutures.add(producerExecutor.submit(() -> {
-          producersStarted.countDown();
-          recordTransformer.processPut(Lazy.of(() -> key), lazyValue, 0, recordMetadata);
-        }));
+    Thread stopThread = new Thread(() -> {
+      try {
+        veniceChangelogConsumer.stop();
+      } catch (Throwable throwable) {
+        threadFailure.compareAndSet(null, throwable);
       }
+    }, "cdc-consumer-stop");
 
-      assertTrue(producersStarted.await(5, TimeUnit.SECONDS), "Every producer should start");
-      TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, true, () -> {
-        assertEquals(producerThreads.size(), blockedProducerCount, "Every producer should have a worker thread");
-        for (int i = 0; i < blockedProducerCount; i++) {
-          assertFalse(producerFutures.get(i).isDone(), "Producer should remain blocked until stop clears the queue");
-          assertEquals(
-              producerThreads.get(i).getState(),
-              Thread.State.WAITING,
-              "Producer should be blocked in the full output queue");
-        }
-      });
+    try {
+      TestUtils.waitForNonDeterministicAssertion(
+          5,
+          TimeUnit.SECONDS,
+          true,
+          () -> assertTrue(
+              producerThreads.stream().allMatch(producer -> producer.getState() == Thread.State.WAITING),
+              "Every producer should be blocked in the full output queue"));
 
-      stopFuture = CompletableFuture.runAsync(() -> {
-        try {
-          veniceChangelogConsumer.stop();
-        } catch (Exception e) {
-          throw new RuntimeException(e);
-        }
-      });
+      stopThread.start();
       assertTrue(daVinciCloseStarted.await(5, TimeUnit.SECONDS), "Stop should reach the DaVinci client");
 
-      for (Future<?> producerFuture: producerFutures) {
-        producerFuture.get(5, TimeUnit.SECONDS);
+      for (Thread producerThread: producerThreads) {
+        producerThread.join(TimeUnit.SECONDS.toMillis(5));
+        assertFalse(producerThread.isAlive(), "Producer should exit after stop clears the queue");
       }
-      assertFalse(stopFuture.isDone(), "Stop should still be waiting for DaVinci close");
+      assertNull(threadFailure.get(), "Producer threads should not fail");
+      assertTrue(stopThread.isAlive(), "Stop should still be waiting for DaVinci close");
       assertTrue(
           outputQueue.isEmpty(),
           "The initial clear and post-put removal should release every producer without shutdown output");
       assertTrue(veniceChangelogConsumer.isClosed(), "Stop should leave the consumer terminally closed");
     } finally {
       allowDaVinciClose.countDown();
-      if (stopFuture != null) {
-        stopFuture.get(5, TimeUnit.SECONDS);
+      stopThread.join(TimeUnit.SECONDS.toMillis(5));
+      for (Thread producerThread: producerThreads) {
+        if (producerThread.isAlive()) {
+          producerThread.interrupt();
+          producerThread.join(TimeUnit.SECONDS.toMillis(5));
+        }
       }
-      producerExecutor.shutdownNow();
     }
+    assertFalse(stopThread.isAlive(), "Stop should finish after DaVinci close is released");
+    assertNull(threadFailure.get(), "Shutdown threads should not fail");
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
@@ -594,17 +594,18 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
 
   @Test
   public void testMaxBufferSize() throws NoSuchFieldException, IllegalAccessException, InterruptedException {
-    ReentrantLock bufferLock = spy(new ReentrantLock());
-    Condition bufferIsFullCondition = spy(bufferLock.newCondition());
+    ReentrantLock pubSubMessagesStateLock = spy(new ReentrantLock());
+    Condition pubSubMessagesFullCondition = spy(pubSubMessagesStateLock.newCondition());
 
-    Field bufferLockField = VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField("bufferLock");
-    bufferLockField.setAccessible(true);
-    bufferLockField.set(veniceChangelogConsumer, bufferLock);
+    Field pubSubMessagesStateLockField =
+        VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField("pubSubMessagesStateLock");
+    pubSubMessagesStateLockField.setAccessible(true);
+    pubSubMessagesStateLockField.set(veniceChangelogConsumer, pubSubMessagesStateLock);
 
-    Field bufferIsFullConditionField =
-        VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField("bufferIsFullCondition");
-    bufferIsFullConditionField.setAccessible(true);
-    bufferIsFullConditionField.set(veniceChangelogConsumer, bufferIsFullCondition);
+    Field pubSubMessagesFullConditionField =
+        VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField("pubSubMessagesFullCondition");
+    pubSubMessagesFullConditionField.setAccessible(true);
+    pubSubMessagesFullConditionField.set(veniceChangelogConsumer, pubSubMessagesFullCondition);
 
     assertEquals(changelogClientConfig.getMaxBufferSize(), MAX_BUFFER_SIZE);
 
@@ -622,9 +623,9 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
     }
 
     // Buffer is full signal should be hit
-    verify(bufferLock, timeout(1000).atLeastOnce()).lock();
-    verify(bufferLock, timeout(1000L).atLeastOnce()).unlock();
-    verify(bufferIsFullCondition, atLeastOnce()).signal();
+    verify(pubSubMessagesStateLock, timeout(1000).atLeastOnce()).lock();
+    verify(pubSubMessagesStateLock, timeout(1000L).atLeastOnce()).unlock();
+    verify(pubSubMessagesFullCondition, atLeastOnce()).signal();
 
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
       // Verify every CompletableFuture in completableFutureList is completed besides one
@@ -641,30 +642,30 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
       assertEquals(uncompletedFutures, 1);
     });
 
-    reset(bufferLock);
-    reset(bufferIsFullCondition);
+    reset(pubSubMessagesStateLock);
+    reset(pubSubMessagesFullCondition);
 
     // Buffer is full, so poll shouldn't await on the buffer full condition
     int timeoutInMs = 100;
     veniceChangelogConsumer.poll(timeoutInMs);
-    verify(bufferIsFullCondition, never()).await(timeoutInMs, TimeUnit.MILLISECONDS);
+    verify(pubSubMessagesFullCondition, never()).await(timeoutInMs, TimeUnit.MILLISECONDS);
 
-    reset(bufferLock);
-    reset(bufferIsFullCondition);
+    reset(pubSubMessagesStateLock);
+    reset(pubSubMessagesFullCondition);
 
     // Empty the buffer and verify that all CompletableFutures are done
     veniceChangelogConsumer.poll(timeoutInMs);
-    verify(bufferLock).lock();
-    verify(bufferLock).unlock();
+    verify(pubSubMessagesStateLock).lock();
+    verify(pubSubMessagesStateLock).unlock();
     // Buffer isn't full, so poll should await on the buffer is full condition and timeout
-    verify(bufferIsFullCondition).await(timeoutInMs, TimeUnit.MILLISECONDS);
+    verify(pubSubMessagesFullCondition).await(timeoutInMs, TimeUnit.MILLISECONDS);
 
     for (int i = 0; i <= MAX_BUFFER_SIZE; i++) {
       assertTrue(completableFutureList.get(i).isDone());
     }
 
-    reset(bufferLock);
-    reset(bufferIsFullCondition);
+    reset(pubSubMessagesStateLock);
+    reset(pubSubMessagesFullCondition);
 
     /*
      * Test the case where the buffer isn't full initially, so poll awaits on the condition and doesn't hit the timeout
@@ -676,7 +677,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
     });
 
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
-      verify(bufferIsFullCondition).await(timeoutInMs, TimeUnit.MILLISECONDS);
+      verify(pubSubMessagesFullCondition).await(timeoutInMs, TimeUnit.MILLISECONDS);
     });
 
     for (int i = 0; i < MAX_BUFFER_SIZE; i++) {
@@ -687,7 +688,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
     }
 
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
-      verify(bufferIsFullCondition, atLeastOnce()).signal();
+      verify(pubSubMessagesFullCondition, atLeastOnce()).signal();
     });
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
@@ -30,6 +30,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
@@ -382,7 +383,8 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
   public void testStartAndSeekRejectedAfterCloseAndDuplicateStopIsHarmless() throws Exception {
     veniceChangelogConsumer.stop();
 
-    assertThrows(VeniceClientException.class, veniceChangelogConsumer::start);
+    VeniceClientException exception = expectThrows(VeniceClientException.class, veniceChangelogConsumer::start);
+    assertTrue(exception.getMessage().contains(TEST_STORE_NAME), "Closed-consumer error should identify the store");
     assertThrows(
         VeniceClientException.class,
         () -> veniceChangelogConsumer.seekToBeginningOfPush(Collections.singleton(0)));

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
@@ -11,8 +11,10 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -54,9 +56,17 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.avro.Schema;
@@ -231,10 +241,178 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
 
     veniceChangelogConsumer.stop();
     assertFalse(veniceChangelogConsumer.isStarted(), "isStarted should be false");
+    assertTrue(veniceChangelogConsumer.isClosed(), "isClosed should be true");
 
     verify(mockDaVinciClient).close();
     verify(veniceChangelogConsumer).clearPartitionState(eq(Collections.emptySet()));
     verify(veniceChangelogConsumerClientFactory).deregisterClient(changelogClientConfig.getConsumerName());
+  }
+
+  @Test
+  public void testStopReleasesAllBlockedProducersWithoutPoller() throws Exception {
+    veniceChangelogConsumer.start();
+    onStartVersionIngestionHelper(true, true);
+
+    int blockedProducerCount = MAX_BUFFER_SIZE + 3;
+    CountDownLatch blockedPutAttempts = new CountDownLatch(blockedProducerCount);
+    BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> outputQueue =
+        new ArrayBlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>>(MAX_BUFFER_SIZE) {
+          @Override
+          public void put(PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate> message)
+              throws InterruptedException {
+            if (remainingCapacity() == 0) {
+              blockedPutAttempts.countDown();
+            }
+            super.put(message);
+          }
+        };
+    setOutputQueue(outputQueue);
+
+    for (int i = 0; i < MAX_BUFFER_SIZE; i++) {
+      int key = i;
+      recordTransformer.processPut(Lazy.of(() -> key), lazyValue, 0, recordMetadata);
+    }
+    assertEquals(outputQueue.size(), MAX_BUFFER_SIZE, "Output queue should be full before producers block");
+
+    ExecutorService producerExecutor = Executors.newFixedThreadPool(blockedProducerCount);
+    List<Future<?>> producerFutures = new ArrayList<>();
+    try {
+      for (int i = 0; i < blockedProducerCount; i++) {
+        int key = MAX_BUFFER_SIZE + i;
+        producerFutures.add(
+            producerExecutor
+                .submit(() -> recordTransformer.processPut(Lazy.of(() -> key), lazyValue, 0, recordMetadata)));
+      }
+
+      assertTrue(blockedPutAttempts.await(5, TimeUnit.SECONDS), "Every producer should reach the full output queue");
+      for (Future<?> producerFuture: producerFutures) {
+        assertFalse(producerFuture.isDone(), "Producer should remain blocked until stop clears the queue");
+      }
+
+      veniceChangelogConsumer.stop();
+
+      for (Future<?> producerFuture: producerFutures) {
+        producerFuture.get(5, TimeUnit.SECONDS);
+      }
+      assertTrue(outputQueue.isEmpty(), "Stop should release blocked producers without leaving shutdown output");
+      assertTrue(veniceChangelogConsumer.isClosed(), "Stop should leave the consumer terminally closed");
+    } finally {
+      producerExecutor.shutdownNow();
+    }
+  }
+
+  @Test
+  public void testLatePutRemovesOnlyInsertedMessage() throws Exception {
+    veniceChangelogConsumer.start();
+    onStartVersionIngestionHelper(true, true);
+
+    AtomicBoolean closedFlag = getAtomicBooleanField("isClosed");
+    AtomicBoolean startedFlag = getAtomicBooleanField("isStarted");
+    AtomicReference<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> insertedMessage =
+        new AtomicReference<>();
+    PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate> sentinelMessage = mock(PubSubMessage.class);
+    BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> outputQueue =
+        new ArrayBlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>>(2) {
+          @Override
+          public void put(PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate> message)
+              throws InterruptedException {
+            super.put(message);
+            insertedMessage.set(message);
+            super.put(sentinelMessage);
+            startedFlag.set(false);
+            closedFlag.set(true);
+          }
+        };
+    setOutputQueue(outputQueue);
+
+    recordTransformer.processPut(keys.get(0), lazyValue, 0, recordMetadata);
+
+    assertNotNull(insertedMessage.get(), "The test producer should insert its message before observing close");
+    assertFalse(
+        outputQueue.stream().anyMatch(message -> message == insertedMessage.get()),
+        "The exact message inserted across the shutdown boundary should be removed");
+    assertEquals(outputQueue.size(), 1, "Removal should not purge unrelated queue entries");
+    assertSame(outputQueue.peek(), sentinelMessage, "Only the exact late message should be removed");
+  }
+
+  @Test
+  public void testPollDuringCloseReturnsNoShutdownWindowOutput() throws Exception {
+    veniceChangelogConsumer.start();
+    onStartVersionIngestionHelper(true, true);
+
+    CountDownLatch daVinciCloseStarted = new CountDownLatch(1);
+    CountDownLatch allowDaVinciClose = new CountDownLatch(1);
+    doAnswer(invocation -> {
+      daVinciCloseStarted.countDown();
+      assertTrue(allowDaVinciClose.await(5, TimeUnit.SECONDS), "Test should release DaVinci close");
+      return null;
+    }).when(mockDaVinciClient).close();
+
+    CompletableFuture<Void> closeFuture = CompletableFuture.runAsync(() -> {
+      try {
+        veniceChangelogConsumer.stop();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    try {
+      assertTrue(daVinciCloseStarted.await(5, TimeUnit.SECONDS), "Close should reach the DaVinci client");
+      BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> outputQueue =
+          getOutputQueue();
+      PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate> shutdownWindowMessage =
+          mock(PubSubMessage.class);
+      outputQueue.add(shutdownWindowMessage);
+
+      assertTrue(
+          veniceChangelogConsumer.poll(POLL_TIMEOUT).isEmpty(),
+          "Poll must not emit a message inserted after close begins");
+      assertTrue(
+          outputQueue.contains(shutdownWindowMessage),
+          "Poll should return before draining once the consumer is closed");
+    } finally {
+      allowDaVinciClose.countDown();
+    }
+
+    closeFuture.get(5, TimeUnit.SECONDS);
+    assertTrue(getOutputQueue().isEmpty(), "Final close cleanup should empty the output queue");
+  }
+
+  @Test
+  public void testStartAndSeekRejectedAfterCloseAndDuplicateStopIsHarmless() throws Exception {
+    veniceChangelogConsumer.stop();
+
+    assertThrows(VeniceClientException.class, veniceChangelogConsumer::start);
+    assertThrows(
+        VeniceClientException.class,
+        () -> veniceChangelogConsumer.seekToBeginningOfPush(Collections.singleton(0)));
+
+    veniceChangelogConsumer.stop();
+
+    assertTrue(veniceChangelogConsumer.isClosed(), "A stopped consumer must remain terminally closed");
+    verify(mockDaVinciClient).close();
+    verify(veniceChangelogConsumerClientFactory).deregisterClient(changelogClientConfig.getConsumerName());
+  }
+
+  @Test
+  public void testCloseFailureStillLeavesTerminalStateAndCleansFactory() throws Exception {
+    veniceChangelogConsumer.start();
+    onStartVersionIngestionHelper(true, true);
+    recordTransformer.processPut(keys.get(0), lazyValue, 0, recordMetadata);
+    assertFalse(getOutputQueue().isEmpty(), "Test setup should buffer a message before close");
+    doThrow(new VeniceException("close failure")).when(mockDaVinciClient).close();
+
+    assertThrows(VeniceException.class, veniceChangelogConsumer::stop);
+
+    assertTrue(veniceChangelogConsumer.isClosed(), "A failed close must still be terminal");
+    assertFalse(veniceChangelogConsumer.isStarted(), "A failed close must not leave the consumer started");
+    assertTrue(getOutputQueue().isEmpty(), "A failed close must still clear buffered output");
+    assertTrue(veniceChangelogConsumer.getSubscribedPartitions().isEmpty(), "Partition state should be cleared");
+    verify(veniceChangelogConsumerClientFactory).deregisterClient(changelogClientConfig.getConsumerName());
+    verify(veniceChangelogConsumer).clearPartitionState(eq(Collections.emptySet()));
+
+    veniceChangelogConsumer.stop();
+    verify(mockDaVinciClient).close();
   }
 
   @Test
@@ -712,6 +890,31 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
         () -> assertFalse(
             veniceChangelogConsumer.getSubscribedPartitions().contains(1),
             "Partition 1 should be removed from subscribedPartitions after failure"));
+  }
+
+  @SuppressWarnings("unchecked")
+  private BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> getOutputQueue()
+      throws NoSuchFieldException, IllegalAccessException {
+    Field outputQueueField =
+        VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField("pubSubMessages");
+    outputQueueField.setAccessible(true);
+    return (BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>>) outputQueueField
+        .get(veniceChangelogConsumer);
+  }
+
+  private void setOutputQueue(
+      BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> outputQueue)
+      throws NoSuchFieldException, IllegalAccessException {
+    Field outputQueueField =
+        VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField("pubSubMessages");
+    outputQueueField.setAccessible(true);
+    outputQueueField.set(veniceChangelogConsumer, outputQueue);
+  }
+
+  private AtomicBoolean getAtomicBooleanField(String fieldName) throws NoSuchFieldException, IllegalAccessException {
+    Field field = VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return (AtomicBoolean) field.get(veniceChangelogConsumer);
   }
 
   private void onStartVersionIngestionHelper(boolean currentRecordTransformer, boolean isCurrentVersion) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
@@ -383,11 +383,21 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
   public void testStartAndSeekRejectedAfterCloseAndDuplicateStopIsHarmless() throws Exception {
     veniceChangelogConsumer.stop();
 
-    VeniceClientException exception = expectThrows(VeniceClientException.class, veniceChangelogConsumer::start);
-    assertTrue(exception.getMessage().contains(TEST_STORE_NAME), "Closed-consumer error should identify the store");
-    assertThrows(
+    String freshConsumerInstruction = "Create a new consumer from VeniceChangelogConsumerClientFactory";
+    VeniceClientException startException = expectThrows(VeniceClientException.class, veniceChangelogConsumer::start);
+    assertTrue(
+        startException.getMessage().contains(TEST_STORE_NAME),
+        "Closed-consumer error should identify the store");
+    assertTrue(
+        startException.getMessage().contains(freshConsumerInstruction),
+        "Closed-consumer error should explain how to create a fresh consumer");
+    VeniceClientException seekException = expectThrows(
         VeniceClientException.class,
         () -> veniceChangelogConsumer.seekToBeginningOfPush(Collections.singleton(0)));
+    assertTrue(seekException.getMessage().contains(TEST_STORE_NAME), "Closed-consumer error should identify the store");
+    assertTrue(
+        seekException.getMessage().contains(freshConsumerInstruction),
+        "Closed-consumer error should explain how to create a fresh consumer");
 
     veniceChangelogConsumer.stop();
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
@@ -57,7 +57,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -66,8 +65,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.avro.Schema;
@@ -250,24 +247,29 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
   }
 
   @Test
+  public void testStopCompletesPendingStartWithoutStartingReporterAndShutsDownExecutor() throws Exception {
+    CompletableFuture<Void> startFuture = veniceChangelogConsumer.start();
+    ExecutorService completableFutureThreadPool = getField("completableFutureThreadPool");
+
+    assertFalse(startFuture.isDone(), "Start should wait for the first record");
+
+    veniceChangelogConsumer.stop();
+
+    startFuture.get(5, TimeUnit.SECONDS);
+    assertNull(getField("backgroundReporterThread"), "A reporter must not start after close wins");
+    assertTrue(completableFutureThreadPool.isShutdown(), "Stop should shut down the dedicated start executor");
+    assertTrue(
+        completableFutureThreadPool.awaitTermination(5, TimeUnit.SECONDS),
+        "The dedicated start executor should terminate after the pending start completes");
+  }
+
+  @Test
   public void testStopReleasesAllBlockedProducersWithoutPoller() throws Exception {
     veniceChangelogConsumer.start();
     onStartVersionIngestionHelper(true, true);
 
     int blockedProducerCount = MAX_BUFFER_SIZE + 3;
-    CountDownLatch blockedPutAttempts = new CountDownLatch(blockedProducerCount);
-    BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> outputQueue =
-        new ArrayBlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>>(MAX_BUFFER_SIZE) {
-          @Override
-          public void put(PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate> message)
-              throws InterruptedException {
-            if (remainingCapacity() == 0) {
-              blockedPutAttempts.countDown();
-            }
-            super.put(message);
-          }
-        };
-    setOutputQueue(outputQueue);
+    BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> outputQueue = getOutputQueue();
 
     for (int i = 0; i < MAX_BUFFER_SIZE; i++) {
       int key = i;
@@ -275,65 +277,67 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
     }
     assertEquals(outputQueue.size(), MAX_BUFFER_SIZE, "Output queue should be full before producers block");
 
-    ExecutorService producerExecutor = Executors.newFixedThreadPool(blockedProducerCount);
+    CountDownLatch producersStarted = new CountDownLatch(blockedProducerCount);
+    List<Thread> producerThreads = new ArrayList<>();
+    ExecutorService producerExecutor = Executors.newFixedThreadPool(blockedProducerCount, runnable -> {
+      Thread thread = new Thread(runnable, "blocked-cdc-producer-" + producerThreads.size());
+      producerThreads.add(thread);
+      return thread;
+    });
     List<Future<?>> producerFutures = new ArrayList<>();
+    CountDownLatch daVinciCloseStarted = new CountDownLatch(1);
+    CountDownLatch allowDaVinciClose = new CountDownLatch(1);
+    doAnswer(invocation -> {
+      daVinciCloseStarted.countDown();
+      assertTrue(allowDaVinciClose.await(30, TimeUnit.SECONDS), "Test should release DaVinci close");
+      return null;
+    }).when(mockDaVinciClient).close();
+    CompletableFuture<Void> stopFuture = null;
     try {
       for (int i = 0; i < blockedProducerCount; i++) {
         int key = MAX_BUFFER_SIZE + i;
-        producerFutures.add(
-            producerExecutor
-                .submit(() -> recordTransformer.processPut(Lazy.of(() -> key), lazyValue, 0, recordMetadata)));
+        producerFutures.add(producerExecutor.submit(() -> {
+          producersStarted.countDown();
+          recordTransformer.processPut(Lazy.of(() -> key), lazyValue, 0, recordMetadata);
+        }));
       }
 
-      assertTrue(blockedPutAttempts.await(5, TimeUnit.SECONDS), "Every producer should reach the full output queue");
-      for (Future<?> producerFuture: producerFutures) {
-        assertFalse(producerFuture.isDone(), "Producer should remain blocked until stop clears the queue");
-      }
+      assertTrue(producersStarted.await(5, TimeUnit.SECONDS), "Every producer should start");
+      TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, true, () -> {
+        assertEquals(producerThreads.size(), blockedProducerCount, "Every producer should have a worker thread");
+        for (int i = 0; i < blockedProducerCount; i++) {
+          assertFalse(producerFutures.get(i).isDone(), "Producer should remain blocked until stop clears the queue");
+          assertEquals(
+              producerThreads.get(i).getState(),
+              Thread.State.WAITING,
+              "Producer should be blocked in the full output queue");
+        }
+      });
 
-      veniceChangelogConsumer.stop();
+      stopFuture = CompletableFuture.runAsync(() -> {
+        try {
+          veniceChangelogConsumer.stop();
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      });
+      assertTrue(daVinciCloseStarted.await(5, TimeUnit.SECONDS), "Stop should reach the DaVinci client");
 
       for (Future<?> producerFuture: producerFutures) {
         producerFuture.get(5, TimeUnit.SECONDS);
       }
-      assertTrue(outputQueue.isEmpty(), "Stop should release blocked producers without leaving shutdown output");
+      assertFalse(stopFuture.isDone(), "Stop should still be waiting for DaVinci close");
+      assertTrue(
+          outputQueue.isEmpty(),
+          "The initial clear and post-put removal should release every producer without shutdown output");
       assertTrue(veniceChangelogConsumer.isClosed(), "Stop should leave the consumer terminally closed");
     } finally {
+      allowDaVinciClose.countDown();
+      if (stopFuture != null) {
+        stopFuture.get(5, TimeUnit.SECONDS);
+      }
       producerExecutor.shutdownNow();
     }
-  }
-
-  @Test
-  public void testLatePutRemovesOnlyInsertedMessage() throws Exception {
-    veniceChangelogConsumer.start();
-    onStartVersionIngestionHelper(true, true);
-
-    AtomicBoolean closedFlag = getAtomicBooleanField("isClosed");
-    AtomicBoolean startedFlag = getAtomicBooleanField("isStarted");
-    AtomicReference<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> insertedMessage =
-        new AtomicReference<>();
-    PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate> sentinelMessage = mock(PubSubMessage.class);
-    BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> outputQueue =
-        new ArrayBlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>>(2) {
-          @Override
-          public void put(PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate> message)
-              throws InterruptedException {
-            super.put(message);
-            insertedMessage.set(message);
-            super.put(sentinelMessage);
-            startedFlag.set(false);
-            closedFlag.set(true);
-          }
-        };
-    setOutputQueue(outputQueue);
-
-    recordTransformer.processPut(keys.get(0), lazyValue, 0, recordMetadata);
-
-    assertNotNull(insertedMessage.get(), "The test producer should insert its message before observing close");
-    assertFalse(
-        outputQueue.stream().anyMatch(message -> message == insertedMessage.get()),
-        "The exact message inserted across the shutdown boundary should be removed");
-    assertEquals(outputQueue.size(), 1, "Removal should not purge unrelated queue entries");
-    assertSame(outputQueue.peek(), sentinelMessage, "Only the exact late message should be removed");
   }
 
   @Test
@@ -907,26 +911,14 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
   @SuppressWarnings("unchecked")
   private BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> getOutputQueue()
       throws NoSuchFieldException, IllegalAccessException {
-    Field outputQueueField =
-        VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField("pubSubMessages");
-    outputQueueField.setAccessible(true);
-    return (BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>>) outputQueueField
-        .get(veniceChangelogConsumer);
+    return getField("pubSubMessages");
   }
 
-  private void setOutputQueue(
-      BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> outputQueue)
-      throws NoSuchFieldException, IllegalAccessException {
-    Field outputQueueField =
-        VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField("pubSubMessages");
-    outputQueueField.setAccessible(true);
-    outputQueueField.set(veniceChangelogConsumer, outputQueue);
-  }
-
-  private AtomicBoolean getAtomicBooleanField(String fieldName) throws NoSuchFieldException, IllegalAccessException {
+  @SuppressWarnings("unchecked")
+  private <T> T getField(String fieldName) throws NoSuchFieldException, IllegalAccessException {
     Field field = VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField(fieldName);
     field.setAccessible(true);
-    return (AtomicBoolean) field.get(veniceChangelogConsumer);
+    return (T) field.get(veniceChangelogConsumer);
   }
 
   private void onStartVersionIngestionHelper(boolean currentRecordTransformer, boolean isCurrentVersion) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
@@ -249,14 +249,14 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
   @Test
   public void testStopCompletesPendingStartWithoutStartingReporterAndShutsDownExecutor() throws Exception {
     CompletableFuture<Void> startFuture = veniceChangelogConsumer.start();
-    ExecutorService completableFutureThreadPool = getField("completableFutureThreadPool");
+    ExecutorService completableFutureThreadPool = veniceChangelogConsumer.getCompletableFutureThreadPool();
 
     assertFalse(startFuture.isDone(), "Start should wait for the first record");
 
     veniceChangelogConsumer.stop();
 
     startFuture.get(5, TimeUnit.SECONDS);
-    assertNull(getField("backgroundReporterThread"), "A reporter must not start after close wins");
+    assertNull(veniceChangelogConsumer.getBackgroundReporterThread(), "A reporter must not start after close wins");
     assertTrue(completableFutureThreadPool.isShutdown(), "Stop should shut down the dedicated start executor");
     assertTrue(
         completableFutureThreadPool.awaitTermination(5, TimeUnit.SECONDS),
@@ -909,16 +909,8 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
   }
 
   @SuppressWarnings("unchecked")
-  private BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> getOutputQueue()
-      throws NoSuchFieldException, IllegalAccessException {
-    return getField("pubSubMessages");
-  }
-
-  @SuppressWarnings("unchecked")
-  private <T> T getField(String fieldName) throws NoSuchFieldException, IllegalAccessException {
-    Field field = VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField(fieldName);
-    field.setAccessible(true);
-    return (T) field.get(veniceChangelogConsumer);
+  private BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> getOutputQueue() {
+    return veniceChangelogConsumer.getPubSubMessages();
   }
 
   private void onStartVersionIngestionHelper(boolean currentRecordTransformer, boolean isCurrentVersion) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/StatefulVeniceChangelogConsumerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/StatefulVeniceChangelogConsumerTest.java
@@ -325,34 +325,34 @@ public class StatefulVeniceChangelogConsumerTest {
           assertTrue(consumer2EventsList.size() >= 10);
         });
 
-        // Restart the first consumer - DVRT should be properly re-hooked into a new SIT
-        statefulVeniceChangelogConsumer.start().get();
+        // Create a fresh consumer after stop. Closed consumer instances are terminal.
+        try (StatefulVeniceChangelogConsumer<GenericRecord, GenericRecord> restartedConsumer =
+            veniceChangelogConsumerClientFactory.getStatefulChangelogConsumer(storeName)) {
+          restartedConsumer.start().get();
 
-        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, false, () -> {
-          pollChangeEventsFromChangeCaptureConsumer(
-              polledChangeEventsMap,
-              polledChangeEventsList,
-              statefulVeniceChangelogConsumer);
-          // 40 near-line put events, but one of them overwrites a key from batch push.
-          // Also, Deletes won't show up on restart when scanning RocksDB.
-          // Use >= to be resilient to at-least-once delivery: the change capture topic replay
-          // after restart may surface a few extra delete or duplicate events as unique keys.
-          // Upper bound guards against gross duplication bugs.
-          int expectedRecordCount = DEFAULT_USER_DATA_RECORD_COUNT + 39;
-          int upperBound = (int) (expectedRecordCount * 1.1);
-          assertTrue(
-              polledChangeEventsMap.size() >= expectedRecordCount,
-              "Expected at least " + expectedRecordCount + " records, but got " + polledChangeEventsMap.size());
-          assertTrue(
-              polledChangeEventsMap.size() <= upperBound,
-              "Too many records (" + polledChangeEventsMap.size() + "), expected at most " + upperBound
-                  + ". Possible duplicate event production.");
-          verifyPut(polledChangeEventsMap, 100, 110, 3, false);
-          verifyPut(polledChangeEventsMap, 120, 130, 3, false);
-          verifyPut(polledChangeEventsMap, 140, 150, 3, false);
-          verifyPut(polledChangeEventsMap, 160, 170, 3, false);
-        });
-        verifyVCCSequenceId(polledChangeEventsList, partitionSequenceIdMap, startingSequenceId);
+          TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, false, () -> {
+            pollChangeEventsFromChangeCaptureConsumer(polledChangeEventsMap, polledChangeEventsList, restartedConsumer);
+            // 40 near-line put events, but one of them overwrites a key from batch push.
+            // Also, Deletes won't show up on restart when scanning RocksDB.
+            // Use >= to be resilient to at-least-once delivery: the change capture topic replay
+            // after restart may surface a few extra delete or duplicate events as unique keys.
+            // Upper bound guards against gross duplication bugs.
+            int expectedRecordCount = DEFAULT_USER_DATA_RECORD_COUNT + 39;
+            int upperBound = (int) (expectedRecordCount * 1.1);
+            assertTrue(
+                polledChangeEventsMap.size() >= expectedRecordCount,
+                "Expected at least " + expectedRecordCount + " records, but got " + polledChangeEventsMap.size());
+            assertTrue(
+                polledChangeEventsMap.size() <= upperBound,
+                "Too many records (" + polledChangeEventsMap.size() + "), expected at most " + upperBound
+                    + ". Possible duplicate event production.");
+            verifyPut(polledChangeEventsMap, 100, 110, 3, false);
+            verifyPut(polledChangeEventsMap, 120, 130, 3, false);
+            verifyPut(polledChangeEventsMap, 140, 150, 3, false);
+            verifyPut(polledChangeEventsMap, 160, 170, 3, false);
+          });
+          verifyVCCSequenceId(polledChangeEventsList, new HashMap<>(), -1);
+        }
       } finally {
         cleanUpStoreAndVerify(storeName2);
       }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
@@ -499,13 +499,17 @@ public class TestVersionSpecificChangelogConsumer {
         initTimestampNs);
 
     // Restart client to ensure it seeks to the beginning of the topic and all record metadata is available
+    testCloseables.remove(changeLogConsumer);
     changeLogConsumer.close();
-    changeLogConsumer.subscribeAll().get();
+    VeniceChangelogConsumer<Integer, Utf8> restartedChangeLogConsumer =
+        veniceChangelogConsumerClientFactory.getVersionSpecificChangelogConsumer(storeName, 1, true);
+    testCloseables.add(restartedChangeLogConsumer);
+    restartedChangeLogConsumer.subscribeAll().get();
 
     // All data should be from version 1
     // there are 3 partitions, so we expect 3 control messages EOP
     pollAndVerify(
-        changeLogConsumer,
+        restartedChangeLogConsumer,
         1,
         numKeys,
         createControlMessageCountMap(partitionCount, 0),
@@ -518,12 +522,18 @@ public class TestVersionSpecificChangelogConsumer {
     IntegrationTestPushUtils.runVPJ(props, 2, childControllerClientRegion0);
 
     // Client should see VersionSwap control messages since new version is pushed
-    pollAndVerify(changeLogConsumer, 1, 0, createControlMessageCountMap(0, partitionCount), partitionCount, true);
+    pollAndVerify(
+        restartedChangeLogConsumer,
+        1,
+        0,
+        createControlMessageCountMap(0, partitionCount),
+        partitionCount,
+        true);
 
     // Client shouldn't be able to poll anything besides heartbeat messages, since it's still on version 1
     int nonHeartbeatMessagesCount = 0;
     Collection<PubSubMessage<Integer, ChangeEvent<Utf8>, VeniceChangeCoordinate>> oldVersionMessages =
-        changeLogConsumer.poll(1000);
+        restartedChangeLogConsumer.poll(1000);
     for (PubSubMessage<Integer, ChangeEvent<Utf8>, VeniceChangeCoordinate> message: oldVersionMessages) {
       if (message.getKey() != null) {
         nonHeartbeatMessagesCount++;
@@ -538,7 +548,8 @@ public class TestVersionSpecificChangelogConsumer {
     assertEquals(nonHeartbeatMessagesCount, 0);
 
     // Restart a new client
-    changeLogConsumer.close();
+    testCloseables.remove(restartedChangeLogConsumer);
+    restartedChangeLogConsumer.close();
     long newClientTimestampNs = Utils.getCurrentTimeInNanosForSeeding();
     VeniceChangelogConsumer<Integer, Utf8> newChangeLogConsumer =
         veniceChangelogConsumerClientFactory.getVersionSpecificChangelogConsumer(storeName, 1, true);
@@ -556,6 +567,7 @@ public class TestVersionSpecificChangelogConsumer {
         newClientTimestampNs);
 
     // Push version 3 with deferred version swap and subscribe to the future version
+    testCloseables.remove(newChangeLogConsumer);
     newChangeLogConsumer.close();
     version++;
     TestWriteUtils.writeSimpleAvroFileWithIntToStringSchema(inputDir, Integer.toString(version), numKeys);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VersionSpecificCDCShutdownTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VersionSpecificCDCShutdownTest.java
@@ -5,6 +5,9 @@ import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLA
 import static com.linkedin.venice.ConfigKeys.ADMIN_CONSUMPTION_MAX_WORKER_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_OFFLINE_PUSH_STRATEGY;
+import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SORTED_INPUT_DRAINER_SIZE;
+import static com.linkedin.venice.ConfigKeys.UNSORTED_INPUT_DRAINER_SIZE;
 import static com.linkedin.venice.integration.utils.VeniceControllerWrapper.D2_SERVICE_NAME;
 import static com.linkedin.venice.stats.ClientType.CHANGE_DATA_CAPTURE_CLIENT;
 import static com.linkedin.venice.stats.VeniceMetricsRepository.getVeniceMetricsRepository;
@@ -16,17 +19,21 @@ import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFile;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.d2.balancer.D2ClientBuilder;
+import com.linkedin.davinci.DaVinciBackend;
+import com.linkedin.davinci.client.AvroGenericDaVinciClient;
 import com.linkedin.davinci.consumer.ChangeEvent;
 import com.linkedin.davinci.consumer.ChangelogClientConfig;
 import com.linkedin.davinci.consumer.VeniceChangeCoordinate;
 import com.linkedin.davinci.consumer.VeniceChangelogConsumer;
 import com.linkedin.davinci.consumer.VeniceChangelogConsumerClientFactory;
+import com.linkedin.davinci.consumer.VeniceChangelogConsumerDaVinciRecordTransformerImpl;
 import com.linkedin.venice.D2.D2ClientUtils;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
@@ -48,17 +55,21 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.view.TestView;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.File;
+import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.Lock;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -83,6 +94,12 @@ public class VersionSpecificCDCShutdownTest {
   private static final Logger LOGGER = LogManager.getLogger(VersionSpecificCDCShutdownTest.class);
   private static final int TEST_TIMEOUT = 3 * Time.MS_PER_MINUTE;
   private static final int PARTITION_COUNT = 3;
+  private static final int CDC_OUTPUT_BUFFER_SIZE = 2;
+  private static final int FLINK_CLOSE_TIMEOUT_SECONDS = 30;
+  private static final int BLOCKING_RECORD_START = 110;
+  private static final int BLOCKING_RECORD_COUNT = 20;
+  private static final int STORE_B_BLOCKED_RECORD_COUNT = 10;
+  private static final String HYBRID_DRAINER_THREAD_PREFIX = "Store-writer-hybrid";
 
   private String clusterName;
   private VeniceClusterWrapper clusterWrapper;
@@ -144,160 +161,315 @@ public class VersionSpecificCDCShutdownTest {
   public void testVersionSpecificCDCConsumerRestartWithinFlinkTimeout() throws Exception {
     String storeA = Utils.getUniqueString("storeA");
     String storeB = Utils.getUniqueString("storeB");
-    String inputDir = setUpStore(storeA);
-    setUpStore(storeB);
+    VeniceChangelogConsumer<GenericRecord, GenericRecord> consumerA = null;
+    VeniceChangelogConsumer<GenericRecord, GenericRecord> consumerB = null;
+    VeniceChangelogConsumer<GenericRecord, GenericRecord> restartedConsumerA = null;
+    ExecutorService closeExecutor = null;
+    Future<?> closeFuture = null;
 
-    // Produce nearline records BEFORE consumers subscribe so the version topic contains:
-    // batch data (100 records) → EOP → nearline records (10 per store).
-    // This ensures checkpoints captured during polling are past EOP.
-    try (
-        VeniceSystemProducer producerA =
-            IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeA, Version.PushType.STREAM);
-        VeniceSystemProducer producerB =
-            IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeB, Version.PushType.STREAM)) {
-      runSamzaStreamJob(producerA, storeA, 10, 100);
-      runSamzaStreamJob(producerB, storeB, 10, 100);
-    }
-
-    VeniceChangelogConsumerClientFactory factory = createFactory(inputDir);
-
-    // Store B consumer keeps DaVinciBackend alive across the close/restart of store A
-    VeniceChangelogConsumer<GenericRecord, GenericRecord> consumerB =
-        factory.getVersionSpecificChangelogConsumer(storeB, 1);
-    consumerB.subscribeAll().get();
-    // Verify batch + nearline data received
-    Map<String, GenericRecord> consumerBEvents = new HashMap<>();
-    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
-      pollAndCollect(consumerB, consumerBEvents);
-      int expectedMinEvents = DEFAULT_USER_DATA_RECORD_COUNT + 9;
-      assertTrue(
-          consumerBEvents.size() >= expectedMinEvents,
-          "Store B expected >= " + expectedMinEvents + " but got " + consumerBEvents.size());
-    });
-    verifyNearlineValues(consumerBEvents, 100, 110);
-    LOGGER.info("Store B consumer verified with {} events.", consumerBEvents.size());
-
-    // Store A consumer subscribes, receives data, and captures checkpoints
-    VeniceChangelogConsumer<GenericRecord, GenericRecord> consumerA =
-        factory.getVersionSpecificChangelogConsumer(storeA, 1);
-    consumerA.subscribeAll().get();
-    Map<String, GenericRecord> consumerAEvents = new HashMap<>();
-    Set<VeniceChangeCoordinate> checkpoints = new HashSet<>();
-    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
-      pollAndCollectWithCheckpoints(consumerA, consumerAEvents, checkpoints);
-      int expectedMinEventsA = DEFAULT_USER_DATA_RECORD_COUNT + 9;
-      assertTrue(
-          consumerAEvents.size() >= expectedMinEventsA,
-          "Store A expected >= " + expectedMinEventsA + " but got " + consumerAEvents.size());
-    });
-    verifyNearlineValues(consumerAEvents, 100, 110);
-    // Verify checkpoints cover all partitions to ensure seekToCheckpoint subscribes to all of them
-    Set<Integer> checkpointPartitions = new HashSet<>();
-    for (VeniceChangeCoordinate checkpoint: checkpoints) {
-      checkpointPartitions.add(checkpoint.getPartition());
-    }
-    assertTrue(
-        checkpointPartitions.size() >= PARTITION_COUNT,
-        "Expected checkpoints from all " + PARTITION_COUNT + " partitions but got " + checkpointPartitions.size());
-    LOGGER.info(
-        "Store A consumer verified with {} events, captured checkpoints from {} partitions.",
-        consumerAEvents.size(),
-        checkpointPartitions.size());
-
-    // Produce more nearline records to load the drainer before close
-    try (
-        VeniceSystemProducer producerA =
-            IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeA, Version.PushType.STREAM);
-        VeniceSystemProducer producerB =
-            IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeB, Version.PushType.STREAM)) {
-      runSamzaStreamJob(producerA, storeA, 10, 110);
-      runSamzaStreamJob(producerB, storeB, 10, 110);
-    }
-
-    // Simulate Flink: close in background with 30s timeout. Use daemon thread so a blocked
-    // close() cannot keep the test JVM alive after TestNG's timeout kills the test.
-    ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
-      Thread t = new Thread(r, "cdc-consumer-close");
-      t.setDaemon(true);
-      return t;
-    });
-    long closeStartMs = System.currentTimeMillis();
-    Future<?> closeFuture = executor.submit(() -> consumerA.close());
-
-    boolean closedInTime = false;
     try {
-      closeFuture.get(30, TimeUnit.SECONDS);
-      closedInTime = true;
-    } catch (TimeoutException e) {
-      closeFuture.cancel(true);
+      String inputDir = setUpStore(storeA);
+      setUpStore(storeB);
+
+      // Produce nearline records before subscribing so the external checkpoints are past EOP.
+      try (
+          VeniceSystemProducer producerA =
+              IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeA, Version.PushType.STREAM);
+          VeniceSystemProducer producerB =
+              IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeB, Version.PushType.STREAM)) {
+        runSamzaStreamJob(producerA, storeA, 10, 100);
+        runSamzaStreamJob(producerB, storeB, 10, 100);
+      }
+
+      VeniceChangelogConsumerClientFactory factory = createFactory(inputDir);
+
+      VeniceChangelogConsumer<GenericRecord, GenericRecord> activeConsumerB =
+          factory.getVersionSpecificChangelogConsumer(storeB, 1);
+      consumerB = activeConsumerB;
+      activeConsumerB.subscribeAll().get();
+      Map<String, GenericRecord> consumerBEvents = new HashMap<>();
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
+        pollAndCollect(activeConsumerB, consumerBEvents);
+        int expectedMinEvents = DEFAULT_USER_DATA_RECORD_COUNT + 9;
+        assertTrue(
+            consumerBEvents.size() >= expectedMinEvents,
+            "Store B expected >= " + expectedMinEvents + " but got " + consumerBEvents.size());
+      });
+      verifyNearlineValues(consumerBEvents, 100, 110);
+
+      VeniceChangelogConsumer<GenericRecord, GenericRecord> activeConsumerA =
+          factory.getVersionSpecificChangelogConsumer(storeA, 1);
+      consumerA = activeConsumerA;
+      activeConsumerA.subscribeAll().get();
+      Map<String, GenericRecord> consumerAEvents = new HashMap<>();
+      Set<VeniceChangeCoordinate> checkpoints = new HashSet<>();
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
+        pollAndCollectWithCheckpoints(activeConsumerA, consumerAEvents, checkpoints);
+        int expectedMinEvents = DEFAULT_USER_DATA_RECORD_COUNT + 9;
+        assertTrue(
+            consumerAEvents.size() >= expectedMinEvents,
+            "Store A expected >= " + expectedMinEvents + " but got " + consumerAEvents.size());
+      });
+      verifyNearlineValues(consumerAEvents, 100, 110);
+
+      Set<Integer> checkpointPartitions = new HashSet<>();
+      for (VeniceChangeCoordinate checkpoint: checkpoints) {
+        checkpointPartitions.add(checkpoint.getPartition());
+      }
+      assertEquals(
+          checkpointPartitions.size(),
+          PARTITION_COUNT,
+          "External checkpoints must cover every partition before the restart");
+
+      BlockingQueue<?> consumerAOutputQueue = getOutputQueue(activeConsumerA);
+      BlockingQueue<?> consumerBOutputQueue = getOutputQueue(activeConsumerB);
+      assertTrue(consumerAOutputQueue.isEmpty(), "Store A output queue must start empty");
+      assertTrue(consumerBOutputQueue.isEmpty(), "Store B output queue must start empty");
+
+      // Stop polling A, fill its tiny output queue, and block the sole shared hybrid drainer in put().
+      try (VeniceSystemProducer producerA =
+          IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeA, Version.PushType.STREAM)) {
+        runSamzaStreamJob(producerA, storeA, BLOCKING_RECORD_COUNT, BLOCKING_RECORD_START);
+      }
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
+        assertEquals(
+            consumerAOutputQueue.size(),
+            CDC_OUTPUT_BUFFER_SIZE,
+            "Store A output queue should be full before shutdown");
+        assertNotNull(
+            findBlockedSharedHybridDrainer(),
+            "The sole shared hybrid drainer should be blocked in consumer A's ArrayBlockingQueue.put");
+      });
+
+      // Queue store B records behind the blocked A record and prove B cannot make progress before A shuts down.
+      try (VeniceSystemProducer producerB =
+          IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeB, Version.PushType.STREAM)) {
+        runSamzaStreamJob(producerB, storeB, STORE_B_BLOCKED_RECORD_COUNT, BLOCKING_RECORD_START);
+      }
+
+      BlockingQueue<?> sharedHybridDrainerQueue = getSharedHybridDrainerQueue();
+      String storeBVersionTopic = Version.composeKafkaTopic(storeB, 1);
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
+        assertTrue(
+            drainerQueueContainsTopic(sharedHybridDrainerQueue, storeBVersionTopic),
+            "Store B records should be queued behind the blocked store A record");
+      });
+      assertTrue(consumerBOutputQueue.isEmpty(), "Store B must not progress while the shared drainer is blocked");
+
+      Thread blockedDrainer = findBlockedSharedHybridDrainer();
+      assertNotNull(blockedDrainer, "Shared hybrid drainer unexpectedly unblocked before consumer A shutdown");
+      LOGGER.info(
+          "CDC shutdown precondition reproduced: consumerAQueueSize={}, consumerBQueueSize={}, "
+              + "sharedDrainerQueueSize={}, blockedDrainer={} ({})",
+          consumerAOutputQueue.size(),
+          consumerBOutputQueue.size(),
+          sharedHybridDrainerQueue.size(),
+          blockedDrainer.getName(),
+          blockedDrainer.getState());
+
+      VeniceChangelogConsumer<GenericRecord, GenericRecord> consumerAToClose = consumerA;
+      closeExecutor = Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread(r, "cdc-consumer-close");
+        t.setDaemon(true);
+        return t;
+      });
+      long closeStartMs = System.currentTimeMillis();
+      closeFuture = closeExecutor.submit(consumerAToClose::close);
+
+      boolean closedInTime = false;
+      try {
+        closeFuture.get(FLINK_CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        closedInTime = true;
+      } catch (TimeoutException e) {
+        Thread stillBlockedDrainer = findBlockedSharedHybridDrainer();
+        LOGGER.error(
+            "CDC shutdown red reproduction: close exceeded Flink's {}s timeout; "
+                + "consumerAQueueSize={}, consumerBQueueSize={}, blockedDrainer={}",
+            FLINK_CLOSE_TIMEOUT_SECONDS,
+            consumerAOutputQueue.size(),
+            consumerBOutputQueue.size(),
+            describeThread(stillBlockedDrainer));
+      }
+
+      long closeElapsedMs = System.currentTimeMillis() - closeStartMs;
+      assertTrue(
+          closedInTime,
+          "CDC consumer A close exceeded Flink's 30s timeout while the shared StoreBuffer drainer was blocked "
+              + "in its full output queue; elapsedMs=" + closeElapsedMs + ", drainer="
+              + describeThread(findBlockedSharedHybridDrainer()));
+
+      Map<String, GenericRecord> resumedBEvents = new HashMap<>();
+      try {
+        pollAndVerifyNearlineRecords(
+            activeConsumerB,
+            resumedBEvents,
+            BLOCKING_RECORD_START,
+            BLOCKING_RECORD_START + STORE_B_BLOCKED_RECORD_COUNT);
+      } catch (AssertionError e) {
+        throw new AssertionError(
+            "Store B did not resume after consumer A shutdown; shared drainer="
+                + describeThread(findBlockedSharedHybridDrainer()),
+            e);
+      }
+
+      restartedConsumerA = factory.getVersionSpecificChangelogConsumer(storeA, 1);
+      assertNotNull(restartedConsumerA);
+      assertNotSame(
+          restartedConsumerA,
+          consumerA,
+          "Factory should return a fresh consumer after the old consumer is closed");
+      restartedConsumerA.seekToCheckpoint(checkpoints).get();
+
+      Map<String, GenericRecord> replayedAEvents = new HashMap<>();
+      pollAndVerifyNearlineRecords(
+          restartedConsumerA,
+          replayedAEvents,
+          BLOCKING_RECORD_START,
+          BLOCKING_RECORD_START + BLOCKING_RECORD_COUNT);
+      LOGGER.info(
+          "Restarted consumer A replayed all {} expected records from external checkpoints; "
+              + "store B resumed with {} records.",
+          BLOCKING_RECORD_COUNT,
+          resumedBEvents.size());
     } finally {
-      executor.shutdownNow();
+      releaseBlockedSharedDrainerForCleanup(consumerA);
+      if (closeFuture != null && !closeFuture.isDone()) {
+        try {
+          closeFuture.get(30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+          LOGGER.warn("Consumer A close did not finish during test cleanup", e);
+        }
+      } else if (closeFuture == null && consumerA != null) {
+        closeInBackground(consumerA);
+      }
+      if (closeExecutor != null) {
+        closeExecutor.shutdownNow();
+      }
+      closeInBackground(restartedConsumerA);
+      closeInBackground(consumerB);
+      cleanUpStore(storeA);
+      cleanUpStore(storeB);
     }
-
-    long closeElapsedMs = System.currentTimeMillis() - closeStartMs;
-    LOGGER.info("Consumer A close() completed in {}ms", closeElapsedMs);
-    assertTrue(closedInTime, "CDC consumer close() took " + closeElapsedMs + "ms, exceeding 30s threshold.");
-
-    // Restart consumer A with seekToCheckpoint (simulating Flink checkpoint restore).
-    // The factory must return a fresh consumer — if deregisterClient() didn't run during close,
-    // the factory returns the stale cached consumer which would throw "already subscribed".
-    VeniceChangelogConsumer<GenericRecord, GenericRecord> newConsumerA =
-        factory.getVersionSpecificChangelogConsumer(storeA, 1);
-    assertNotNull(newConsumerA);
-    assertNotSame(newConsumerA, consumerA, "Factory should return a fresh consumer, not the closed stale instance");
-    newConsumerA.seekToCheckpoint(checkpoints).get();
-    LOGGER.info("Restarted consumer A seeked to {} checkpoints.", checkpoints.size());
-
-    // seekToCheckpoint(...).get() only awaits the subscribe, not the inclusive re-scan backlog the
-    // seek schedules. Drain that backlog before producing the next batch so the new records (keys
-    // 120-129) never share the consumer pipeline with the re-scan of the pre-restart nearline tail.
-    // Key 119 is the last record produced before the restart, so re-observing it confirms the
-    // re-scan frontier has reached the checkpoint position and the backlog is quiesced.
-    Map<String, GenericRecord> drainEvents = new HashMap<>();
-    drainUntilKeyObserved(newConsumerA, drainEvents, "119");
-    LOGGER.info(
-        "Restarted consumer A drained re-scan backlog ({} events) before producing new batch.",
-        drainEvents.size());
-
-    // Produce new nearline records after restart
-    try (
-        VeniceSystemProducer producerA =
-            IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeA, Version.PushType.STREAM);
-        VeniceSystemProducer producerB =
-            IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeB, Version.PushType.STREAM)) {
-      runSamzaStreamJob(producerA, storeA, 10, 120);
-      runSamzaStreamJob(producerB, storeB, 10, 120);
-    }
-
-    // Verify restarted consumer A receives the new nearline records (keys 120-129)
-    Map<String, GenericRecord> restartedAEvents = new HashMap<>();
-    pollAndVerifyNearlineRecords(newConsumerA, restartedAEvents, 120, 130);
-    LOGGER.info("Restarted consumer A received {} events after checkpoint seek.", restartedAEvents.size());
-
-    // Verify store B receives the new nearline records (keys 120-129)
-    Map<String, GenericRecord> newConsumerBEvents = new HashMap<>();
-    pollAndVerifyNearlineRecords(consumerB, newConsumerBEvents, 120, 130);
-    LOGGER.info("Store B received {} nearline records after store A restart.", newConsumerBEvents.size());
-
-    // Cleanup
-    closeInBackground(newConsumerA);
-    closeInBackground(consumerB);
-    cleanUpStore(storeA);
-    cleanUpStore(storeB);
   }
 
-  /**
-   * Polls until the given key is observed, draining whatever the consumer has buffered (e.g. an
-   * inclusive seekToCheckpoint re-scan backlog) so it does not contend with records produced next.
-   */
-  private void drainUntilKeyObserved(
-      VeniceChangelogConsumer<GenericRecord, GenericRecord> consumer,
-      Map<String, GenericRecord> eventsMap,
-      String key) {
-    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
-      pollAndCollect(consumer, eventsMap);
-      assertNotNull(eventsMap.get(key), "Drain did not observe re-scanned key " + key);
-    });
+  private BlockingQueue<?> getOutputQueue(VeniceChangelogConsumer<?, ?> consumer) throws ReflectiveOperationException {
+    Field outputQueueField =
+        VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField("pubSubMessages");
+    outputQueueField.setAccessible(true);
+    return (BlockingQueue<?>) outputQueueField.get(consumer);
+  }
+
+  private BlockingQueue<?> getSharedHybridDrainerQueue() throws ReflectiveOperationException {
+    DaVinciBackend backend = AvroGenericDaVinciClient.getBackend();
+    Object ingestionService = readField(backend, "ingestionService");
+    Object storeBufferService = readField(ingestionService, "storeBufferService");
+    if (storeBufferService.getClass().getSimpleName().equals("SeparatedStoreBufferService")) {
+      storeBufferService = readField(storeBufferService, "unsortedStoreBufferServiceDelegate");
+    }
+
+    List<?> drainerQueues = (List<?>) readField(storeBufferService, "blockingQueueArr");
+    assertEquals(drainerQueues.size(), 1, "The integration test must use exactly one shared hybrid drainer");
+    return (BlockingQueue<?>) drainerQueues.get(0);
+  }
+
+  private boolean drainerQueueContainsTopic(BlockingQueue<?> drainerQueue, String topicName) {
+    try {
+      Lock queueLock = (Lock) readField(drainerQueue, "memoryLock");
+      queueLock.lock();
+      try {
+        for (Object queueNode: drainerQueue.toArray()) {
+          PubSubMessage consumerRecord = (PubSubMessage) readField(queueNode, "consumerRecord");
+          if (topicName.equals(consumerRecord.getTopicPartition().getPubSubTopic().getName())) {
+            return true;
+          }
+        }
+        return false;
+      } finally {
+        queueLock.unlock();
+      }
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Unable to inspect the shared drainer queue", e);
+    }
+  }
+
+  private Object readField(Object target, String fieldName) throws ReflectiveOperationException {
+    Class<?> currentClass = target.getClass();
+    while (currentClass != null) {
+      try {
+        Field field = currentClass.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+      } catch (NoSuchFieldException e) {
+        currentClass = currentClass.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(target.getClass().getName() + "." + fieldName);
+  }
+
+  private Thread findBlockedSharedHybridDrainer() {
+    for (Map.Entry<Thread, StackTraceElement[]> entry: Thread.getAllStackTraces().entrySet()) {
+      Thread thread = entry.getKey();
+      if (!thread.getName().startsWith(HYBRID_DRAINER_THREAD_PREFIX)) {
+        continue;
+      }
+
+      boolean blockedInOutputQueuePut = false;
+      boolean insideConsumerBufferAdd = false;
+      for (StackTraceElement stackFrame: entry.getValue()) {
+        if (stackFrame.getClassName().equals("java.util.concurrent.ArrayBlockingQueue")
+            && stackFrame.getMethodName().equals("put")) {
+          blockedInOutputQueuePut = true;
+        }
+        if (stackFrame.getClassName().startsWith(VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getName())
+            && stackFrame.getMethodName().equals("internalAddMessageToBuffer")) {
+          insideConsumerBufferAdd = true;
+        }
+      }
+
+      if (blockedInOutputQueuePut && insideConsumerBufferAdd) {
+        return thread;
+      }
+    }
+    return null;
+  }
+
+  private String describeThread(Thread thread) {
+    if (thread == null) {
+      return "none";
+    }
+
+    StringBuilder description = new StringBuilder(thread.getName()).append('(').append(thread.getState()).append(')');
+    StackTraceElement[] stackTrace = thread.getStackTrace();
+    for (int i = 0; i < Math.min(stackTrace.length, 8); i++) {
+      description.append(System.lineSeparator()).append("  at ").append(stackTrace[i]);
+    }
+    return description.toString();
+  }
+
+  private void releaseBlockedSharedDrainerForCleanup(VeniceChangelogConsumer<?, ?> consumer) {
+    if (consumer == null) {
+      return;
+    }
+
+    long deadlineMs = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+    Thread blockedDrainer;
+    while ((blockedDrainer = findBlockedSharedHybridDrainer()) != null && System.currentTimeMillis() < deadlineMs) {
+      try {
+        consumer.poll(0);
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        break;
+      } catch (Exception e) {
+        LOGGER.warn("Failed to drain consumer A during test cleanup", e);
+        break;
+      }
+    }
+
+    if (blockedDrainer != null) {
+      LOGGER.warn("Shared hybrid drainer remained blocked after test cleanup: {}", describeThread(blockedDrainer));
+    }
   }
 
   private void pollAndVerifyNearlineRecords(
@@ -411,21 +583,23 @@ public class VersionSpecificCDCShutdownTest {
 
   private VeniceChangelogConsumerClientFactory createFactory(String inputDirRef) {
     Properties consumerProps = ChangelogConsumerTestUtils.buildConsumerProperties(clusterWrapper, inputDirRef);
+    consumerProps.put(SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED, true);
+    consumerProps.put(SORTED_INPUT_DRAINER_SIZE, 1);
+    consumerProps.put(UNSORTED_INPUT_DRAINER_SIZE, 1);
     ChangelogClientConfig globalConfig = new ChangelogClientConfig().setConsumerProperties(consumerProps)
         .setControllerD2ServiceName(D2_SERVICE_NAME)
         .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
         .setLocalD2ZkHosts(zkAddress)
         .setControllerRequestRetryCount(3)
         .setD2Client(d2Client)
-        // The buffer must stay well above the per-restart nearline batch size (10). At parity (10),
-        // the inclusive seekToCheckpoint storage re-scan contends with the freshly produced target
-        // records for the same ArrayBlockingQueue slots, intermittently starving keys at the batch
-        // boundary and failing pollAndVerifyNearlineRecords within its 30s window.
-        .setMaxBufferSize(100);
+        .setMaxBufferSize(CDC_OUTPUT_BUFFER_SIZE);
     return new VeniceChangelogConsumerClientFactory(globalConfig, metricsRepository);
   }
 
   private void closeInBackground(VeniceChangelogConsumer<?, ?> consumer) {
+    if (consumer == null) {
+      return;
+    }
     ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
       Thread t = new Thread(r, "cdc-consumer-close-bg");
       t.setDaemon(true);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VersionSpecificCDCShutdownTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VersionSpecificCDCShutdownTest.java
@@ -94,10 +94,10 @@ public class VersionSpecificCDCShutdownTest {
   private static final Logger LOGGER = LogManager.getLogger(VersionSpecificCDCShutdownTest.class);
   private static final int TEST_TIMEOUT = 3 * Time.MS_PER_MINUTE;
   private static final int PARTITION_COUNT = 3;
-  private static final int CDC_OUTPUT_BUFFER_SIZE = 2;
+  private static final int CDC_OUTPUT_BUFFER_SIZE = 100;
   private static final int FLINK_CLOSE_TIMEOUT_SECONDS = 30;
   private static final int BLOCKING_RECORD_START = 110;
-  private static final int BLOCKING_RECORD_COUNT = 20;
+  private static final int BLOCKING_RECORD_COUNT = 120;
   private static final int STORE_B_BLOCKED_RECORD_COUNT = 10;
   private static final String HYBRID_DRAINER_THREAD_PREFIX = "Store-writer-hybrid";
 
@@ -202,9 +202,9 @@ public class VersionSpecificCDCShutdownTest {
       consumerA = activeConsumerA;
       activeConsumerA.subscribeAll().get();
       Map<String, GenericRecord> consumerAEvents = new HashMap<>();
-      Set<VeniceChangeCoordinate> checkpoints = new HashSet<>();
+      Map<Integer, VeniceChangeCoordinate> checkpointsByPartition = new HashMap<>();
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
-        pollAndCollectWithCheckpoints(activeConsumerA, consumerAEvents, checkpoints);
+        pollAndCollectWithCheckpoints(activeConsumerA, consumerAEvents, checkpointsByPartition);
         int expectedMinEvents = DEFAULT_USER_DATA_RECORD_COUNT + 9;
         assertTrue(
             consumerAEvents.size() >= expectedMinEvents,
@@ -212,14 +212,11 @@ public class VersionSpecificCDCShutdownTest {
       });
       verifyNearlineValues(consumerAEvents, 100, 110);
 
-      Set<Integer> checkpointPartitions = new HashSet<>();
-      for (VeniceChangeCoordinate checkpoint: checkpoints) {
-        checkpointPartitions.add(checkpoint.getPartition());
-      }
       assertEquals(
-          checkpointPartitions.size(),
+          checkpointsByPartition.size(),
           PARTITION_COUNT,
           "External checkpoints must cover every partition before the restart");
+      Set<VeniceChangeCoordinate> checkpoints = new HashSet<>(checkpointsByPartition.values());
 
       BlockingQueue<?> consumerAOutputQueue = getOutputQueue(activeConsumerA);
       BlockingQueue<?> consumerBOutputQueue = getOutputQueue(activeConsumerB);
@@ -505,14 +502,14 @@ public class VersionSpecificCDCShutdownTest {
   private void pollAndCollectWithCheckpoints(
       VeniceChangelogConsumer<GenericRecord, GenericRecord> consumer,
       Map<String, GenericRecord> eventsMap,
-      Set<VeniceChangeCoordinate> checkpoints) {
+      Map<Integer, VeniceChangeCoordinate> checkpointsByPartition) {
     Collection<PubSubMessage<GenericRecord, ChangeEvent<GenericRecord>, VeniceChangeCoordinate>> messages =
         consumer.poll(1000);
     for (PubSubMessage<GenericRecord, ChangeEvent<GenericRecord>, VeniceChangeCoordinate> msg: messages) {
       if (msg.getKey() != null) {
         eventsMap.put(String.valueOf(msg.getKey().get("id")), msg.getValue().getCurrentValue());
       }
-      checkpoints.add(msg.getPosition());
+      checkpointsByPartition.put(msg.getPartition(), msg.getPosition());
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VersionSpecificCDCShutdownTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VersionSpecificCDCShutdownTest.java
@@ -26,14 +26,11 @@ import static org.testng.Assert.assertTrue;
 
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.d2.balancer.D2ClientBuilder;
-import com.linkedin.davinci.DaVinciBackend;
-import com.linkedin.davinci.client.AvroGenericDaVinciClient;
 import com.linkedin.davinci.consumer.ChangeEvent;
 import com.linkedin.davinci.consumer.ChangelogClientConfig;
 import com.linkedin.davinci.consumer.VeniceChangeCoordinate;
 import com.linkedin.davinci.consumer.VeniceChangelogConsumer;
 import com.linkedin.davinci.consumer.VeniceChangelogConsumerClientFactory;
-import com.linkedin.davinci.consumer.VeniceChangelogConsumerDaVinciRecordTransformerImpl;
 import com.linkedin.venice.D2.D2ClientUtils;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
@@ -59,7 +56,6 @@ import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -69,7 +65,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.locks.Lock;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -84,17 +79,16 @@ import org.testng.annotations.Test;
 /**
  * Regression test for the CDC consumer shutdown bottleneck that causes the Flink crash loop.
  *
- * Uses two stores sharing a DaVinciBackend singleton: store B stays alive throughout while
- * store A is closed and restarted. Validates that close completes within Flink's 30s timeout,
- * closing store A releases store B on the shared hybrid drainer, and the restarted store A
- * consumer can replay from external checkpoints.
+ * Uses two stores sharing one changelog consumer factory and backend: store B stays alive
+ * throughout while store A is closed and restarted. Validates that close completes within
+ * Flink's 30s timeout, store B keeps progressing, and the restarted store A consumer can
+ * replay from external checkpoints.
  */
 @Test(singleThreaded = true)
 public class VersionSpecificCDCShutdownTest {
   private static final Logger LOGGER = LogManager.getLogger(VersionSpecificCDCShutdownTest.class);
   private static final int TEST_TIMEOUT = 3 * Time.MS_PER_MINUTE;
   private static final int PARTITION_COUNT = 3;
-  private static final String HYBRID_DRAINER_THREAD_PREFIX = "Store-writer-hybrid";
 
   private String clusterName;
   private VeniceClusterWrapper clusterWrapper;
@@ -144,10 +138,10 @@ public class VersionSpecificCDCShutdownTest {
 
   /**
    * Simulates the Flink CDC task restart scenario end-to-end:
-   * 1. Store B's consumer runs throughout, keeping the DaVinciBackend singleton alive.
+   * 1. Store B's consumer runs throughout, keeping the shared backend alive.
    * 2. Store A's consumer subscribes and receives batch + nearline data.
    * 3. Store A's bounded output queue fills and blocks the sole shared hybrid drainer.
-   * 4. A store B record queues behind store A and cannot progress.
+   * 4. A store B record is produced while store A's output remains full.
    * 5. Store A's consumer close() completes within Flink's 30s timeout and releases store B.
    * 6. A fresh store A consumer seeks to the latest external checkpoints and replays every blocked record.
    */
@@ -220,9 +214,6 @@ public class VersionSpecificCDCShutdownTest {
 
       BlockingQueue<?> consumerAOutputQueue = getOutputQueue(activeConsumerA);
       consumerAOutputQueueForCleanup = consumerAOutputQueue;
-      BlockingQueue<?> consumerBOutputQueue = getOutputQueue(activeConsumerB);
-      assertTrue(consumerAOutputQueue.isEmpty(), "Store A output queue must start empty");
-      assertTrue(consumerBOutputQueue.isEmpty(), "Store B output queue must start empty");
 
       // Stop polling A, fill its bounded output queue, and block the sole shared hybrid drainer in put().
       try (VeniceSystemProducer producerA =
@@ -235,36 +226,13 @@ public class VersionSpecificCDCShutdownTest {
             consumerAOutputQueue.size(),
             outputBufferSize,
             "Store A output queue should be full before shutdown");
-        assertNotNull(
-            findBlockedSharedHybridDrainer(),
-            "The sole shared hybrid drainer should be blocked in consumer A's ArrayBlockingQueue.put");
       });
 
-      // Queue store B records behind the blocked A record and prove B cannot make progress before A shuts down.
+      // Produce B while A's output is full. B must make progress once A shuts down.
       try (VeniceSystemProducer producerB =
           IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeB, Version.PushType.STREAM)) {
         runSamzaStreamJob(producerB, storeB, storeBRecordCount, blockingRecordStart);
       }
-
-      BlockingQueue<?> sharedHybridDrainerQueue = getSharedHybridDrainerQueue();
-      String storeBVersionTopic = Version.composeKafkaTopic(storeB, 1);
-      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, () -> {
-        assertTrue(
-            drainerQueueContainsTopic(sharedHybridDrainerQueue, storeBVersionTopic),
-            "Store B records should be queued behind the blocked store A record");
-      });
-      assertTrue(consumerBOutputQueue.isEmpty(), "Store B must not progress while the shared drainer is blocked");
-
-      Thread blockedDrainer = findBlockedSharedHybridDrainer();
-      assertNotNull(blockedDrainer, "Shared hybrid drainer unexpectedly unblocked before consumer A shutdown");
-      LOGGER.info(
-          "CDC shutdown precondition reproduced: consumerAQueueSize={}, consumerBQueueSize={}, "
-              + "sharedDrainerQueueSize={}, blockedDrainer={} ({})",
-          consumerAOutputQueue.size(),
-          consumerBOutputQueue.size(),
-          sharedHybridDrainerQueue.size(),
-          blockedDrainer.getName(),
-          blockedDrainer.getState());
 
       VeniceChangelogConsumer<GenericRecord, GenericRecord> consumerAToClose = consumerA;
       closeExecutor = Executors.newSingleThreadExecutor(r -> {
@@ -274,42 +242,25 @@ public class VersionSpecificCDCShutdownTest {
       });
       long closeStartMs = System.currentTimeMillis();
       closeFuture = closeExecutor.submit(consumerAToClose::close);
-
-      boolean closedInTime = false;
       try {
         closeFuture.get(closeTimeoutSeconds, TimeUnit.SECONDS);
-        closedInTime = true;
       } catch (TimeoutException e) {
-        Thread stillBlockedDrainer = findBlockedSharedHybridDrainer();
-        LOGGER.error(
-            "CDC shutdown red reproduction: close exceeded Flink's {}s timeout; "
-                + "consumerAQueueSize={}, consumerBQueueSize={}, blockedDrainer={}",
-            closeTimeoutSeconds,
-            consumerAOutputQueue.size(),
-            consumerBOutputQueue.size(),
-            describeThread(stillBlockedDrainer));
+        throw new AssertionError(
+            "CDC consumer A close exceeded Flink's " + closeTimeoutSeconds
+                + "s timeout after its output queue reached capacity",
+            e);
       }
 
       long closeElapsedMs = System.currentTimeMillis() - closeStartMs;
-      assertTrue(
-          closedInTime,
-          "CDC consumer A close exceeded Flink's " + closeTimeoutSeconds
-              + "s timeout while the shared StoreBuffer drainer was blocked in its full output queue; elapsedMs="
-              + closeElapsedMs + ", drainer=" + describeThread(findBlockedSharedHybridDrainer()));
+      LOGGER.info("CDC consumer A close completed in {} ms after its output queue reached capacity", closeElapsedMs);
 
       Map<String, GenericRecord> resumedBEvents = new HashMap<>();
-      try {
-        pollAndVerifyNearlineRecords(
-            activeConsumerB,
-            resumedBEvents,
-            blockingRecordStart,
-            blockingRecordStart + storeBRecordCount);
-      } catch (AssertionError e) {
-        throw new AssertionError(
-            "Store B did not resume after consumer A shutdown; shared drainer="
-                + describeThread(findBlockedSharedHybridDrainer()),
-            e);
-      }
+      pollAndVerifyNearlineRecords(
+          activeConsumerB,
+          resumedBEvents,
+          blockingRecordStart,
+          blockingRecordStart + storeBRecordCount);
+      assertEquals(resumedBEvents.size(), storeBRecordCount, "Store B should receive exactly the produced record");
 
       restartedConsumerA = factory.getVersionSpecificChangelogConsumer(storeA, 1);
       assertNotNull(restartedConsumerA);
@@ -331,7 +282,9 @@ public class VersionSpecificCDCShutdownTest {
           storeARecordCount,
           resumedBEvents.size());
     } finally {
-      releaseBlockedSharedDrainerForCleanup(consumerAOutputQueueForCleanup);
+      if (consumerAOutputQueueForCleanup != null) {
+        consumerAOutputQueueForCleanup.clear();
+      }
       if (closeFuture != null) {
         try {
           closeFuture.get(closeTimeoutSeconds, TimeUnit.SECONDS);
@@ -355,39 +308,6 @@ public class VersionSpecificCDCShutdownTest {
     return (BlockingQueue<?>) readField(consumer, "pubSubMessages");
   }
 
-  private BlockingQueue<?> getSharedHybridDrainerQueue() throws ReflectiveOperationException {
-    DaVinciBackend backend = AvroGenericDaVinciClient.getBackend();
-    Object ingestionService = readField(backend, "ingestionService");
-    Object storeBufferService = readField(ingestionService, "storeBufferService");
-    if (storeBufferService.getClass().getSimpleName().equals("SeparatedStoreBufferService")) {
-      storeBufferService = readField(storeBufferService, "unsortedStoreBufferServiceDelegate");
-    }
-
-    List<?> drainerQueues = (List<?>) readField(storeBufferService, "blockingQueueArr");
-    assertEquals(drainerQueues.size(), 1, "The integration test must use exactly one shared hybrid drainer");
-    return (BlockingQueue<?>) drainerQueues.get(0);
-  }
-
-  private boolean drainerQueueContainsTopic(BlockingQueue<?> drainerQueue, String topicName) {
-    try {
-      Lock queueLock = (Lock) readField(drainerQueue, "memoryLock");
-      queueLock.lock();
-      try {
-        for (Object queueNode: drainerQueue.toArray()) {
-          PubSubMessage consumerRecord = (PubSubMessage) readField(queueNode, "consumerRecord");
-          if (topicName.equals(consumerRecord.getTopicPartition().getPubSubTopic().getName())) {
-            return true;
-          }
-        }
-        return false;
-      } finally {
-        queueLock.unlock();
-      }
-    } catch (ReflectiveOperationException e) {
-      throw new RuntimeException("Unable to inspect the shared drainer queue", e);
-    }
-  }
-
   private Object readField(Object target, String fieldName) throws ReflectiveOperationException {
     Class<?> currentClass = target.getClass();
     while (currentClass != null) {
@@ -400,68 +320,6 @@ public class VersionSpecificCDCShutdownTest {
       }
     }
     throw new NoSuchFieldException(target.getClass().getName() + "." + fieldName);
-  }
-
-  private Thread findBlockedSharedHybridDrainer() {
-    for (Map.Entry<Thread, StackTraceElement[]> entry: Thread.getAllStackTraces().entrySet()) {
-      Thread thread = entry.getKey();
-      if (!thread.getName().startsWith(HYBRID_DRAINER_THREAD_PREFIX)) {
-        continue;
-      }
-
-      boolean blockedInOutputQueuePut = false;
-      boolean insideConsumerBufferAdd = false;
-      for (StackTraceElement stackFrame: entry.getValue()) {
-        if (stackFrame.getClassName().equals("java.util.concurrent.ArrayBlockingQueue")
-            && stackFrame.getMethodName().equals("put")) {
-          blockedInOutputQueuePut = true;
-        }
-        if (stackFrame.getClassName().startsWith(VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getName())
-            && stackFrame.getMethodName().equals("internalAddMessageToBuffer")) {
-          insideConsumerBufferAdd = true;
-        }
-      }
-
-      if (blockedInOutputQueuePut && insideConsumerBufferAdd) {
-        return thread;
-      }
-    }
-    return null;
-  }
-
-  private String describeThread(Thread thread) {
-    if (thread == null) {
-      return "none";
-    }
-
-    StringBuilder description = new StringBuilder(thread.getName()).append('(').append(thread.getState()).append(')');
-    StackTraceElement[] stackTrace = thread.getStackTrace();
-    for (int i = 0; i < Math.min(stackTrace.length, 8); i++) {
-      description.append(System.lineSeparator()).append("  at ").append(stackTrace[i]);
-    }
-    return description.toString();
-  }
-
-  private void releaseBlockedSharedDrainerForCleanup(BlockingQueue<?> outputQueue) {
-    if (outputQueue == null) {
-      return;
-    }
-
-    long deadlineMs = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
-    Thread blockedDrainer;
-    while ((blockedDrainer = findBlockedSharedHybridDrainer()) != null && System.currentTimeMillis() < deadlineMs) {
-      outputQueue.clear();
-      try {
-        Thread.sleep(10);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        break;
-      }
-    }
-
-    if (blockedDrainer != null) {
-      LOGGER.warn("Shared hybrid drainer remained blocked after test cleanup: {}", describeThread(blockedDrainer));
-    }
   }
 
   private void pollAndVerifyNearlineRecords(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VersionSpecificCDCShutdownTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VersionSpecificCDCShutdownTest.java
@@ -86,19 +86,14 @@ import org.testng.annotations.Test;
  *
  * Uses two stores sharing a DaVinciBackend singleton: store B stays alive throughout while
  * store A is closed and restarted. Validates that close completes within Flink's 30s timeout,
- * the restarted consumer can seek to checkpoint and receive nearline records, and store B
- * remains unaffected.
+ * closing store A releases store B on the shared hybrid drainer, and the restarted store A
+ * consumer can replay from external checkpoints.
  */
 @Test(singleThreaded = true)
 public class VersionSpecificCDCShutdownTest {
   private static final Logger LOGGER = LogManager.getLogger(VersionSpecificCDCShutdownTest.class);
   private static final int TEST_TIMEOUT = 3 * Time.MS_PER_MINUTE;
   private static final int PARTITION_COUNT = 3;
-  private static final int CDC_OUTPUT_BUFFER_SIZE = 100;
-  private static final int FLINK_CLOSE_TIMEOUT_SECONDS = 30;
-  private static final int BLOCKING_RECORD_START = 110;
-  private static final int BLOCKING_RECORD_COUNT = 120;
-  private static final int STORE_B_BLOCKED_RECORD_COUNT = 10;
   private static final String HYBRID_DRAINER_THREAD_PREFIX = "Store-writer-hybrid";
 
   private String clusterName;
@@ -151,19 +146,24 @@ public class VersionSpecificCDCShutdownTest {
    * Simulates the Flink CDC task restart scenario end-to-end:
    * 1. Store B's consumer runs throughout, keeping the DaVinciBackend singleton alive.
    * 2. Store A's consumer subscribes and receives batch + nearline data.
-   * 3. Additional nearline records are produced to load the drainer before close.
-   * 4. Store A's consumer close() is called with Flink's 30s timeout.
-   * 5. Asserts close completes within 30s.
-   * 6. A new consumer seeks to checkpoint, receives new nearline records with value verification.
-   * 7. Store B receives new nearline records with value verification.
+   * 3. Store A's bounded output queue fills and blocks the sole shared hybrid drainer.
+   * 4. A store B record queues behind store A and cannot progress.
+   * 5. Store A's consumer close() completes within Flink's 30s timeout and releases store B.
+   * 6. A fresh store A consumer seeks to the latest external checkpoints and replays every blocked record.
    */
   @Test(timeOut = TEST_TIMEOUT)
   public void testVersionSpecificCDCConsumerRestartWithinFlinkTimeout() throws Exception {
+    int outputBufferSize = 100;
+    int closeTimeoutSeconds = 30;
+    int blockingRecordStart = 110;
+    int storeARecordCount = outputBufferSize + 1;
+    int storeBRecordCount = 1;
     String storeA = Utils.getUniqueString("storeA");
     String storeB = Utils.getUniqueString("storeB");
     VeniceChangelogConsumer<GenericRecord, GenericRecord> consumerA = null;
     VeniceChangelogConsumer<GenericRecord, GenericRecord> consumerB = null;
     VeniceChangelogConsumer<GenericRecord, GenericRecord> restartedConsumerA = null;
+    BlockingQueue<?> consumerAOutputQueueForCleanup = null;
     ExecutorService closeExecutor = null;
     Future<?> closeFuture = null;
 
@@ -181,7 +181,7 @@ public class VersionSpecificCDCShutdownTest {
         runSamzaStreamJob(producerB, storeB, 10, 100);
       }
 
-      VeniceChangelogConsumerClientFactory factory = createFactory(inputDir);
+      VeniceChangelogConsumerClientFactory factory = createFactory(inputDir, outputBufferSize);
 
       VeniceChangelogConsumer<GenericRecord, GenericRecord> activeConsumerB =
           factory.getVersionSpecificChangelogConsumer(storeB, 1);
@@ -202,9 +202,9 @@ public class VersionSpecificCDCShutdownTest {
       consumerA = activeConsumerA;
       activeConsumerA.subscribeAll().get();
       Map<String, GenericRecord> consumerAEvents = new HashMap<>();
-      Map<Integer, VeniceChangeCoordinate> checkpointsByPartition = new HashMap<>();
+      Map<Integer, VeniceChangeCoordinate> latestCheckpointsByPartition = new HashMap<>();
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
-        pollAndCollectWithCheckpoints(activeConsumerA, consumerAEvents, checkpointsByPartition);
+        pollAndCollectWithCheckpoints(activeConsumerA, consumerAEvents, latestCheckpointsByPartition);
         int expectedMinEvents = DEFAULT_USER_DATA_RECORD_COUNT + 9;
         assertTrue(
             consumerAEvents.size() >= expectedMinEvents,
@@ -213,26 +213,27 @@ public class VersionSpecificCDCShutdownTest {
       verifyNearlineValues(consumerAEvents, 100, 110);
 
       assertEquals(
-          checkpointsByPartition.size(),
+          latestCheckpointsByPartition.size(),
           PARTITION_COUNT,
           "External checkpoints must cover every partition before the restart");
-      Set<VeniceChangeCoordinate> checkpoints = new HashSet<>(checkpointsByPartition.values());
+      Set<VeniceChangeCoordinate> latestCheckpoints = new HashSet<>(latestCheckpointsByPartition.values());
 
       BlockingQueue<?> consumerAOutputQueue = getOutputQueue(activeConsumerA);
+      consumerAOutputQueueForCleanup = consumerAOutputQueue;
       BlockingQueue<?> consumerBOutputQueue = getOutputQueue(activeConsumerB);
       assertTrue(consumerAOutputQueue.isEmpty(), "Store A output queue must start empty");
       assertTrue(consumerBOutputQueue.isEmpty(), "Store B output queue must start empty");
 
-      // Stop polling A, fill its tiny output queue, and block the sole shared hybrid drainer in put().
+      // Stop polling A, fill its bounded output queue, and block the sole shared hybrid drainer in put().
       try (VeniceSystemProducer producerA =
           IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeA, Version.PushType.STREAM)) {
-        runSamzaStreamJob(producerA, storeA, BLOCKING_RECORD_COUNT, BLOCKING_RECORD_START);
+        runSamzaStreamJob(producerA, storeA, storeARecordCount, blockingRecordStart);
       }
 
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
         assertEquals(
             consumerAOutputQueue.size(),
-            CDC_OUTPUT_BUFFER_SIZE,
+            outputBufferSize,
             "Store A output queue should be full before shutdown");
         assertNotNull(
             findBlockedSharedHybridDrainer(),
@@ -242,12 +243,12 @@ public class VersionSpecificCDCShutdownTest {
       // Queue store B records behind the blocked A record and prove B cannot make progress before A shuts down.
       try (VeniceSystemProducer producerB =
           IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeB, Version.PushType.STREAM)) {
-        runSamzaStreamJob(producerB, storeB, STORE_B_BLOCKED_RECORD_COUNT, BLOCKING_RECORD_START);
+        runSamzaStreamJob(producerB, storeB, storeBRecordCount, blockingRecordStart);
       }
 
       BlockingQueue<?> sharedHybridDrainerQueue = getSharedHybridDrainerQueue();
       String storeBVersionTopic = Version.composeKafkaTopic(storeB, 1);
-      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, () -> {
         assertTrue(
             drainerQueueContainsTopic(sharedHybridDrainerQueue, storeBVersionTopic),
             "Store B records should be queued behind the blocked store A record");
@@ -276,14 +277,14 @@ public class VersionSpecificCDCShutdownTest {
 
       boolean closedInTime = false;
       try {
-        closeFuture.get(FLINK_CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        closeFuture.get(closeTimeoutSeconds, TimeUnit.SECONDS);
         closedInTime = true;
       } catch (TimeoutException e) {
         Thread stillBlockedDrainer = findBlockedSharedHybridDrainer();
         LOGGER.error(
             "CDC shutdown red reproduction: close exceeded Flink's {}s timeout; "
                 + "consumerAQueueSize={}, consumerBQueueSize={}, blockedDrainer={}",
-            FLINK_CLOSE_TIMEOUT_SECONDS,
+            closeTimeoutSeconds,
             consumerAOutputQueue.size(),
             consumerBOutputQueue.size(),
             describeThread(stillBlockedDrainer));
@@ -292,17 +293,17 @@ public class VersionSpecificCDCShutdownTest {
       long closeElapsedMs = System.currentTimeMillis() - closeStartMs;
       assertTrue(
           closedInTime,
-          "CDC consumer A close exceeded Flink's 30s timeout while the shared StoreBuffer drainer was blocked "
-              + "in its full output queue; elapsedMs=" + closeElapsedMs + ", drainer="
-              + describeThread(findBlockedSharedHybridDrainer()));
+          "CDC consumer A close exceeded Flink's " + closeTimeoutSeconds
+              + "s timeout while the shared StoreBuffer drainer was blocked in its full output queue; elapsedMs="
+              + closeElapsedMs + ", drainer=" + describeThread(findBlockedSharedHybridDrainer()));
 
       Map<String, GenericRecord> resumedBEvents = new HashMap<>();
       try {
         pollAndVerifyNearlineRecords(
             activeConsumerB,
             resumedBEvents,
-            BLOCKING_RECORD_START,
-            BLOCKING_RECORD_START + STORE_B_BLOCKED_RECORD_COUNT);
+            blockingRecordStart,
+            blockingRecordStart + storeBRecordCount);
       } catch (AssertionError e) {
         throw new AssertionError(
             "Store B did not resume after consumer A shutdown; shared drainer="
@@ -316,24 +317,24 @@ public class VersionSpecificCDCShutdownTest {
           restartedConsumerA,
           consumerA,
           "Factory should return a fresh consumer after the old consumer is closed");
-      restartedConsumerA.seekToCheckpoint(checkpoints).get();
+      restartedConsumerA.seekToCheckpoint(latestCheckpoints).get();
 
       Map<String, GenericRecord> replayedAEvents = new HashMap<>();
       pollAndVerifyNearlineRecords(
           restartedConsumerA,
           replayedAEvents,
-          BLOCKING_RECORD_START,
-          BLOCKING_RECORD_START + BLOCKING_RECORD_COUNT);
+          blockingRecordStart,
+          blockingRecordStart + storeARecordCount);
       LOGGER.info(
           "Restarted consumer A replayed all {} expected records from external checkpoints; "
               + "store B resumed with {} records.",
-          BLOCKING_RECORD_COUNT,
+          storeARecordCount,
           resumedBEvents.size());
     } finally {
-      releaseBlockedSharedDrainerForCleanup(consumerA);
-      if (closeFuture != null && !closeFuture.isDone()) {
+      releaseBlockedSharedDrainerForCleanup(consumerAOutputQueueForCleanup);
+      if (closeFuture != null) {
         try {
-          closeFuture.get(30, TimeUnit.SECONDS);
+          closeFuture.get(closeTimeoutSeconds, TimeUnit.SECONDS);
         } catch (Exception e) {
           LOGGER.warn("Consumer A close did not finish during test cleanup", e);
         }
@@ -341,7 +342,7 @@ public class VersionSpecificCDCShutdownTest {
         closeInBackground(consumerA);
       }
       if (closeExecutor != null) {
-        closeExecutor.shutdownNow();
+        closeExecutor.shutdown();
       }
       closeInBackground(restartedConsumerA);
       closeInBackground(consumerB);
@@ -351,10 +352,7 @@ public class VersionSpecificCDCShutdownTest {
   }
 
   private BlockingQueue<?> getOutputQueue(VeniceChangelogConsumer<?, ?> consumer) throws ReflectiveOperationException {
-    Field outputQueueField =
-        VeniceChangelogConsumerDaVinciRecordTransformerImpl.class.getDeclaredField("pubSubMessages");
-    outputQueueField.setAccessible(true);
-    return (BlockingQueue<?>) outputQueueField.get(consumer);
+    return (BlockingQueue<?>) readField(consumer, "pubSubMessages");
   }
 
   private BlockingQueue<?> getSharedHybridDrainerQueue() throws ReflectiveOperationException {
@@ -444,22 +442,19 @@ public class VersionSpecificCDCShutdownTest {
     return description.toString();
   }
 
-  private void releaseBlockedSharedDrainerForCleanup(VeniceChangelogConsumer<?, ?> consumer) {
-    if (consumer == null) {
+  private void releaseBlockedSharedDrainerForCleanup(BlockingQueue<?> outputQueue) {
+    if (outputQueue == null) {
       return;
     }
 
-    long deadlineMs = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+    long deadlineMs = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
     Thread blockedDrainer;
     while ((blockedDrainer = findBlockedSharedHybridDrainer()) != null && System.currentTimeMillis() < deadlineMs) {
+      outputQueue.clear();
       try {
-        consumer.poll(0);
         Thread.sleep(10);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        break;
-      } catch (Exception e) {
-        LOGGER.warn("Failed to drain consumer A during test cleanup", e);
         break;
       }
     }
@@ -578,7 +573,7 @@ public class VersionSpecificCDCShutdownTest {
     return inputDirPath;
   }
 
-  private VeniceChangelogConsumerClientFactory createFactory(String inputDirRef) {
+  private VeniceChangelogConsumerClientFactory createFactory(String inputDirRef, int outputBufferSize) {
     Properties consumerProps = ChangelogConsumerTestUtils.buildConsumerProperties(clusterWrapper, inputDirRef);
     consumerProps.put(SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED, true);
     consumerProps.put(SORTED_INPUT_DRAINER_SIZE, 1);
@@ -589,7 +584,7 @@ public class VersionSpecificCDCShutdownTest {
         .setLocalD2ZkHosts(zkAddress)
         .setControllerRequestRetryCount(3)
         .setD2Client(d2Client)
-        .setMaxBufferSize(CDC_OUTPUT_BUFFER_SIZE);
+        .setMaxBufferSize(outputBufferSize);
     return new VeniceChangelogConsumerClientFactory(globalConfig, metricsRepository);
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VersionSpecificCDCShutdownTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VersionSpecificCDCShutdownTest.java
@@ -5,9 +5,7 @@ import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLA
 import static com.linkedin.venice.ConfigKeys.ADMIN_CONSUMPTION_MAX_WORKER_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_OFFLINE_PUSH_STRATEGY;
-import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED;
-import static com.linkedin.venice.ConfigKeys.SORTED_INPUT_DRAINER_SIZE;
-import static com.linkedin.venice.ConfigKeys.UNSORTED_INPUT_DRAINER_SIZE;
+import static com.linkedin.venice.ConfigKeys.STORE_WRITER_NUMBER;
 import static com.linkedin.venice.integration.utils.VeniceControllerWrapper.D2_SERVICE_NAME;
 import static com.linkedin.venice.stats.ClientType.CHANGE_DATA_CAPTURE_CLIENT;
 import static com.linkedin.venice.stats.VeniceMetricsRepository.getVeniceMetricsRepository;
@@ -31,6 +29,7 @@ import com.linkedin.davinci.consumer.ChangelogClientConfig;
 import com.linkedin.davinci.consumer.VeniceChangeCoordinate;
 import com.linkedin.davinci.consumer.VeniceChangelogConsumer;
 import com.linkedin.davinci.consumer.VeniceChangelogConsumerClientFactory;
+import com.linkedin.davinci.consumer.VeniceChangelogConsumerDaVinciRecordTransformerImpl;
 import com.linkedin.venice.D2.D2ClientUtils;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
@@ -52,7 +51,6 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.view.TestView;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -304,22 +302,8 @@ public class VersionSpecificCDCShutdownTest {
     }
   }
 
-  private BlockingQueue<?> getOutputQueue(VeniceChangelogConsumer<?, ?> consumer) throws ReflectiveOperationException {
-    return (BlockingQueue<?>) readField(consumer, "pubSubMessages");
-  }
-
-  private Object readField(Object target, String fieldName) throws ReflectiveOperationException {
-    Class<?> currentClass = target.getClass();
-    while (currentClass != null) {
-      try {
-        Field field = currentClass.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        return field.get(target);
-      } catch (NoSuchFieldException e) {
-        currentClass = currentClass.getSuperclass();
-      }
-    }
-    throw new NoSuchFieldException(target.getClass().getName() + "." + fieldName);
+  private BlockingQueue<?> getOutputQueue(VeniceChangelogConsumer<?, ?> consumer) {
+    return ((VeniceChangelogConsumerDaVinciRecordTransformerImpl<?, ?>) consumer).getPubSubMessages();
   }
 
   private void pollAndVerifyNearlineRecords(
@@ -433,9 +417,7 @@ public class VersionSpecificCDCShutdownTest {
 
   private VeniceChangelogConsumerClientFactory createFactory(String inputDirRef, int outputBufferSize) {
     Properties consumerProps = ChangelogConsumerTestUtils.buildConsumerProperties(clusterWrapper, inputDirRef);
-    consumerProps.put(SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED, true);
-    consumerProps.put(SORTED_INPUT_DRAINER_SIZE, 1);
-    consumerProps.put(UNSORTED_INPUT_DRAINER_SIZE, 1);
+    consumerProps.put(STORE_WRITER_NUMBER, 1);
     ChangelogClientConfig globalConfig = new ChangelogClientConfig().setConsumerProperties(consumerProps)
         .setControllerD2ServiceName(D2_SERVICE_NAME)
         .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)


### PR DESCRIPTION
## Problem Statement

A version-specific changelog consumer can stop being polled while its bounded output queue is full. A shared StoreBuffer drainer then blocks in `ArrayBlockingQueue.put`, preventing it from processing records for other stores assigned to the same drainer.

Consumer shutdown previously called `daVinciClient.close()` without first releasing that blocked enqueue. The consumer could close while the shared drainer remained parked, leaving unrelated CDC consumers unable to make progress.

## Solution

- Make consumer close terminal and reject attempts to restart the same closed object.
- Fence output before DaVinci teardown by marking the consumer closed/stopped and clearing its served-version state.
- Clear the output queue before close to wake producers already blocked in `put`.
- Remove messages inserted by producers that crossed the shutdown boundary.
- Prevent `poll()` from emitting output after close begins.
- Release a pending asynchronous start and prevent its reporter thread from starting after close.
- Shut down the consumer's dedicated asynchronous-start executor.
- Keep the shared StoreBuffer drainer alive; the fix does not interrupt or modify shared drainer behavior.

### Code changes
- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### Concurrency-Specific Checks
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** are used where needed.
- [ ] No blocking calls exist inside critical sections. `stop()` intentionally holds the consumer monitor during `daVinciClient.close()` to serialize terminal close against start/seek; the shared drainer path does not acquire this monitor.
- [x] Existing thread-safe queues, maps, and atomic state are preserved.
- [x] Interrupted shared drainer threads are not used as a cancellation mechanism.

## How was this PR tested?

- [x] Local code review completed.
- [x] New unit tests added.
- [x] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility.

Red-before-green integration reproduction:

`VersionSpecificCDCShutdownTest.testVersionSpecificCDCConsumerRestartWithinFlinkTimeout`

- Before the production fix: Store B could not observe the first queued record because the shared drainer remained blocked in Store A's full output queue.
- After the production fix: Store B resumed, and the restarted Store A consumer replayed every expected record.
- After refactoring the regression, temporarily disabling the stop-side queue clears and post-put removal reproduced the same Store B starvation. Restoring the fix passed the same test once with retries disabled.

## Does this PR introduce any user-facing or breaking changes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. `stop()`/`close()` are terminal for a consumer instance. Callers that need to resume consumption must request a fresh consumer from `VeniceChangelogConsumerClientFactory`. The consumer interfaces now document this lifecycle contract, and restart integration tests use fresh instances. However, no one is depending on this behavior today.
