### PR TITLE
[da-vinci] Preserve targetRegionPromoted in ReadOnlyStore.convertVersion

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -2060,6 +2060,7 @@ public class ReadOnlyStore implements Store {
     storeVersion.setRepushSourceVersion(version.getRepushSourceVersion());
     storeVersion.setTargetSwapRegion(version.getTargetSwapRegion());
     storeVersion.setTargetSwapRegionWaitTime(version.getTargetSwapRegionWaitTime());
+    storeVersion.setTargetRegionPromoted(version.isTargetRegionPromoted());
     storeVersion.setIsDaVinciHeartBeatReported(version.getIsDavinciHeartbeatReported());
     storeVersion.setGlobalRtDivEnabled(version.isGlobalRtDivEnabled());
     storeVersion.setViews(convertViewConfigsStringMap(version.getViewConfigs()));

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/ReadOnlyStoreTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/ReadOnlyStoreTest.java
@@ -346,6 +346,41 @@ public class ReadOnlyStoreTest {
   }
 
   @Test
+  public void testCloneStorePropertiesPreservesVersionTargetRegionPromoted() {
+    ZKStore store = (ZKStore) TestUtils.createTestStore(
+        Long.toString(RANDOM.nextLong()),
+        Long.toString(RANDOM.nextLong()),
+        System.currentTimeMillis());
+    store.addVersion(new VersionImpl(store.getName(), 1, "push1"));
+    store.setVersionTargetRegionPromoted(1, true);
+    assertTrue(store.getVersion(1).isTargetRegionPromoted());
+
+    // Regression: ReadOnlyStore.convertVersion previously dropped targetRegionPromoted, so a
+    // Store -> StoreProperties round-trip via cloneStoreProperties emitted the schema default
+    // (false) for every version. Non-target DaVinci clients read this field (via the meta system
+    // store / request-based store_properties, both built from cloneStoreProperties) to know when
+    // to resume paused ingestion, so losing it here deadlocked paused-SIT resume.
+    StoreProperties promoted = new ReadOnlyStore(store).cloneStoreProperties();
+    assertEquals(promoted.getVersions().size(), 1);
+    assertTrue(promoted.getVersions().get(0).getTargetRegionPromoted());
+  }
+
+  @Test
+  public void testCloneStorePropertiesTargetRegionPromotedDefaultsFalse() {
+    ZKStore store = (ZKStore) TestUtils.createTestStore(
+        Long.toString(RANDOM.nextLong()),
+        Long.toString(RANDOM.nextLong()),
+        System.currentTimeMillis());
+    store.addVersion(new VersionImpl(store.getName(), 1, "push1"));
+    assertFalse(store.getVersion(1).isTargetRegionPromoted());
+
+    // Unpromoted versions must round-trip as false (not silently flipped).
+    StoreProperties cloned = new ReadOnlyStore(store).cloneStoreProperties();
+    assertEquals(cloned.getVersions().size(), 1);
+    assertFalse(cloned.getVersions().get(0).getTargetRegionPromoted());
+  }
+
+  @Test
   public void testReadOnlyEtlConfigDelegatesGetEtlActiveFabrics() {
     ZKStore store = (ZKStore) TestUtils.createTestStore("test_store", "owner", System.currentTimeMillis());
     store.setEtlStoreConfig(new ETLStoreConfigImpl("proxy", true, false, 2, Arrays.asList("dc-0", "dc-1")));


### PR DESCRIPTION
## Problem Statement

`ReadOnlyStore.convertVersion()` copies every version-level field into the `StoreVersion` Avro record **except `targetRegionPromoted`**. As a result, a `Store -> StoreProperties` round-trip via `cloneStoreProperties()` emits the schema default (`false`) for `targetRegionPromoted` on every version, regardless of the real value.

`cloneStoreProperties()` backs both consumer-facing read paths:
- the server `/store_properties` endpoint (consumed by `RequestBasedMetaRepository`), and
- the meta-system-store `STORE_PROPERTIES` snapshot (consumed by `ThinClientMetaStoreBasedRepository`).

These are exactly the paths a **non-target DaVinci client** reads to learn that the parent controller has promoted the target region (`targetRegionPromoted=true`). With the flag silently dropped to `false`, `StoreBackend.maybeResumeDaVinciFutureVersion()` never resumes a paused future-version SIT — even after the controller correctly flips `targetRegionPromoted=true`. This deadlocks deferred-version-swap roll-forward for the non-head region: the DaVinci host stays paused, so the region push never completes, so the controller never rolls forward.

`describe-store` on the controller showed `targetRegionPromoted=True` for the future version, but the server `/store_properties` payload (and both DaVinci metadata repositories) showed `false` for **all** versions — the tell that the field was being stripped at serialization, not lagging.

## Solution

Copy `targetRegionPromoted` in `convertVersion()`, alongside the existing `targetSwapRegion` / `targetSwapRegionWaitTime` copies. This restores propagation of the flag to the servers' store view, the meta system store, and both DaVinci metadata repositories, so a paused SIT resumes as designed once the controller flips the flag.

No config or behavior gates — this is a serialization correctness fix.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

Added `ReadOnlyStoreTest` regression coverage:
- `testCloneStorePropertiesPreservesVersionTargetRegionPromoted` — a promoted version round-trips as `true`. Verified this fails on `main` (`expected [true] but found [false]`) and passes with the fix.
- `testCloneStorePropertiesTargetRegionPromotedDefaultsFalse` — an unpromoted version round-trips as `false`, guarding against a blanket flip.

The full `ReadOnlyStoreTest` suite passes locally.

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).
- [x] Local code review completed

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
