### PR TITLE
[da-vinci] Lazily discover server blob fallback peers

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferManagerBuilder.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobTransferManagerBuilder.java
@@ -125,8 +125,9 @@ public class BlobTransferManagerBuilder {
   }
 
   /**
-   * Enable the client-side fallback to include Venice servers after Da Vinci peers in the discovered host list. Defaults
-   * to false; typically set only on the Da Vinci / Stateful CDC client path.
+   * Enable the client-side fallback to Venice servers once the Da Vinci peers are exhausted. Server discovery is lazy:
+   * it only runs when no Da Vinci peer is available or every Da Vinci peer transfer fails. Defaults to false; typically
+   * set only on the Da Vinci / Stateful CDC client path.
    */
   public BlobTransferManagerBuilder setServerFallbackEnabled(boolean serverFallbackEnabled) {
     this.serverFallbackEnabled = serverFallbackEnabled;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/NettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/NettyP2PBlobTransferManager.java
@@ -113,29 +113,102 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
       BlobTransferTableFormat tableFormat) throws VenicePeersNotFoundException {
     String replicaId = Utils.getReplicaId(Version.composeKafkaTopic(storeName, version), partition);
     CompletableFuture<InputStream> perPartitionTransferFuture = new CompletableFuture<>();
+    Instant transferStartTime = Instant.now();
 
     // Register the transfer with the status tracking manager
     statusTrackingManager.startedTransfer(replicaId);
 
-    // 1. Discover peers for the requested blob
+    // 1. Discover primary peers for the requested blob.
     BlobPeersDiscoveryResponse response = peerFinder.discoverBlobPeers(storeName, version, partition);
-    if (response == null || response.isError() || response.getDiscoveryResult() == null
-        || response.getDiscoveryResult().isEmpty()) {
-      // error case 1: no peers are found for the requested blob
-      String errorMsg = String.format(
-          NO_PEERS_FOUND_ERROR_MSG_FORMAT,
-          Utils.getReplicaId(Version.composeKafkaTopic(storeName, version), partition));
-      perPartitionTransferFuture.completeExceptionally(new VenicePeersNotFoundException(errorMsg));
+    if (isDiscoveryUnavailable(response)) {
+      if (peerFinder.supportsFallback()) {
+        processFallbackPeers(
+            storeName,
+            version,
+            partition,
+            tableFormat,
+            transferStartTime,
+            perPartitionTransferFuture,
+            false);
+      } else {
+        completeWithNoPeersFound(replicaId, perPartitionTransferFuture);
+      }
       return perPartitionTransferFuture;
     }
 
     List<String> discoverPeers = response.getDiscoveryResult();
     List<String> connectablePeers = getConnectableHosts(discoverPeers, storeName, version, partition);
 
-    // 2. Process the discovered peers sequentially in finder-provided priority order.
-    processPeersSequentially(connectablePeers, storeName, version, partition, tableFormat, perPartitionTransferFuture);
+    // 2. Process the primary peers sequentially. Discover fallback peers only after this tier is exhausted.
+    processPeersSequentially(
+        connectablePeers,
+        storeName,
+        version,
+        partition,
+        tableFormat,
+        transferStartTime,
+        perPartitionTransferFuture,
+        () -> {
+          if (peerFinder.supportsFallback()) {
+            replicaBlobFetchExecutor.execute(
+                () -> processFallbackPeers(
+                    storeName,
+                    version,
+                    partition,
+                    tableFormat,
+                    transferStartTime,
+                    perPartitionTransferFuture,
+                    true));
+          } else {
+            completeWithAllPeersFailed(replicaId, perPartitionTransferFuture);
+          }
+        });
 
     return perPartitionTransferFuture;
+  }
+
+  private void processFallbackPeers(
+      String storeName,
+      int version,
+      int partition,
+      BlobTransferTableFormat tableFormat,
+      Instant transferStartTime,
+      CompletableFuture<InputStream> perPartitionTransferFuture,
+      boolean primaryPeersDiscovered) {
+    String replicaId = Utils.getReplicaId(Version.composeKafkaTopic(storeName, version), partition);
+    if (completeIfCancelled(replicaId, perPartitionTransferFuture)) {
+      return;
+    }
+
+    BlobPeersDiscoveryResponse fallbackResponse = peerFinder.discoverFallbackBlobPeers(storeName, version, partition);
+    if (perPartitionTransferFuture.isDone() || completeIfCancelled(replicaId, perPartitionTransferFuture)) {
+      return;
+    }
+    if (isDiscoveryUnavailable(fallbackResponse)) {
+      if (primaryPeersDiscovered) {
+        completeWithAllPeersFailed(replicaId, perPartitionTransferFuture);
+      } else {
+        completeWithNoPeersFound(replicaId, perPartitionTransferFuture);
+      }
+      return;
+    }
+
+    List<String> connectablePeers =
+        getConnectableHosts(fallbackResponse.getDiscoveryResult(), storeName, version, partition);
+    processPeersSequentially(
+        connectablePeers,
+        storeName,
+        version,
+        partition,
+        tableFormat,
+        transferStartTime,
+        perPartitionTransferFuture,
+        () -> completeWithAllPeersFailed(replicaId, perPartitionTransferFuture));
+  }
+
+  private static boolean isDiscoveryUnavailable(BlobPeersDiscoveryResponse response) {
+    return response == null || response.isError() || response.getDiscoveryResult() == null
+        || response.getDiscoveryResult().isEmpty();
   }
 
   /**
@@ -189,7 +262,9 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
    * @param version the version of the store
    * @param partition the partition of the store
    * @param tableFormat the needed table format
+   * @param transferStartTime the start time of the partition-level transfer across all peer tiers
    * @param perPartitionTransferFuture the future to complete with the InputStream of the blob
+   * @param peersExhaustedHandler action to run after every peer in this tier fails
    */
   private void processPeersSequentially(
       List<String> uniqueConnectablePeers,
@@ -197,9 +272,10 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
       int version,
       int partition,
       BlobTransferTableFormat tableFormat,
-      CompletableFuture<InputStream> perPartitionTransferFuture) {
+      Instant transferStartTime,
+      CompletableFuture<InputStream> perPartitionTransferFuture,
+      Runnable peersExhaustedHandler) {
     String replicaId = Utils.getReplicaId(Version.composeKafkaTopic(storeName, version), partition);
-    Instant startTime = Instant.now();
 
     // Create a CompletableFuture that represents the chain of processing all peers
     CompletableFuture<Void> chainOfPeersFuture = CompletableFuture.completedFuture(null);
@@ -231,7 +307,7 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
 
         return perHostTransferFuture.toCompletableFuture().thenAccept(inputStream -> {
           // Success case: Complete the future with the input stream
-          long transferTime = Duration.between(startTime, Instant.now()).getSeconds();
+          long transferTime = Duration.between(transferStartTime, Instant.now()).getSeconds();
           LOGGER.info(FETCHED_BLOB_SUCCESS_MSG, replicaId, chosenHost, transferTime);
           perPartitionTransferFuture.complete(inputStream);
           // Updating the blob transfer stats with the transfer time and throughput
@@ -248,16 +324,34 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
       if (perPartitionTransferFuture.isDone()) {
         return;
       }
-      if (statusTrackingManager.isBlobTransferCancelRequested(replicaId)) {
-        // Receive cancellation request, skip Kafka bootstrapping
-        perPartitionTransferFuture.completeExceptionally(
-            new VeniceBlobTransferCancelledException(String.format(TRANSFER_CANCELLED_MSG_FORMAT, replicaId)));
+      if (completeIfCancelled(replicaId, perPartitionTransferFuture)) {
         return;
       }
-      // No usable peers available, fall back to Kafka bootstrapping.
-      perPartitionTransferFuture.completeExceptionally(
-          new VenicePeersAllFailedException(String.format(NO_VALID_PEERS_MSG_FORMAT, replicaId)));
+      peersExhaustedHandler.run();
     });
+  }
+
+  private boolean completeIfCancelled(String replicaId, CompletableFuture<InputStream> perPartitionTransferFuture) {
+    if (!statusTrackingManager.isBlobTransferCancelRequested(replicaId)) {
+      return false;
+    }
+    perPartitionTransferFuture.completeExceptionally(
+        new VeniceBlobTransferCancelledException(String.format(TRANSFER_CANCELLED_MSG_FORMAT, replicaId)));
+    return true;
+  }
+
+  private static void completeWithNoPeersFound(
+      String replicaId,
+      CompletableFuture<InputStream> perPartitionTransferFuture) {
+    perPartitionTransferFuture.completeExceptionally(
+        new VenicePeersNotFoundException(String.format(NO_PEERS_FOUND_ERROR_MSG_FORMAT, replicaId)));
+  }
+
+  private static void completeWithAllPeersFailed(
+      String replicaId,
+      CompletableFuture<InputStream> perPartitionTransferFuture) {
+    perPartitionTransferFuture
+        .completeExceptionally(new VenicePeersAllFailedException(String.format(NO_VALID_PEERS_MSG_FORMAT, replicaId)));
   }
 
   /**
@@ -365,9 +459,7 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
         connectablePeersList.add(peer);
       }
     }
-    if (!peerFinder.shouldPreservePeerOrder()) {
-      Collections.shuffle(connectablePeersList);
-    }
+    Collections.shuffle(connectablePeersList);
     return connectablePeersList;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/NettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/NettyP2PBlobTransferManager.java
@@ -182,7 +182,8 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
         return;
       }
 
-      BlobPeersDiscoveryResponse fallbackResponse = peerFinder.discoverFallbackBlobPeers(storeName, version, partition);
+      BlobPeersDiscoveryResponse fallbackResponse =
+          peerFinder.discoverFallbackBlobPeersIfEnabled(storeName, version, partition);
       if (perPartitionTransferFuture.isDone() || completeIfCancelled(replicaId, perPartitionTransferFuture)) {
         return;
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/NettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/NettyP2PBlobTransferManager.java
@@ -62,6 +62,13 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
       "Replica {} failed to fetch blob from peer {}. Deleting partially downloaded blobs. Exception: {}";
   private static final String PEER_SCHEMA_MISMATCH_MSG =
       "Replica {} peer {} rejected blob transfer due to schema-version mismatch. Exception: {}";
+  private static final String FALLBACK_DISPATCH_FAILED_MSG =
+      "Replica {} could not dispatch fallback peer discovery, failing the partition-level transfer.";
+  private static final String FALLBACK_DISCOVERY_FAILED_MSG =
+      "Replica {} failed unexpectedly during fallback peer discovery, failing the partition-level transfer.";
+  private static final String FALLBACK_DISCOVERY_ERROR_MSG = "Replica {} fallback peer discovery failed. Error: {}";
+  private static final String PEER_CHAIN_FAILED_MSG =
+      "Replica {} peer processing chain failed, failing the partition-level transfer.";
 
   private final P2PBlobTransferService blobTransferService;
   // netty client is responsible to make requests against other peers for blob fetching
@@ -113,7 +120,6 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
       BlobTransferTableFormat tableFormat) throws VenicePeersNotFoundException {
     String replicaId = Utils.getReplicaId(Version.composeKafkaTopic(storeName, version), partition);
     CompletableFuture<InputStream> perPartitionTransferFuture = new CompletableFuture<>();
-    Instant transferStartTime = Instant.now();
 
     // Register the transfer with the status tracking manager
     statusTrackingManager.startedTransfer(replicaId);
@@ -122,14 +128,7 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
     BlobPeersDiscoveryResponse response = peerFinder.discoverBlobPeers(storeName, version, partition);
     if (isDiscoveryUnavailable(response)) {
       if (peerFinder.supportsFallback()) {
-        processFallbackPeers(
-            storeName,
-            version,
-            partition,
-            tableFormat,
-            transferStartTime,
-            perPartitionTransferFuture,
-            false);
+        processFallbackPeers(storeName, version, partition, tableFormat, perPartitionTransferFuture, false);
       } else {
         completeWithNoPeersFound(replicaId, perPartitionTransferFuture);
       }
@@ -146,21 +145,24 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
         version,
         partition,
         tableFormat,
-        transferStartTime,
         perPartitionTransferFuture,
         () -> {
-          if (peerFinder.supportsFallback()) {
+          if (!peerFinder.supportsFallback()) {
+            completeWithAllPeersFailed(replicaId, perPartitionTransferFuture);
+            return;
+          }
+          try {
             replicaBlobFetchExecutor.execute(
                 () -> processFallbackPeers(
                     storeName,
                     version,
                     partition,
                     tableFormat,
-                    transferStartTime,
                     perPartitionTransferFuture,
                     true));
-          } else {
-            completeWithAllPeersFailed(replicaId, perPartitionTransferFuture);
+          } catch (RuntimeException e) {
+            LOGGER.error(FALLBACK_DISPATCH_FAILED_MSG, replicaId, e);
+            completeAfterPeersUnavailable(replicaId, perPartitionTransferFuture);
           }
         });
 
@@ -172,38 +174,46 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
       int version,
       int partition,
       BlobTransferTableFormat tableFormat,
-      Instant transferStartTime,
       CompletableFuture<InputStream> perPartitionTransferFuture,
       boolean primaryPeersDiscovered) {
     String replicaId = Utils.getReplicaId(Version.composeKafkaTopic(storeName, version), partition);
-    if (completeIfCancelled(replicaId, perPartitionTransferFuture)) {
-      return;
-    }
-
-    BlobPeersDiscoveryResponse fallbackResponse = peerFinder.discoverFallbackBlobPeers(storeName, version, partition);
-    if (perPartitionTransferFuture.isDone() || completeIfCancelled(replicaId, perPartitionTransferFuture)) {
-      return;
-    }
-    if (isDiscoveryUnavailable(fallbackResponse)) {
-      if (primaryPeersDiscovered) {
-        completeWithAllPeersFailed(replicaId, perPartitionTransferFuture);
-      } else {
-        completeWithNoPeersFound(replicaId, perPartitionTransferFuture);
+    try {
+      if (completeIfCancelled(replicaId, perPartitionTransferFuture)) {
+        return;
       }
-      return;
-    }
 
-    List<String> connectablePeers =
-        getConnectableHosts(fallbackResponse.getDiscoveryResult(), storeName, version, partition);
-    processPeersSequentially(
-        connectablePeers,
-        storeName,
-        version,
-        partition,
-        tableFormat,
-        transferStartTime,
-        perPartitionTransferFuture,
-        () -> completeWithAllPeersFailed(replicaId, perPartitionTransferFuture));
+      BlobPeersDiscoveryResponse fallbackResponse = peerFinder.discoverFallbackBlobPeers(storeName, version, partition);
+      if (perPartitionTransferFuture.isDone() || completeIfCancelled(replicaId, perPartitionTransferFuture)) {
+        return;
+      }
+      if (isDiscoveryUnavailable(fallbackResponse)) {
+        if (fallbackResponse != null && fallbackResponse.isError()) {
+          LOGGER.warn(FALLBACK_DISCOVERY_ERROR_MSG, replicaId, fallbackResponse.getErrorMessage());
+        }
+        if (primaryPeersDiscovered) {
+          completeWithAllPeersFailed(replicaId, perPartitionTransferFuture);
+        } else {
+          completeWithNoPeersFound(replicaId, perPartitionTransferFuture);
+        }
+        return;
+      }
+
+      List<String> connectablePeers =
+          getConnectableHosts(fallbackResponse.getDiscoveryResult(), storeName, version, partition);
+      processPeersSequentially(
+          connectablePeers,
+          storeName,
+          version,
+          partition,
+          tableFormat,
+          perPartitionTransferFuture,
+          () -> completeWithAllPeersFailed(replicaId, perPartitionTransferFuture));
+    } catch (RuntimeException e) {
+      // This runs on the replica blob fetch executor, so an escaping exception would be lost and the partition
+      // transfer would never complete. Always resolve the future so the caller can fall back to Kafka bootstrapping.
+      LOGGER.error(FALLBACK_DISCOVERY_FAILED_MSG, replicaId, e);
+      completeAfterPeersUnavailable(replicaId, perPartitionTransferFuture);
+    }
   }
 
   private static boolean isDiscoveryUnavailable(BlobPeersDiscoveryResponse response) {
@@ -262,7 +272,6 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
    * @param version the version of the store
    * @param partition the partition of the store
    * @param tableFormat the needed table format
-   * @param transferStartTime the start time of the partition-level transfer across all peer tiers
    * @param perPartitionTransferFuture the future to complete with the InputStream of the blob
    * @param peersExhaustedHandler action to run after every peer in this tier fails
    */
@@ -272,10 +281,10 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
       int version,
       int partition,
       BlobTransferTableFormat tableFormat,
-      Instant transferStartTime,
       CompletableFuture<InputStream> perPartitionTransferFuture,
       Runnable peersExhaustedHandler) {
     String replicaId = Utils.getReplicaId(Version.composeKafkaTopic(storeName, version), partition);
+    Instant startTime = Instant.now();
 
     // Create a CompletableFuture that represents the chain of processing all peers
     CompletableFuture<Void> chainOfPeersFuture = CompletableFuture.completedFuture(null);
@@ -307,7 +316,7 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
 
         return perHostTransferFuture.toCompletableFuture().thenAccept(inputStream -> {
           // Success case: Complete the future with the input stream
-          long transferTime = Duration.between(transferStartTime, Instant.now()).getSeconds();
+          long transferTime = Duration.between(startTime, Instant.now()).getSeconds();
           LOGGER.info(FETCHED_BLOB_SUCCESS_MSG, replicaId, chosenHost, transferTime);
           perPartitionTransferFuture.complete(inputStream);
           // Updating the blob transfer stats with the transfer time and throughput
@@ -324,10 +333,22 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
       if (perPartitionTransferFuture.isDone()) {
         return;
       }
-      if (completeIfCancelled(replicaId, perPartitionTransferFuture)) {
+      if (statusTrackingManager.isBlobTransferCancelRequested(replicaId)) {
+        // Receive cancellation request, skip Kafka bootstrapping
+        perPartitionTransferFuture.completeExceptionally(
+            new VeniceBlobTransferCancelledException(String.format(TRANSFER_CANCELLED_MSG_FORMAT, replicaId)));
         return;
       }
+      // No usable peers available in this tier.
       peersExhaustedHandler.run();
+    });
+
+    // A chain that completes exceptionally (for example the executor rejecting a queued host once close() shut it
+    // down) never reaches thenRun, which would leave the partition transfer hanging instead of falling back to Kafka.
+    chainOfPeersFuture.exceptionally(chainFailure -> {
+      LOGGER.error(PEER_CHAIN_FAILED_MSG, replicaId, chainFailure);
+      completeAfterPeersUnavailable(replicaId, perPartitionTransferFuture);
+      return null;
     });
   }
 
@@ -338,6 +359,19 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
     perPartitionTransferFuture.completeExceptionally(
         new VeniceBlobTransferCancelledException(String.format(TRANSFER_CANCELLED_MSG_FORMAT, replicaId)));
     return true;
+  }
+
+  /**
+   * Resolve a peer tier that could not deliver a blob. Reports cancellation when one was requested, so a transfer
+   * aborted mid-flight is not misreported as having exhausted every peer, and otherwise reports that all peers failed
+   * so the caller falls back to Kafka bootstrapping.
+   */
+  private void completeAfterPeersUnavailable(
+      String replicaId,
+      CompletableFuture<InputStream> perPartitionTransferFuture) {
+    if (!completeIfCancelled(replicaId, perPartitionTransferFuture)) {
+      completeWithAllPeersFailed(replicaId, perPartitionTransferFuture);
+    }
   }
 
   private static void completeWithNoPeersFound(
@@ -433,8 +467,8 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
    * @return the set of unique connectable hosts
    */
   private List<String> getConnectableHosts(List<String> discoverPeers, String storeName, int version, int partition) {
-    // Extract unique hosts from the discovered peers while preserving discovery order. Composite finders can mark this
-    // order as meaningful (for example, Da Vinci peers before Venice servers); otherwise we shuffle as before.
+    // Extract unique hosts from the discovered peers, then randomize so concurrent replicas do not all hammer the
+    // same peer. Peer tiers (for example Da Vinci before Venice servers) are ordered by the caller, not by this list.
     Set<String> uniquePeers = new LinkedHashSet<>();
     for (String peer: discoverPeers) {
       uniquePeers.add(peer.split("_")[0]);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
@@ -24,6 +24,7 @@ import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.acl.VeniceComponent;
 import com.linkedin.venice.blobtransfer.BlobFinder;
 import com.linkedin.venice.blobtransfer.BlobPeersDiscoveryResponse;
+import com.linkedin.venice.exceptions.VeniceBlobTransferCancelledException;
 import com.linkedin.venice.exceptions.VeniceBlobTransferFileNotFoundException;
 import com.linkedin.venice.exceptions.VeniceBlobTransferIncompatibleSchemaException;
 import com.linkedin.venice.exceptions.VenicePeersAllFailedException;
@@ -42,6 +43,7 @@ import com.linkedin.venice.store.rocksdb.RocksDBUtils;
 import com.linkedin.venice.utils.LogContext;
 import com.linkedin.venice.utils.SslUtils;
 import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.netty.handler.traffic.GlobalChannelTrafficShapingHandler;
@@ -381,12 +383,14 @@ public class TestNettyP2PBlobTransferManager {
 
   @Test
   public void testFallsBackFromDaVinciPeerToServerAfterTransferFailure() throws Exception {
-    List<String> hostlist = Arrays.asList("dvc-host", "server-host");
-    BlobPeersDiscoveryResponse response = new BlobPeersDiscoveryResponse();
-    response.setDiscoveryResult(hostlist);
-    doReturn(response).when(finder).discoverBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
-    doReturn(true).when(finder).shouldPreservePeerOrder();
-    doReturn(new HashSet<>(hostlist)).when(client)
+    BlobPeersDiscoveryResponse primaryResponse = new BlobPeersDiscoveryResponse();
+    primaryResponse.setDiscoveryResult(Collections.singletonList("dvc-host"));
+    doReturn(primaryResponse).when(finder).discoverBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    BlobPeersDiscoveryResponse fallbackResponse = new BlobPeersDiscoveryResponse();
+    fallbackResponse.setDiscoveryResult(Collections.singletonList("server-host"));
+    doReturn(true).when(finder).supportsFallback();
+    doReturn(fallbackResponse).when(finder).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    doReturn(new HashSet<>(Arrays.asList("dvc-host", "server-host"))).when(client)
         .getConnectableHosts(any(), eq(TEST_STORE), eq(TEST_VERSION), eq(TEST_PARTITION));
 
     CompletableFuture<InputStream> daVinciFailure = new CompletableFuture<>();
@@ -403,11 +407,89 @@ public class TestNettyP2PBlobTransferManager {
             .get(10, TimeUnit.SECONDS);
 
     Assert.assertSame(result, serverResponse);
-    InOrder transferOrder = Mockito.inOrder(client);
+    InOrder transferOrder = Mockito.inOrder(finder, client);
+    transferOrder.verify(finder).discoverBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
     transferOrder.verify(client)
         .get("dvc-host", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
+    transferOrder.verify(finder).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
     transferOrder.verify(client)
         .get("server-host", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
+  }
+
+  @Test
+  public void testDoesNotDiscoverFallbackAfterPrimaryTransferSucceeds() throws Exception {
+    BlobPeersDiscoveryResponse primaryResponse = new BlobPeersDiscoveryResponse();
+    primaryResponse.setDiscoveryResult(Collections.singletonList("dvc-host"));
+    doReturn(primaryResponse).when(finder).discoverBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    doReturn(true).when(finder).supportsFallback();
+    doReturn(Collections.singleton("dvc-host")).when(client)
+        .getConnectableHosts(any(), eq(TEST_STORE), eq(TEST_VERSION), eq(TEST_PARTITION));
+
+    InputStream daVinciResponse = mock(InputStream.class);
+    doReturn(CompletableFuture.completedFuture(daVinciResponse)).when(client)
+        .get("dvc-host", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
+
+    InputStream result =
+        manager.get(TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE)
+            .toCompletableFuture()
+            .get(10, TimeUnit.SECONDS);
+
+    Assert.assertSame(result, daVinciResponse);
+    Mockito.verify(finder, Mockito.never()).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+  }
+
+  @Test
+  public void testDiscoversFallbackWhenNoPrimaryPeersExist() throws Exception {
+    BlobPeersDiscoveryResponse primaryResponse = new BlobPeersDiscoveryResponse();
+    primaryResponse.setDiscoveryResult(Collections.emptyList());
+    doReturn(primaryResponse).when(finder).discoverBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    BlobPeersDiscoveryResponse fallbackResponse = new BlobPeersDiscoveryResponse();
+    fallbackResponse.setDiscoveryResult(Collections.singletonList("server-host"));
+    doReturn(true).when(finder).supportsFallback();
+    doReturn(fallbackResponse).when(finder).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    doReturn(Collections.singleton("server-host")).when(client)
+        .getConnectableHosts(any(), eq(TEST_STORE), eq(TEST_VERSION), eq(TEST_PARTITION));
+
+    InputStream serverResponse = mock(InputStream.class);
+    doReturn(CompletableFuture.completedFuture(serverResponse)).when(client)
+        .get("server-host", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
+
+    InputStream result =
+        manager.get(TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE)
+            .toCompletableFuture()
+            .get(10, TimeUnit.SECONDS);
+
+    Assert.assertSame(result, serverResponse);
+    Mockito.verify(finder).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+  }
+
+  @Test
+  public void testCancellationDoesNotDiscoverFallback() throws Exception {
+    BlobPeersDiscoveryResponse primaryResponse = new BlobPeersDiscoveryResponse();
+    primaryResponse.setDiscoveryResult(Collections.singletonList("dvc-host"));
+    doReturn(primaryResponse).when(finder).discoverBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    doReturn(true).when(finder).supportsFallback();
+    doReturn(Collections.singleton("dvc-host")).when(client)
+        .getConnectableHosts(any(), eq(TEST_STORE), eq(TEST_VERSION), eq(TEST_PARTITION));
+
+    CompletableFuture<InputStream> daVinciTransfer = new CompletableFuture<>();
+    doReturn(daVinciTransfer).when(client)
+        .get("dvc-host", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
+
+    CompletableFuture<InputStream> result =
+        manager.get(TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE)
+            .toCompletableFuture();
+    String replicaId = Utils.getReplicaId(Version.composeKafkaTopic(TEST_STORE, TEST_VERSION), TEST_PARTITION);
+    manager.getTransferStatusTrackingManager().cancelTransfer(replicaId);
+    daVinciTransfer.completeExceptionally(new VeniceBlobTransferFileNotFoundException("DVC snapshot unavailable"));
+
+    try {
+      result.get(10, TimeUnit.SECONDS);
+      Assert.fail("Expected the partition transfer to be cancelled");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof VeniceBlobTransferCancelledException);
+    }
+    Mockito.verify(finder, Mockito.never()).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
@@ -389,7 +389,8 @@ public class TestNettyP2PBlobTransferManager {
     BlobPeersDiscoveryResponse fallbackResponse = new BlobPeersDiscoveryResponse();
     fallbackResponse.setDiscoveryResult(Collections.singletonList("server-host"));
     doReturn(true).when(finder).supportsFallback();
-    doReturn(fallbackResponse).when(finder).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    doReturn(fallbackResponse).when(finder)
+        .discoverFallbackBlobPeersIfEnabled(TEST_STORE, TEST_VERSION, TEST_PARTITION);
     doReturn(new HashSet<>(Arrays.asList("dvc-host", "server-host"))).when(client)
         .getConnectableHosts(any(), eq(TEST_STORE), eq(TEST_VERSION), eq(TEST_PARTITION));
 
@@ -411,7 +412,7 @@ public class TestNettyP2PBlobTransferManager {
     transferOrder.verify(finder).discoverBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
     transferOrder.verify(client)
         .get("dvc-host", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
-    transferOrder.verify(finder).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    transferOrder.verify(finder).discoverFallbackBlobPeersIfEnabled(TEST_STORE, TEST_VERSION, TEST_PARTITION);
     transferOrder.verify(client)
         .get("server-host", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
   }
@@ -435,7 +436,8 @@ public class TestNettyP2PBlobTransferManager {
             .get(10, TimeUnit.SECONDS);
 
     Assert.assertSame(result, daVinciResponse);
-    Mockito.verify(finder, Mockito.never()).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    Mockito.verify(finder, Mockito.never())
+        .discoverFallbackBlobPeersIfEnabled(TEST_STORE, TEST_VERSION, TEST_PARTITION);
   }
 
   @Test
@@ -446,7 +448,8 @@ public class TestNettyP2PBlobTransferManager {
     BlobPeersDiscoveryResponse fallbackResponse = new BlobPeersDiscoveryResponse();
     fallbackResponse.setDiscoveryResult(Collections.singletonList("server-host"));
     doReturn(true).when(finder).supportsFallback();
-    doReturn(fallbackResponse).when(finder).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    doReturn(fallbackResponse).when(finder)
+        .discoverFallbackBlobPeersIfEnabled(TEST_STORE, TEST_VERSION, TEST_PARTITION);
     doReturn(Collections.singleton("server-host")).when(client)
         .getConnectableHosts(any(), eq(TEST_STORE), eq(TEST_VERSION), eq(TEST_PARTITION));
 
@@ -460,7 +463,7 @@ public class TestNettyP2PBlobTransferManager {
             .get(10, TimeUnit.SECONDS);
 
     Assert.assertSame(result, serverResponse);
-    Mockito.verify(finder).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    Mockito.verify(finder).discoverFallbackBlobPeersIfEnabled(TEST_STORE, TEST_VERSION, TEST_PARTITION);
   }
 
   @Test
@@ -489,7 +492,8 @@ public class TestNettyP2PBlobTransferManager {
     } catch (ExecutionException e) {
       Assert.assertTrue(e.getCause() instanceof VeniceBlobTransferCancelledException);
     }
-    Mockito.verify(finder, Mockito.never()).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    Mockito.verify(finder, Mockito.never())
+        .discoverFallbackBlobPeersIfEnabled(TEST_STORE, TEST_VERSION, TEST_PARTITION);
   }
 
   @Test
@@ -501,7 +505,8 @@ public class TestNettyP2PBlobTransferManager {
     fallbackResponse.setError(true);
     fallbackResponse.setErrorMessage("server metadata unavailable");
     doReturn(true).when(finder).supportsFallback();
-    doReturn(fallbackResponse).when(finder).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    doReturn(fallbackResponse).when(finder)
+        .discoverFallbackBlobPeersIfEnabled(TEST_STORE, TEST_VERSION, TEST_PARTITION);
     doReturn(Collections.singleton("dvc-host")).when(client)
         .getConnectableHosts(any(), eq(TEST_STORE), eq(TEST_VERSION), eq(TEST_PARTITION));
 
@@ -518,7 +523,7 @@ public class TestNettyP2PBlobTransferManager {
     } catch (ExecutionException e) {
       Assert.assertTrue(e.getCause() instanceof VenicePeersAllFailedException);
     }
-    Mockito.verify(finder).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    Mockito.verify(finder).discoverFallbackBlobPeersIfEnabled(TEST_STORE, TEST_VERSION, TEST_PARTITION);
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/TestNettyP2PBlobTransferManager.java
@@ -492,6 +492,201 @@ public class TestNettyP2PBlobTransferManager {
     Mockito.verify(finder, Mockito.never()).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
   }
 
+  @Test
+  public void testFallbackDiscoveryErrorAfterPrimaryPeersFail() throws Exception {
+    BlobPeersDiscoveryResponse primaryResponse = new BlobPeersDiscoveryResponse();
+    primaryResponse.setDiscoveryResult(Collections.singletonList("dvc-host"));
+    doReturn(primaryResponse).when(finder).discoverBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    BlobPeersDiscoveryResponse fallbackResponse = new BlobPeersDiscoveryResponse();
+    fallbackResponse.setError(true);
+    fallbackResponse.setErrorMessage("server metadata unavailable");
+    doReturn(true).when(finder).supportsFallback();
+    doReturn(fallbackResponse).when(finder).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    doReturn(Collections.singleton("dvc-host")).when(client)
+        .getConnectableHosts(any(), eq(TEST_STORE), eq(TEST_VERSION), eq(TEST_PARTITION));
+
+    CompletableFuture<InputStream> daVinciFailure = new CompletableFuture<>();
+    daVinciFailure.completeExceptionally(new VeniceBlobTransferFileNotFoundException("DVC snapshot unavailable"));
+    doReturn(daVinciFailure).when(client)
+        .get("dvc-host", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
+
+    try {
+      manager.get(TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE)
+          .toCompletableFuture()
+          .get(10, TimeUnit.SECONDS);
+      Assert.fail("Expected the partition transfer to fail after fallback discovery returned an error");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof VenicePeersAllFailedException);
+    }
+    Mockito.verify(finder).discoverFallbackBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+  }
+
+  /**
+   * When the manager is closed while a transfer is in flight, dispatching fallback discovery onto the shut down
+   * replica blob fetch executor is rejected. The rejection must fail the partition transfer instead of leaving the
+   * future uncompleted, otherwise the replica never falls back to Kafka bootstrapping.
+   */
+  @Test
+  public void testFallbackDispatchRejectionFailsTransfer() throws Exception {
+    NettyFileTransferClient closedManagerClient = mock(NettyFileTransferClient.class);
+    BlobFinder closedManagerFinder = mock(BlobFinder.class);
+    NettyP2PBlobTransferManager closedManager = new NettyP2PBlobTransferManager(
+        mock(P2PBlobTransferService.class),
+        closedManagerClient,
+        closedManagerFinder,
+        tmpPartitionDir.toString(),
+        versionedBlobTransferStats,
+        1,
+        LogContext.forTests(VeniceComponent.DAVINCI_CLIENT.name()));
+
+    BlobPeersDiscoveryResponse primaryResponse = new BlobPeersDiscoveryResponse();
+    primaryResponse.setDiscoveryResult(Collections.singletonList("dvc-host"));
+    doReturn(primaryResponse).when(closedManagerFinder).discoverBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    doReturn(true).when(closedManagerFinder).supportsFallback();
+    doReturn(Collections.singleton("dvc-host")).when(closedManagerClient)
+        .getConnectableHosts(any(), eq(TEST_STORE), eq(TEST_VERSION), eq(TEST_PARTITION));
+
+    CompletableFuture<InputStream> daVinciTransfer = new CompletableFuture<>();
+    doReturn(daVinciTransfer).when(closedManagerClient)
+        .get("dvc-host", TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE);
+
+    CompletableFuture<InputStream> result =
+        closedManager.get(TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE)
+            .toCompletableFuture();
+    closedManager.close();
+    daVinciTransfer.completeExceptionally(new VeniceBlobTransferFileNotFoundException("DVC snapshot unavailable"));
+
+    try {
+      result.get(10, TimeUnit.SECONDS);
+      Assert.fail("Expected the partition transfer to fail once fallback dispatch was rejected");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof VenicePeersAllFailedException);
+    }
+  }
+
+  /**
+   * Second rejection race: the fallback dispatch is never reached because the executor is shut down while the chain is
+   * mid-flight, so the next host's {@code thenComposeAsync} dispatch is rejected and the chain completes
+   * exceptionally. {@code thenRun} skips exceptional completion, so the partition future must be failed from a
+   * {@code whenComplete} observer rather than left hanging.
+   */
+  @Test
+  public void testPeerChainRejectionMidFlightFailsTransfer() throws Exception {
+    NettyFileTransferClient closedManagerClient = mock(NettyFileTransferClient.class);
+    BlobFinder closedManagerFinder = mock(BlobFinder.class);
+    NettyP2PBlobTransferManager closedManager = new NettyP2PBlobTransferManager(
+        mock(P2PBlobTransferService.class),
+        closedManagerClient,
+        closedManagerFinder,
+        tmpPartitionDir.toString(),
+        versionedBlobTransferStats,
+        1,
+        LogContext.forTests(VeniceComponent.DAVINCI_CLIENT.name()));
+
+    // Two peers, so the second host still needs an executor dispatch after the first host resolves.
+    BlobPeersDiscoveryResponse primaryResponse = new BlobPeersDiscoveryResponse();
+    primaryResponse.setDiscoveryResult(Arrays.asList("dvc-host-1", "dvc-host-2"));
+    doReturn(primaryResponse).when(closedManagerFinder).discoverBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    doReturn(true).when(closedManagerFinder).supportsFallback();
+    doReturn(new HashSet<>(Arrays.asList("dvc-host-1", "dvc-host-2"))).when(closedManagerClient)
+        .getConnectableHosts(any(), eq(TEST_STORE), eq(TEST_VERSION), eq(TEST_PARTITION));
+
+    CompletableFuture<InputStream> firstTransfer = new CompletableFuture<>();
+    doReturn(firstTransfer).when(closedManagerClient)
+        .get(
+            anyString(),
+            eq(TEST_STORE),
+            eq(TEST_VERSION),
+            eq(TEST_PARTITION),
+            eq(BlobTransferTableFormat.BLOCK_BASED_TABLE));
+
+    CompletableFuture<InputStream> result =
+        closedManager.get(TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE)
+            .toCompletableFuture();
+    // Let the first host be dispatched before the executor goes away, so the rejection lands on the second host.
+    TestUtils.waitForNonDeterministicAssertion(
+        10,
+        TimeUnit.SECONDS,
+        () -> Mockito.verify(closedManagerClient)
+            .get(
+                anyString(),
+                eq(TEST_STORE),
+                eq(TEST_VERSION),
+                eq(TEST_PARTITION),
+                eq(BlobTransferTableFormat.BLOCK_BASED_TABLE)));
+    closedManager.close();
+    firstTransfer.completeExceptionally(new VeniceBlobTransferFileNotFoundException("DVC snapshot unavailable"));
+
+    try {
+      result.get(10, TimeUnit.SECONDS);
+      Assert.fail("Expected the partition transfer to fail once the peer chain was rejected");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof VenicePeersAllFailedException);
+    }
+  }
+
+  /**
+   * A rejection that races a cancellation must report the cancellation rather than claiming every peer was tried,
+   * matching what the normal peer-exhaustion path reports.
+   */
+  @Test
+  public void testCancellationWinsOverChainRejection() throws Exception {
+    NettyFileTransferClient closedManagerClient = mock(NettyFileTransferClient.class);
+    BlobFinder closedManagerFinder = mock(BlobFinder.class);
+    NettyP2PBlobTransferManager closedManager = new NettyP2PBlobTransferManager(
+        mock(P2PBlobTransferService.class),
+        closedManagerClient,
+        closedManagerFinder,
+        tmpPartitionDir.toString(),
+        versionedBlobTransferStats,
+        1,
+        LogContext.forTests(VeniceComponent.DAVINCI_CLIENT.name()));
+
+    BlobPeersDiscoveryResponse primaryResponse = new BlobPeersDiscoveryResponse();
+    primaryResponse.setDiscoveryResult(Arrays.asList("dvc-host-1", "dvc-host-2"));
+    doReturn(primaryResponse).when(closedManagerFinder).discoverBlobPeers(TEST_STORE, TEST_VERSION, TEST_PARTITION);
+    doReturn(true).when(closedManagerFinder).supportsFallback();
+    doReturn(new HashSet<>(Arrays.asList("dvc-host-1", "dvc-host-2"))).when(closedManagerClient)
+        .getConnectableHosts(any(), eq(TEST_STORE), eq(TEST_VERSION), eq(TEST_PARTITION));
+
+    CompletableFuture<InputStream> firstTransfer = new CompletableFuture<>();
+    doReturn(firstTransfer).when(closedManagerClient)
+        .get(
+            anyString(),
+            eq(TEST_STORE),
+            eq(TEST_VERSION),
+            eq(TEST_PARTITION),
+            eq(BlobTransferTableFormat.BLOCK_BASED_TABLE));
+
+    CompletableFuture<InputStream> result =
+        closedManager.get(TEST_STORE, TEST_VERSION, TEST_PARTITION, BlobTransferTableFormat.BLOCK_BASED_TABLE)
+            .toCompletableFuture();
+    TestUtils.waitForNonDeterministicAssertion(
+        10,
+        TimeUnit.SECONDS,
+        () -> Mockito.verify(closedManagerClient)
+            .get(
+                anyString(),
+                eq(TEST_STORE),
+                eq(TEST_VERSION),
+                eq(TEST_PARTITION),
+                eq(BlobTransferTableFormat.BLOCK_BASED_TABLE)));
+    // Cancel and shut the executor down, so the next host's dispatch is rejected while a cancellation is pending.
+    String replicaId = Utils.getReplicaId(Version.composeKafkaTopic(TEST_STORE, TEST_VERSION), TEST_PARTITION);
+    closedManager.getTransferStatusTrackingManager().cancelTransfer(replicaId);
+    closedManager.close();
+    firstTransfer.completeExceptionally(new VeniceBlobTransferFileNotFoundException("DVC snapshot unavailable"));
+
+    try {
+      result.get(10, TimeUnit.SECONDS);
+      Assert.fail("Expected the partition transfer to be cancelled");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(
+          e.getCause() instanceof VeniceBlobTransferCancelledException,
+          "Expected a cancellation, but got: " + e.getCause());
+    }
+  }
+
   /**
    * The client is initialized with host freshness 30 sec, so when purgeStaleConnectivityRecords is called,
    * All hosts connectivity records older than 30s should be purged.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/BlobFinder.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/BlobFinder.java
@@ -14,7 +14,10 @@ public interface BlobFinder extends AutoCloseable {
 
   /** Discovers fallback peers after primary peers are exhausted. */
   default BlobPeersDiscoveryResponse discoverFallbackBlobPeers(String storeName, int version, int partitionId) {
-    return null;
+    BlobPeersDiscoveryResponse response = new BlobPeersDiscoveryResponse();
+    response.setError(true);
+    response.setErrorMessage("Fallback blob peer discovery is not supported");
+    return response;
   }
 
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/BlobFinder.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/BlobFinder.java
@@ -7,8 +7,14 @@ public interface BlobFinder extends AutoCloseable {
    */
   BlobPeersDiscoveryResponse discoverBlobPeers(String storeName, int version, int partitionId);
 
-  default boolean shouldPreservePeerOrder() {
+  /** Returns whether the transfer manager should attempt fallback discovery after primary peers are exhausted. */
+  default boolean supportsFallback() {
     return false;
+  }
+
+  /** Discovers fallback peers after primary peers are exhausted. */
+  default BlobPeersDiscoveryResponse discoverFallbackBlobPeers(String storeName, int version, int partitionId) {
+    return null;
   }
 
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/BlobFinder.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/BlobFinder.java
@@ -12,8 +12,11 @@ public interface BlobFinder extends AutoCloseable {
     return false;
   }
 
-  /** Discovers fallback peers after primary peers are exhausted. */
-  default BlobPeersDiscoveryResponse discoverFallbackBlobPeers(String storeName, int version, int partitionId) {
+  /** Discovers fallback peers after primary peers are exhausted, if fallback discovery is enabled. */
+  default BlobPeersDiscoveryResponse discoverFallbackBlobPeersIfEnabled(
+      String storeName,
+      int version,
+      int partitionId) {
     BlobPeersDiscoveryResponse response = new BlobPeersDiscoveryResponse();
     response.setError(true);
     response.setErrorMessage("Fallback blob peer discovery is not supported");

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/ServerAndDaVinciBlobFinder.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/ServerAndDaVinciBlobFinder.java
@@ -2,15 +2,12 @@ package com.linkedin.venice.blobtransfer;
 
 import com.linkedin.venice.annotation.VisibleForTesting;
 import com.linkedin.venice.client.store.ClientConfig;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
 /**
- * Discovers Da Vinci peers first and Venice servers second for client cold-start blob transfer.
+ * Discovers Da Vinci peers first and lazily discovers Venice servers only after the primary peers are exhausted.
  */
 public class ServerAndDaVinciBlobFinder implements BlobFinder {
   private static final Logger LOGGER = LogManager.getLogger(ServerAndDaVinciBlobFinder.class);
@@ -30,30 +27,10 @@ public class ServerAndDaVinciBlobFinder implements BlobFinder {
 
   @Override
   public BlobPeersDiscoveryResponse discoverBlobPeers(String storeName, int version, int partitionId) {
-    BlobPeersDiscoveryResponse daVinciResponse = daVinciBlobFinder.discoverBlobPeers(storeName, version, partitionId);
-    BlobPeersDiscoveryResponse serverResponse = serverBlobFinder.discoverBlobPeers(storeName, version, partitionId);
-
-    List<String> daVinciPeers = getDiscoveredPeers(daVinciResponse);
-    List<String> serverPeers = getDiscoveredPeers(serverResponse);
-    Collections.shuffle(daVinciPeers);
-    Collections.shuffle(serverPeers);
-
-    BlobPeersDiscoveryResponse response = new BlobPeersDiscoveryResponse();
-    List<String> discoveredPeers = new ArrayList<>(daVinciPeers.size() + serverPeers.size());
-    discoveredPeers.addAll(daVinciPeers);
-    discoveredPeers.addAll(serverPeers);
-    response.setDiscoveryResult(discoveredPeers);
-
-    if (discoveredPeers.isEmpty() && hasError(daVinciResponse) && hasError(serverResponse)) {
-      response.setError(true);
-      response.setErrorMessage(
-          "Failed to discover both Da Vinci peers and Venice servers. Da Vinci error: "
-              + getErrorMessage(daVinciResponse) + "; server error: " + getErrorMessage(serverResponse));
-    }
+    BlobPeersDiscoveryResponse response = daVinciBlobFinder.discoverBlobPeers(storeName, version, partitionId);
     LOGGER.info(
-        "Discovered {} Da Vinci peer(s) and {} Venice server peer(s) for store {} version {} partition {}.",
-        daVinciPeers.size(),
-        serverPeers.size(),
+        "Discovered {} Da Vinci peer(s) for store {} version {} partition {}.",
+        getDiscoveredPeerCount(response),
         storeName,
         version,
         partitionId);
@@ -61,24 +38,24 @@ public class ServerAndDaVinciBlobFinder implements BlobFinder {
   }
 
   @Override
-  public boolean shouldPreservePeerOrder() {
+  public boolean supportsFallback() {
     return true;
   }
 
-  private static List<String> getDiscoveredPeers(BlobPeersDiscoveryResponse response) {
-    if (response == null || response.isError() || response.getDiscoveryResult() == null
-        || response.getDiscoveryResult().isEmpty()) {
-      return new ArrayList<>();
-    }
-    return new ArrayList<>(response.getDiscoveryResult());
+  @Override
+  public BlobPeersDiscoveryResponse discoverFallbackBlobPeers(String storeName, int version, int partitionId) {
+    BlobPeersDiscoveryResponse response = serverBlobFinder.discoverBlobPeers(storeName, version, partitionId);
+    LOGGER.info(
+        "Discovered {} Venice server peer(s) for store {} version {} partition {}.",
+        getDiscoveredPeerCount(response),
+        storeName,
+        version,
+        partitionId);
+    return response;
   }
 
-  private static boolean hasError(BlobPeersDiscoveryResponse response) {
-    return response == null || response.isError();
-  }
-
-  private static String getErrorMessage(BlobPeersDiscoveryResponse response) {
-    return response == null ? "null response" : response.getErrorMessage();
+  private static int getDiscoveredPeerCount(BlobPeersDiscoveryResponse response) {
+    return response == null || response.getDiscoveryResult() == null ? 0 : response.getDiscoveryResult().size();
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/ServerAndDaVinciBlobFinder.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/ServerAndDaVinciBlobFinder.java
@@ -43,7 +43,7 @@ public class ServerAndDaVinciBlobFinder implements BlobFinder {
   }
 
   @Override
-  public BlobPeersDiscoveryResponse discoverFallbackBlobPeers(String storeName, int version, int partitionId) {
+  public BlobPeersDiscoveryResponse discoverFallbackBlobPeersIfEnabled(String storeName, int version, int partitionId) {
     BlobPeersDiscoveryResponse response = serverBlobFinder.discoverBlobPeers(storeName, version, partitionId);
     LOGGER.info(
         "Discovered {} Venice server peer(s) for store {} version {} partition {}.",

--- a/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/ServerAndDaVinciBlobFinderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/ServerAndDaVinciBlobFinderTest.java
@@ -5,8 +5,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
-import java.util.Arrays;
 import java.util.Collections;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -18,65 +18,46 @@ public class ServerAndDaVinciBlobFinderTest {
   private static final int PARTITION = 0;
 
   @Test
-  public void testDiscoverBlobPeersReturnsDaVinciPeersBeforeServerPeers() {
+  public void testDiscoverBlobPeersReturnsOnlyDaVinciPeers() {
     BlobFinder daVinciBlobFinder = mock(BlobFinder.class);
     BlobPeersDiscoveryResponse daVinciResponse = new BlobPeersDiscoveryResponse();
     daVinciResponse.setDiscoveryResult(Collections.singletonList("dvc-host"));
     doReturn(daVinciResponse).when(daVinciBlobFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
 
     BlobFinder serverBlobFinder = mock(BlobFinder.class);
-    BlobPeersDiscoveryResponse serverResponse = new BlobPeersDiscoveryResponse();
-    serverResponse.setDiscoveryResult(Collections.singletonList("server-host"));
-    doReturn(serverResponse).when(serverBlobFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
-
-    ServerAndDaVinciBlobFinder finder = new ServerAndDaVinciBlobFinder(daVinciBlobFinder, serverBlobFinder);
-
-    BlobPeersDiscoveryResponse response = finder.discoverBlobPeers(STORE_NAME, VERSION, PARTITION);
-
-    Assert.assertFalse(response.isError());
-    Assert.assertEquals(response.getDiscoveryResult(), Arrays.asList("dvc-host", "server-host"));
-    verify(daVinciBlobFinder).discoverBlobPeers(STORE_NAME, VERSION, PARTITION);
-    verify(serverBlobFinder).discoverBlobPeers(STORE_NAME, VERSION, PARTITION);
-  }
-
-  @Test
-  public void testDiscoverBlobPeersUsesServerPeersWhenDaVinciDiscoveryHasNoPeers() {
-    BlobFinder daVinciBlobFinder = mock(BlobFinder.class);
-    BlobPeersDiscoveryResponse daVinciResponse = new BlobPeersDiscoveryResponse();
-    daVinciResponse.setDiscoveryResult(Collections.emptyList());
-    doReturn(daVinciResponse).when(daVinciBlobFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
-
-    BlobFinder serverBlobFinder = mock(BlobFinder.class);
-    BlobPeersDiscoveryResponse serverResponse = new BlobPeersDiscoveryResponse();
-    serverResponse.setDiscoveryResult(Collections.singletonList("server-host"));
-    doReturn(serverResponse).when(serverBlobFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
-    ServerAndDaVinciBlobFinder finder = new ServerAndDaVinciBlobFinder(daVinciBlobFinder, serverBlobFinder);
-
-    BlobPeersDiscoveryResponse response = finder.discoverBlobPeers(STORE_NAME, VERSION, PARTITION);
-
-    Assert.assertFalse(response.isError());
-    Assert.assertEquals(response.getDiscoveryResult(), Collections.singletonList("server-host"));
-  }
-
-  @Test
-  public void testDiscoverBlobPeersUsesDaVinciPeersWhenServerDiscoveryErrors() {
-    BlobFinder daVinciBlobFinder = mock(BlobFinder.class);
-    BlobPeersDiscoveryResponse daVinciResponse = new BlobPeersDiscoveryResponse();
-    daVinciResponse.setDiscoveryResult(Collections.singletonList("dvc-host"));
-    doReturn(daVinciResponse).when(daVinciBlobFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
-
-    BlobFinder serverBlobFinder = mock(BlobFinder.class);
-    BlobPeersDiscoveryResponse serverResponse = new BlobPeersDiscoveryResponse();
-    serverResponse.setError(true);
-    serverResponse.setErrorMessage("server discovery failed");
-    doReturn(serverResponse).when(serverBlobFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
-
     ServerAndDaVinciBlobFinder finder = new ServerAndDaVinciBlobFinder(daVinciBlobFinder, serverBlobFinder);
 
     BlobPeersDiscoveryResponse response = finder.discoverBlobPeers(STORE_NAME, VERSION, PARTITION);
 
     Assert.assertFalse(response.isError());
     Assert.assertEquals(response.getDiscoveryResult(), Collections.singletonList("dvc-host"));
+    verify(daVinciBlobFinder).discoverBlobPeers(STORE_NAME, VERSION, PARTITION);
+    verifyNoInteractions(serverBlobFinder);
+  }
+
+  @Test
+  public void testDiscoverFallbackBlobPeersReturnsServerPeers() {
+    BlobFinder daVinciBlobFinder = mock(BlobFinder.class);
+    BlobFinder serverBlobFinder = mock(BlobFinder.class);
+    BlobPeersDiscoveryResponse serverResponse = new BlobPeersDiscoveryResponse();
+    serverResponse.setDiscoveryResult(Collections.singletonList("server-host"));
+    doReturn(serverResponse).when(serverBlobFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
+    ServerAndDaVinciBlobFinder finder = new ServerAndDaVinciBlobFinder(daVinciBlobFinder, serverBlobFinder);
+
+    BlobPeersDiscoveryResponse response = finder.discoverFallbackBlobPeers(STORE_NAME, VERSION, PARTITION);
+
+    Assert.assertFalse(response.isError());
+    Assert.assertEquals(response.getDiscoveryResult(), Collections.singletonList("server-host"));
+    verify(serverBlobFinder).discoverBlobPeers(STORE_NAME, VERSION, PARTITION);
+    verifyNoInteractions(daVinciBlobFinder);
+  }
+
+  @Test
+  public void testSupportsFallback() {
+    BlobFinder daVinciBlobFinder = mock(BlobFinder.class);
+    BlobFinder serverBlobFinder = mock(BlobFinder.class);
+
+    Assert.assertTrue(new ServerAndDaVinciBlobFinder(daVinciBlobFinder, serverBlobFinder).supportsFallback());
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/ServerAndDaVinciBlobFinderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/blobtransfer/ServerAndDaVinciBlobFinderTest.java
@@ -36,7 +36,7 @@ public class ServerAndDaVinciBlobFinderTest {
   }
 
   @Test
-  public void testDiscoverFallbackBlobPeersReturnsServerPeers() {
+  public void testDiscoverFallbackBlobPeersIfEnabledReturnsServerPeers() {
     BlobFinder daVinciBlobFinder = mock(BlobFinder.class);
     BlobFinder serverBlobFinder = mock(BlobFinder.class);
     BlobPeersDiscoveryResponse serverResponse = new BlobPeersDiscoveryResponse();
@@ -44,7 +44,7 @@ public class ServerAndDaVinciBlobFinderTest {
     doReturn(serverResponse).when(serverBlobFinder).discoverBlobPeers(anyString(), anyInt(), anyInt());
     ServerAndDaVinciBlobFinder finder = new ServerAndDaVinciBlobFinder(daVinciBlobFinder, serverBlobFinder);
 
-    BlobPeersDiscoveryResponse response = finder.discoverFallbackBlobPeers(STORE_NAME, VERSION, PARTITION);
+    BlobPeersDiscoveryResponse response = finder.discoverFallbackBlobPeersIfEnabled(STORE_NAME, VERSION, PARTITION);
 
     Assert.assertFalse(response.isError());
     Assert.assertEquals(response.getDiscoveryResult(), Collections.singletonList("server-host"));


### PR DESCRIPTION
## Problem Statement

`ServerAndDaVinciBlobFinder` eagerly fetched Venice server metadata for every partition, even when a Da Vinci peer was available and could serve the blob. The server metadata response contains routing and schema information for the entire store, so eager requests during a partitioned cold start can add unnecessary storage-node load and affect Fast Client read latency.

## Solution

Introduce lazy, tiered peer discovery:

- Discover and attempt Da Vinci peers first.
- Discover Venice server peers only when no Da Vinci peers are available or every primary peer transfer fails.
- Stop before fallback discovery when the partition transfer is cancelled.
- Preserve existing randomization within each peer tier.

The behavior remains gated by the existing `davinci.blob.transfer.server.fallback.enabled` config, which defaults to `false`.

### Always resolving the partition transfer future

Fallback discovery is dispatched onto `replicaBlobFetchExecutor` rather than running inline in `get()`, which makes failure paths reachable that the eager implementation could not hit. A partition transfer future that is never completed stalls the replica forever, because `StoreIngestionTask` waits on it to decide whether to fall back to Kafka bootstrapping. Each path is now resolved explicitly:

- Guard the fallback dispatch and the discovery body, so a rejected execution (`close()` shutting the executor down) or an unexpected runtime failure still completes the future.
- Observe the peer chain with `exceptionally()`. A chain that completes exceptionally never reaches `thenRun`, so the transfer previously hung. This also covers the pre-existing single-tier path, where the same window existed but was only reachable during shutdown.
- Report a requested cancellation from these handlers instead of claiming every peer was tried, matching what the normal peer-exhaustion path reports.
- Log the fallback discovery error message rather than dropping it.

Blob transfer time and throughput are still measured per discovery pass, so `recordBlobTransferTimeInSec` and `recordBlobTransferFileReceiveThroughput` keep their existing meaning on the default (fallback-disabled) path.

###  Code changes
- [x] Added new code behind **a config**. Existing config: `davinci.blob.transfer.server.fallback.enabled` (default: `false`).
- [x] Introduced new **log lines**.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging. Primary discovery retains the existing per-partition logging pattern; server discovery logs only when fallback is actually attempted. The failure log lines are terminal for a partition-level transfer, so they cannot repeat within a pass.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**. Cancellation is re-checked at each hand-off, including after a rejected dispatch, so a cancellation racing a failure is reported as a cancellation.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed. State is confined to the per-partition `CompletableFuture`, whose completion is idempotent, so no additional locking is introduced.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation. Fallback discovery blocks on the metadata fetch, so it runs on `replicaBlobFetchExecutor` instead of a Netty event-loop thread, consistent with the existing `thenComposeAsync` rationale.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination. Work dispatched to the executor is wrapped so an escaping exception cannot be swallowed by an unobserved future; `Error` is deliberately left to propagate.

## How was this PR tested?

- [x] Local code review completed.
- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

New `TestNettyP2PBlobTransferManager` cases:

- `testDoesNotDiscoverFallbackAfterPrimaryTransferSucceeds` - server discovery is skipped when a Da Vinci peer serves the blob.
- `testDiscoversFallbackWhenNoPrimaryPeersExist` and `testFallsBackFromDaVinciPeerToServerAfterTransferFailure` - both fallback triggers, asserting discovery and transfer ordering.
- `testCancellationDoesNotDiscoverFallback` - a cancelled transfer stops before fallback discovery.
- `testFallbackDiscoveryErrorAfterPrimaryPeersFail` - fallback discovery returning an error surfaces `VenicePeersAllFailedException`.
- `testFallbackDispatchRejectionFailsTransfer` and `testPeerChainRejectionMidFlightFailsTransfer` - both executor-rejection windows resolve the future instead of hanging.
- `testCancellationWinsOverChainRejection` - a rejection racing a cancellation reports `VeniceBlobTransferCancelledException`.

Each new failure-path test was confirmed to fail against the unfixed code before the fix was applied.

Commands:

- `./gradlew :internal:venice-common:test --tests 'com.linkedin.venice.blobtransfer.ServerAndDaVinciBlobFinderTest'`
- `./gradlew :clients:da-vinci-client:test --tests 'com.linkedin.davinci.blobtransfer.TestNettyP2PBlobTransferManager'`
- `./gradlew spotlessCheck`

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
