### PR TITLE
Fix ForkedJavaProcess IOException: Argument list too long

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/ForkedJavaProcess.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/ForkedJavaProcess.java
@@ -63,8 +63,25 @@ public final class ForkedJavaProcess extends Process {
       Optional<LogContext> logContext) throws IOException {
     LOGGER.info("Forking " + appClass.getSimpleName() + " with arguments " + args + " and jvm arguments " + jvmArgs);
     List<String> command = prepareCommandArgList(appClass, classPath, args, jvmArgs);
+    File argFile = writeArgFile(command);
+    List<String> wrappedCommand = Arrays.asList(command.get(0), "@" + argFile.getAbsolutePath());
 
-    Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+    Process process = new ProcessBuilder(wrappedCommand).redirectErrorStream(true).start();
+    // The argfile is only needed for the JVM launcher to read at startup; once the process has exited (for any
+    // reason), delete it right away instead of leaving it around for the whole lifetime of this (potentially
+    // long-lived, e.g. Gradle daemon) JVM. deleteOnExit() alone is not sufficient here since a single long-lived
+    // JVM can fork many processes over its lifetime, and files would otherwise accumulate until that JVM exits.
+    Thread argFileCleanupThread = new Thread(() -> {
+      try {
+        process.waitFor();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } finally {
+        deleteQuietly(argFile);
+      }
+    }, "ForkedJavaProcess-argfile-cleanup");
+    argFileCleanupThread.setDaemon(true);
+    argFileCleanupThread.start();
     Logger logger = LogManager.getLogger(
         logContext.map(s -> s + ", ").orElse("") + appClass.getSimpleName() + ", PID=" + getPidOfProcess(process));
     return new ForkedJavaProcess(process, logger, killOnExit);
@@ -299,6 +316,58 @@ public final class ForkedJavaProcess extends Process {
       throw new VeniceException(e);
     }
     return configFilePath;
+  }
+
+  /**
+   * Forked processes (in particular, in test environments) can end up with an extremely long classpath, which can
+   * cause the overall command line (as passed to {@link ProcessBuilder#start()}, and ultimately to the OS' exec()
+   * syscall) to exceed the OS-level limit on argument list size (e.g. Linux's {@code ARG_MAX}), leading to a
+   * {@code java.io.IOException: error=7, Argument list too long}.
+   *
+   * To avoid this, we write all the java arguments (i.e. everything except the path to the {@code java} executable
+   * itself) into a JDK {@code @argfile} (supported since Java 9) and invoke {@code java @argfile}. This way, only
+   * the (short) path to the argfile is passed through exec(), regardless of how large the classpath is. The caller
+   * is responsible for deleting the returned file once the forked process no longer needs it (see
+   * {@link #deleteQuietly(File)}).
+   */
+  private static File writeArgFile(List<String> command) {
+    try {
+      File argFile = File.createTempFile("forked-java-process-args", ".txt", Utils.getTempDataDirectory());
+      try (FileWriter fw = new FileWriter(argFile)) {
+        for (int i = 1; i < command.size(); i++) {
+          if (i > 1) {
+            fw.write(System.lineSeparator());
+          }
+          fw.write(quoteArgFileToken(command.get(i)));
+        }
+      }
+      return argFile;
+    } catch (IOException e) {
+      throw new VeniceException("Failed to write java @argfile for forked process", e);
+    }
+  }
+
+  private static void deleteQuietly(File file) {
+    try {
+      if (!file.delete() && file.exists()) {
+        LOGGER.warn("Failed to delete forked process argfile: " + file.getAbsolutePath());
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Failed to delete forked process argfile: " + file.getAbsolutePath(), e);
+    }
+  }
+
+  /**
+   * Quotes a single token for inclusion in a JDK {@code @argfile}, per the rules documented for the {@code java}
+   * launcher: tokens containing whitespace or quote characters must be wrapped in double quotes, with internal
+   * backslashes and double quotes escaped.
+   */
+  private static String quoteArgFileToken(String token) {
+    if (token.chars().noneMatch(c -> Character.isWhitespace(c) || c == '"' || c == '\'')) {
+      return token;
+    }
+    String escaped = token.replace("\\", "\\\\").replace("\"", "\\\"");
+    return "\"" + escaped + "\"";
   }
 
   private static List<String> prepareCommandArgList(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/ForkedJavaProcess.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/ForkedJavaProcess.java
@@ -64,36 +64,31 @@ public final class ForkedJavaProcess extends Process {
     LOGGER.info("Forking " + appClass.getSimpleName() + " with arguments " + args + " and jvm arguments " + jvmArgs);
     List<String> command = prepareCommandArgList(appClass, classPath, args, jvmArgs);
 
-    File argFile = null;
-    List<String> commandToRun = command;
     // The `java` launcher only understands `@argfile` syntax starting with JDK 9 (JEP 293); on JDK 8 (still used by
     // some of our test/runtime environments) it would literally try to load a main class named "@<path>" and fail.
     // Fall back to passing the arguments directly on JDK 8, accepting the pre-existing risk of hitting the OS
     // "Argument list too long" error in that case.
-    if (isArgFileSupported()) {
-      argFile = writeArgFile(command);
-      commandToRun = Arrays.asList(command.get(0), "@" + argFile.getAbsolutePath());
-    }
+    File argFile = writeArgFile(command);
+    List<String> commandToRun =
+        isArgFileSupported() ? Arrays.asList(command.get(0), "@" + argFile.getAbsolutePath()) : command;
 
     Process process = new ProcessBuilder(commandToRun).redirectErrorStream(true).start();
-    if (argFile != null) {
-      // The argfile is only needed for the JVM launcher to read at startup; once the process has exited (for any
-      // reason), delete it right away instead of leaving it around for the whole lifetime of this (potentially
-      // long-lived, e.g. Gradle daemon) JVM. deleteOnExit() alone is not sufficient here since a single long-lived
-      // JVM can fork many processes over its lifetime, and files would otherwise accumulate until that JVM exits.
-      File argFileToDelete = argFile;
-      Thread argFileCleanupThread = new Thread(() -> {
-        try {
-          process.waitFor();
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-        } finally {
-          deleteQuietly(argFileToDelete);
-        }
-      }, "ForkedJavaProcess-argfile-cleanup");
-      argFileCleanupThread.setDaemon(true);
-      argFileCleanupThread.start();
-    }
+    // The argfile is only needed for the JVM launcher to read at startup (if used at all); once the process has
+    // exited (for any reason), delete it right away instead of leaving it around for the whole lifetime of this
+    // (potentially long-lived, e.g. Gradle daemon) JVM. deleteOnExit() alone is not sufficient here since a single
+    // long-lived JVM can fork many processes over its lifetime, and files would otherwise accumulate until that JVM
+    // exits.
+    Thread argFileCleanupThread = new Thread(() -> {
+      try {
+        process.waitFor();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } finally {
+        deleteQuietly(argFile);
+      }
+    }, "ForkedJavaProcess-argfile-cleanup");
+    argFileCleanupThread.setDaemon(true);
+    argFileCleanupThread.start();
     Logger logger = LogManager.getLogger(
         logContext.map(s -> s + ", ").orElse("") + appClass.getSimpleName() + ", PID=" + getPidOfProcess(process));
     return new ForkedJavaProcess(process, logger, killOnExit);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/ForkedJavaProcess.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/ForkedJavaProcess.java
@@ -63,25 +63,37 @@ public final class ForkedJavaProcess extends Process {
       Optional<LogContext> logContext) throws IOException {
     LOGGER.info("Forking " + appClass.getSimpleName() + " with arguments " + args + " and jvm arguments " + jvmArgs);
     List<String> command = prepareCommandArgList(appClass, classPath, args, jvmArgs);
-    File argFile = writeArgFile(command);
-    List<String> wrappedCommand = Arrays.asList(command.get(0), "@" + argFile.getAbsolutePath());
 
-    Process process = new ProcessBuilder(wrappedCommand).redirectErrorStream(true).start();
-    // The argfile is only needed for the JVM launcher to read at startup; once the process has exited (for any
-    // reason), delete it right away instead of leaving it around for the whole lifetime of this (potentially
-    // long-lived, e.g. Gradle daemon) JVM. deleteOnExit() alone is not sufficient here since a single long-lived
-    // JVM can fork many processes over its lifetime, and files would otherwise accumulate until that JVM exits.
-    Thread argFileCleanupThread = new Thread(() -> {
-      try {
-        process.waitFor();
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      } finally {
-        deleteQuietly(argFile);
-      }
-    }, "ForkedJavaProcess-argfile-cleanup");
-    argFileCleanupThread.setDaemon(true);
-    argFileCleanupThread.start();
+    File argFile = null;
+    List<String> commandToRun = command;
+    // The `java` launcher only understands `@argfile` syntax starting with JDK 9 (JEP 293); on JDK 8 (still used by
+    // some of our test/runtime environments) it would literally try to load a main class named "@<path>" and fail.
+    // Fall back to passing the arguments directly on JDK 8, accepting the pre-existing risk of hitting the OS
+    // "Argument list too long" error in that case.
+    if (isArgFileSupported()) {
+      argFile = writeArgFile(command);
+      commandToRun = Arrays.asList(command.get(0), "@" + argFile.getAbsolutePath());
+    }
+
+    Process process = new ProcessBuilder(commandToRun).redirectErrorStream(true).start();
+    if (argFile != null) {
+      // The argfile is only needed for the JVM launcher to read at startup; once the process has exited (for any
+      // reason), delete it right away instead of leaving it around for the whole lifetime of this (potentially
+      // long-lived, e.g. Gradle daemon) JVM. deleteOnExit() alone is not sufficient here since a single long-lived
+      // JVM can fork many processes over its lifetime, and files would otherwise accumulate until that JVM exits.
+      File argFileToDelete = argFile;
+      Thread argFileCleanupThread = new Thread(() -> {
+        try {
+          process.waitFor();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          deleteQuietly(argFileToDelete);
+        }
+      }, "ForkedJavaProcess-argfile-cleanup");
+      argFileCleanupThread.setDaemon(true);
+      argFileCleanupThread.start();
+    }
     Logger logger = LogManager.getLogger(
         logContext.map(s -> s + ", ").orElse("") + appClass.getSimpleName() + ", PID=" + getPidOfProcess(process));
     return new ForkedJavaProcess(process, logger, killOnExit);
@@ -330,6 +342,26 @@ public final class ForkedJavaProcess extends Process {
    * is responsible for deleting the returned file once the forked process no longer needs it (see
    * {@link #deleteQuietly(File)}).
    */
+  /**
+   * The {@code java} launcher only understands {@code @argfile} syntax starting with JDK 9 (JEP 293). On JDK 8 (and
+   * earlier), {@code java @somefile} is interpreted as an attempt to run a main class literally named
+   * {@code @somefile}, which fails immediately. We fork using the same {@code java.home} as the current JVM (see
+   * {@link #JAVA_PATH}), so checking the current JVM's version tells us what the forked JVM will support.
+   */
+  private static boolean isArgFileSupported() {
+    // Pre-JDK9, java.specification.version was formatted as "1.<major>" (e.g. "1.8"); JDK9+ uses just "<major>".
+    String specVersion = System.getProperty("java.specification.version", "");
+    if (specVersion.startsWith("1.")) {
+      return false;
+    }
+    try {
+      return Integer.parseInt(specVersion) >= 9;
+    } catch (NumberFormatException e) {
+      // Unrecognized/unparseable version format; assume it's a modern JVM using the new-style version scheme.
+      return true;
+    }
+  }
+
   private static File writeArgFile(List<String> command) {
     try {
       File argFile = File.createTempFile("forked-java-process-args", ".txt", Utils.getTempDataDirectory());

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/ForkedJavaProcessEchoMain.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/ForkedJavaProcessEchoMain.java
@@ -1,0 +1,25 @@
+package com.linkedin.venice.utils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+
+/**
+ * Top-level helper main-class used by {@link TestForkedJavaProcessArgFile} to verify that
+ * {@link ForkedJavaProcess#exec} correctly forks a process and propagates program args and JVM properties via the
+ * {@code @argfile} mechanism, even when the classpath is artificially huge.
+ *
+ * Writes its received args/properties to the file path passed as the first argument, instead of stdout, since
+ * {@link ForkedJavaProcess} already consumes the forked process' stdout internally for logging purposes.
+ */
+public class ForkedJavaProcessEchoMain {
+  public static void main(String[] args) throws IOException {
+    String outputFilePath = args[0];
+    String remainingArgs = String.join(",", java.util.Arrays.copyOfRange(args, 1, args.length));
+    String content = "ARGS=" + remainingArgs + System.lineSeparator() + "PROP="
+        + System.getProperty("forkedJavaProcessArgFileTest.prop") + System.lineSeparator();
+    Files.write(Paths.get(outputFilePath), content.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestForkedJavaProcessArgFile.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestForkedJavaProcessArgFile.java
@@ -1,0 +1,90 @@
+package com.linkedin.venice.utils;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for the {@code @argfile} mechanism in {@link ForkedJavaProcess#exec}, which avoids OS-level
+ * "Argument list too long" (execve() E2BIG) failures that can otherwise occur when the classpath passed to a forked
+ * JVM is very large.
+ */
+public class TestForkedJavaProcessArgFile {
+  private static final String PROP_KEY = "forkedJavaProcessArgFileTest.prop";
+
+  /**
+   * Builds a classpath long enough to exceed a typical OS argv size limit if passed directly (instead of via
+   * {@code @argfile}), by padding a valid classpath with a large number of fake entries.
+   */
+  private static String buildHugeClasspath() {
+    StringBuilder hugeClasspath = new StringBuilder(ForkedJavaProcess.getClasspath());
+    for (int i = 0; i < 20000; i++) {
+      hugeClasspath.append(File.pathSeparatorChar)
+          .append("/tmp/fake/very/long/gradle/cache/path/segment/")
+          .append(i)
+          .append("/some-fake-artifact-name-")
+          .append(i)
+          .append(".jar");
+    }
+    return hugeClasspath.toString();
+  }
+
+  @Test(timeOut = 60 * Time.MS_PER_SECOND)
+  public void testForkWithHugeClasspathPropagatesArgsAndJvmProperties() throws Exception {
+    String hugeClasspath = buildHugeClasspath();
+    File outputFile = File.createTempFile("forked-java-process-argfile-test-output", ".txt");
+    outputFile.deleteOnExit();
+
+    // Includes both a token requiring @argfile quoting ("hello world") and one that doesn't ("arg2"), as well as a
+    // JVM property whose value contains whitespace, exercising both branches of the argfile token quoting logic.
+    ForkedJavaProcess forked = ForkedJavaProcess.exec(
+        ForkedJavaProcessEchoMain.class,
+        Arrays.asList(outputFile.getAbsolutePath(), "hello world", "arg2"),
+        Collections.singletonList("-D" + PROP_KEY + "=value with spaces"),
+        hugeClasspath,
+        true,
+        Optional.empty());
+
+    int exitCode = forked.waitFor();
+    String output = new String(Files.readAllBytes(outputFile.toPath()), StandardCharsets.UTF_8);
+
+    Assert.assertEquals(exitCode, 0, "Forked process should exit cleanly. Output was:\n" + output);
+    Assert.assertTrue(output.contains("ARGS=hello world,arg2"), "Unexpected output: " + output);
+    Assert.assertTrue(output.contains("PROP=value with spaces"), "Unexpected output: " + output);
+  }
+
+  @Test(timeOut = 60 * Time.MS_PER_SECOND)
+  public void testArgFileIsCleanedUpAfterForkedProcessExits() throws Exception {
+    File tempDir = Utils.getTempDataDirectory();
+    long argFilesBefore = countArgFiles(tempDir);
+    File outputFile = File.createTempFile("forked-java-process-argfile-test-output", ".txt");
+    outputFile.deleteOnExit();
+
+    ForkedJavaProcess forked = ForkedJavaProcess.exec(
+        ForkedJavaProcessEchoMain.class,
+        Collections.singletonList(outputFile.getAbsolutePath()),
+        Collections.emptyList(),
+        false);
+    Assert.assertEquals(forked.waitFor(), 0);
+
+    TestUtils.waitForNonDeterministicAssertion(
+        10,
+        TimeUnit.SECONDS,
+        () -> Assert.assertEquals(
+            countArgFiles(tempDir),
+            argFilesBefore,
+            "The @argfile created for the forked process should be deleted once the process exits."));
+  }
+
+  private static long countArgFiles(File tempDir) {
+    File[] files = tempDir.listFiles((dir, name) -> name.startsWith("forked-java-process-args"));
+    return files == null ? 0 : files.length;
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestForkedJavaProcessArgFile.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestForkedJavaProcessArgFile.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 
@@ -38,6 +39,12 @@ public class TestForkedJavaProcessArgFile {
 
   @Test(timeOut = 60 * Time.MS_PER_SECOND)
   public void testForkWithHugeClasspathPropagatesArgsAndJvmProperties() throws Exception {
+    if (!isArgFileSupported()) {
+      // On JDK 8, the java launcher doesn't understand @argfile syntax at all, so ForkedJavaProcess falls back to
+      // passing arguments directly; a huge classpath is then expected to still hit the OS argument-length limit,
+      // same as it always has on JDK 8.
+      throw new SkipException("The @argfile mechanism is only supported on JDK 9+.");
+    }
     String hugeClasspath = buildHugeClasspath();
     File outputFile = File.createTempFile("forked-java-process-argfile-test-output", ".txt");
     outputFile.deleteOnExit();
@@ -86,5 +93,21 @@ public class TestForkedJavaProcessArgFile {
   private static long countArgFiles(File tempDir) {
     File[] files = tempDir.listFiles((dir, name) -> name.startsWith("forked-java-process-args"));
     return files == null ? 0 : files.length;
+  }
+
+  /**
+   * Mirrors {@code ForkedJavaProcess.isArgFileSupported()}: the java launcher only understands {@code @argfile}
+   * syntax starting with JDK 9.
+   */
+  private static boolean isArgFileSupported() {
+    String specVersion = System.getProperty("java.specification.version", "");
+    if (specVersion.startsWith("1.")) {
+      return false;
+    }
+    try {
+      return Integer.parseInt(specVersion) >= 9;
+    } catch (NumberFormatException e) {
+      return true;
+    }
   }
 }


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat], [protocol]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Problem Statement
ForkedJavaProcess.exec() builds the full runtime classpath and passes it directly as a single -cp argument to ProcessBuilder.start(), which ultimately calls the OS execve() syscall. Since execve() caps the total size of argv+envp (e.g. Linux ARG_MAX), a sufficiently large classpath (many dependency jars with long Gradle-cache paths) can exceed that limit, causing:

  java.io.IOException: Cannot run program "...java": error=7,
  Argument list too long




## Solution
This is an OS-level limit that gets worse as dependencies grow over time, independent of any single code change.

Fix: write all java arguments (classpath, JVM args, app class, program args) to a temporary @argfile (supported by the java launcher since Java 9) and invoke "java @argfile" instead of passing them directly. Only the short @path token goes through execve(), so classpath size no longer matters.

The argfile is cleaned up as soon as its forked process exits (tracked via a dedicated daemon thread), rather than relying solely on File#deleteOnExit(), since a single long-lived JVM (e.g. a Gradle daemon) can fork many processes over its lifetime and would otherwise accumulate orphaned temp files until that JVM exits.

Verified locally: reproduced the original failure with an artificially oversized classpath, confirmed it no longer occurs with this fix, and confirmed args/JVM properties (including ones containing spaces) are still propagated correctly end-to-end.



###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**. 
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?
<!--  
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.