### PR TITLE
[da-vinci] Fix sequential roll-forward deadlock by keying paused-SIT off roll-forward order

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci;
 
 import com.linkedin.davinci.client.DaVinciSeekCheckpointInfo;
 import com.linkedin.davinci.config.StoreBackendConfig;
+import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
@@ -14,6 +15,7 @@ import com.linkedin.venice.utils.ConcurrentRef;
 import com.linkedin.venice.utils.ReferenceCounted;
 import com.linkedin.venice.utils.RegionUtils;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -306,20 +308,47 @@ public class StoreBackend {
       return;
     }
 
-    Set<String> targetRegions = RegionUtils.parseRegionsFilterList(targetSwapRegion);
-    String currentRegion = backend.getConfigLoader().getVeniceServerConfig().getRegionName();
+    VeniceServerConfig serverConfig = backend.getConfigLoader().getVeniceServerConfig();
+    String currentRegion = serverConfig.getRegionName();
 
-    if (targetRegions.contains(currentRegion)) {
-      // This DVC instance IS in the target region — always subscribe active.
+    // Determine which region ingests actively (unpaused) for this deferred-swap push.
+    // When the cluster is configured for sequential roll-forward, the controller promotes regions one
+    // at a time following the roll-forward order, and the active region is its head
+    // (rollForwardOrder.get(0)). Da Vinci must key off the SAME order the controller uses (see
+    // AbstractPushMonitor#sequentialRollForwardFirstRegion); otherwise it can pause the very region the
+    // controller is waiting on to complete, deadlocking the swap (the region never completes because
+    // DVC is paused, and DVC never resumes because the region is not promoted). When sequential
+    // roll-forward is not configured, fall back to the version's targetSwapRegion (parallel
+    // target-region push).
+    String rollForwardOrder = serverConfig.getDeferredVersionSwapRegionRollforwardOrder();
+    boolean isActiveRegion;
+    if (!StringUtils.isEmpty(rollForwardOrder)) {
+      List<String> rollForwardOrderList = RegionUtils.parseRegionRolloutOrderList(rollForwardOrder);
+      isActiveRegion = !rollForwardOrderList.isEmpty() && rollForwardOrderList.get(0).equals(currentRegion);
+    } else {
+      isActiveRegion = RegionUtils.parseRegionsFilterList(targetSwapRegion).contains(currentRegion);
+    }
+
+    if (isActiveRegion) {
+      // This DVC instance is in the active (target / roll-forward head) region — always subscribe active.
       subscribeFutureVersion(targetVersion, false);
       return;
     }
 
-    // Non-target region with a target-region push in flight.
-    boolean pausedSitEnabled = backend.getConfigLoader().getVeniceServerConfig().isDaVinciPausedSitEnabled();
+    // Non-active region with a deferred-swap push in flight.
+    boolean pausedSitEnabled = serverConfig.isDaVinciPausedSitEnabled();
     if (pausedSitEnabled) {
       // Paused-SIT mode: subscribe immediately in a paused state; resume when targetRegionPromoted fires.
       boolean createPaused = !targetVersion.isTargetRegionPromoted();
+      LOGGER.info(
+          "Subscribing to future version {} in region {} with createPaused={} "
+              + "(targetSwapRegion={}, rollForwardOrder='{}', targetRegionPromoted={})",
+          targetVersion.kafkaTopicName(),
+          currentRegion,
+          createPaused,
+          targetSwapRegion,
+          rollForwardOrder,
+          targetVersion.isTargetRegionPromoted());
       subscribeFutureVersion(targetVersion, createPaused);
     } else {
       // Legacy mode: subscribe only once the version is ONLINE in this region.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
@@ -15,7 +15,6 @@ import com.linkedin.venice.utils.ConcurrentRef;
 import com.linkedin.venice.utils.ReferenceCounted;
 import com.linkedin.venice.utils.RegionUtils;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -313,19 +312,32 @@ public class StoreBackend {
 
     // Determine which region ingests actively (unpaused) for this deferred-swap push.
     // When the cluster is configured for sequential roll-forward, the controller promotes regions one
-    // at a time following the roll-forward order, and the active region is its head
-    // (rollForwardOrder.get(0)). Da Vinci must key off the SAME order the controller uses (see
-    // AbstractPushMonitor#sequentialRollForwardFirstRegion); otherwise it can pause the very region the
-    // controller is waiting on to complete, deadlocking the swap (the region never completes because
-    // DVC is paused, and DVC never resumes because the region is not promoted). When sequential
-    // roll-forward is not configured, fall back to the version's targetSwapRegion (parallel
+    // at a time following the roll-forward order, and the active region is its head. Da Vinci must key
+    // off the SAME order the controller uses (see AbstractPushMonitor#sequentialRollForwardFirstRegion);
+    // otherwise it can pause the very region the controller is waiting on to complete, deadlocking the
+    // swap (the region never completes because DVC is paused, and DVC never resumes because the region
+    // is not promoted).
+    //
+    // Skip blank entries when reading the head: a whitespace-only config or a leading comma would
+    // otherwise yield an empty-string head, which matches no region and — in paused-SIT mode — would
+    // pause EVERY region, reintroducing the deadlock. If the config is unset or has no non-blank
+    // entries, treat it as not configured and fall back to the version's targetSwapRegion (parallel
     // target-region push).
-    String rollForwardOrder = serverConfig.getDeferredVersionSwapRegionRollforwardOrder();
+    String rollForwardHead = null;
+    for (String region: RegionUtils
+        .parseRegionRolloutOrderList(serverConfig.getDeferredVersionSwapRegionRollforwardOrder())) {
+      if (!StringUtils.isBlank(region)) {
+        rollForwardHead = region;
+        break;
+      }
+    }
+
     boolean isActiveRegion;
-    if (!StringUtils.isEmpty(rollForwardOrder)) {
-      List<String> rollForwardOrderList = RegionUtils.parseRegionRolloutOrderList(rollForwardOrder);
-      isActiveRegion = !rollForwardOrderList.isEmpty() && rollForwardOrderList.get(0).equals(currentRegion);
+    if (rollForwardHead != null) {
+      // Sequential roll-forward: the active (unpaused) region is the head of the roll-forward order.
+      isActiveRegion = rollForwardHead.equals(currentRegion);
     } else {
+      // Parallel target-region push (or roll-forward not configured): use targetSwapRegion membership.
       isActiveRegion = RegionUtils.parseRegionsFilterList(targetSwapRegion).contains(currentRegion);
     }
 
@@ -342,12 +354,12 @@ public class StoreBackend {
       boolean createPaused = !targetVersion.isTargetRegionPromoted();
       LOGGER.info(
           "Subscribing to future version {} in region {} with createPaused={} "
-              + "(targetSwapRegion={}, rollForwardOrder='{}', targetRegionPromoted={})",
+              + "(targetSwapRegion={}, rollForwardHead={}, targetRegionPromoted={})",
           targetVersion.kafkaTopicName(),
           currentRegion,
           createPaused,
           targetSwapRegion,
-          rollForwardOrder,
+          rollForwardHead,
           targetVersion.isTargetRegionPromoted());
       subscribeFutureVersion(targetVersion, createPaused);
     } else {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -33,6 +33,7 @@ import static com.linkedin.venice.ConfigKeys.DA_VINCI_CURRENT_VERSION_BOOTSTRAPP
 import static com.linkedin.venice.ConfigKeys.DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_QUOTA_RECORDS_PER_SECOND;
 import static com.linkedin.venice.ConfigKeys.DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_SPEEDUP_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_RECORD_SIZE_BYTES;
+import static com.linkedin.venice.ConfigKeys.DEFERRED_VERSION_SWAP_REGION_ROLL_FORWARD_ORDER;
 import static com.linkedin.venice.ConfigKeys.DIV_PRODUCER_STATE_MAX_AGE_MS;
 import static com.linkedin.venice.ConfigKeys.ENABLE_GRPC_READ_SERVER;
 import static com.linkedin.venice.ConfigKeys.ENABLE_SERVER_ALLOW_LIST;
@@ -703,6 +704,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final int dvcP2pBlobTransferClientPort;
   private final boolean daVinciCurrentVersionBootstrappingSpeedupEnabled;
   private final boolean daVinciPausedSitEnabled;
+  private final String deferredVersionSwapRegionRollforwardOrder;
   private final long daVinciCurrentVersionBootstrappingQuotaRecordsPerSecond;
   private final long daVinciCurrentVersionBootstrappingQuotaBytesPerSecond;
   private final boolean resubscriptionTriggeredByVersionIngestionContextChangeEnabled;
@@ -1224,6 +1226,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     daVinciCurrentVersionBootstrappingSpeedupEnabled =
         serverProperties.getBoolean(DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_SPEEDUP_ENABLED, true);
     daVinciPausedSitEnabled = serverProperties.getBoolean(DAVINCI_PAUSED_SIT_ENABLED, false);
+    deferredVersionSwapRegionRollforwardOrder =
+        serverProperties.getString(DEFERRED_VERSION_SWAP_REGION_ROLL_FORWARD_ORDER, "");
     daVinciCurrentVersionBootstrappingQuotaRecordsPerSecond =
         serverProperties.getLong(DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_QUOTA_RECORDS_PER_SECOND, 500000);
     daVinciCurrentVersionBootstrappingQuotaBytesPerSecond = serverProperties
@@ -2189,6 +2193,18 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isDaVinciPausedSitEnabled() {
     return daVinciPausedSitEnabled;
+  }
+
+  /**
+   * The cluster's sequential roll-forward region order (mirrors the controller config
+   * {@link com.linkedin.venice.ConfigKeys#DEFERRED_VERSION_SWAP_REGION_ROLL_FORWARD_ORDER}). When set,
+   * a deferred-swap push is rolled forward region-by-region in this order and the active (unpaused)
+   * region for Da Vinci is its head. Empty string means sequential roll-forward is not configured, in
+   * which case the version's {@code targetSwapRegion} governs the active region (parallel target-region
+   * push).
+   */
+  public String getDeferredVersionSwapRegionRollforwardOrder() {
+    return deferredVersionSwapRegionRollforwardOrder;
   }
 
   public long getDaVinciCurrentVersionBootstrappingQuotaRecordsPerSecond() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
@@ -711,6 +711,118 @@ public class StoreBackendTest {
   }
 
   /**
+   * Rebuilds {@link #storeBackend} with the given sequential roll-forward region order configured
+   * (mirrors the controller config {@code deferred.version.swap.region.roll.forward.order}). Local
+   * region stays {@code dc-0} and paused-SIT stays enabled.
+   */
+  private void rebuildStoreBackendWithRollForwardOrder(String rollForwardOrder) {
+    VeniceProperties config = new PropertyBuilder().put(ConfigKeys.CLUSTER_NAME, "test-cluster")
+        .put(ConfigKeys.ZOOKEEPER_ADDRESS, "test-zookeeper")
+        .put(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, "test-kafka")
+        .put(ConfigKeys.DATA_BASE_PATH, baseDataPath.getAbsolutePath())
+        .put(ConfigKeys.LOCAL_REGION_NAME, "dc-0")
+        .put(ConfigKeys.DAVINCI_PAUSED_SIT_ENABLED, "true")
+        .put(ConfigKeys.DEFERRED_VERSION_SWAP_REGION_ROLL_FORWARD_ORDER, rollForwardOrder)
+        .build();
+    when(backend.getConfigLoader()).thenReturn(new VeniceConfigLoader(config));
+    storeBackend = new StoreBackend(backend, store.getName());
+    when(backend.getStoreOrThrow(store.getName())).thenReturn(storeBackend);
+  }
+
+  /**
+   * Under sequential roll-forward, the HEAD region of the roll-forward order must subscribe ACTIVE
+   * (createPaused=false) even when it is NOT the version's targetSwapRegion. This is the deadlock the
+   * controller's sequential path would otherwise cause: it waits for the roll-forward head to complete,
+   * but the head's DVC would (incorrectly) pause because it keyed off targetSwapRegion instead of the
+   * roll-forward order, so the head never completes and never gets promoted.
+   */
+  @Test
+  public void testSequentialRollForwardHeadRegionSubscribesActive() throws Exception {
+    // Local region dc-0 is the HEAD of the roll-forward order, but the version's targetSwapRegion is dc-1.
+    rebuildStoreBackendWithRollForwardOrder("dc-0,dc-1");
+
+    CompletableFuture subscribeResult = storeBackend.subscribe(ComplementSet.of(0));
+    versionMap.get(version1.kafkaTopicName()).completePartition(0);
+    subscribeResult.get(3, TimeUnit.SECONDS);
+    versionMap.get(version2.kafkaTopicName()).completePartition(0);
+    store.setCurrentVersion(version2.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    Version version3 = new VersionImpl(store.getName(), store.peekNextVersionNumber(), null, 15);
+    version3.setTargetSwapRegion("dc-1"); // dc-0 (local) is NOT in targetSwapRegion, but IS the roll-forward head
+    store.addVersion(version3);
+    store.setCurrentVersion(version3.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    // Head region must subscribe ACTIVE (not paused), otherwise the sequential swap deadlocks.
+    assertTrue(versionMap.containsKey(version3.kafkaTopicName()), "Roll-forward head region must subscribe");
+    verify(ingestionBackend, never()).startConsumption(any(), anyInt(), any(), any(), eq(true));
+  }
+
+  /**
+   * Under sequential roll-forward, a region that is NOT the roll-forward head must subscribe PAUSED
+   * (createPaused=true), even when it IS listed in the version's targetSwapRegion. The roll-forward
+   * order takes precedence over targetSwapRegion for the pause decision.
+   */
+  @Test
+  public void testSequentialRollForwardNonHeadRegionSubscribesPaused() throws Exception {
+    // Roll-forward head is dc-1; local region dc-0 is NOT the head, even though targetSwapRegion contains dc-0.
+    rebuildStoreBackendWithRollForwardOrder("dc-1,dc-0");
+
+    CompletableFuture subscribeResult = storeBackend.subscribe(ComplementSet.of(0));
+    versionMap.get(version1.kafkaTopicName()).completePartition(0);
+    subscribeResult.get(3, TimeUnit.SECONDS);
+    versionMap.get(version2.kafkaTopicName()).completePartition(0);
+    store.setCurrentVersion(version2.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    Version version3 = new VersionImpl(store.getName(), store.peekNextVersionNumber(), null, 15);
+    version3.setTargetSwapRegion("dc-0"); // local IS in targetSwapRegion, but is NOT the roll-forward head
+    store.addVersion(version3);
+    store.setCurrentVersion(version3.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    // Non-head region must subscribe PAUSED, deferring until it is promoted.
+    assertTrue(versionMap.containsKey(version3.kafkaTopicName()), "Non-head region must subscribe immediately");
+    verify(ingestionBackend, times(1)).startConsumption(any(), eq(0), any(), any(), eq(true));
+  }
+
+  /**
+   * Under sequential roll-forward, a paused non-head region must resume once targetRegionPromoted flips
+   * to true (the controller promotes after the roll-forward head completes).
+   */
+  @Test
+  public void testSequentialRollForwardNonHeadResumesOnPromotion() throws Exception {
+    rebuildStoreBackendWithRollForwardOrder("dc-1,dc-0"); // head dc-1, local dc-0 is non-head
+
+    CompletableFuture subscribeResult = storeBackend.subscribe(ComplementSet.of(0));
+    versionMap.get(version1.kafkaTopicName()).completePartition(0);
+    subscribeResult.get(3, TimeUnit.SECONDS);
+    versionMap.get(version2.kafkaTopicName()).completePartition(0);
+    store.setCurrentVersion(version2.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    KafkaStoreIngestionService ingestionService = backend.getIngestionService();
+    StoreIngestionTask pausedTask = mock(StoreIngestionTask.class);
+    Version version3 = new VersionImpl(store.getName(), store.peekNextVersionNumber(), null, 15);
+    version3.setTargetSwapRegion("dc-0");
+    store.addVersion(version3);
+    store.setCurrentVersion(version3.getNumber());
+    when(ingestionService.getStoreIngestionTask(version3.kafkaTopicName())).thenReturn(pausedTask);
+    when(pausedTask.isPauseAfterStartOfPush()).thenReturn(true);
+    backend.handleStoreChanged(storeBackend);
+
+    assertTrue(versionMap.containsKey(version3.kafkaTopicName()), "Non-head region must subscribe");
+    verify(pausedTask, never()).resumeFromFutureSlotPause();
+
+    // Flip targetRegionPromoted — maybeResumeDaVinciFutureVersion should resume the paused task.
+    store.setVersionTargetRegionPromoted(version3.getNumber(), true);
+    backend.handleStoreChanged(storeBackend);
+
+    verify(pausedTask, times(1)).resumeFromFutureSlotPause();
+  }
+
+  /**
    * Verify that {@link StoreBackend#setDaVinciFutureVersion} keeps
    * {@link KafkaStoreIngestionService}'s future-slot registry in sync so the
    * current-version-bootstrapping speedup throttler can skip future-slot versions.

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
@@ -823,6 +823,62 @@ public class StoreBackendTest {
   }
 
   /**
+   * A whitespace-only roll-forward order must be treated as "not configured" and fall back to the
+   * version's targetSwapRegion, rather than yielding an empty-string head that matches no region. If it
+   * did, paused-SIT mode would pause EVERY region and reintroduce the deadlock. Here the local region
+   * dc-0 is in targetSwapRegion, so it must subscribe ACTIVE.
+   */
+  @Test
+  public void testSequentialRollForwardBlankOrderFallsBackToTargetSwapRegion() throws Exception {
+    rebuildStoreBackendWithRollForwardOrder("   "); // whitespace-only — no usable head
+
+    CompletableFuture subscribeResult = storeBackend.subscribe(ComplementSet.of(0));
+    versionMap.get(version1.kafkaTopicName()).completePartition(0);
+    subscribeResult.get(3, TimeUnit.SECONDS);
+    versionMap.get(version2.kafkaTopicName()).completePartition(0);
+    store.setCurrentVersion(version2.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    Version version3 = new VersionImpl(store.getName(), store.peekNextVersionNumber(), null, 15);
+    version3.setTargetSwapRegion("dc-0"); // local IS the target region
+    store.addVersion(version3);
+    store.setCurrentVersion(version3.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    // Falls back to targetSwapRegion membership — local region is the target, so subscribe ACTIVE.
+    assertTrue(versionMap.containsKey(version3.kafkaTopicName()), "Region must subscribe");
+    verify(ingestionBackend, never()).startConsumption(any(), anyInt(), any(), any(), eq(true));
+  }
+
+  /**
+   * A roll-forward order with a leading (blank) entry must skip the blank and read the first non-blank
+   * region as the head, rather than treating the empty string as the head. Here a leading comma makes
+   * dc-0 (local) the effective head, so it must subscribe ACTIVE even though it is not in
+   * targetSwapRegion.
+   */
+  @Test
+  public void testSequentialRollForwardLeadingCommaSkipsBlankHead() throws Exception {
+    rebuildStoreBackendWithRollForwardOrder(",dc-0,dc-1"); // leading blank; first non-blank head = dc-0
+
+    CompletableFuture subscribeResult = storeBackend.subscribe(ComplementSet.of(0));
+    versionMap.get(version1.kafkaTopicName()).completePartition(0);
+    subscribeResult.get(3, TimeUnit.SECONDS);
+    versionMap.get(version2.kafkaTopicName()).completePartition(0);
+    store.setCurrentVersion(version2.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    Version version3 = new VersionImpl(store.getName(), store.peekNextVersionNumber(), null, 15);
+    version3.setTargetSwapRegion("dc-1"); // dc-0 (local) is NOT in targetSwapRegion, but IS the head
+    store.addVersion(version3);
+    store.setCurrentVersion(version3.getNumber());
+    backend.handleStoreChanged(storeBackend);
+
+    // Head resolves to dc-0 (first non-blank) — local region must subscribe ACTIVE.
+    assertTrue(versionMap.containsKey(version3.kafkaTopicName()), "Roll-forward head region must subscribe");
+    verify(ingestionBackend, never()).startConsumption(any(), anyInt(), any(), any(), eq(true));
+  }
+
+  /**
    * Verify that {@link StoreBackend#setDaVinciFutureVersion} keeps
    * {@link KafkaStoreIngestionService}'s future-slot registry in sync so the
    * current-version-bootstrapping speedup throttler can skip future-slot versions.


### PR DESCRIPTION
## Problem Statement

The DaVinci (DVC) paused-SIT swap deadlocks under **sequential** deferred version swap.

When a deferred-swap push is in flight, DVC decides whether the local region should ingest actively or in a paused state. Today that decision keys **only** off the version's `targetSwapRegion`. The controller's sequential roll-forward path, however, promotes regions one at a time following the cluster config `deferred.version.swap.region.roll.forward.order`, and gates promotion on the **head** of that order (see `AbstractPushMonitor#sequentialRollForwardFirstRegion` / `DeferredVersionSwapService#performSequentialRollForward`).

When the roll-forward head is **not** the version's `targetSwapRegion`, the two disagree:

- The controller waits for the roll-forward head region to reach COMPLETED before promoting.
- DVC in that head region pauses (because the head ≠ `targetSwapRegion`), so it never completes.
- Because the head never completes, the controller never flips `targetRegionPromoted`, so DVC never resumes.

This is a circular wait — the push status never completes and the swap never happens. Observed in a cert-0 run: `ei4` reached COMPLETED but the roll-forward head `ei-ltx1` stayed stuck at END_OF_PUSH with DVC paused.

## Solution

Make DVC read the **same** roll-forward order config the controller already reads, so both sides agree on which region is active:

- When `deferred.version.swap.region.roll.forward.order` is configured (sequential path), the active/unpaused region is its **head** (`rollForwardOrder.get(0)`), mirroring `AbstractPushMonitor#sequentialRollForwardFirstRegion`.
- When it is empty (parallel target-region push), fall back to the existing `targetSwapRegion` membership check — **unchanged** behavior.

The resume path is unchanged: it still keys off `targetRegionPromoted`, which the controller flips once the head completes.

Trade-offs: this reuses the existing controller config rather than introducing a new one, avoiding config drift. `targetSwapRegion` semantics are left intact, so degraded-mode recovery, the push monitor, and the swap-eligibility gate are unaffected.

###  Code changes
- [x] Added new code behind **a config**. Config: `deferred.version.swap.region.roll.forward.order` (default: `""` / empty). This config already exists and is read by the controller; DVC now reads it too. Empty preserves prior (parallel) behavior.
- [x] Introduced new **log lines**. One INFO line in the paused-SIT branch of `StoreBackend#trySubscribeDaVinciFutureVersion` logging region / createPaused / targetSwapRegion / rollForwardOrder / targetRegionPromoted for diagnosability.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging. Not needed — logged once per future-version subscribe (store-change driven), not on any hot/per-record path.

###  **Concurrency-Specific Checks**
- [x] Code has **no race conditions** or **thread safety issues**. Change is a read of immutable config + version fields within the existing store-change handling path; no new shared mutable state.
- [x] Proper **synchronization mechanisms** are used where needed. No new synchronization required; runs within the existing `StoreBackend` flow.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation. This change **removes** a distributed deadlock; adds no blocking calls.
- [x] Verified **thread-safe collections** are used. No new collections introduced (parses config into a local list).
- [x] Validated proper exception handling in multi-threaded code. No new exception surface; empty/unset config is handled explicitly.

## How was this PR tested?

- [x] New unit tests added. Three tests in `StoreBackendTest`:
  - `testSequentialRollForwardHeadRegionSubscribesActive` — regression test: the roll-forward head subscribes **active** even when it is not in `targetSwapRegion` (proves the deadlock is gone).
  - `testSequentialRollForwardNonHeadRegionSubscribesPaused` — a non-head region subscribes **paused** even when it is in `targetSwapRegion` (roll-forward order takes precedence).
  - `testSequentialRollForwardNonHeadResumesOnPromotion` — a paused non-head region resumes once `targetRegionPromoted` flips.
- [ ] New integration tests added.
- [x] Modified or extended existing tests. Existing paused-SIT / legacy tests continue to pass (`:clients:da-vinci-client:test --tests StoreBackendTest` → all 21 tests PASSED).
- [x] Verified backward compatibility (if applicable). Empty roll-forward config → unchanged `targetSwapRegion` behavior.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
