### PR TITLE
[controller] Delete Stranded PUSHED Versions at Start-of-Push with a Cross-Fabric Guardrail

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStrandedVersionCleanupAtStartOfPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStrandedVersionCleanupAtStartOfPush.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 import org.testng.annotations.Test;
 
 
@@ -105,11 +106,13 @@ public class TestStrandedVersionCleanupAtStartOfPush extends AbstractMultiRegion
   @Test(timeOut = TEST_TIMEOUT)
   public void testStrandedRolledBackVersionIsReapedAtStartOfNextPush() throws InterruptedException {
     String storeName = Utils.getUniqueString("strandedVersionCleanup");
-    Map<String, ControllerClient> childControllerClients = new LinkedHashMap<>();
-    try (ControllerClient parentControllerClient =
-        new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl())) {
+    // Keyed by region label, with the parent first so it is the first region reported on assertion failures.
+    Map<String, ControllerClient> controllerClients = new LinkedHashMap<>();
+    try {
+      ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl());
+      controllerClients.put(PARENT, parentControllerClient);
       for (int i = 0; i < childDatacenters.size(); i++) {
-        childControllerClients.put(
+        controllerClients.put(
             multiRegionMultiClusterWrapper.getChildRegionNames().get(i),
             new ControllerClient(CLUSTER_NAME, childDatacenters.get(i).getControllerConnectString()));
       }
@@ -130,13 +133,10 @@ public class TestStrandedVersionCleanupAtStartOfPush extends AbstractMultiRegion
       // The parent aggregates the rollback from its child regions asynchronously, so wait until it reports
       // ROLLED_BACK — only then is v2 a cleanup candidate there. The child regions must still hold v2 as
       // ROLLED_BACK while serving v1, which is the cross-fabric evidence the parent acts on.
-      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
-        assertRolledBackToVersionOne(getStore(parentControllerClient, storeName, PARENT), PARENT);
-        childControllerClients.forEach(
-            (regionName, childControllerClient) -> assertRolledBackToVersionOne(
-                getStore(childControllerClient, storeName, regionName),
-                regionName));
-      });
+      assertEverywhere(
+          controllerClients,
+          storeName,
+          TestStrandedVersionCleanupAtStartOfPush::assertRolledBackToVersionOne);
 
       // The rollback-origin guard rejects a new push while v2 is within its retention window, so wait it
       // out before pushing v3. The buffer absorbs clock skew against the rollback's promote timestamp.
@@ -147,16 +147,28 @@ public class TestStrandedVersionCleanupAtStartOfPush extends AbstractMultiRegion
 
       // The delete is issued at start-of-push and propagates over the admin channel, so it can land after
       // the push itself completes.
-      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
-        assertStrandedVersionReaped(getStore(parentControllerClient, storeName, PARENT), PARENT);
-        childControllerClients.forEach(
-            (regionName, childControllerClient) -> assertStrandedVersionReaped(
-                getStore(childControllerClient, storeName, regionName),
-                regionName));
-      });
+      assertEverywhere(
+          controllerClients,
+          storeName,
+          TestStrandedVersionCleanupAtStartOfPush::assertStrandedVersionReaped);
     } finally {
-      childControllerClients.values().forEach(Utils::closeQuietlyWithErrorLogged);
+      controllerClients.values().forEach(Utils::closeQuietlyWithErrorLogged);
     }
+  }
+
+  /**
+   * Retries {@code assertion} against every region until they all agree or the wait expires. The assertion receives
+   * a region's view of the store along with the label naming that region.
+   */
+  private static void assertEverywhere(
+      Map<String, ControllerClient> controllerClients,
+      String storeName,
+      BiConsumer<StoreInfo, String> assertion) {
+    TestUtils.waitForNonDeterministicAssertion(
+        60,
+        TimeUnit.SECONDS,
+        () -> controllerClients.forEach(
+            (label, controllerClient) -> assertion.accept(getStore(controllerClient, storeName, label), label)));
   }
 
   private static void assertRolledBackToVersionOne(StoreInfo store, String label) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStrandedVersionCleanupAtStartOfPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStrandedVersionCleanupAtStartOfPush.java
@@ -1,0 +1,197 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_BACKUP_VERSION_RETENTION_BASED_CLEANUP_ENABLED;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_EARLY_DELETE_BACKUP_ENABLED;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_ROLLED_BACK_VERSION_RETENTION_MS;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
+import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
+import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS;
+import static com.linkedin.venice.utils.TestUtils.assertCommand;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+
+
+/**
+ * Integration test for {@code VeniceParentHelixAdmin#deleteStrandedNonCurrentVersions}, complementing the
+ * mock-based coverage of its cross-fabric decision matrix in {@code TestVeniceParentHelixAdmin}.
+ *
+ * <p>Scenario: v1 and v2 are pushed, then a rollback strands v2 — v1 serves again while v2 lingers as
+ * ROLLED_BACK in every fabric. The next push must reap v2 fleet-wide at start-of-push, without touching
+ * the healthy backup (v1) or the version being pushed (v3). Empty pushes drive this: they go through the
+ * same parent {@code incrementVersionIdempotent} path a data push does, minus the cost of a push job.
+ *
+ * <p>Two other mechanisms can independently delete a rolled-back version in a child region, and both are
+ * disabled here so the parent's DELETE_OLD_VERSION admin message is the only thing that can remove v2
+ * anywhere, making the assertions attributable to the code under test:
+ * <ul>
+ *   <li>{@code CONTROLLER_EARLY_DELETE_BACKUP_ENABLED} — the child's own start-of-push
+ *       {@code retireOldStoreVersions} sweep.</li>
+ *   <li>{@code CONTROLLER_BACKUP_VERSION_RETENTION_BASED_CLEANUP_ENABLED} — the child's background
+ *       {@code StoreBackupVersionCleanupService}.</li>
+ * </ul>
+ * A child also retires old versions once a push completes, but promoting v3 to current resets the retention
+ * clock that path keys off, so it leaves v2 alone here. On the parent, {@code cleanupHistoricalVersions}
+ * only trims above the user-store retention count (5), which this test stays under.
+ *
+ * <p>The rolled-back retention is shortened so the rollback-origin guard — which blocks a new push while a
+ * rolled-back version is within retention — lifts in time for the v3 push. It has to stay above zero,
+ * otherwise the push-completion sweep above becomes eligible to reap v2 on its own.
+ */
+public class TestStrandedVersionCleanupAtStartOfPush extends AbstractMultiRegionTest {
+  private static final int TEST_TIMEOUT = 180_000; // ms
+  private static final long ROLLED_BACK_RETENTION_MS = TimeUnit.SECONDS.toMillis(2);
+  private static final String PARENT = "parent";
+
+  @Override
+  protected int getNumberOfRegions() {
+    return 2;
+  }
+
+  @Override
+  protected int getNumberOfServers() {
+    return 1;
+  }
+
+  @Override
+  protected int getReplicationFactor() {
+    return 1;
+  }
+
+  @Override
+  protected Properties getExtraControllerProperties() {
+    Properties controllerProps = new Properties();
+    controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 1);
+    controllerProps.put(DEFAULT_PARTITION_SIZE, 10);
+    controllerProps
+        .setProperty(TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS, String.valueOf(Long.MAX_VALUE));
+    controllerProps.put(CONTROLLER_ROLLED_BACK_VERSION_RETENTION_MS, ROLLED_BACK_RETENTION_MS);
+    controllerProps.put(CONTROLLER_EARLY_DELETE_BACKUP_ENABLED, false);
+    controllerProps.put(CONTROLLER_BACKUP_VERSION_RETENTION_BASED_CLEANUP_ENABLED, false);
+    // This store is only ever inspected through the controllers, so skip materializing its system stores.
+    controllerProps.put(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, false);
+    controllerProps.put(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, false);
+    return controllerProps;
+  }
+
+  @Override
+  protected Properties getExtraServerProperties() {
+    Properties serverProps = new Properties();
+    // Every version pushed here waits out this delay in the non-source region before its leader can switch
+    // topics, and the test pushes three of them.
+    serverProps.put(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, 1L);
+    return serverProps;
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testStrandedRolledBackVersionIsReapedAtStartOfNextPush() throws InterruptedException {
+    String storeName = Utils.getUniqueString("strandedVersionCleanup");
+    Map<String, ControllerClient> childControllerClients = new LinkedHashMap<>();
+    try (ControllerClient parentControllerClient =
+        new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl())) {
+      for (int i = 0; i < childDatacenters.size(); i++) {
+        childControllerClients.put(
+            multiRegionMultiClusterWrapper.getChildRegionNames().get(i),
+            new ControllerClient(CLUSTER_NAME, childDatacenters.get(i).getControllerConnectString()));
+      }
+      assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+      assertCommand(
+          parentControllerClient.updateStore(
+              storeName,
+              new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)));
+
+      // Push v1 and v2 so the store has two versions to roll back between.
+      pushAndWaitForCompletion(parentControllerClient, storeName, 1);
+      pushAndWaitForCompletion(parentControllerClient, storeName, 2);
+
+      // Rollback strands v2: v1 becomes current again and v2 is left behind as ROLLED_BACK.
+      ControllerResponse rollbackResponse = parentControllerClient.rollbackToBackupVersion(storeName);
+      assertFalse(rollbackResponse.isError(), "rollback failed: " + rollbackResponse.getError());
+
+      // The parent aggregates the rollback from its child regions asynchronously, so wait until it reports
+      // ROLLED_BACK — only then is v2 a cleanup candidate there. The child regions must still hold v2 as
+      // ROLLED_BACK while serving v1, which is the cross-fabric evidence the parent acts on.
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        assertRolledBackToVersionOne(getStore(parentControllerClient, storeName, PARENT), PARENT);
+        childControllerClients.forEach(
+            (regionName, childControllerClient) -> assertRolledBackToVersionOne(
+                getStore(childControllerClient, storeName, regionName),
+                regionName));
+      });
+
+      // The rollback-origin guard rejects a new push while v2 is within its retention window, so wait it
+      // out before pushing v3. The buffer absorbs clock skew against the rollback's promote timestamp.
+      Thread.sleep(ROLLED_BACK_RETENTION_MS + TimeUnit.SECONDS.toMillis(1));
+
+      // The v3 push is what triggers the start-of-push cleanup on the parent.
+      pushAndWaitForCompletion(parentControllerClient, storeName, 3);
+
+      // The delete is issued at start-of-push and propagates over the admin channel, so it can land after
+      // the push itself completes.
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        assertStrandedVersionReaped(getStore(parentControllerClient, storeName, PARENT), PARENT);
+        childControllerClients.forEach(
+            (regionName, childControllerClient) -> assertStrandedVersionReaped(
+                getStore(childControllerClient, storeName, regionName),
+                regionName));
+      });
+    } finally {
+      childControllerClients.values().forEach(Utils::closeQuietlyWithErrorLogged);
+    }
+  }
+
+  private static void assertRolledBackToVersionOne(StoreInfo store, String label) {
+    assertTrue(
+        store.getVersion(2).isPresent() && store.getVersion(2).get().getStatus() == VersionStatus.ROLLED_BACK,
+        "Expected v2 to be ROLLED_BACK on " + label + " after rollback, got: " + store.getVersion(2));
+    assertEquals(store.getCurrentVersion(), 1, "Expected " + label + " to have rolled back to v1");
+  }
+
+  private static void assertStrandedVersionReaped(StoreInfo store, String label) {
+    assertFalse(
+        store.getVersion(2).isPresent(),
+        "Stranded v2 should have been deleted on " + label + " at the start of the v3 push, got: "
+            + store.getVersion(2));
+    // The cleanup must be narrow: the healthy backup and the freshly pushed version stay put.
+    assertTrue(store.getVersion(1).isPresent(), "Healthy backup v1 should not have been deleted on " + label);
+    assertTrue(store.getVersion(3).isPresent(), "v3 should exist on " + label + " after its push completed");
+    assertEquals(store.getCurrentVersion(), 3, "Expected " + label + " to be serving v3");
+  }
+
+  private static void pushAndWaitForCompletion(
+      ControllerClient parentControllerClient,
+      String storeName,
+      int versionNumber) {
+    VersionCreationResponse response =
+        assertCommand(parentControllerClient.emptyPush(storeName, "push-" + versionNumber, 1000));
+    assertEquals(response.getVersion(), versionNumber);
+    TestUtils.waitForNonDeterministicPushCompletion(
+        Version.composeKafkaTopic(storeName, versionNumber),
+        parentControllerClient,
+        60,
+        TimeUnit.SECONDS);
+  }
+
+  private static StoreInfo getStore(ControllerClient controllerClient, String storeName, String label) {
+    return assertCommand(controllerClient.getStore(storeName), "getStore failed on " + label).getStore();
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1258,6 +1258,121 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   /**
+   * Reap "stranded" bootstrapped versions at the start of a new push. A stranded version is one that
+   * finished bootstrapping (status {@link VersionStatus#PUSHED}) or was rolled back (status
+   * {@link VersionStatus#ROLLED_BACK}) but is non-current in every colo, so it is invisible to both
+   * cleanup paths: {@code StoreBackupVersionCleanupService} only deletes versions numbered below the
+   * current version, and SOP cleanup deliberately retains PUSHED versions. This happens when a
+   * deferred version swap fails post-swap validation: the target region rolls the version back while
+   * the non-target regions keep their copy in PUSHED status numbered above their unchanged current
+   * version, leaking one on-disk version per failed swap.
+   * <p>
+   * Because PUSHED is also the legitimate status of a completed push that is still awaiting its swap,
+   * a version is only deleted when there is positive cross-fabric evidence that it has been abandoned:
+   * at least one fabric reports it as ROLLED_BACK, or at least one fabric has already cleaned it up
+   * (the version is absent there) while at least one other fabric still has it. A version that is
+   * uniformly PUSHED/STARTED across the fabrics with none rolled back and none missing is left
+   * untouched, since that can be an in-progress or healthy push pending a deferred swap. The version
+   * is never touched if it is the current (serving) version in any fabric.
+   * <p>
+   * The delete is issued through the existing {@link #deleteOldVersionInStore} plumbing
+   * (DELETE_OLD_VERSION admin message), which is ACL-free, ordered, and no-ops in fabrics where the
+   * version is already absent.
+   */
+  void deleteStrandedNonCurrentVersions(String clusterName, String storeName) {
+    Store store = getVeniceHelixAdmin().getStore(clusterName, storeName);
+    if (store == null) {
+      return;
+    }
+    // Cheap local pre-filter: only versions that finished a push (PUSHED) or were rolled back (ROLLED_BACK)
+    // can be stranded leaks. Skip the cross-fabric queries entirely on the common path where there are none.
+    List<Integer> candidateVersionNums = new ArrayList<>();
+    for (Version version: store.getVersions()) {
+      VersionStatus parentStatus = version.getStatus();
+      if (parentStatus == PUSHED || parentStatus == ROLLED_BACK) {
+        candidateVersionNums.add(version.getNumber());
+      }
+    }
+    if (candidateVersionNums.isEmpty()) {
+      return;
+    }
+    Map<String, ControllerClient> controllerClientMap = getVeniceHelixAdmin().getControllerClientMap(clusterName);
+    if (controllerClientMap.isEmpty()) {
+      return;
+    }
+    Set<Integer> currentVersions = new HashSet<>(getCurrentVersionsForMultiColos(clusterName, storeName).values());
+    for (int versionNum: candidateVersionNums) {
+      // Never touch a version that is serving (current) in any colo.
+      if (currentVersions.contains(versionNum)) {
+        continue;
+      }
+      if (!isVersionStrandedAcrossFabrics(storeName, versionNum, controllerClientMap)) {
+        continue;
+      }
+      try {
+        LOGGER.info(
+            "Deleting stranded non-current version: {} for store: {} in cluster: {}",
+            versionNum,
+            storeName,
+            clusterName);
+        deleteOldVersionInStore(clusterName, storeName, versionNum);
+      } catch (Exception e) {
+        LOGGER.warn(
+            "Failed to delete stranded version: {} for store: {} in cluster: {}",
+            versionNum,
+            storeName,
+            clusterName,
+            e);
+      }
+    }
+  }
+
+  /**
+   * Returns {@code true} only when the given version has positive cross-fabric evidence of being an
+   * abandoned, stranded version that is safe to delete fleet-wide. See
+   * {@link #deleteStrandedNonCurrentVersions} for the guardrail rationale. Returns {@code false}
+   * (conservatively skipping the delete) if any fabric's state cannot be read, if the version is
+   * current or actively pushing (STARTED) in any fabric, or if there is no evidence of abandonment.
+   */
+  private boolean isVersionStrandedAcrossFabrics(
+      String storeName,
+      int versionNum,
+      Map<String, ControllerClient> controllerClientMap) {
+    boolean rolledBackInSomeFabric = false;
+    boolean presentInSomeFabric = false;
+    boolean absentInSomeFabric = false;
+    for (Map.Entry<String, ControllerClient> entry: controllerClientMap.entrySet()) {
+      String region = entry.getKey();
+      StoreResponse storeResponse = entry.getValue().getStore(storeName);
+      if (storeResponse == null || storeResponse.isError() || storeResponse.getStore() == null) {
+        // Cannot determine this fabric's state; be conservative and skip the delete entirely.
+        LOGGER.warn(
+            "Skipping stranded-version cleanup for store: {} version: {}; failed to read store from region: {}",
+            storeName,
+            versionNum,
+            region);
+        return false;
+      }
+      StoreInfo storeInfo = storeResponse.getStore();
+      Optional<Version> regionVersion = storeInfo.getVersion(versionNum);
+      if (!regionVersion.isPresent()) {
+        absentInSomeFabric = true;
+        continue;
+      }
+      presentInSomeFabric = true;
+      // Never delete a version that is serving (current) or still actively pushing in any fabric.
+      if (storeInfo.getCurrentVersion() == versionNum || regionVersion.get().getStatus() == STARTED) {
+        return false;
+      }
+      if (regionVersion.get().getStatus() == ROLLED_BACK) {
+        rolledBackInSomeFabric = true;
+      }
+    }
+    // Delete only with positive evidence of abandonment: rolled back somewhere, or partially cleaned up.
+    return rolledBackInSomeFabric || (absentInSomeFabric && presentInSomeFabric);
+  }
+
+  /**
   * Check whether any topic for this store exists or not.
   * The existing topic could be introduced by two cases:
   * 1. The previous job push is still running;
@@ -2061,6 +2176,7 @@ public class VeniceParentHelixAdmin implements Admin {
       }
       getSystemStoreLifeCycleHelper().maybeCreateSystemStoreWildcardAcl(storeName);
     }
+    deleteStrandedNonCurrentVersions(clusterName, storeName);
     cleanupHistoricalVersions(clusterName, storeName);
     return newVersion;
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1300,13 +1300,23 @@ public class VeniceParentHelixAdmin implements Admin {
     if (controllerClientMap.isEmpty()) {
       return;
     }
-    Set<Integer> currentVersions = new HashSet<>(getCurrentVersionsForMultiColos(clusterName, storeName).values());
-    for (int versionNum: candidateVersionNums) {
-      // Never touch a version that is serving (current) in any colo.
-      if (currentVersions.contains(versionNum)) {
-        continue;
+    Map<String, StoreInfo> regionStores = new HashMap<>();
+    for (Map.Entry<String, ControllerClient> entry: controllerClientMap.entrySet()) {
+      String region = entry.getKey();
+      StoreResponse storeResponse = entry.getValue().getStore(storeName);
+      if (storeResponse == null || storeResponse.isError() || storeResponse.getStore() == null) {
+        // Cannot determine this fabric's state; be conservative and skip the delete entirely.
+        LOGGER.warn(
+            "Skipping stranded-version cleanup for store: {} version: {}; failed to read store from region: {}",
+            storeName,
+            candidateVersionNums,
+            region);
+        return;
       }
-      if (!isVersionStrandedAcrossFabrics(storeName, versionNum, controllerClientMap)) {
+      regionStores.put(region, storeResponse.getStore());
+    }
+    for (int versionNum: candidateVersionNums) {
+      if (!isVersionStrandedAcrossFabrics(versionNum, regionStores)) {
         continue;
       }
       try {
@@ -1334,37 +1344,23 @@ public class VeniceParentHelixAdmin implements Admin {
    * (conservatively skipping the delete) if any fabric's state cannot be read, if the version is
    * current or actively pushing (STARTED) in any fabric, or if there is no evidence of abandonment.
    */
-  private boolean isVersionStrandedAcrossFabrics(
-      String storeName,
-      int versionNum,
-      Map<String, ControllerClient> controllerClientMap) {
+  private boolean isVersionStrandedAcrossFabrics(int versionNum, Map<String, StoreInfo> regionStores) {
     boolean rolledBackInSomeFabric = false;
     boolean presentInSomeFabric = false;
     boolean absentInSomeFabric = false;
-    for (Map.Entry<String, ControllerClient> entry: controllerClientMap.entrySet()) {
-      String region = entry.getKey();
-      StoreResponse storeResponse = entry.getValue().getStore(storeName);
-      if (storeResponse == null || storeResponse.isError() || storeResponse.getStore() == null) {
-        // Cannot determine this fabric's state; be conservative and skip the delete entirely.
-        LOGGER.warn(
-            "Skipping stranded-version cleanup for store: {} version: {}; failed to read store from region: {}",
-            storeName,
-            versionNum,
-            region);
-        return false;
-      }
-      StoreInfo storeInfo = storeResponse.getStore();
+    for (StoreInfo storeInfo: regionStores.values()) {
       Optional<Version> regionVersion = storeInfo.getVersion(versionNum);
       if (!regionVersion.isPresent()) {
         absentInSomeFabric = true;
         continue;
       }
       presentInSomeFabric = true;
+      VersionStatus regionStatus = regionVersion.get().getStatus();
       // Never delete a version that is serving (current) or still actively pushing in any fabric.
-      if (storeInfo.getCurrentVersion() == versionNum || regionVersion.get().getStatus() == STARTED) {
+      if (storeInfo.getCurrentVersion() == versionNum || regionStatus == STARTED) {
         return false;
       }
-      if (regionVersion.get().getStatus() == ROLLED_BACK) {
+      if (regionStatus == ROLLED_BACK) {
         rolledBackInSomeFabric = true;
       }
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1269,11 +1269,10 @@ public class VeniceParentHelixAdmin implements Admin {
    * <p>
    * Because PUSHED is also the legitimate status of a completed push that is still awaiting its swap,
    * a version is only deleted when there is positive cross-fabric evidence that it has been abandoned:
-   * at least one fabric reports it as ROLLED_BACK, or at least one fabric has already cleaned it up
-   * (the version is absent there) while at least one other fabric still has it. A version that is
-   * uniformly PUSHED/STARTED across the fabrics with none rolled back and none missing is left
-   * untouched, since that can be an in-progress or healthy push pending a deferred swap. The version
-   * is never touched if it is the current (serving) version in any fabric.
+   * at least one fabric reports it as ROLLED_BACK or KILLED. A version that is uniformly PUSHED/STARTED
+   * across the fabrics with none rolled back or killed is left untouched, since that can be an in-progress
+   * or healthy push pending a deferred swap. The version is never touched if it is the current (serving)
+   * version in any fabric.
    * <p>
    * The delete is issued through the existing {@link #deleteOldVersionInStore} plumbing
    * (DELETE_OLD_VERSION admin message), which is ACL-free, ordered, and no-ops in fabrics where the
@@ -1284,12 +1283,18 @@ public class VeniceParentHelixAdmin implements Admin {
     if (store == null) {
       return;
     }
-    // Cheap local pre-filter: only versions that finished a push (PUSHED) or were rolled back (ROLLED_BACK)
-    // can be stranded leaks. Skip the cross-fabric queries entirely on the common path where there are none.
+    // Cheap local pre-filter: only versions that finished a push (PUSHED), were rolled back (ROLLED_BACK),
+    // or were killed (KILLED) can be stranded leaks. Skip the cross-fabric queries entirely on the common path
+    // where there are none.
+    // A deferred-swap rollback propagates ROLLED_BACK to the parent version here (DeferredVersionSwapService
+    // updates the parent store repository right after rolling back the target region), so the stranded version
+    // is reliably a candidate. PUSHED is the fallback: it is the parent status before the swap attempt, which is
+    // what remains if that ROLLED_BACK write is ever skipped/fails. Child-fabric statuses are consulted later,
+    // in isVersionStrandedAcrossFabrics, only as the guardrail confirming abandonment before deleting.
     List<Integer> candidateVersionNums = new ArrayList<>();
     for (Version version: store.getVersions()) {
       VersionStatus parentStatus = version.getStatus();
-      if (parentStatus == PUSHED || parentStatus == ROLLED_BACK) {
+      if (parentStatus == PUSHED || parentStatus == ROLLED_BACK || parentStatus == KILLED) {
         candidateVersionNums.add(version.getNumber());
       }
     }
@@ -1303,14 +1308,29 @@ public class VeniceParentHelixAdmin implements Admin {
     Map<String, StoreInfo> regionStores = new HashMap<>();
     for (Map.Entry<String, ControllerClient> entry: controllerClientMap.entrySet()) {
       String region = entry.getKey();
-      StoreResponse storeResponse = entry.getValue().getStore(storeName);
-      if (storeResponse == null || storeResponse.isError() || storeResponse.getStore() == null) {
+      StoreResponse storeResponse;
+      try {
+        storeResponse = entry.getValue().getStore(storeName);
+      } catch (Exception e) {
         // Cannot determine this fabric's state; be conservative and skip the delete entirely.
         LOGGER.warn(
             "Skipping stranded-version cleanup for store: {} version: {}; failed to read store from region: {}",
             storeName,
             candidateVersionNums,
-            region);
+            region,
+            e);
+        return;
+      }
+      if (storeResponse == null || storeResponse.isError() || storeResponse.getStore() == null) {
+        // Cannot determine this fabric's state; be conservative and skip the delete entirely.
+        LOGGER.warn(
+            "Skipping stranded-version cleanup for store: {} version: {}; failed to read store from region: {} ({})",
+            storeName,
+            candidateVersionNums,
+            region,
+            storeResponse == null
+                ? "null response"
+                : storeResponse.isError() ? storeResponse.getError() : "store payload was null");
         return;
       }
       regionStores.put(region, storeResponse.getStore());
@@ -1345,27 +1365,23 @@ public class VeniceParentHelixAdmin implements Admin {
    * current or actively pushing (STARTED) in any fabric, or if there is no evidence of abandonment.
    */
   private boolean isVersionStrandedAcrossFabrics(int versionNum, Map<String, StoreInfo> regionStores) {
-    boolean rolledBackInSomeFabric = false;
-    boolean presentInSomeFabric = false;
-    boolean absentInSomeFabric = false;
+    boolean abandonedInSomeFabric = false;
     for (StoreInfo storeInfo: regionStores.values()) {
       Optional<Version> regionVersion = storeInfo.getVersion(versionNum);
       if (!regionVersion.isPresent()) {
-        absentInSomeFabric = true;
         continue;
       }
-      presentInSomeFabric = true;
       VersionStatus regionStatus = regionVersion.get().getStatus();
       // Never delete a version that is serving (current) or still actively pushing in any fabric.
       if (storeInfo.getCurrentVersion() == versionNum || regionStatus == STARTED) {
         return false;
       }
-      if (regionStatus == ROLLED_BACK) {
-        rolledBackInSomeFabric = true;
+      if (regionStatus == ROLLED_BACK || regionStatus == KILLED) {
+        abandonedInSomeFabric = true;
       }
     }
-    // Delete only with positive evidence of abandonment: rolled back somewhere, or partially cleaned up.
-    return rolledBackInSomeFabric || (absentInSomeFabric && presentInSomeFabric);
+    // Delete only with positive evidence of abandonment: rolled back or killed in at least one fabric.
+    return abandonedInSomeFabric;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1258,39 +1258,20 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   /**
-   * Reap "stranded" bootstrapped versions at the start of a new push. A stranded version is one that
-   * finished bootstrapping (status {@link VersionStatus#PUSHED}) or was rolled back (status
-   * {@link VersionStatus#ROLLED_BACK}) but is non-current in every colo, so it is invisible to both
-   * cleanup paths: {@code StoreBackupVersionCleanupService} only deletes versions numbered below the
-   * current version, and SOP cleanup deliberately retains PUSHED versions. This happens when a
-   * deferred version swap fails post-swap validation: the target region rolls the version back while
-   * the non-target regions keep their copy in PUSHED status numbered above their unchanged current
-   * version, leaking one on-disk version per failed swap.
-   * <p>
-   * Because PUSHED is also the legitimate status of a completed push that is still awaiting its swap,
-   * a version is only deleted when there is positive cross-fabric evidence that it has been abandoned:
-   * at least one fabric reports it as ROLLED_BACK or KILLED. A version that is uniformly PUSHED/STARTED
-   * across the fabrics with none rolled back or killed is left untouched, since that can be an in-progress
-   * or healthy push pending a deferred swap. The version is never touched if it is the current (serving)
-   * version in any fabric.
-   * <p>
-   * The delete is issued through the existing {@link #deleteOldVersionInStore} plumbing
-   * (DELETE_OLD_VERSION admin message), which is ACL-free, ordered, and no-ops in fabrics where the
-   * version is already absent.
+   * Reap "stranded" bootstrapped versions at the start of a new push using the DELETE_OLD_VERSION admin message.
+   * PUSHED can mean a colo is awaiting its swap, so a version is only deleted when we know it has been abandoned
+   * (at least one fabric reports it as ROLLED_BACK or KILLED).
+   *
+   * A version that is uniformly PUSHED/STARTED across the fabrics with none rolled back or killed is left untouched,
+   * since that can be an in-progress or healthy push pending a deferred swap. The version is never touched if it is
+   * the current (serving) version in any fabric.
    */
   void deleteStrandedNonCurrentVersions(String clusterName, String storeName) {
     Store store = getVeniceHelixAdmin().getStore(clusterName, storeName);
     if (store == null) {
       return;
     }
-    // Cheap local pre-filter: only versions that finished a push (PUSHED), were rolled back (ROLLED_BACK),
-    // or were killed (KILLED) can be stranded leaks. Skip the cross-fabric queries entirely on the common path
-    // where there are none.
-    // A deferred-swap rollback propagates ROLLED_BACK to the parent version here (DeferredVersionSwapService
-    // updates the parent store repository right after rolling back the target region), so the stranded version
-    // is reliably a candidate. PUSHED is the fallback: it is the parent status before the swap attempt, which is
-    // what remains if that ROLLED_BACK write is ever skipped/fails. Child-fabric statuses are consulted later,
-    // in isVersionStrandedAcrossFabrics, only as the guardrail confirming abandonment before deleting.
+    // Filter for PUSHED, ROLLED_BACK, and KILLED. Only further check multiple child fabrics if there are candidates.
     List<Integer> candidateVersionNums = new ArrayList<>();
     for (Version version: store.getVersions()) {
       VersionStatus parentStatus = version.getStatus();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -1874,7 +1874,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     // Parent metadata marks the failed swap version (2) as ROLLED_BACK; the current version (1) is serving.
     mockParentStoreWithVersions(storeName, ROLLED_BACK);
     // One fabric rolled the version back, the others still hold it in PUSHED: positive evidence of abandonment.
-    doReturn(buildStrandedRegionClients(storeName, Arrays.asList(ROLLED_BACK, PUSHED, PUSHED))).when(internalAdmin)
+    doReturn(buildStrandedRegionClients(Arrays.asList(ROLLED_BACK, PUSHED, PUSHED))).when(internalAdmin)
         .getControllerClientMap(anyString());
 
     parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
@@ -1891,7 +1891,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     String storeName = "stranded_store";
     mockParentStoreWithVersions(storeName, PUSHED);
     // The version was already cleaned up in one fabric (absent) but still lingers as PUSHED elsewhere.
-    doReturn(buildStrandedRegionClients(storeName, Arrays.asList(null, PUSHED, PUSHED))).when(internalAdmin)
+    doReturn(buildStrandedRegionClients(Arrays.asList(null, PUSHED, PUSHED))).when(internalAdmin)
         .getControllerClientMap(anyString());
 
     parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
@@ -1906,7 +1906,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     String storeName = "stranded_store";
     mockParentStoreWithVersions(storeName, PUSHED);
     // Uniformly PUSHED with no fabric rolled back and none missing: could be a healthy push pending swap, so skip.
-    doReturn(buildStrandedRegionClients(storeName, Arrays.asList(PUSHED, PUSHED, PUSHED))).when(internalAdmin)
+    doReturn(buildStrandedRegionClients(Arrays.asList(PUSHED, PUSHED, PUSHED))).when(internalAdmin)
         .getControllerClientMap(anyString());
 
     parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
@@ -1934,9 +1934,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
    * Builds one mocked controller client per region. Every region reports current version 1. Version 2 is present with
    * the given status per region, or absent when the status entry is {@code null}.
    */
-  private Map<String, ControllerClient> buildStrandedRegionClients(
-      String storeName,
-      List<VersionStatus> versionTwoStatusPerRegion) {
+  private Map<String, ControllerClient> buildStrandedRegionClients(List<VersionStatus> versionTwoStatusPerRegion) {
     Map<String, ControllerClient> controllerClientMap = new HashMap<>();
     for (int i = 0; i < versionTwoStatusPerRegion.size(); i++) {
       VersionStatus versionTwoStatus = versionTwoStatusPerRegion.get(i);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -8,6 +8,9 @@ import static com.linkedin.venice.meta.BufferReplayPolicy.REWIND_FROM_SOP;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
 import static com.linkedin.venice.meta.Version.DEFAULT_RT_VERSION_NUMBER;
 import static com.linkedin.venice.meta.Version.VERSION_SEPARATOR;
+import static com.linkedin.venice.meta.VersionStatus.ONLINE;
+import static com.linkedin.venice.meta.VersionStatus.PUSHED;
+import static com.linkedin.venice.meta.VersionStatus.ROLLED_BACK;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
@@ -38,6 +41,7 @@ import com.linkedin.venice.controller.kafka.AdminTopicUtils;
 import com.linkedin.venice.controller.kafka.consumer.AdminConsumerService;
 import com.linkedin.venice.controller.kafka.consumer.AdminConsumptionTask;
 import com.linkedin.venice.controller.kafka.protocol.admin.AdminOperation;
+import com.linkedin.venice.controller.kafka.protocol.admin.DeleteOldVersion;
 import com.linkedin.venice.controller.kafka.protocol.admin.DeleteStore;
 import com.linkedin.venice.controller.kafka.protocol.admin.DisableStoreRead;
 import com.linkedin.venice.controller.kafka.protocol.admin.ETLStoreConfigRecord;
@@ -1862,6 +1866,97 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     for (int i = 9; i <= 10; ++i) {
       Assert.assertTrue(capturedStore.containsVersion(i));
     }
+  }
+
+  @Test
+  public void testDeleteStrandedNonCurrentVersionsDeletesRolledBackVersion() {
+    String storeName = "stranded_store";
+    // Parent metadata marks the failed swap version (2) as ROLLED_BACK; the current version (1) is serving.
+    mockParentStoreWithVersions(storeName, ROLLED_BACK);
+    // One fabric rolled the version back, the others still hold it in PUSHED: positive evidence of abandonment.
+    doReturn(buildStrandedRegionClients(storeName, Arrays.asList(ROLLED_BACK, PUSHED, PUSHED))).when(internalAdmin)
+        .getControllerClientMap(anyString());
+
+    parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
+
+    AdminOperation adminMessage = verifyAndGetSingleAdminOperation();
+    assertEquals(adminMessage.operationType, AdminMessageType.DELETE_OLD_VERSION.getValue());
+    DeleteOldVersion deleteOldVersion = (DeleteOldVersion) adminMessage.payloadUnion;
+    assertEquals(deleteOldVersion.versionNum, 2);
+    assertEquals(deleteOldVersion.storeName.toString(), storeName);
+  }
+
+  @Test
+  public void testDeleteStrandedNonCurrentVersionsDeletesPartiallyCleanedVersion() {
+    String storeName = "stranded_store";
+    mockParentStoreWithVersions(storeName, PUSHED);
+    // The version was already cleaned up in one fabric (absent) but still lingers as PUSHED elsewhere.
+    doReturn(buildStrandedRegionClients(storeName, Arrays.asList(null, PUSHED, PUSHED))).when(internalAdmin)
+        .getControllerClientMap(anyString());
+
+    parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
+
+    AdminOperation adminMessage = verifyAndGetSingleAdminOperation();
+    assertEquals(adminMessage.operationType, AdminMessageType.DELETE_OLD_VERSION.getValue());
+    assertEquals(((DeleteOldVersion) adminMessage.payloadUnion).versionNum, 2);
+  }
+
+  @Test
+  public void testDeleteStrandedNonCurrentVersionsSkipsInProgressPush() {
+    String storeName = "stranded_store";
+    mockParentStoreWithVersions(storeName, PUSHED);
+    // Uniformly PUSHED with no fabric rolled back and none missing: could be a healthy push pending swap, so skip.
+    doReturn(buildStrandedRegionClients(storeName, Arrays.asList(PUSHED, PUSHED, PUSHED))).when(internalAdmin)
+        .getControllerClientMap(anyString());
+
+    parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
+
+    verify(veniceWriter, never()).put(any(), any(), anyInt(), any(), any(), anyLong(), any(), any(), any(), any());
+  }
+
+  /**
+   * Mocks the parent store returned by the internal admin with version 1 ONLINE (serving) and version 2 in the given
+   * status. Version 2 is the stranded/failed-swap version under test.
+   */
+  private void mockParentStoreWithVersions(String storeName, VersionStatus versionTwoStatus) {
+    Version versionOne = mock(Version.class);
+    doReturn(1).when(versionOne).getNumber();
+    doReturn(ONLINE).when(versionOne).getStatus();
+    Version versionTwo = mock(Version.class);
+    doReturn(2).when(versionTwo).getNumber();
+    doReturn(versionTwoStatus).when(versionTwo).getStatus();
+    Store parentStore = mock(Store.class);
+    doReturn(Arrays.asList(versionOne, versionTwo)).when(parentStore).getVersions();
+    doReturn(parentStore).when(internalAdmin).getStore(clusterName, storeName);
+  }
+
+  /**
+   * Builds one mocked controller client per region. Every region reports current version 1. Version 2 is present with
+   * the given status per region, or absent when the status entry is {@code null}.
+   */
+  private Map<String, ControllerClient> buildStrandedRegionClients(
+      String storeName,
+      List<VersionStatus> versionTwoStatusPerRegion) {
+    Map<String, ControllerClient> controllerClientMap = new HashMap<>();
+    for (int i = 0; i < versionTwoStatusPerRegion.size(); i++) {
+      VersionStatus versionTwoStatus = versionTwoStatusPerRegion.get(i);
+      StoreInfo storeInfo = mock(StoreInfo.class);
+      doReturn(1).when(storeInfo).getCurrentVersion();
+      if (versionTwoStatus == null) {
+        doReturn(Optional.empty()).when(storeInfo).getVersion(2);
+      } else {
+        Version regionVersionTwo = mock(Version.class);
+        doReturn(2).when(regionVersionTwo).getNumber();
+        doReturn(versionTwoStatus).when(regionVersionTwo).getStatus();
+        doReturn(Optional.of(regionVersionTwo)).when(storeInfo).getVersion(2);
+      }
+      StoreResponse storeResponse = new StoreResponse();
+      storeResponse.setStore(storeInfo);
+      ControllerClient client = mock(ControllerClient.class);
+      doReturn(storeResponse).when(client).getStore(anyString());
+      controllerClientMap.put("region" + i, client);
+    }
+    return controllerClientMap;
   }
 
   private void mockControllerClients(String storeName) {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -136,6 +136,7 @@ import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -1869,53 +1870,45 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     }
   }
 
-  @Test
-  public void testDeleteStrandedNonCurrentVersionsDeletesRolledBackVersion() {
-    String storeName = "stranded_store";
-    // Parent metadata marks the failed swap version (2) as ROLLED_BACK; the current version (1) is serving.
-    mockParentStoreWithVersions(storeName, ROLLED_BACK);
-    // One fabric rolled the version back, the others still hold it in PUSHED: positive evidence of abandonment.
-    doReturn(buildStrandedRegionClients(Arrays.asList(ROLLED_BACK, PUSHED, PUSHED))).when(internalAdmin)
-        .getControllerClientMap(anyString());
-
-    parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
-
-    AdminOperation adminMessage = verifyAndGetSingleAdminOperation();
-    assertEquals(adminMessage.operationType, AdminMessageType.DELETE_OLD_VERSION.getValue());
-    DeleteOldVersion deleteOldVersion = (DeleteOldVersion) adminMessage.payloadUnion;
-    assertEquals(deleteOldVersion.versionNum, 2);
-    assertEquals(deleteOldVersion.storeName.toString(), storeName);
+  /**
+   * Cross-fabric decision matrix for {@link VeniceParentHelixAdmin#deleteStrandedNonCurrentVersions}. Version 2 is
+   * the candidate under test and version 1 is the serving version everywhere. A {@code null} region status means the
+   * version is already absent in that fabric. The version is only deleted with positive evidence of abandonment,
+   * meaning at least one fabric reports it as ROLLED_BACK or KILLED.
+   */
+  @DataProvider(name = "strandedVersionEvidence")
+  public static Object[][] strandedVersionEvidence() {
+    return new Object[][] {
+        { "rolled back in one fabric, still PUSHED in the rest", ROLLED_BACK,
+            Arrays.asList(ROLLED_BACK, PUSHED, PUSHED), true },
+        { "killed in one fabric, still PUSHED in the rest", KILLED, Arrays.asList(KILLED, PUSHED, PUSHED), true },
+        { "uniformly PUSHED, so possibly a healthy push awaiting its swap", PUSHED,
+            Arrays.asList(PUSHED, PUSHED, PUSHED), false },
+        { "already cleaned up in one fabric but never abandoned in any", PUSHED, Arrays.asList(null, PUSHED, PUSHED),
+            false } };
   }
 
-  @Test
-  public void testDeleteStrandedNonCurrentVersionsSkipsPartiallyCleanedVersionWithoutRollback() {
+  @Test(dataProvider = "strandedVersionEvidence")
+  public void testDeleteStrandedNonCurrentVersions(
+      String scenario,
+      VersionStatus parentStatus,
+      List<VersionStatus> regionStatuses,
+      boolean expectDelete) {
     String storeName = "stranded_store";
-    mockParentStoreWithVersions(storeName, PUSHED);
-    // The version was cleaned up in one fabric (absent) but lingers as PUSHED elsewhere with no fabric rolled back:
-    // without positive ROLLED_BACK evidence this could still be a healthy push pending swap, so skip.
-    doReturn(buildStrandedRegionClients(Arrays.asList(null, PUSHED, PUSHED))).when(internalAdmin)
-        .getControllerClientMap(anyString());
+    mockParentStoreWithVersions(storeName, parentStatus);
+    doReturn(buildStrandedRegionClients(regionStatuses)).when(internalAdmin).getControllerClientMap(anyString());
 
     parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
 
-    verify(veniceWriter, never()).put(any(), any(), anyInt(), any(), any(), anyLong(), any(), any(), any(), any());
-  }
-
-  @Test
-  public void testDeleteStrandedNonCurrentVersionsDeletesKilledVersion() {
-    String storeName = "stranded_store";
-    mockParentStoreWithVersions(storeName, KILLED);
-    // KILLED is also positive evidence that the version was abandoned, while the other fabrics can still retain it.
-    doReturn(buildStrandedRegionClients(Arrays.asList(KILLED, PUSHED, PUSHED))).when(internalAdmin)
-        .getControllerClientMap(anyString());
-
-    parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
-
+    if (!expectDelete) {
+      assertNoAdminMessageSent();
+      return;
+    }
     AdminOperation adminMessage = verifyAndGetSingleAdminOperation();
-    assertEquals(adminMessage.operationType, AdminMessageType.DELETE_OLD_VERSION.getValue());
+    assertEquals(adminMessage.operationType, AdminMessageType.DELETE_OLD_VERSION.getValue(), scenario);
     DeleteOldVersion deleteOldVersion = (DeleteOldVersion) adminMessage.payloadUnion;
-    assertEquals(deleteOldVersion.versionNum, 2);
-    assertEquals(deleteOldVersion.storeName.toString(), storeName);
+    assertEquals(deleteOldVersion.versionNum, 2, scenario);
+    assertEquals(deleteOldVersion.storeName.toString(), storeName, scenario);
   }
 
   @Test
@@ -1929,19 +1922,10 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
     parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
 
-    verify(veniceWriter, never()).put(any(), any(), anyInt(), any(), any(), anyLong(), any(), any(), any(), any());
+    assertNoAdminMessageSent();
   }
 
-  @Test
-  public void testDeleteStrandedNonCurrentVersionsSkipsInProgressPush() {
-    String storeName = "stranded_store";
-    mockParentStoreWithVersions(storeName, PUSHED);
-    // Uniformly PUSHED with no fabric rolled back and none missing: could be a healthy push pending swap, so skip.
-    doReturn(buildStrandedRegionClients(Arrays.asList(PUSHED, PUSHED, PUSHED))).when(internalAdmin)
-        .getControllerClientMap(anyString());
-
-    parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
-
+  private void assertNoAdminMessageSent() {
     verify(veniceWriter, never()).put(any(), any(), anyInt(), any(), any(), anyLong(), any(), any(), any(), any());
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -8,6 +8,7 @@ import static com.linkedin.venice.meta.BufferReplayPolicy.REWIND_FROM_SOP;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
 import static com.linkedin.venice.meta.Version.DEFAULT_RT_VERSION_NUMBER;
 import static com.linkedin.venice.meta.Version.VERSION_SEPARATOR;
+import static com.linkedin.venice.meta.VersionStatus.KILLED;
 import static com.linkedin.venice.meta.VersionStatus.ONLINE;
 import static com.linkedin.venice.meta.VersionStatus.PUSHED;
 import static com.linkedin.venice.meta.VersionStatus.ROLLED_BACK;
@@ -1887,18 +1888,48 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   @Test
-  public void testDeleteStrandedNonCurrentVersionsDeletesPartiallyCleanedVersion() {
+  public void testDeleteStrandedNonCurrentVersionsSkipsPartiallyCleanedVersionWithoutRollback() {
     String storeName = "stranded_store";
     mockParentStoreWithVersions(storeName, PUSHED);
-    // The version was already cleaned up in one fabric (absent) but still lingers as PUSHED elsewhere.
+    // The version was cleaned up in one fabric (absent) but lingers as PUSHED elsewhere with no fabric rolled back:
+    // without positive ROLLED_BACK evidence this could still be a healthy push pending swap, so skip.
     doReturn(buildStrandedRegionClients(Arrays.asList(null, PUSHED, PUSHED))).when(internalAdmin)
+        .getControllerClientMap(anyString());
+
+    parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
+
+    verify(veniceWriter, never()).put(any(), any(), anyInt(), any(), any(), anyLong(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testDeleteStrandedNonCurrentVersionsDeletesKilledVersion() {
+    String storeName = "stranded_store";
+    mockParentStoreWithVersions(storeName, KILLED);
+    // KILLED is also positive evidence that the version was abandoned, while the other fabrics can still retain it.
+    doReturn(buildStrandedRegionClients(Arrays.asList(KILLED, PUSHED, PUSHED))).when(internalAdmin)
         .getControllerClientMap(anyString());
 
     parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
 
     AdminOperation adminMessage = verifyAndGetSingleAdminOperation();
     assertEquals(adminMessage.operationType, AdminMessageType.DELETE_OLD_VERSION.getValue());
-    assertEquals(((DeleteOldVersion) adminMessage.payloadUnion).versionNum, 2);
+    DeleteOldVersion deleteOldVersion = (DeleteOldVersion) adminMessage.payloadUnion;
+    assertEquals(deleteOldVersion.versionNum, 2);
+    assertEquals(deleteOldVersion.storeName.toString(), storeName);
+  }
+
+  @Test
+  public void testDeleteStrandedNonCurrentVersionsSkipsWhenRegionStoreReadThrows() {
+    String storeName = "stranded_store";
+    mockParentStoreWithVersions(storeName, ROLLED_BACK);
+    Map<String, ControllerClient> controllerClientMap =
+        buildStrandedRegionClients(Arrays.asList(ROLLED_BACK, PUSHED, PUSHED));
+    doThrow(new VeniceException("child read failed")).when(controllerClientMap.get("region1")).getStore(anyString());
+    doReturn(controllerClientMap).when(internalAdmin).getControllerClientMap(anyString());
+
+    parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
+
+    verify(veniceWriter, never()).put(any(), any(), anyInt(), any(), any(), anyLong(), any(), any(), any(), any());
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -12,6 +12,7 @@ import static com.linkedin.venice.meta.VersionStatus.KILLED;
 import static com.linkedin.venice.meta.VersionStatus.ONLINE;
 import static com.linkedin.venice.meta.VersionStatus.PUSHED;
 import static com.linkedin.venice.meta.VersionStatus.ROLLED_BACK;
+import static com.linkedin.venice.meta.VersionStatus.STARTED;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
@@ -130,6 +131,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
 import org.mockito.ArgumentCaptor;
@@ -1872,9 +1874,10 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
   /**
    * Cross-fabric decision matrix for {@link VeniceParentHelixAdmin#deleteStrandedNonCurrentVersions}. Version 2 is
-   * the candidate under test and version 1 is the serving version everywhere. A {@code null} region status means the
-   * version is already absent in that fabric. The version is only deleted with positive evidence of abandonment,
-   * meaning at least one fabric reports it as ROLLED_BACK or KILLED.
+   * the candidate under test and version 1 is the serving version everywhere, except where version 2 is ONLINE and
+   * therefore serving in that fabric. A {@code null} region status means the version is already absent in that
+   * fabric. The version is only deleted with positive evidence of abandonment, meaning at least one fabric reports it
+   * as ROLLED_BACK or KILLED, and no fabric is still serving or pushing it.
    */
   @DataProvider(name = "strandedVersionEvidence")
   public static Object[][] strandedVersionEvidence() {
@@ -1885,7 +1888,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         { "uniformly PUSHED, so possibly a healthy push awaiting its swap", PUSHED,
             Arrays.asList(PUSHED, PUSHED, PUSHED), false },
         { "already cleaned up in one fabric but never abandoned in any", PUSHED, Arrays.asList(null, PUSHED, PUSHED),
-            false } };
+            false },
+        { "rolled back in one fabric but still serving in another", ROLLED_BACK,
+            Arrays.asList(ROLLED_BACK, ONLINE, PUSHED), false },
+        { "rolled back in one fabric but still pushing in another", ROLLED_BACK,
+            Arrays.asList(ROLLED_BACK, STARTED, PUSHED), false } };
   }
 
   @Test(dataProvider = "strandedVersionEvidence")
@@ -1911,13 +1918,34 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     assertEquals(deleteOldVersion.storeName.toString(), storeName, scenario);
   }
 
-  @Test
-  public void testDeleteStrandedNonCurrentVersionsSkipsWhenRegionStoreReadThrows() {
+  /**
+   * The ways a fabric's state can be unreadable. Each entry sabotages one region's controller client. All of them
+   * must abort the cleanup, since a version cannot be proven abandoned without every fabric's state.
+   */
+  @DataProvider(name = "unreadableRegion")
+  public static Object[][] unreadableRegion() {
+    StoreResponse errorResponse = new StoreResponse();
+    errorResponse.setError("region unavailable");
+    return new Object[][] {
+        { "read throws",
+            (Consumer<ControllerClient>) client -> doThrow(new VeniceException("child read failed")).when(client)
+                .getStore(anyString()) },
+        { "error response",
+            (Consumer<ControllerClient>) client -> doReturn(errorResponse).when(client).getStore(anyString()) },
+        { "null store payload",
+            (Consumer<ControllerClient>) client -> doReturn(new StoreResponse()).when(client).getStore(anyString()) },
+        { "null response", (Consumer<ControllerClient>) client -> doReturn(null).when(client).getStore(anyString()) } };
+  }
+
+  @Test(dataProvider = "unreadableRegion")
+  public void testDeleteStrandedNonCurrentVersionsSkipsWhenRegionStoreIsUnreadable(
+      String scenario,
+      Consumer<ControllerClient> sabotage) {
     String storeName = "stranded_store";
     mockParentStoreWithVersions(storeName, ROLLED_BACK);
     Map<String, ControllerClient> controllerClientMap =
         buildStrandedRegionClients(Arrays.asList(ROLLED_BACK, PUSHED, PUSHED));
-    doThrow(new VeniceException("child read failed")).when(controllerClientMap.get("region1")).getStore(anyString());
+    sabotage.accept(controllerClientMap.get("region1"));
     doReturn(controllerClientMap).when(internalAdmin).getControllerClientMap(anyString());
 
     parentAdmin.deleteStrandedNonCurrentVersions(clusterName, storeName);
@@ -1946,15 +1974,16 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   /**
-   * Builds one mocked controller client per region. Every region reports current version 1. Version 2 is present with
-   * the given status per region, or absent when the status entry is {@code null}.
+   * Builds one mocked controller client per region. Version 2 is present with the given status per region, or absent
+   * when the status entry is {@code null}. A region serves version 2 when its status there is ONLINE, and version 1
+   * otherwise.
    */
   private Map<String, ControllerClient> buildStrandedRegionClients(List<VersionStatus> versionTwoStatusPerRegion) {
     Map<String, ControllerClient> controllerClientMap = new HashMap<>();
     for (int i = 0; i < versionTwoStatusPerRegion.size(); i++) {
       VersionStatus versionTwoStatus = versionTwoStatusPerRegion.get(i);
       StoreInfo storeInfo = mock(StoreInfo.class);
-      doReturn(1).when(storeInfo).getCurrentVersion();
+      doReturn(versionTwoStatus == ONLINE ? 2 : 1).when(storeInfo).getCurrentVersion();
       if (versionTwoStatus == null) {
         doReturn(Optional.empty()).when(storeInfo).getVersion(2);
       } else {


### PR DESCRIPTION
## Problem Statement

When a target-region push with **deferred version swap** fails post-version-swap validation (the store lifecycle hook returns `ROLLBACK`/`ABORT` in `DeferredVersionSwapService.didPostVersionSwapValidationsPass`), the controller rolls back the target region and marks the parent version `ROLLED_BACK`. In the target region the failed version becomes `ROLLED_BACK` and current reverts to the backup; but the **non-target regions never swapped**, so their copy of that same version is left in `PUSHED` status, numbered **above** their unchanged current version.

Such a version is invisible to every cleanup path and leaks one on-disk version per failed swap:
- `PUSHED` is not `canDelete` (only `ERROR`/`KILLED` are).
- `StoreBackupVersionCleanupService` only deletes versions numbered **below** the current version.
- SOP `AbstractStore.retrieveVersionsToDelete` explicitly **retains** `PUSHED` versions.

## Solution

Reap these stranded versions at the **start of the next push**, in the parent's `addVersionAndTopicOnly` path, immediately **before** `cleanupHistoricalVersions` (so the child on-disk copies are reaped via broadcast before the parent metadata is pruned and orphans them).

New `VeniceParentHelixAdmin.deleteStrandedNonCurrentVersions(...)`:
- **Cheap local pre-filter:** only parent versions with status `PUSHED` or `ROLLED_BACK` are candidates; returns early with **no cross-fabric calls** on the common path.
- **Cross-fabric guardrail** (`isVersionStrandedAcrossFabrics`): because `PUSHED` is also the legitimate status of a completed push still awaiting its swap, a version is deleted **only** with positive evidence of abandonment — **(a)** at least one fabric reports it `ROLLED_BACK`, **or (b)** at least one fabric has already cleaned it up (absent) while at least one other still has it. A version that is uniformly `PUSHED`/`STARTED` with none rolled back and none missing is left untouched; a version that is **current** or `STARTED` in any fabric is never touched; and any fabric read failure conservatively skips the delete.

### Code changes
- No new config.
- Introduced two new log lines (one INFO on delete, one WARN on failure / unreadable fabric) — low volume, gated on the rare candidate path.

### No schema change
The delete reuses the existing `deleteOldVersionInStore` → `DELETE_OLD_VERSION` admin-message plumbing, which is **ACL-free**, **ordered** (same per-store admin channel), and **idempotent** (the child no-ops where the version is already absent). **No avro/schema, admin-message-type, or enum changes.**

> Note: this replaces the earlier eager-delete-at-rollback approach that was initially on this branch. That change (in `DeferredVersionSwapService`) has been reverted; this start-of-push, cross-fabric-guarded cleanup is the sole fix and also covers versions stranded by earlier partial cleanup.

## Testing

Added 3 unit tests in `TestVeniceParentHelixAdmin` (all pass; existing cleanup tests still pass; module compiles clean):
- `testDeleteStrandedNonCurrentVersionsDeletesRolledBackVersion` — `ROLLED_BACK` in one fabric, `PUSHED` in others → broadcasts `DELETE_OLD_VERSION` for the stranded version.
- `testDeleteStrandedNonCurrentVersionsDeletesPartiallyCleanedVersion` — absent in one fabric, `PUSHED` in others → deletes.
- `testDeleteStrandedNonCurrentVersionsSkipsInProgressPush` — uniformly `PUSHED` with none rolled back / none missing → no delete.