### PR TITLE
[vpj] Fix NorthGuard repush ZSTD dictionary routing

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1663,10 +1663,14 @@ public class VenicePushJob implements AutoCloseable {
   }
 
   private VeniceProperties getSourceDictionaryConsumerProperties() {
+    return getSourceDictionaryConsumerProperties(pushJobSetting.repushSourcePubsubBroker);
+  }
+
+  private VeniceProperties getSourceDictionaryConsumerProperties(String sourcePubsubBroker) {
     return buildSourceDictionaryConsumerProperties(
         props,
         pushJobSetting.enableSSL ? sslProperties.get() : new Properties(),
-        pushJobSetting.repushSourcePubsubBroker);
+        sourcePubsubBroker);
   }
 
   @VisibleForTesting
@@ -1686,7 +1690,6 @@ public class VenicePushJob implements AutoCloseable {
     KafkaInputDictTrainer.ParamBuilder paramBuilder = new KafkaInputDictTrainer.ParamBuilder()
         .setKeySchema(AvroCompatibilityHelper.toParsingForm(pushJobSetting.storeKeySchema))
         .setNewKMESchemasFromController(pushJobSetting.newKmeSchemasFromController)
-        .setSslProperties(pushJobSetting.enableSSL ? sslProperties.get() : new Properties())
         .setCompressionDictSize(
             props.getInt(
                 COMPRESSION_DICTIONARY_SIZE_LIMIT,
@@ -1701,6 +1704,7 @@ public class VenicePushJob implements AutoCloseable {
           LOGGER.info("Rebuild a new Zstd dictionary from the input topic: {}", pushJobSetting.kafkaInputTopic);
           paramBuilder.setKafkaInputBroker(pushJobSetting.repushSourcePubsubBroker)
               .setTopicName(pushJobSetting.kafkaInputTopic)
+              .setConsumerProperties(getSourceDictionaryConsumerProperties().toProperties())
               .setSourceVersionCompressionStrategy(pushJobSetting.sourceKafkaInputVersionInfo.getCompressionStrategy());
           KafkaInputDictTrainer dictTrainer = new KafkaInputDictTrainer(paramBuilder.build());
           return ByteBuffer.wrap(dictTrainer.trainDict());
@@ -1749,8 +1753,9 @@ public class VenicePushJob implements AutoCloseable {
           "Rebuild a new Zstd dictionary from the source topic: {} in Kafka: {}",
           sourceTopicName,
           sourceKafkaUrl);
-      paramBuilder.setKafkaInputBroker(repushInfoResponse.getRepushInfo().getKafkaBrokerUrl())
+      paramBuilder.setKafkaInputBroker(sourceKafkaUrl)
           .setTopicName(sourceTopicName)
+          .setConsumerProperties(getSourceDictionaryConsumerProperties(sourceKafkaUrl).toProperties())
           .setSourceVersionCompressionStrategy(
               repushInfoResponse.getRepushInfo().getVersion().getCompressionStrategy());
       KafkaInputDictTrainer dictTrainer = new KafkaInputDictTrainer(paramBuilder.build());

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_DELIVERY_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_REQUEST_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_RETRIES_CONFIG;
 import static com.linkedin.venice.ConfigKeys.MULTI_REGION;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.VENICE_PARTITIONERS;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENABLED_CONFIG;
@@ -866,13 +867,8 @@ public class VenicePushJob implements AutoCloseable {
       if (pushJobSetting.isSourceKafka) {
         if (pushJobSetting.sourceVersionCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT) {
           LOGGER.info("Source version uses ZSTD_WITH_DICT. Fetching source dictionary.");
-          Properties kafkaConsumerProperties = new Properties();
-          if (pushJobSetting.enableSSL) {
-            kafkaConsumerProperties.putAll(this.sslProperties.get());
-          }
-          kafkaConsumerProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, pushJobSetting.repushSourcePubsubBroker);
           ByteBuffer sourceDict = DictionaryUtils
-              .readDictionaryFromKafka(pushJobSetting.kafkaInputTopic, new VeniceProperties(kafkaConsumerProperties));
+              .readDictionaryFromKafka(pushJobSetting.kafkaInputTopic, getSourceDictionaryConsumerProperties());
           if (sourceDict != null) {
             pushJobSetting.sourceDictionary = ByteUtils.extractByteArray(sourceDict);
           }
@@ -1666,6 +1662,25 @@ public class VenicePushJob implements AutoCloseable {
     return Optional.of(emptyPushZstdDictionary.get());
   }
 
+  private VeniceProperties getSourceDictionaryConsumerProperties() {
+    return buildSourceDictionaryConsumerProperties(
+        props,
+        pushJobSetting.enableSSL ? sslProperties.get() : new Properties(),
+        pushJobSetting.repushSourcePubsubBroker);
+  }
+
+  @VisibleForTesting
+  static VeniceProperties buildSourceDictionaryConsumerProperties(
+      VeniceProperties jobProperties,
+      Properties sslProperties,
+      String sourcePubsubBroker) {
+    Properties consumerProperties = jobProperties.toProperties();
+    consumerProperties.putAll(sslProperties);
+    consumerProperties.setProperty(PUBSUB_BROKER_ADDRESS, sourcePubsubBroker);
+    consumerProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, sourcePubsubBroker);
+    return new VeniceProperties(consumerProperties);
+  }
+
   private ByteBuffer fetchOrBuildCompressionDictionary() throws VeniceException {
     // Prepare the param builder, which can be used by different scenarios.
     KafkaInputDictTrainer.ParamBuilder paramBuilder = new KafkaInputDictTrainer.ParamBuilder()
@@ -1691,14 +1706,8 @@ public class VenicePushJob implements AutoCloseable {
           return ByteBuffer.wrap(dictTrainer.trainDict());
         } else {
           LOGGER.info("Reading Zstd dictionary from input topic: {}", pushJobSetting.kafkaInputTopic);
-          // set up ssl properties and kafka consumer properties
-          Properties kafkaConsumerProperties = new Properties();
-          if (pushJobSetting.enableSSL) {
-            kafkaConsumerProperties.putAll(this.sslProperties.get());
-          }
-          kafkaConsumerProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, pushJobSetting.repushSourcePubsubBroker);
           return DictionaryUtils
-              .readDictionaryFromKafka(pushJobSetting.kafkaInputTopic, new VeniceProperties(kafkaConsumerProperties));
+              .readDictionaryFromKafka(pushJobSetting.kafkaInputTopic, getSourceDictionaryConsumerProperties());
         }
       }
       LOGGER.info(

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1666,7 +1666,8 @@ public class VenicePushJob implements AutoCloseable {
     return getSourceDictionaryConsumerProperties(pushJobSetting.repushSourcePubsubBroker);
   }
 
-  private VeniceProperties getSourceDictionaryConsumerProperties(String sourcePubsubBroker) {
+  @VisibleForTesting
+  VeniceProperties getSourceDictionaryConsumerProperties(String sourcePubsubBroker) {
     return buildSourceDictionaryConsumerProperties(
         props,
         pushJobSetting.enableSSL ? sslProperties.get() : new Properties(),

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
@@ -50,7 +50,7 @@ public class KafkaInputDictTrainer {
     private final String kafkaInputBroker;
     private final String topicName;
     private final String keySchema;
-    private final Properties sslProperties;
+    private final Properties consumerProperties;
     private final int compressionDictSize;
     private final int dictSampleSize;
     private final CompressionStrategy sourceVersionCompressionStrategy;
@@ -62,7 +62,7 @@ public class KafkaInputDictTrainer {
       this.kafkaInputBroker = builder.kafkaInputBroker;
       this.topicName = builder.topicName;
       this.keySchema = builder.keySchema;
-      this.sslProperties = builder.sslProperties;
+      this.consumerProperties = builder.consumerProperties;
       this.compressionDictSize = builder.compressionDictSize;
       this.dictSampleSize = builder.dictSampleSize;
       this.sourceVersionCompressionStrategy = builder.sourceVersionCompressionStrategy;
@@ -75,7 +75,7 @@ public class KafkaInputDictTrainer {
     private String kafkaInputBroker;
     private String topicName;
     private String keySchema;
-    private Properties sslProperties;
+    private Properties consumerProperties;
     private int compressionDictSize;
     private int dictSampleSize;
     private CompressionStrategy sourceVersionCompressionStrategy;
@@ -97,8 +97,8 @@ public class KafkaInputDictTrainer {
       return this;
     }
 
-    public ParamBuilder setSslProperties(Properties sslProperties) {
-      this.sslProperties = sslProperties;
+    public ParamBuilder setConsumerProperties(Properties consumerProperties) {
+      this.consumerProperties = consumerProperties;
       return this;
     }
 
@@ -166,11 +166,11 @@ public class KafkaInputDictTrainer {
     this.trainerSupplier = trainerSupplier;
     this.sourceVersionCompressionStrategy = param.sourceVersionCompressionStrategy;
     Properties properties = new Properties();
+    properties.putAll(param.consumerProperties);
     properties.setProperty(VENICE_REPUSH_SOURCE_PUBSUB_BROKER, param.kafkaInputBroker);
     properties.setProperty(KAFKA_INPUT_TOPIC, param.topicName);
     properties.setProperty(KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, param.keySchema);
     this.sourceTopicName = param.topicName;
-    properties.putAll(param.sslProperties);
     properties.setProperty(COMPRESSION_DICTIONARY_SIZE_LIMIT, Integer.toString(param.compressionDictSize));
     properties.setProperty(COMPRESSION_DICTIONARY_SAMPLE_SIZE, Integer.toString(param.dictSampleSize));
     properties

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobRepushTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobRepushTest.java
@@ -61,24 +61,23 @@ public class VenicePushJobRepushTest extends VenicePushJobTestBase {
     jobProperties.setProperty(PUBSUB_BROKER_ADDRESS, "destination-broker");
     jobProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, "legacy-broker");
 
-    VeniceProperties consumerProperties = VenicePushJob.buildSourceDictionaryConsumerProperties(
-        new VeniceProperties(jobProperties),
-        new Properties(),
-        "source-broker");
+    try (VenicePushJob pushJob = getSpyVenicePushJob(jobProperties, null)) {
+      VeniceProperties consumerProperties = pushJob.getSourceDictionaryConsumerProperties("source-broker");
 
-    assertEquals(
-        consumerProperties.getString(PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS),
-        "com.linkedin.venice.pubsub.adapter.xinfra.consumer.XcConsumerAdapterFactory");
-    assertEquals(
-        consumerProperties.getString(PUBSUB_TYPE_ID_TO_POSITION_CLASS_NAME_MAP),
-        "1:com.linkedin.venice.pubsub.adapter.xinfra.XinfraPosition");
-    assertEquals(consumerProperties.getString("xc.pubsub.broker.url.to.region.name.map"), "northguard:ei4");
-    assertEquals(consumerProperties.getString(PUBSUB_BROKER_ADDRESS), "source-broker");
-    assertEquals(consumerProperties.getString(KAFKA_BOOTSTRAP_SERVERS), "source-broker");
-    assertEquals(
-        jobProperties.getProperty(PUBSUB_BROKER_ADDRESS),
-        "destination-broker",
-        "Building consumer properties must not mutate the job properties");
+      assertEquals(
+          consumerProperties.getString(PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS),
+          "com.linkedin.venice.pubsub.adapter.xinfra.consumer.XcConsumerAdapterFactory");
+      assertEquals(
+          consumerProperties.getString(PUBSUB_TYPE_ID_TO_POSITION_CLASS_NAME_MAP),
+          "1:com.linkedin.venice.pubsub.adapter.xinfra.XinfraPosition");
+      assertEquals(consumerProperties.getString("xc.pubsub.broker.url.to.region.name.map"), "northguard:ei4");
+      assertEquals(consumerProperties.getString(PUBSUB_BROKER_ADDRESS), "source-broker");
+      assertEquals(consumerProperties.getString(KAFKA_BOOTSTRAP_SERVERS), "source-broker");
+      assertEquals(
+          jobProperties.getProperty(PUBSUB_BROKER_ADDRESS),
+          "destination-broker",
+          "Building consumer properties must not mutate the job properties");
+    }
   }
 
   @Test

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobRepushTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobRepushTest.java
@@ -1,5 +1,10 @@
 package com.linkedin.venice.hadoop;
 
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_SECURITY_PROTOCOL;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_TYPE_ID_TO_POSITION_CLASS_NAME_MAP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ALLOW_REGULAR_PUSH_WITH_TTL_REPUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.COMPLIANCE_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
@@ -26,6 +31,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.VeniceProperties;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -42,6 +48,58 @@ import org.testng.annotations.Test;
  */
 
 public class VenicePushJobRepushTest extends VenicePushJobTestBase {
+  @Test
+  public void testSourceDictionaryConsumerPropertiesRetainPubSubConfigAndOverrideBrokers() {
+    Properties jobProperties = new Properties();
+    jobProperties.setProperty(
+        PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS,
+        "com.linkedin.venice.pubsub.adapter.xinfra.consumer.XcConsumerAdapterFactory");
+    jobProperties.setProperty(
+        PUBSUB_TYPE_ID_TO_POSITION_CLASS_NAME_MAP,
+        "1:com.linkedin.venice.pubsub.adapter.xinfra.XinfraPosition");
+    jobProperties.setProperty("xc.pubsub.broker.url.to.region.name.map", "northguard:ei4");
+    jobProperties.setProperty(PUBSUB_BROKER_ADDRESS, "destination-broker");
+    jobProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, "legacy-broker");
+
+    VeniceProperties consumerProperties = VenicePushJob.buildSourceDictionaryConsumerProperties(
+        new VeniceProperties(jobProperties),
+        new Properties(),
+        "source-broker");
+
+    assertEquals(
+        consumerProperties.getString(PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS),
+        "com.linkedin.venice.pubsub.adapter.xinfra.consumer.XcConsumerAdapterFactory");
+    assertEquals(
+        consumerProperties.getString(PUBSUB_TYPE_ID_TO_POSITION_CLASS_NAME_MAP),
+        "1:com.linkedin.venice.pubsub.adapter.xinfra.XinfraPosition");
+    assertEquals(consumerProperties.getString("xc.pubsub.broker.url.to.region.name.map"), "northguard:ei4");
+    assertEquals(consumerProperties.getString(PUBSUB_BROKER_ADDRESS), "source-broker");
+    assertEquals(consumerProperties.getString(KAFKA_BOOTSTRAP_SERVERS), "source-broker");
+    assertEquals(
+        jobProperties.getProperty(PUBSUB_BROKER_ADDRESS),
+        "destination-broker",
+        "Building consumer properties must not mutate the job properties");
+  }
+
+  @Test
+  public void testSourceDictionaryConsumerPropertiesApplySslOverrides() {
+    Properties jobProperties = new Properties();
+    jobProperties.setProperty(PUBSUB_SECURITY_PROTOCOL, "PLAINTEXT");
+    jobProperties.setProperty("ssl.keystore.location", "stale-keystore");
+    jobProperties.setProperty("xc.tls.key.store.type", "PKCS12");
+
+    Properties sslProperties = new Properties();
+    sslProperties.setProperty(PUBSUB_SECURITY_PROTOCOL, "SSL");
+    sslProperties.setProperty("ssl.keystore.location", "credential-keystore");
+
+    VeniceProperties consumerProperties = VenicePushJob
+        .buildSourceDictionaryConsumerProperties(new VeniceProperties(jobProperties), sslProperties, "source-broker");
+
+    assertEquals(consumerProperties.getString(PUBSUB_SECURITY_PROTOCOL), "SSL");
+    assertEquals(consumerProperties.getString("ssl.keystore.location"), "credential-keystore");
+    assertEquals(consumerProperties.getString("xc.tls.key.store.type"), "PKCS12");
+  }
+
   @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Repush with TTL is only supported while using Kafka Input Format.*")
   public void testRepushTTLJobWithNonKafkaInput() {
     Properties repushProps = new Properties();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
@@ -1,5 +1,11 @@
 package com.linkedin.venice.hadoop.input.kafka;
 
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_SECURITY_PROTOCOL;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_TYPE_ID_TO_POSITION_CLASS_NAME_MAP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -7,6 +13,10 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import com.github.luben.zstd.ZstdDictTrainer;
 import com.linkedin.venice.compression.CompressionStrategy;
@@ -37,6 +47,7 @@ import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.RecordReader;
+import org.mockito.ArgumentCaptor;
 import org.testng.annotations.Test;
 
 
@@ -52,6 +63,13 @@ public class TestKafkaInputDictTrainer {
   }
 
   private KafkaInputDictTrainer.Param getParam(int sampleSize, CompressionStrategy sourceVersionCompressionStrategy) {
+    return getParam(sampleSize, sourceVersionCompressionStrategy, new Properties());
+  }
+
+  private KafkaInputDictTrainer.Param getParam(
+      int sampleSize,
+      CompressionStrategy sourceVersionCompressionStrategy,
+      Properties consumerProperties) {
     Map<Integer, Schema> allSchemas = Utils.getAllSchemasFromResources(AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE);
     Map<Integer, String> allSchemaStr =
         allSchemas.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
@@ -60,14 +78,14 @@ public class TestKafkaInputDictTrainer {
         .setKeySchema("\"string\"")
         .setCompressionDictSize(900 * 1024)
         .setDictSampleSize(sampleSize)
-        .setSslProperties(new Properties())
+        .setConsumerProperties(consumerProperties)
         .setSourceVersionCompressionStrategy(sourceVersionCompressionStrategy)
         .setNewKMESchemasFromController(allSchemaStr)
         .build();
   }
 
-  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "No record.*")
-  public void testEmptyTopic() throws IOException {
+  @Test
+  public void testConsumerPropertiesPropagateToEmptyTopicTraining() throws IOException {
     KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
     PubSubTopicPartition topicPartition =
         new PubSubTopicPartitionImpl(PUB_SUB_TOPIC_REPOSITORY.getTopic("test_topic"), 0);
@@ -79,12 +97,48 @@ public class TestKafkaInputDictTrainer {
     doReturn(false).when(mockRecordReader).next(any(), any());
     doReturn(mockRecordReader).when(mockFormat).getRecordReader(any(), any(), any(), any());
 
+    Properties consumerProperties = new Properties();
+    consumerProperties.setProperty(
+        PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS,
+        "com.linkedin.venice.pubsub.adapter.xinfra.consumer.XcConsumerAdapterFactory");
+    consumerProperties.setProperty(
+        PUBSUB_TYPE_ID_TO_POSITION_CLASS_NAME_MAP,
+        "1:com.linkedin.venice.pubsub.adapter.xinfra.XinfraPosition");
+    consumerProperties.setProperty("xc.pubsub.broker.url.to.region.name.map", "northguard:ei4");
+    consumerProperties.setProperty(PUBSUB_BROKER_ADDRESS, "test_url");
+    consumerProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, "test_url");
+    consumerProperties.setProperty(PUBSUB_SECURITY_PROTOCOL, "SSL");
+    consumerProperties.setProperty("ssl.keystore.location", "credential-keystore");
+
     KafkaInputDictTrainer trainer = new KafkaInputDictTrainer(
         mockFormat,
         Optional.empty(),
-        getParam(100),
+        getParam(100, CompressionStrategy.NO_OP, consumerProperties),
         getCompressorBuilder(new NoopCompressor()));
-    trainer.trainDict(Optional.of(mock(PubSubConsumerAdapter.class)));
+    try {
+      trainer.trainDict(Optional.of(mock(PubSubConsumerAdapter.class)));
+      fail("Expected training on an empty topic to fail");
+    } catch (VeniceException e) {
+      assertTrue(e.getMessage().startsWith("No record"));
+    }
+
+    ArgumentCaptor<VeniceProperties> consumerPropertiesCaptor = ArgumentCaptor.forClass(VeniceProperties.class);
+    verify(mockFormat).getSplits(consumerPropertiesCaptor.capture());
+    VeniceProperties actualConsumerProperties = consumerPropertiesCaptor.getValue();
+    assertEquals(
+        actualConsumerProperties.getString(PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS),
+        "com.linkedin.venice.pubsub.adapter.xinfra.consumer.XcConsumerAdapterFactory");
+    assertEquals(
+        actualConsumerProperties.getString(PUBSUB_TYPE_ID_TO_POSITION_CLASS_NAME_MAP),
+        "1:com.linkedin.venice.pubsub.adapter.xinfra.XinfraPosition");
+    assertEquals(actualConsumerProperties.getString("xc.pubsub.broker.url.to.region.name.map"), "northguard:ei4");
+    assertEquals(actualConsumerProperties.getString(PUBSUB_BROKER_ADDRESS), "test_url");
+    assertEquals(actualConsumerProperties.getString(KAFKA_BOOTSTRAP_SERVERS), "test_url");
+    assertEquals(actualConsumerProperties.getString(PUBSUB_SECURITY_PROTOCOL), "SSL");
+    assertEquals(actualConsumerProperties.getString("ssl.keystore.location"), "credential-keystore");
+    assertFalse(
+        consumerProperties.containsKey(KAFKA_INPUT_TOPIC),
+        "Building trainer properties must not mutate the supplied consumer properties");
   }
 
   interface ResettableRecordReader<K, V> extends RecordReader<K, V> {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
Kafka-input repushes read the source compression dictionary in the Spark driver when the source version uses `ZSTD_WITH_DICT`. The dictionary-read paths constructed new consumer properties containing only SSL configuration and a broker address. This discarded the configured pub-sub consumer adapter, Xinfra routing maps, position configuration, and other job-level pub-sub properties.

Without the configured adapter factory, `PubSubClientsFactory` defaults to `ApacheKafkaConsumerAdapterFactory`. A NorthGuard-backed source topic is then queried through legacy Kafka, which returns `UNKNOWN_TOPIC_OR_PARTITION` until the push job times out.

## Solution
Build the source dictionary consumer properties from the complete VPJ job configuration, then apply SSL overrides and set both the pub-sub and Kafka broker properties to the repush source broker.

Both driver-side dictionary-read paths now use the same helper. The helper preserves Xinfra and pub-sub configuration without mutating the original job properties. Copying the properties occurs once during driver-side dictionary lookup and has no material performance impact.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

No new configuration or log lines were introduced.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

This change does not alter concurrency behavior.

## How was this PR tested?
- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

```shell
./gradlew :clients:venice-push-job:test \
  --tests com.linkedin.venice.hadoop.VenicePushJobRepushTest \
  --no-daemon
```

All 9 tests passed.

```shell
./gradlew spotlessCheck --no-daemon
```

## Does this PR introduce any user-facing or breaking changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
