### PR TITLE
[build] Avoid interpolating Git ref names directly into run: shell commands

### DIFF
--- a/.github/workflows/build-and-upload-archives-upon-pushing-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-pushing-tags.yml
@@ -33,4 +33,5 @@ jobs:
         env:
           JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
           JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
-        run: ./gradlew -Pversion=${{  github.ref_name }} publishAllPublicationsToLinkedInJFrogRepository
+          REF_NAME: ${{ github.ref_name }}
+        run: ./gradlew -Pversion="$REF_NAME" publishAllPublicationsToLinkedInJFrogRepository

--- a/.github/workflows/build-and-upload-archives.yml
+++ b/.github/workflows/build-and-upload-archives.yml
@@ -32,4 +32,4 @@ jobs:
         env:
           JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
           JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
-        run: ./gradlew -Pversion=${{  env.GIT_TAG }} publishAllPublicationsToLinkedInJFrogRepository
+        run: ./gradlew -Pversion="$GIT_TAG" publishAllPublicationsToLinkedInJFrogRepository


### PR DESCRIPTION
## Problem Statement
The two archive-publication workflows interpolated a Git tag name directly into a `run:` shell command via `${{ github.ref_name }}` / `${{ env.GIT_TAG }}`. Tag names can contain shell metacharacters, so this splices arbitrary text into the command line of a step that carries JFrog release credentials.

## Solution
Pass the tag name through a quoted shell environment variable (`"$REF_NAME"` / `"$GIT_TAG"`) so it is treated as data, not shell syntax. No change to the version passed to Gradle for normal tags.

## How was this PR tested?
- [x] N/A, workflow-only change; version value is unchanged for normal tags.

## Does this PR introduce any user-facing or breaking changes?
- [x] No.