### PR TITLE
[cc][da-vinci] Hotfix CDC shutdown deadlock

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/StatefulVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/StatefulVeniceChangelogConsumer.java
@@ -49,6 +49,10 @@ public interface StatefulVeniceChangelogConsumer<K, V> extends AutoCloseable {
    */
   CompletableFuture<Void> start();
 
+  /**
+   * Stops this consumer and releases its internal resources. This consumer instance cannot be restarted after this
+   * method is called. Create a new consumer from {@link VeniceChangelogConsumerClientFactory} to resume consumption.
+   */
   void stop() throws Exception;
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
@@ -225,7 +225,8 @@ public interface VeniceChangelogConsumer<K, V> extends AutoCloseable {
   Map<Integer, Long> getLastHeartbeatPerPartition();
 
   /**
-   * Release the internal resources.
+   * Releases the internal resources. This consumer instance cannot be restarted or sought after close. Create a new
+   * consumer from {@link VeniceChangelogConsumerClientFactory} to resume consumption.
    */
   void close();
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -81,6 +81,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   private final CachingDaVinciClientFactory daVinciClientFactory;
   private final SeekableDaVinciClient<K, V> daVinciClient;
   private final AtomicBoolean isStarted = new AtomicBoolean(false);
+  private final AtomicBoolean isClosed = new AtomicBoolean(false);
   private final CountDownLatch startLatch = new CountDownLatch(1);
   // Using a dedicated thread pool for CompletableFutures created by this class to avoid potential thread starvation
   // issues in the default ForkJoinPool
@@ -197,10 +198,20 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   }
 
   private synchronized void startDaVinciClient() {
+    throwIfClosed();
     // Start daVinci client if not already started
     if (!isStarted.get()) {
       daVinciClient.start();
       isStarted.set(true);
+    }
+  }
+
+  private void throwIfClosed() {
+    if (isClosed.get()) {
+      throw new VeniceClientException(
+          "This VeniceChangelogConsumer instance is closed and cannot be restarted. Create a new consumer from "
+              + "VeniceChangelogConsumerClientFactory for store: " + storeName + ", consumer name: "
+              + changelogClientConfig.getConsumerName());
     }
   }
 
@@ -215,6 +226,7 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   private synchronized CompletableFuture<Void> initializeAndSubscribe(
       Set<Integer> partitions,
       Function<Set<Integer>, CompletableFuture<Void>> subscriptionCall) {
+    throwIfClosed();
     Set<Integer> targetPartitions = new HashSet<>();
     boolean partitionsAdded = false;
     try {
@@ -268,8 +280,15 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
           }
 
           if (changeCaptureStats != null) {
-            backgroundReporterThread = new BackgroundReporterThread();
-            backgroundReporterThread.start();
+            bufferLock.lock();
+            try {
+              if (!isClosed.get()) {
+                backgroundReporterThread = new BackgroundReporterThread();
+                backgroundReporterThread.start();
+              }
+            } finally {
+              bufferLock.unlock();
+            }
           }
         } catch (InterruptedException e) {
           LOGGER.info("Thread was interrupted", e);
@@ -321,8 +340,24 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   }
 
   @Override
-  public void stop() throws Exception {
-    LOGGER.info("Closing Changelog Consumer with name: {}", changelogClientConfig.getConsumerName());
+  public synchronized void stop() throws Exception {
+    if (isClosed.get()) {
+      return;
+    }
+
+    LOGGER.info("Closing VeniceChangelogConsumer with name: {}", changelogClientConfig.getConsumerName());
+    bufferLock.lock();
+    try {
+      isClosed.set(true);
+      isStarted.set(false);
+      partitionToVersionToServe.clear();
+      pubSubMessages.clear();
+      startLatch.countDown();
+      bufferIsFullCondition.signalAll();
+    } finally {
+      bufferLock.unlock();
+    }
+    completableFutureThreadPool.shutdown();
     try {
       if (backgroundReporterThread != null) {
         backgroundReporterThread.interrupt();
@@ -330,9 +365,10 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
       daVinciClient.close();
     } finally {
       isStarted.set(false);
+      pubSubMessages.clear();
       veniceChangelogConsumerClientFactory.deregisterClient(changelogClientConfig.getConsumerName());
       clearPartitionState(Collections.emptySet());
-      LOGGER.info("Closed Changelog Consumer with name: {}", changelogClientConfig.getConsumerName());
+      LOGGER.info("Closed VeniceChangelogConsumer with name: {}", changelogClientConfig.getConsumerName());
     }
   }
 
@@ -453,13 +489,18 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   @Override
   public Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> poll(long timeoutInMs) {
     try {
+      Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> drainedPubSubMessages = new ArrayList<>();
       try {
         bufferLock.lock();
 
         // Wait until pubSubMessages becomes full, or until the timeout is reached
-        if (pubSubMessages.remainingCapacity() > 0) {
+        if (!isClosed.get() && pubSubMessages.remainingCapacity() > 0) {
           bufferIsFullCondition.await(timeoutInMs, TimeUnit.MILLISECONDS);
         }
+        if (isClosed.get()) {
+          return Collections.emptyList();
+        }
+        pubSubMessages.drainTo(drainedPubSubMessages);
       } catch (InterruptedException exception) {
         LOGGER.info("Thread was interrupted", exception);
         // Restore the interrupt status
@@ -468,8 +509,6 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
         bufferLock.unlock();
       }
 
-      Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> drainedPubSubMessages = new ArrayList<>();
-      pubSubMessages.drainTo(drainedPubSubMessages);
       int messagesPolled = drainedPubSubMessages.size();
 
       if (changelogClientConfig.shouldCompactMessages()) {
@@ -784,12 +823,16 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
     private void internalAddMessageToBuffer(
         int partitionId,
         ImmutableChangeCapturePubSubMessage<K, ChangeEvent<V>> pubSubMessage) {
-      if (!isServedByThisVersion(partitionId)) {
+      if (isClosed.get() || !isStarted.get() || !isServedByThisVersion(partitionId)) {
         return;
       }
 
       try {
         pubSubMessages.put(pubSubMessage);
+        if (isClosed.get() || !isStarted.get()) {
+          pubSubMessages.remove(pubSubMessage);
+          return;
+        }
         /*
          * pubSubMessages is full, signal to a poll thread awaiting on bufferFullCondition.
          * Not signaling to all threads, because if multiple poll threads try to read pubSubMessages at
@@ -968,6 +1011,26 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
   @VisibleForTesting
   public boolean isStarted() {
     return isStarted.get();
+  }
+
+  @VisibleForTesting
+  public boolean isClosed() {
+    return isClosed.get();
+  }
+
+  @VisibleForTesting
+  public BlockingQueue<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> getPubSubMessages() {
+    return pubSubMessages;
+  }
+
+  @VisibleForTesting
+  ExecutorService getCompletableFutureThreadPool() {
+    return completableFutureThreadPool;
+  }
+
+  @VisibleForTesting
+  Thread getBackgroundReporterThread() {
+    return backgroundReporterThread;
   }
 
   @VisibleForTesting

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
@@ -11,8 +11,10 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -28,6 +30,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.davinci.client.DaVinciRecordTransformerConfig;
@@ -54,9 +57,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.avro.Schema;
@@ -231,10 +238,199 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
 
     veniceChangelogConsumer.stop();
     assertFalse(veniceChangelogConsumer.isStarted(), "isStarted should be false");
+    assertTrue(veniceChangelogConsumer.isClosed(), "isClosed should be true");
 
     verify(mockDaVinciClient).close();
     verify(veniceChangelogConsumer).clearPartitionState(eq(Collections.emptySet()));
     verify(veniceChangelogConsumerClientFactory).deregisterClient(changelogClientConfig.getConsumerName());
+  }
+
+  @Test
+  public void testStopCompletesPendingStartWithoutStartingReporterAndShutsDownExecutor() throws Exception {
+    CompletableFuture<Void> startFuture = veniceChangelogConsumer.start();
+    ExecutorService completableFutureThreadPool = veniceChangelogConsumer.getCompletableFutureThreadPool();
+
+    assertFalse(startFuture.isDone(), "Start should wait for the first record");
+
+    veniceChangelogConsumer.stop();
+
+    startFuture.get(5, TimeUnit.SECONDS);
+    assertNull(veniceChangelogConsumer.getBackgroundReporterThread(), "A reporter must not start after close wins");
+    assertTrue(completableFutureThreadPool.isShutdown(), "Stop should shut down the dedicated start executor");
+    assertTrue(
+        completableFutureThreadPool.awaitTermination(5, TimeUnit.SECONDS),
+        "The dedicated start executor should terminate after the pending start completes");
+  }
+
+  @Test
+  public void testStopReleasesAllBlockedProducersWithoutPoller() throws Exception {
+    veniceChangelogConsumer.start();
+    onStartVersionIngestionHelper(true, true);
+
+    BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> outputQueue = getOutputQueue();
+
+    for (int i = 0; i < MAX_BUFFER_SIZE; i++) {
+      int key = i;
+      recordTransformer.processPut(Lazy.of(() -> key), lazyValue, 0, recordMetadata);
+    }
+    assertEquals(outputQueue.size(), MAX_BUFFER_SIZE, "Output queue should be full before producers block");
+
+    int blockedProducerCount = outputQueue.size() + 1;
+    AtomicReference<Throwable> threadFailure = new AtomicReference<>();
+    List<Thread> producerThreads = new ArrayList<>();
+    for (int i = 0; i < blockedProducerCount; i++) {
+      int key = MAX_BUFFER_SIZE + i;
+      Thread producerThread = new Thread(() -> {
+        try {
+          recordTransformer.processPut(Lazy.of(() -> key), lazyValue, 0, recordMetadata);
+        } catch (Throwable throwable) {
+          threadFailure.compareAndSet(null, throwable);
+        }
+      }, "blocked-cdc-producer-" + i);
+      producerThreads.add(producerThread);
+      producerThread.start();
+    }
+
+    CountDownLatch daVinciCloseStarted = new CountDownLatch(1);
+    CountDownLatch allowDaVinciClose = new CountDownLatch(1);
+    doAnswer(invocation -> {
+      daVinciCloseStarted.countDown();
+      assertTrue(allowDaVinciClose.await(30, TimeUnit.SECONDS), "Test should release DaVinci close");
+      return null;
+    }).when(mockDaVinciClient).close();
+    Thread stopThread = new Thread(() -> {
+      try {
+        veniceChangelogConsumer.stop();
+      } catch (Throwable throwable) {
+        threadFailure.compareAndSet(null, throwable);
+      }
+    }, "cdc-consumer-stop");
+
+    try {
+      TestUtils.waitForNonDeterministicAssertion(
+          5,
+          TimeUnit.SECONDS,
+          true,
+          () -> assertTrue(
+              producerThreads.stream().allMatch(producer -> producer.getState() == Thread.State.WAITING),
+              "Every producer should be blocked in the full output queue"));
+
+      stopThread.start();
+      assertTrue(daVinciCloseStarted.await(5, TimeUnit.SECONDS), "Stop should reach the DaVinci client");
+
+      for (Thread producerThread: producerThreads) {
+        producerThread.join(TimeUnit.SECONDS.toMillis(5));
+        assertFalse(producerThread.isAlive(), "Producer should exit after stop clears the queue");
+      }
+      assertNull(threadFailure.get(), "Producer threads should not fail");
+      assertTrue(stopThread.isAlive(), "Stop should still be waiting for DaVinci close");
+      assertTrue(
+          outputQueue.isEmpty(),
+          "The initial clear and post-put removal should release every producer without shutdown output");
+      assertTrue(veniceChangelogConsumer.isClosed(), "Stop should leave the consumer terminally closed");
+    } finally {
+      allowDaVinciClose.countDown();
+      stopThread.join(TimeUnit.SECONDS.toMillis(5));
+      for (Thread producerThread: producerThreads) {
+        if (producerThread.isAlive()) {
+          producerThread.interrupt();
+          producerThread.join(TimeUnit.SECONDS.toMillis(5));
+        }
+      }
+    }
+    assertFalse(stopThread.isAlive(), "Stop should finish after DaVinci close is released");
+    assertNull(threadFailure.get(), "Shutdown threads should not fail");
+  }
+
+  @Test
+  public void testPollDuringCloseReturnsNoShutdownWindowOutput() throws Exception {
+    veniceChangelogConsumer.start();
+    onStartVersionIngestionHelper(true, true);
+
+    CountDownLatch daVinciCloseStarted = new CountDownLatch(1);
+    CountDownLatch allowDaVinciClose = new CountDownLatch(1);
+    doAnswer(invocation -> {
+      daVinciCloseStarted.countDown();
+      assertTrue(allowDaVinciClose.await(5, TimeUnit.SECONDS), "Test should release DaVinci close");
+      return null;
+    }).when(mockDaVinciClient).close();
+
+    CompletableFuture<Void> closeFuture = CompletableFuture.runAsync(() -> {
+      try {
+        veniceChangelogConsumer.stop();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    try {
+      assertTrue(daVinciCloseStarted.await(5, TimeUnit.SECONDS), "Close should reach the DaVinci client");
+      BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> outputQueue =
+          getOutputQueue();
+      PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate> shutdownWindowMessage =
+          mock(PubSubMessage.class);
+      outputQueue.add(shutdownWindowMessage);
+
+      assertTrue(
+          veniceChangelogConsumer.poll(POLL_TIMEOUT).isEmpty(),
+          "Poll must not emit a message inserted after close begins");
+      assertTrue(
+          outputQueue.contains(shutdownWindowMessage),
+          "Poll should return before draining once the consumer is closed");
+    } finally {
+      allowDaVinciClose.countDown();
+    }
+
+    closeFuture.get(5, TimeUnit.SECONDS);
+    assertTrue(getOutputQueue().isEmpty(), "Final close cleanup should empty the output queue");
+  }
+
+  @Test
+  public void testStartAndSeekRejectedAfterCloseAndDuplicateStopIsHarmless() throws Exception {
+    veniceChangelogConsumer.stop();
+
+    String freshConsumerInstruction = "Create a new consumer from VeniceChangelogConsumerClientFactory";
+    VeniceClientException startException = expectThrows(VeniceClientException.class, veniceChangelogConsumer::start);
+    assertTrue(
+        startException.getMessage().contains(TEST_STORE_NAME),
+        "Closed-consumer error should identify the store");
+    assertTrue(
+        startException.getMessage().contains(freshConsumerInstruction),
+        "Closed-consumer error should explain how to create a fresh consumer");
+    VeniceClientException seekException = expectThrows(
+        VeniceClientException.class,
+        () -> veniceChangelogConsumer.seekToBeginningOfPush(Collections.singleton(0)));
+    assertTrue(seekException.getMessage().contains(TEST_STORE_NAME), "Closed-consumer error should identify the store");
+    assertTrue(
+        seekException.getMessage().contains(freshConsumerInstruction),
+        "Closed-consumer error should explain how to create a fresh consumer");
+
+    veniceChangelogConsumer.stop();
+
+    assertTrue(veniceChangelogConsumer.isClosed(), "A stopped consumer must remain terminally closed");
+    verify(mockDaVinciClient).close();
+    verify(veniceChangelogConsumerClientFactory).deregisterClient(changelogClientConfig.getConsumerName());
+  }
+
+  @Test
+  public void testCloseFailureStillLeavesTerminalStateAndCleansFactory() throws Exception {
+    veniceChangelogConsumer.start();
+    onStartVersionIngestionHelper(true, true);
+    recordTransformer.processPut(keys.get(0), lazyValue, 0, recordMetadata);
+    assertFalse(getOutputQueue().isEmpty(), "Test setup should buffer a message before close");
+    doThrow(new VeniceException("close failure")).when(mockDaVinciClient).close();
+
+    assertThrows(VeniceException.class, veniceChangelogConsumer::stop);
+
+    assertTrue(veniceChangelogConsumer.isClosed(), "A failed close must still be terminal");
+    assertFalse(veniceChangelogConsumer.isStarted(), "A failed close must not leave the consumer started");
+    assertTrue(getOutputQueue().isEmpty(), "A failed close must still clear buffered output");
+    assertTrue(veniceChangelogConsumer.getSubscribedPartitions().isEmpty(), "Partition state should be cleared");
+    verify(veniceChangelogConsumerClientFactory).deregisterClient(changelogClientConfig.getConsumerName());
+    verify(veniceChangelogConsumer).clearPartitionState(eq(Collections.emptySet()));
+
+    veniceChangelogConsumer.stop();
+    verify(mockDaVinciClient).close();
   }
 
   @Test
@@ -712,6 +908,11 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
         () -> assertFalse(
             veniceChangelogConsumer.getSubscribedPartitions().contains(1),
             "Partition 1 should be removed from subscribedPartitions after failure"));
+  }
+
+  @SuppressWarnings("unchecked")
+  private BlockingQueue<PubSubMessage<Integer, ChangeEvent<Integer>, VeniceChangeCoordinate>> getOutputQueue() {
+    return veniceChangelogConsumer.getPubSubMessages();
   }
 
   private void onStartVersionIngestionHelper(boolean currentRecordTransformer, boolean isCurrentVersion) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/StatefulVeniceChangelogConsumerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/StatefulVeniceChangelogConsumerTest.java
@@ -325,34 +325,34 @@ public class StatefulVeniceChangelogConsumerTest {
           assertTrue(consumer2EventsList.size() >= 10);
         });
 
-        // Restart the first consumer - DVRT should be properly re-hooked into a new SIT
-        statefulVeniceChangelogConsumer.start().get();
+        // Create a fresh consumer after stop. Closed consumer instances are terminal.
+        try (StatefulVeniceChangelogConsumer<GenericRecord, GenericRecord> restartedConsumer =
+            veniceChangelogConsumerClientFactory.getStatefulChangelogConsumer(storeName)) {
+          restartedConsumer.start().get();
 
-        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, false, () -> {
-          pollChangeEventsFromChangeCaptureConsumer(
-              polledChangeEventsMap,
-              polledChangeEventsList,
-              statefulVeniceChangelogConsumer);
-          // 40 near-line put events, but one of them overwrites a key from batch push.
-          // Also, Deletes won't show up on restart when scanning RocksDB.
-          // Use >= to be resilient to at-least-once delivery: the change capture topic replay
-          // after restart may surface a few extra delete or duplicate events as unique keys.
-          // Upper bound guards against gross duplication bugs.
-          int expectedRecordCount = DEFAULT_USER_DATA_RECORD_COUNT + 39;
-          int upperBound = (int) (expectedRecordCount * 1.1);
-          assertTrue(
-              polledChangeEventsMap.size() >= expectedRecordCount,
-              "Expected at least " + expectedRecordCount + " records, but got " + polledChangeEventsMap.size());
-          assertTrue(
-              polledChangeEventsMap.size() <= upperBound,
-              "Too many records (" + polledChangeEventsMap.size() + "), expected at most " + upperBound
-                  + ". Possible duplicate event production.");
-          verifyPut(polledChangeEventsMap, 100, 110, 3, false);
-          verifyPut(polledChangeEventsMap, 120, 130, 3, false);
-          verifyPut(polledChangeEventsMap, 140, 150, 3, false);
-          verifyPut(polledChangeEventsMap, 160, 170, 3, false);
-        });
-        verifyVCCSequenceId(polledChangeEventsList, partitionSequenceIdMap, startingSequenceId);
+          TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, false, () -> {
+            pollChangeEventsFromChangeCaptureConsumer(polledChangeEventsMap, polledChangeEventsList, restartedConsumer);
+            // 40 near-line put events, but one of them overwrites a key from batch push.
+            // Also, Deletes won't show up on restart when scanning RocksDB.
+            // Use >= to be resilient to at-least-once delivery: the change capture topic replay
+            // after restart may surface a few extra delete or duplicate events as unique keys.
+            // Upper bound guards against gross duplication bugs.
+            int expectedRecordCount = DEFAULT_USER_DATA_RECORD_COUNT + 39;
+            int upperBound = (int) (expectedRecordCount * 1.1);
+            assertTrue(
+                polledChangeEventsMap.size() >= expectedRecordCount,
+                "Expected at least " + expectedRecordCount + " records, but got " + polledChangeEventsMap.size());
+            assertTrue(
+                polledChangeEventsMap.size() <= upperBound,
+                "Too many records (" + polledChangeEventsMap.size() + "), expected at most " + upperBound
+                    + ". Possible duplicate event production.");
+            verifyPut(polledChangeEventsMap, 100, 110, 3, false);
+            verifyPut(polledChangeEventsMap, 120, 130, 3, false);
+            verifyPut(polledChangeEventsMap, 140, 150, 3, false);
+            verifyPut(polledChangeEventsMap, 160, 170, 3, false);
+          });
+          verifyVCCSequenceId(polledChangeEventsList, new HashMap<>(), -1);
+        }
       } finally {
         cleanUpStoreAndVerify(storeName2);
       }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/TestVersionSpecificChangelogConsumer.java
@@ -499,13 +499,17 @@ public class TestVersionSpecificChangelogConsumer {
         initTimestampNs);
 
     // Restart client to ensure it seeks to the beginning of the topic and all record metadata is available
+    testCloseables.remove(changeLogConsumer);
     changeLogConsumer.close();
-    changeLogConsumer.subscribeAll().get();
+    VeniceChangelogConsumer<Integer, Utf8> restartedChangeLogConsumer =
+        veniceChangelogConsumerClientFactory.getVersionSpecificChangelogConsumer(storeName, 1, true);
+    testCloseables.add(restartedChangeLogConsumer);
+    restartedChangeLogConsumer.subscribeAll().get();
 
     // All data should be from version 1
     // there are 3 partitions, so we expect 3 control messages EOP
     pollAndVerify(
-        changeLogConsumer,
+        restartedChangeLogConsumer,
         1,
         numKeys,
         createControlMessageCountMap(partitionCount, 0),
@@ -518,12 +522,18 @@ public class TestVersionSpecificChangelogConsumer {
     IntegrationTestPushUtils.runVPJ(props, 2, childControllerClientRegion0);
 
     // Client should see VersionSwap control messages since new version is pushed
-    pollAndVerify(changeLogConsumer, 1, 0, createControlMessageCountMap(0, partitionCount), partitionCount, true);
+    pollAndVerify(
+        restartedChangeLogConsumer,
+        1,
+        0,
+        createControlMessageCountMap(0, partitionCount),
+        partitionCount,
+        true);
 
     // Client shouldn't be able to poll anything besides heartbeat messages, since it's still on version 1
     int nonHeartbeatMessagesCount = 0;
     Collection<PubSubMessage<Integer, ChangeEvent<Utf8>, VeniceChangeCoordinate>> oldVersionMessages =
-        changeLogConsumer.poll(1000);
+        restartedChangeLogConsumer.poll(1000);
     for (PubSubMessage<Integer, ChangeEvent<Utf8>, VeniceChangeCoordinate> message: oldVersionMessages) {
       if (message.getKey() != null) {
         nonHeartbeatMessagesCount++;
@@ -538,7 +548,8 @@ public class TestVersionSpecificChangelogConsumer {
     assertEquals(nonHeartbeatMessagesCount, 0);
 
     // Restart a new client
-    changeLogConsumer.close();
+    testCloseables.remove(restartedChangeLogConsumer);
+    restartedChangeLogConsumer.close();
     long newClientTimestampNs = Utils.getCurrentTimeInNanosForSeeding();
     VeniceChangelogConsumer<Integer, Utf8> newChangeLogConsumer =
         veniceChangelogConsumerClientFactory.getVersionSpecificChangelogConsumer(storeName, 1, true);
@@ -556,6 +567,7 @@ public class TestVersionSpecificChangelogConsumer {
         newClientTimestampNs);
 
     // Push version 3 with deferred version swap and subscribe to the future version
+    testCloseables.remove(newChangeLogConsumer);
     newChangeLogConsumer.close();
     version++;
     TestWriteUtils.writeSimpleAvroFileWithIntToStringSchema(inputDir, Integer.toString(version), numKeys);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VersionSpecificCDCShutdownTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/VersionSpecificCDCShutdownTest.java
@@ -5,6 +5,7 @@ import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLA
 import static com.linkedin.venice.ConfigKeys.ADMIN_CONSUMPTION_MAX_WORKER_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_OFFLINE_PUSH_STRATEGY;
+import static com.linkedin.venice.ConfigKeys.STORE_WRITER_NUMBER;
 import static com.linkedin.venice.integration.utils.VeniceControllerWrapper.D2_SERVICE_NAME;
 import static com.linkedin.venice.stats.ClientType.CHANGE_DATA_CAPTURE_CLIENT;
 import static com.linkedin.venice.stats.VeniceMetricsRepository.getVeniceMetricsRepository;
@@ -16,6 +17,7 @@ import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFile;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertTrue;
@@ -27,6 +29,7 @@ import com.linkedin.davinci.consumer.ChangelogClientConfig;
 import com.linkedin.davinci.consumer.VeniceChangeCoordinate;
 import com.linkedin.davinci.consumer.VeniceChangelogConsumer;
 import com.linkedin.davinci.consumer.VeniceChangelogConsumerClientFactory;
+import com.linkedin.davinci.consumer.VeniceChangelogConsumerDaVinciRecordTransformerImpl;
 import com.linkedin.venice.D2.D2ClientUtils;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
@@ -54,6 +57,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -73,10 +77,10 @@ import org.testng.annotations.Test;
 /**
  * Regression test for the CDC consumer shutdown bottleneck that causes the Flink crash loop.
  *
- * Uses two stores sharing a DaVinciBackend singleton: store B stays alive throughout while
- * store A is closed and restarted. Validates that close completes within Flink's 30s timeout,
- * the restarted consumer can seek to checkpoint and receive nearline records, and store B
- * remains unaffected.
+ * Uses two stores sharing one changelog consumer factory and backend: store B stays alive
+ * throughout while store A is closed and restarted. Validates that close completes within
+ * Flink's 30s timeout, store B keeps progressing, and the restarted store A consumer can
+ * replay from external checkpoints.
  */
 @Test(singleThreaded = true)
 public class VersionSpecificCDCShutdownTest {
@@ -132,172 +136,174 @@ public class VersionSpecificCDCShutdownTest {
 
   /**
    * Simulates the Flink CDC task restart scenario end-to-end:
-   * 1. Store B's consumer runs throughout, keeping the DaVinciBackend singleton alive.
+   * 1. Store B's consumer runs throughout, keeping the shared backend alive.
    * 2. Store A's consumer subscribes and receives batch + nearline data.
-   * 3. Additional nearline records are produced to load the drainer before close.
-   * 4. Store A's consumer close() is called with Flink's 30s timeout.
-   * 5. Asserts close completes within 30s.
-   * 6. A new consumer seeks to checkpoint, receives new nearline records with value verification.
-   * 7. Store B receives new nearline records with value verification.
+   * 3. Store A's bounded output queue fills and blocks the sole shared hybrid drainer.
+   * 4. A store B record is produced while store A's output remains full.
+   * 5. Store A's consumer close() completes within Flink's 30s timeout and releases store B.
+   * 6. A fresh store A consumer seeks to the latest external checkpoints and replays every blocked record.
    */
   @Test(timeOut = TEST_TIMEOUT)
   public void testVersionSpecificCDCConsumerRestartWithinFlinkTimeout() throws Exception {
+    int outputBufferSize = 100;
+    int closeTimeoutSeconds = 30;
+    int blockingRecordStart = 110;
+    int storeARecordCount = outputBufferSize + 1;
+    int storeBRecordCount = 1;
     String storeA = Utils.getUniqueString("storeA");
     String storeB = Utils.getUniqueString("storeB");
-    String inputDir = setUpStore(storeA);
-    setUpStore(storeB);
+    VeniceChangelogConsumer<GenericRecord, GenericRecord> consumerA = null;
+    VeniceChangelogConsumer<GenericRecord, GenericRecord> consumerB = null;
+    VeniceChangelogConsumer<GenericRecord, GenericRecord> restartedConsumerA = null;
+    BlockingQueue<?> consumerAOutputQueueForCleanup = null;
+    ExecutorService closeExecutor = null;
+    Future<?> closeFuture = null;
 
-    // Produce nearline records BEFORE consumers subscribe so the version topic contains:
-    // batch data (100 records) → EOP → nearline records (10 per store).
-    // This ensures checkpoints captured during polling are past EOP.
-    try (
-        VeniceSystemProducer producerA =
-            IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeA, Version.PushType.STREAM);
-        VeniceSystemProducer producerB =
-            IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeB, Version.PushType.STREAM)) {
-      runSamzaStreamJob(producerA, storeA, 10, 100);
-      runSamzaStreamJob(producerB, storeB, 10, 100);
-    }
-
-    VeniceChangelogConsumerClientFactory factory = createFactory(inputDir);
-
-    // Store B consumer keeps DaVinciBackend alive across the close/restart of store A
-    VeniceChangelogConsumer<GenericRecord, GenericRecord> consumerB =
-        factory.getVersionSpecificChangelogConsumer(storeB, 1);
-    consumerB.subscribeAll().get();
-    // Verify batch + nearline data received
-    Map<String, GenericRecord> consumerBEvents = new HashMap<>();
-    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
-      pollAndCollect(consumerB, consumerBEvents);
-      int expectedMinEvents = DEFAULT_USER_DATA_RECORD_COUNT + 9;
-      assertTrue(
-          consumerBEvents.size() >= expectedMinEvents,
-          "Store B expected >= " + expectedMinEvents + " but got " + consumerBEvents.size());
-    });
-    verifyNearlineValues(consumerBEvents, 100, 110);
-    LOGGER.info("Store B consumer verified with {} events.", consumerBEvents.size());
-
-    // Store A consumer subscribes, receives data, and captures checkpoints
-    VeniceChangelogConsumer<GenericRecord, GenericRecord> consumerA =
-        factory.getVersionSpecificChangelogConsumer(storeA, 1);
-    consumerA.subscribeAll().get();
-    Map<String, GenericRecord> consumerAEvents = new HashMap<>();
-    Set<VeniceChangeCoordinate> checkpoints = new HashSet<>();
-    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
-      pollAndCollectWithCheckpoints(consumerA, consumerAEvents, checkpoints);
-      int expectedMinEventsA = DEFAULT_USER_DATA_RECORD_COUNT + 9;
-      assertTrue(
-          consumerAEvents.size() >= expectedMinEventsA,
-          "Store A expected >= " + expectedMinEventsA + " but got " + consumerAEvents.size());
-    });
-    verifyNearlineValues(consumerAEvents, 100, 110);
-    // Verify checkpoints cover all partitions to ensure seekToCheckpoint subscribes to all of them
-    Set<Integer> checkpointPartitions = new HashSet<>();
-    for (VeniceChangeCoordinate checkpoint: checkpoints) {
-      checkpointPartitions.add(checkpoint.getPartition());
-    }
-    assertTrue(
-        checkpointPartitions.size() >= PARTITION_COUNT,
-        "Expected checkpoints from all " + PARTITION_COUNT + " partitions but got " + checkpointPartitions.size());
-    LOGGER.info(
-        "Store A consumer verified with {} events, captured checkpoints from {} partitions.",
-        consumerAEvents.size(),
-        checkpointPartitions.size());
-
-    // Produce more nearline records to load the drainer before close
-    try (
-        VeniceSystemProducer producerA =
-            IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeA, Version.PushType.STREAM);
-        VeniceSystemProducer producerB =
-            IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeB, Version.PushType.STREAM)) {
-      runSamzaStreamJob(producerA, storeA, 10, 110);
-      runSamzaStreamJob(producerB, storeB, 10, 110);
-    }
-
-    // Simulate Flink: close in background with 30s timeout. Use daemon thread so a blocked
-    // close() cannot keep the test JVM alive after TestNG's timeout kills the test.
-    ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
-      Thread t = new Thread(r, "cdc-consumer-close");
-      t.setDaemon(true);
-      return t;
-    });
-    long closeStartMs = System.currentTimeMillis();
-    Future<?> closeFuture = executor.submit(() -> consumerA.close());
-
-    boolean closedInTime = false;
     try {
-      closeFuture.get(30, TimeUnit.SECONDS);
-      closedInTime = true;
-    } catch (TimeoutException e) {
-      closeFuture.cancel(true);
+      String inputDir = setUpStore(storeA);
+      setUpStore(storeB);
+
+      // Produce nearline records before subscribing so the external checkpoints are past EOP.
+      try (
+          VeniceSystemProducer producerA =
+              IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeA, Version.PushType.STREAM);
+          VeniceSystemProducer producerB =
+              IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeB, Version.PushType.STREAM)) {
+        runSamzaStreamJob(producerA, storeA, 10, 100);
+        runSamzaStreamJob(producerB, storeB, 10, 100);
+      }
+
+      VeniceChangelogConsumerClientFactory factory = createFactory(inputDir, outputBufferSize);
+
+      VeniceChangelogConsumer<GenericRecord, GenericRecord> activeConsumerB =
+          factory.getVersionSpecificChangelogConsumer(storeB, 1);
+      consumerB = activeConsumerB;
+      activeConsumerB.subscribeAll().get();
+      Map<String, GenericRecord> consumerBEvents = new HashMap<>();
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
+        pollAndCollect(activeConsumerB, consumerBEvents);
+        int expectedMinEvents = DEFAULT_USER_DATA_RECORD_COUNT + 9;
+        assertTrue(
+            consumerBEvents.size() >= expectedMinEvents,
+            "Store B expected >= " + expectedMinEvents + " but got " + consumerBEvents.size());
+      });
+      verifyNearlineValues(consumerBEvents, 100, 110);
+
+      VeniceChangelogConsumer<GenericRecord, GenericRecord> activeConsumerA =
+          factory.getVersionSpecificChangelogConsumer(storeA, 1);
+      consumerA = activeConsumerA;
+      activeConsumerA.subscribeAll().get();
+      Map<String, GenericRecord> consumerAEvents = new HashMap<>();
+      Map<Integer, VeniceChangeCoordinate> latestCheckpointsByPartition = new HashMap<>();
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
+        pollAndCollectWithCheckpoints(activeConsumerA, consumerAEvents, latestCheckpointsByPartition);
+        int expectedMinEvents = DEFAULT_USER_DATA_RECORD_COUNT + 9;
+        assertTrue(
+            consumerAEvents.size() >= expectedMinEvents,
+            "Store A expected >= " + expectedMinEvents + " but got " + consumerAEvents.size());
+      });
+      verifyNearlineValues(consumerAEvents, 100, 110);
+
+      assertEquals(
+          latestCheckpointsByPartition.size(),
+          PARTITION_COUNT,
+          "External checkpoints must cover every partition before the restart");
+      Set<VeniceChangeCoordinate> latestCheckpoints = new HashSet<>(latestCheckpointsByPartition.values());
+
+      BlockingQueue<?> consumerAOutputQueue = getOutputQueue(activeConsumerA);
+      consumerAOutputQueueForCleanup = consumerAOutputQueue;
+
+      // Stop polling A, fill its bounded output queue, and block the sole shared hybrid drainer in put().
+      try (VeniceSystemProducer producerA =
+          IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeA, Version.PushType.STREAM)) {
+        runSamzaStreamJob(producerA, storeA, storeARecordCount, blockingRecordStart);
+      }
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
+        assertEquals(
+            consumerAOutputQueue.size(),
+            outputBufferSize,
+            "Store A output queue should be full before shutdown");
+      });
+
+      // Produce B while A's output is full. B must make progress once A shuts down.
+      try (VeniceSystemProducer producerB =
+          IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeB, Version.PushType.STREAM)) {
+        runSamzaStreamJob(producerB, storeB, storeBRecordCount, blockingRecordStart);
+      }
+
+      VeniceChangelogConsumer<GenericRecord, GenericRecord> consumerAToClose = consumerA;
+      closeExecutor = Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread(r, "cdc-consumer-close");
+        t.setDaemon(true);
+        return t;
+      });
+      long closeStartMs = System.currentTimeMillis();
+      closeFuture = closeExecutor.submit(consumerAToClose::close);
+      try {
+        closeFuture.get(closeTimeoutSeconds, TimeUnit.SECONDS);
+      } catch (TimeoutException e) {
+        throw new AssertionError(
+            "CDC consumer A close exceeded Flink's " + closeTimeoutSeconds
+                + "s timeout after its output queue reached capacity",
+            e);
+      }
+
+      long closeElapsedMs = System.currentTimeMillis() - closeStartMs;
+      LOGGER.info("CDC consumer A close completed in {} ms after its output queue reached capacity", closeElapsedMs);
+
+      Map<String, GenericRecord> resumedBEvents = new HashMap<>();
+      pollAndVerifyNearlineRecords(
+          activeConsumerB,
+          resumedBEvents,
+          blockingRecordStart,
+          blockingRecordStart + storeBRecordCount);
+      assertEquals(resumedBEvents.size(), storeBRecordCount, "Store B should receive exactly the produced record");
+
+      restartedConsumerA = factory.getVersionSpecificChangelogConsumer(storeA, 1);
+      assertNotNull(restartedConsumerA);
+      assertNotSame(
+          restartedConsumerA,
+          consumerA,
+          "Factory should return a fresh consumer after the old consumer is closed");
+      restartedConsumerA.seekToCheckpoint(latestCheckpoints).get();
+
+      Map<String, GenericRecord> replayedAEvents = new HashMap<>();
+      pollAndVerifyNearlineRecords(
+          restartedConsumerA,
+          replayedAEvents,
+          blockingRecordStart,
+          blockingRecordStart + storeARecordCount);
+      LOGGER.info(
+          "Restarted consumer A replayed all {} expected records from external checkpoints; "
+              + "store B resumed with {} records.",
+          storeARecordCount,
+          resumedBEvents.size());
     } finally {
-      executor.shutdownNow();
+      if (consumerAOutputQueueForCleanup != null) {
+        consumerAOutputQueueForCleanup.clear();
+      }
+      if (closeFuture != null) {
+        try {
+          closeFuture.get(closeTimeoutSeconds, TimeUnit.SECONDS);
+        } catch (Exception e) {
+          LOGGER.warn("Consumer A close did not finish during test cleanup", e);
+        }
+      } else if (closeFuture == null && consumerA != null) {
+        closeInBackground(consumerA);
+      }
+      if (closeExecutor != null) {
+        closeExecutor.shutdown();
+      }
+      closeInBackground(restartedConsumerA);
+      closeInBackground(consumerB);
+      cleanUpStore(storeA);
+      cleanUpStore(storeB);
     }
-
-    long closeElapsedMs = System.currentTimeMillis() - closeStartMs;
-    LOGGER.info("Consumer A close() completed in {}ms", closeElapsedMs);
-    assertTrue(closedInTime, "CDC consumer close() took " + closeElapsedMs + "ms, exceeding 30s threshold.");
-
-    // Restart consumer A with seekToCheckpoint (simulating Flink checkpoint restore).
-    // The factory must return a fresh consumer — if deregisterClient() didn't run during close,
-    // the factory returns the stale cached consumer which would throw "already subscribed".
-    VeniceChangelogConsumer<GenericRecord, GenericRecord> newConsumerA =
-        factory.getVersionSpecificChangelogConsumer(storeA, 1);
-    assertNotNull(newConsumerA);
-    assertNotSame(newConsumerA, consumerA, "Factory should return a fresh consumer, not the closed stale instance");
-    newConsumerA.seekToCheckpoint(checkpoints).get();
-    LOGGER.info("Restarted consumer A seeked to {} checkpoints.", checkpoints.size());
-
-    // seekToCheckpoint(...).get() only awaits the subscribe, not the inclusive re-scan backlog the
-    // seek schedules. Drain that backlog before producing the next batch so the new records (keys
-    // 120-129) never share the consumer pipeline with the re-scan of the pre-restart nearline tail.
-    // Key 119 is the last record produced before the restart, so re-observing it confirms the
-    // re-scan frontier has reached the checkpoint position and the backlog is quiesced.
-    Map<String, GenericRecord> drainEvents = new HashMap<>();
-    drainUntilKeyObserved(newConsumerA, drainEvents, "119");
-    LOGGER.info(
-        "Restarted consumer A drained re-scan backlog ({} events) before producing new batch.",
-        drainEvents.size());
-
-    // Produce new nearline records after restart
-    try (
-        VeniceSystemProducer producerA =
-            IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeA, Version.PushType.STREAM);
-        VeniceSystemProducer producerB =
-            IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeB, Version.PushType.STREAM)) {
-      runSamzaStreamJob(producerA, storeA, 10, 120);
-      runSamzaStreamJob(producerB, storeB, 10, 120);
-    }
-
-    // Verify restarted consumer A receives the new nearline records (keys 120-129)
-    Map<String, GenericRecord> restartedAEvents = new HashMap<>();
-    pollAndVerifyNearlineRecords(newConsumerA, restartedAEvents, 120, 130);
-    LOGGER.info("Restarted consumer A received {} events after checkpoint seek.", restartedAEvents.size());
-
-    // Verify store B receives the new nearline records (keys 120-129)
-    Map<String, GenericRecord> newConsumerBEvents = new HashMap<>();
-    pollAndVerifyNearlineRecords(consumerB, newConsumerBEvents, 120, 130);
-    LOGGER.info("Store B received {} nearline records after store A restart.", newConsumerBEvents.size());
-
-    // Cleanup
-    closeInBackground(newConsumerA);
-    closeInBackground(consumerB);
-    cleanUpStore(storeA);
-    cleanUpStore(storeB);
   }
 
-  /**
-   * Polls until the given key is observed, draining whatever the consumer has buffered (e.g. an
-   * inclusive seekToCheckpoint re-scan backlog) so it does not contend with records produced next.
-   */
-  private void drainUntilKeyObserved(
-      VeniceChangelogConsumer<GenericRecord, GenericRecord> consumer,
-      Map<String, GenericRecord> eventsMap,
-      String key) {
-    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, () -> {
-      pollAndCollect(consumer, eventsMap);
-      assertNotNull(eventsMap.get(key), "Drain did not observe re-scanned key " + key);
-    });
+  private BlockingQueue<?> getOutputQueue(VeniceChangelogConsumer<?, ?> consumer) {
+    return ((VeniceChangelogConsumerDaVinciRecordTransformerImpl<?, ?>) consumer).getPubSubMessages();
   }
 
   private void pollAndVerifyNearlineRecords(
@@ -333,14 +339,14 @@ public class VersionSpecificCDCShutdownTest {
   private void pollAndCollectWithCheckpoints(
       VeniceChangelogConsumer<GenericRecord, GenericRecord> consumer,
       Map<String, GenericRecord> eventsMap,
-      Set<VeniceChangeCoordinate> checkpoints) {
+      Map<Integer, VeniceChangeCoordinate> checkpointsByPartition) {
     Collection<PubSubMessage<GenericRecord, ChangeEvent<GenericRecord>, VeniceChangeCoordinate>> messages =
         consumer.poll(1000);
     for (PubSubMessage<GenericRecord, ChangeEvent<GenericRecord>, VeniceChangeCoordinate> msg: messages) {
       if (msg.getKey() != null) {
         eventsMap.put(String.valueOf(msg.getKey().get("id")), msg.getValue().getCurrentValue());
       }
-      checkpoints.add(msg.getPosition());
+      checkpointsByPartition.put(msg.getPartition(), msg.getPosition());
     }
   }
 
@@ -409,23 +415,23 @@ public class VersionSpecificCDCShutdownTest {
     return inputDirPath;
   }
 
-  private VeniceChangelogConsumerClientFactory createFactory(String inputDirRef) {
+  private VeniceChangelogConsumerClientFactory createFactory(String inputDirRef, int outputBufferSize) {
     Properties consumerProps = ChangelogConsumerTestUtils.buildConsumerProperties(clusterWrapper, inputDirRef);
+    consumerProps.put(STORE_WRITER_NUMBER, 1);
     ChangelogClientConfig globalConfig = new ChangelogClientConfig().setConsumerProperties(consumerProps)
         .setControllerD2ServiceName(D2_SERVICE_NAME)
         .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
         .setLocalD2ZkHosts(zkAddress)
         .setControllerRequestRetryCount(3)
         .setD2Client(d2Client)
-        // The buffer must stay well above the per-restart nearline batch size (10). At parity (10),
-        // the inclusive seekToCheckpoint storage re-scan contends with the freshly produced target
-        // records for the same ArrayBlockingQueue slots, intermittently starving keys at the batch
-        // boundary and failing pollAndVerifyNearlineRecords within its 30s window.
-        .setMaxBufferSize(100);
+        .setMaxBufferSize(outputBufferSize);
     return new VeniceChangelogConsumerClientFactory(globalConfig, metricsRepository);
   }
 
   private void closeInBackground(VeniceChangelogConsumer<?, ?> consumer) {
+    if (consumer == null) {
+      return;
+    }
     ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
       Thread t = new Thread(r, "cdc-consumer-close-bg");
       t.setDaemon(true);


### PR DESCRIPTION
## Problem Statement

Version-specific DaVinci CDC consumers can hit the shutdown deadlock fixed by [#2935](https://github.com/linkedin/venice/pull/2935). A closed consumer can leave a shared StoreBuffer drainer blocked in a full output queue, starving unrelated consumers.

The fix is also needed on the `0.4.910` release line.

## Solution

Cherry-pick merged commit `d8617bb40f3ef6b10e8727f37f3c34a444bdb0f8` onto `hotfix-0.4.910`.

The fix:

- releases producers blocked in the closing consumer's output queue;
- serializes polling and shutdown;
- prevents output and reporter activity after close;
- makes close terminal for a consumer instance;
- adds mutation-verified unit and integration regression coverage.

### Code changes
- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### Concurrency-Specific Checks
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** are used where needed.
- [x] Shared StoreBuffer drainer threads are not interrupted.
- [x] Existing thread-safe queues, maps, and atomic state are preserved.
- [x] Exception paths retain terminal cleanup.

## How was this PR tested?

- [x] Local code review completed.
- [x] New unit tests added.
- [x] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility on the `0.4.910` branch.

Commands run on the hotfix branch:

`./gradlew :clients:da-vinci-client:test --tests com.linkedin.davinci.consumer.VeniceChangelogConsumerDaVinciRecordTransformerImplTest`

`./gradlew :internal:venice-test-common:integrationTest --tests com.linkedin.venice.consumer.VersionSpecificCDCShutdownTest.testVersionSpecificCDCConsumerRestartWithinFlinkTimeout`

`./gradlew :internal:venice-test-common:integrationTest --tests com.linkedin.venice.consumer.StatefulVeniceChangelogConsumerTest.testVeniceChangelogConsumerDaVinciRecordTransformerImpl`

`./gradlew :internal:venice-test-common:integrationTest --tests com.linkedin.venice.consumer.TestVersionSpecificChangelogConsumer.testVersionSpecificChangeLogConsumerWithControlMessages`

`./gradlew spotlessJavaCheck`

## Does this PR introduce any user-facing or breaking changes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. `stop()`/`close()` are terminal for a consumer instance. Callers that need to resume consumption must request a fresh consumer from `VeniceChangelogConsumerClientFactory`.
