### PR TITLE
[vpj] Route repush ZSTD dictionary reads through configured adapter

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_DELIVERY_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_REQUEST_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_RETRIES_CONFIG;
 import static com.linkedin.venice.ConfigKeys.MULTI_REGION;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.VENICE_PARTITIONERS;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENABLED_CONFIG;
@@ -866,13 +867,9 @@ public class VenicePushJob implements AutoCloseable {
       if (pushJobSetting.isSourceKafka) {
         if (pushJobSetting.sourceVersionCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT) {
           LOGGER.info("Source version uses ZSTD_WITH_DICT. Fetching source dictionary.");
-          Properties kafkaConsumerProperties = new Properties();
-          if (pushJobSetting.enableSSL) {
-            kafkaConsumerProperties.putAll(this.sslProperties.get());
-          }
-          kafkaConsumerProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, pushJobSetting.repushSourcePubsubBroker);
-          ByteBuffer sourceDict = DictionaryUtils
-              .readDictionaryFromKafka(pushJobSetting.kafkaInputTopic, new VeniceProperties(kafkaConsumerProperties));
+          ByteBuffer sourceDict = DictionaryUtils.readDictionaryFromKafka(
+              pushJobSetting.kafkaInputTopic,
+              new VeniceProperties(getRepushDictionaryConsumerProperties()));
           if (sourceDict != null) {
             pushJobSetting.sourceDictionary = ByteUtils.extractByteArray(sourceDict);
           }
@@ -1666,12 +1663,46 @@ public class VenicePushJob implements AutoCloseable {
     return Optional.of(emptyPushZstdDictionary.get());
   }
 
+  /**
+   * Build the pub-sub consumer properties used to read the repush source topic's compression dictionary.
+   * Seeds from the full job config so the configured pub-sub consumer adapter factory (e.g. xinfra) and its
+   * client configs are honored, then overlays SSL and the repush source broker. Seeding only SSL + broker would
+   * drop {@code pubsub.consumer.adapter.factory.class} and silently fall back to the default Apache Kafka
+   * consumer, which cannot read the source topic on a non-Kafka (e.g. xinfra) deployment.
+   */
+  private Properties getRepushDictionaryConsumerProperties() {
+    return buildRepushDictionaryConsumerProperties(
+        props,
+        pushJobSetting.enableSSL ? sslProperties.get() : new Properties(),
+        pushJobSetting.repushSourcePubsubBroker);
+  }
+
+  /**
+   * Assemble the pub-sub consumer properties used to read the repush source topic's compression dictionary. The
+   * source dictionary must be read with the same pub-sub client as the rest of the repush, so seed from the full
+   * job configuration (which carries {@code pubsub.consumer.adapter.factory.class} and any client-specific
+   * settings, such as xinfra's routing maps), overlay SSL, and point the broker properties at the repush source
+   * broker. Seeding only SSL and the broker address drops the adapter-factory class and silently falls back to
+   * the default Apache Kafka consumer, which cannot read the source topic on a non-Kafka (e.g. xinfra) deployment.
+   */
+  @VisibleForTesting
+  static Properties buildRepushDictionaryConsumerProperties(
+      VeniceProperties jobProperties,
+      Properties sslProperties,
+      String repushSourcePubsubBroker) {
+    Properties consumerProperties = jobProperties.toProperties();
+    consumerProperties.putAll(sslProperties);
+    consumerProperties.setProperty(PUBSUB_BROKER_ADDRESS, repushSourcePubsubBroker);
+    consumerProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, repushSourcePubsubBroker);
+    return consumerProperties;
+  }
+
   private ByteBuffer fetchOrBuildCompressionDictionary() throws VeniceException {
     // Prepare the param builder, which can be used by different scenarios.
     KafkaInputDictTrainer.ParamBuilder paramBuilder = new KafkaInputDictTrainer.ParamBuilder()
         .setKeySchema(AvroCompatibilityHelper.toParsingForm(pushJobSetting.storeKeySchema))
         .setNewKMESchemasFromController(pushJobSetting.newKmeSchemasFromController)
-        .setSslProperties(pushJobSetting.enableSSL ? sslProperties.get() : new Properties())
+        .setConsumerProperties(getRepushDictionaryConsumerProperties())
         .setCompressionDictSize(
             props.getInt(
                 COMPRESSION_DICTIONARY_SIZE_LIMIT,
@@ -1691,14 +1722,9 @@ public class VenicePushJob implements AutoCloseable {
           return ByteBuffer.wrap(dictTrainer.trainDict());
         } else {
           LOGGER.info("Reading Zstd dictionary from input topic: {}", pushJobSetting.kafkaInputTopic);
-          // set up ssl properties and kafka consumer properties
-          Properties kafkaConsumerProperties = new Properties();
-          if (pushJobSetting.enableSSL) {
-            kafkaConsumerProperties.putAll(this.sslProperties.get());
-          }
-          kafkaConsumerProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, pushJobSetting.repushSourcePubsubBroker);
-          return DictionaryUtils
-              .readDictionaryFromKafka(pushJobSetting.kafkaInputTopic, new VeniceProperties(kafkaConsumerProperties));
+          return DictionaryUtils.readDictionaryFromKafka(
+              pushJobSetting.kafkaInputTopic,
+              new VeniceProperties(getRepushDictionaryConsumerProperties()));
         }
       }
       LOGGER.info(

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
@@ -50,7 +50,7 @@ public class KafkaInputDictTrainer {
     private final String kafkaInputBroker;
     private final String topicName;
     private final String keySchema;
-    private final Properties sslProperties;
+    private final Properties consumerProperties;
     private final int compressionDictSize;
     private final int dictSampleSize;
     private final CompressionStrategy sourceVersionCompressionStrategy;
@@ -62,7 +62,7 @@ public class KafkaInputDictTrainer {
       this.kafkaInputBroker = builder.kafkaInputBroker;
       this.topicName = builder.topicName;
       this.keySchema = builder.keySchema;
-      this.sslProperties = builder.sslProperties;
+      this.consumerProperties = builder.consumerProperties;
       this.compressionDictSize = builder.compressionDictSize;
       this.dictSampleSize = builder.dictSampleSize;
       this.sourceVersionCompressionStrategy = builder.sourceVersionCompressionStrategy;
@@ -75,7 +75,7 @@ public class KafkaInputDictTrainer {
     private String kafkaInputBroker;
     private String topicName;
     private String keySchema;
-    private Properties sslProperties;
+    private Properties consumerProperties;
     private int compressionDictSize;
     private int dictSampleSize;
     private CompressionStrategy sourceVersionCompressionStrategy;
@@ -97,8 +97,14 @@ public class KafkaInputDictTrainer {
       return this;
     }
 
-    public ParamBuilder setSslProperties(Properties sslProperties) {
-      this.sslProperties = sslProperties;
+    /**
+     * Properties the source-topic consumer is built from. These must include the job's pub-sub client
+     * configuration (e.g. {@code pubsub.consumer.adapter.factory.class} and any client-specific configs such as
+     * xinfra's) so the dictionary is read with the same pub-sub client as the rest of the repush; otherwise
+     * {@code PubSubClientsFactory.createConsumerFactory(...)} silently defaults to the Apache Kafka consumer.
+     */
+    public ParamBuilder setConsumerProperties(Properties consumerProperties) {
+      this.consumerProperties = consumerProperties;
       return this;
     }
 
@@ -170,7 +176,7 @@ public class KafkaInputDictTrainer {
     properties.setProperty(KAFKA_INPUT_TOPIC, param.topicName);
     properties.setProperty(KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, param.keySchema);
     this.sourceTopicName = param.topicName;
-    properties.putAll(param.sslProperties);
+    properties.putAll(param.consumerProperties);
     properties.setProperty(COMPRESSION_DICTIONARY_SIZE_LIMIT, Integer.toString(param.compressionDictSize));
     properties.setProperty(COMPRESSION_DICTIONARY_SAMPLE_SIZE, Integer.toString(param.dictSampleSize));
     properties

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobRepushTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobRepushTest.java
@@ -1,5 +1,9 @@
 package com.linkedin.venice.hadoop;
 
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_SECURITY_PROTOCOL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ALLOW_REGULAR_PUSH_WITH_TTL_REPUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.COMPLIANCE_PUSH;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
@@ -26,6 +30,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.VeniceProperties;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -42,6 +47,65 @@ import org.testng.annotations.Test;
  */
 
 public class VenicePushJobRepushTest extends VenicePushJobTestBase {
+  @Test
+  public void testBuildRepushDictionaryConsumerPropertiesRetainsAdapterConfigAndOverridesBrokers() {
+    Properties jobProperties = new Properties();
+    jobProperties.setProperty(
+        PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS,
+        "com.linkedin.venice.pubsub.adapter.xinfra.consumer.XcConsumerAdapterFactory");
+    jobProperties.setProperty("xc.pubsub.broker.url.to.region.name.map", "northguard:ei4");
+    jobProperties.setProperty(PUBSUB_BROKER_ADDRESS, "destination-broker");
+    jobProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, "legacy-broker");
+
+    Properties consumerProperties = VenicePushJob.buildRepushDictionaryConsumerProperties(
+        new VeniceProperties(jobProperties),
+        new Properties(),
+        "source-broker");
+
+    // The configured pub-sub adapter factory and its client-specific configs must survive so the source
+    // dictionary is read with the same adapter as the rest of the repush instead of the implicit Kafka default.
+    assertEquals(
+        consumerProperties.getProperty(PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS),
+        "com.linkedin.venice.pubsub.adapter.xinfra.consumer.XcConsumerAdapterFactory");
+    assertEquals(consumerProperties.getProperty("xc.pubsub.broker.url.to.region.name.map"), "northguard:ei4");
+    // Both broker properties are pointed at the repush source broker.
+    assertEquals(consumerProperties.getProperty(PUBSUB_BROKER_ADDRESS), "source-broker");
+    assertEquals(consumerProperties.getProperty(KAFKA_BOOTSTRAP_SERVERS), "source-broker");
+  }
+
+  @Test
+  public void testBuildRepushDictionaryConsumerPropertiesAppliesSslOverrides() {
+    Properties jobProperties = new Properties();
+    jobProperties.setProperty(PUBSUB_SECURITY_PROTOCOL, "PLAINTEXT");
+    jobProperties.setProperty("ssl.keystore.location", "stale-keystore");
+
+    Properties sslProperties = new Properties();
+    sslProperties.setProperty(PUBSUB_SECURITY_PROTOCOL, "SSL");
+    sslProperties.setProperty("ssl.keystore.location", "credential-keystore");
+
+    Properties consumerProperties = VenicePushJob
+        .buildRepushDictionaryConsumerProperties(new VeniceProperties(jobProperties), sslProperties, "source-broker");
+
+    assertEquals(consumerProperties.getProperty(PUBSUB_SECURITY_PROTOCOL), "SSL");
+    assertEquals(consumerProperties.getProperty("ssl.keystore.location"), "credential-keystore");
+  }
+
+  @Test
+  public void testBuildRepushDictionaryConsumerPropertiesDoesNotMutateJobProperties() {
+    Properties jobProperties = new Properties();
+    jobProperties.setProperty(PUBSUB_BROKER_ADDRESS, "destination-broker");
+
+    VenicePushJob.buildRepushDictionaryConsumerProperties(
+        new VeniceProperties(jobProperties),
+        new Properties(),
+        "source-broker");
+
+    assertEquals(
+        jobProperties.getProperty(PUBSUB_BROKER_ADDRESS),
+        "destination-broker",
+        "Building consumer properties must not mutate the job properties");
+  }
+
   @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Repush with TTL is only supported while using Kafka Input Format.*")
   public void testRepushTTLJobWithNonKafkaInput() {
     Properties repushProps = new Properties();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
@@ -60,7 +60,7 @@ public class TestKafkaInputDictTrainer {
         .setKeySchema("\"string\"")
         .setCompressionDictSize(900 * 1024)
         .setDictSampleSize(sampleSize)
-        .setSslProperties(new Properties())
+        .setConsumerProperties(new Properties())
         .setSourceVersionCompressionStrategy(sourceVersionCompressionStrategy)
         .setNewKMESchemasFromController(allSchemaStr)
         .build();


### PR DESCRIPTION
## Problem Statement

Kafka-input repushes read the source compression dictionary in the VenicePushJob driver when the source version uses `ZSTD_WITH_DICT`. Every driver-side dictionary path constructed fresh consumer properties containing only SSL config and a broker address, discarding the configured pub-sub consumer adapter factory and its client configs (e.g. xinfra routing maps).

Without the adapter-factory class, `PubSubClientsFactory.createConsumerFactory(...)` defaults to `ApacheKafkaConsumerAdapterFactory`. On a NorthGuard-backed (non-Kafka) source the dictionary read is then attempted through legacy Kafka and returns `UNKNOWN_TOPIC_OR_PARTITION` until the push job times out.

An end-to-end xinfra repush test confirmed the leak. On a fully-xinfra cluster the repush constructed 4 `ApacheKafkaConsumerAdapter` instances: the dictionary trainer (`KafkaInputDictTrainer`), two `DictionaryUtilsConsumer` reads, and the split-planner `TopicManager`. The rest of the repush already used the configured adapter.

#2942 fixes the two `DictionaryUtils.readDictionaryFromKafka` sites but not the default build-new-dict trainer path: `kafkaInputBuildNewDictEnabled` defaults to `true`, so a standard `ZSTD_WITH_DICT` repush still falls back to Kafka for the dictionary.

## Solution

Assemble the dictionary consumer properties from the full VPJ job configuration via one shared helper (`buildRepushDictionaryConsumerProperties`), then overlay SSL and point both `pubsub.broker.address` and `kafka.bootstrap.servers` at the repush source broker. The job config already carries `pubsub.consumer.adapter.factory.class` and any client-specific settings, so the dictionary is read with the same pub-sub client as the rest of the repush.

All four driver-side dictionary paths now use the helper:
- the source-dictionary read in `run()`,
- the dictionary read branch (build-new-dict disabled),
- the `KafkaInputDictTrainer` build-new-dict branch (the default), and
- the empty-push / hybrid dictionary rebuild.

`KafkaInputDictTrainer.ParamBuilder.setSslProperties` is renamed to `setConsumerProperties` because the bag is merged into the whole consumer config; the `setSslProperties` name understated what it carries.

This completes the read-path fix in #2942 by also covering the default trainer path, and complements the fail-fast guard in #2943, which turns the same misconfiguration into a hard error instead of a silent Kafka fallback.

The helper copies the job properties once during driver-side dictionary lookup and does not mutate the original job properties. No new configs or log lines.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**. Driver-side, single-threaded dictionary read; the helper returns a fresh `Properties` copy.
- [x] Proper **synchronization mechanisms** are used where needed. No shared mutable state introduced.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used. No new shared collections.
- [x] Validated proper exception handling in multi-threaded code. No new multi-threaded code.

## How was this PR tested?

- [x] New unit tests added. `VenicePushJobRepushTest`: the dictionary consumer properties retain the configured adapter factory and client configs, override both broker properties to the source broker, apply SSL overrides, and do not mutate the job properties.
- [ ] New integration tests added.
- [x] Modified or extended existing tests. `KafkaInputDictTrainer` builder rename.
- [x] Verified backward compatibility.

End-to-end verification: a xinfra `ZSTD_WITH_DICT` repush integration test that captures the pub-sub consumer adapter constructed during the repush. Without this change the repush created 4 `ApacheKafkaConsumerAdapter` instances; with it, 0, and the dictionary trainer, dictionary reader, and split-planner `TopicManager` all use the configured adapter.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
