### PR TITLE
[controller][test] Route version-topic alternative backend by store hybrid status; add per-store inclusion list

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,39 +12,42 @@ Note: PRs with titles not following the format will not be merged
 -->
 
 ## Problem Statement
+
 <!--
 Describe
 - What problem are you trying to solve
 - What issues or limitations exist in the current code
-- Why this change is necessary 
+- Why this change is necessary
 -->
 
-
 ## Solution
+
 <!--
 Describe
-- What changes you are making and why. 
+- What changes you are making and why.
 - How these changes solve the problem.
-- Any performance considerations or trade-offs. 
+- Any performance considerations or trade-offs.
 - Describe what testings you have done, for example, performance testing etc.
 -->
 
+### Code changes
 
-###  Code changes
 - [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
-- [ ] Introduced new **log lines**. 
+- [ ] Introduced new **log lines**.
   - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.
 
-###  **Concurrency-Specific Checks**
+### **Concurrency-Specific Checks**
+
 Both reviewer and PR author to verify
+
 - [ ] Code has **no race conditions** or **thread safety issues**.
 - [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
 - [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
 - [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
 - [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.
 
-
 ## How was this PR tested?
+
 <!--
 If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
 -->
@@ -55,9 +58,11 @@ If you're unsure about what to test, where to add tests, or how to run tests, pl
 - [ ] Verified backward compatibility (if applicable).
 
 ## Does this PR introduce any user-facing or breaking changes?
-<!--  
+
+<!--
 If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
 If no, choose 'No'.
 -->
+
 - [ ] No. You can skip the rest of this section.
 - [ ] Yes. Clearly explain the behavior change and its impact.

--- a/integrations/venice-pulsar/readme.md
+++ b/integrations/venice-pulsar/readme.md
@@ -43,7 +43,7 @@ cd ~/src/venice
  bin/pulsar-admin sinks create --tenant t1 --namespace n1 --name venice --archive ~/src/venice/clients/venice-pulsar/build/libs/pulsar-venice-sink.nar -i t1/n1/input --sink-config '{"veniceDiscoveryUrl":"http://venice-controller:5555","storeName":"t1_n1_s1","kafkaSaslMechanism":"PLAIN","kafkaSecurityProtocol":"SASL_PLAINTEXT","kafkaSaslConfig":"org.apache.kafka.common.security.plain.PlainLoginModule required username=\"public\" password=\"token:eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdXBlcnVzZXIifQ.JQpDWJ9oHD743ZyuIw55Qp0bb8xzP6gK0KIWRniF2WnJB1m3v5MsrpfMlmRIlFc3-htWRAFHCc4E0ipj7JU8HjBqLIvVErRseRG-UTM1EprVkj0mk37jXV3ef7gER0KHn9CUKEQPfmTACeKlQ2oV4_qPAZ6HiEt51vzANfZH24vLCIjiOG77Z4s_w2sfgpiodRmhBLFOg_qnQTfGs7TBDWgu4DRoJ6CYZSEcp8q7j8xp_zNVIFGTRjWskocUvedHS9ZsCGZjzuPvRPp19B0VvAjEjtwpa6j7Khvjf4imjp2QHDnZwpCIEp4DSicwM48F5q4k722IdiyTTsVBWy8Cyg\"\";\");"}'
 ```
 
-  If the sink is packaged in the Pulsar image (e.g. integration tests):
+If the sink is packaged in the Pulsar image (e.g. integration tests):
 
 ```shell
   bin/pulsar-admin sinks create --tenant t1 --namespace n1 --name venice -t venice -i t1/n1/input --sink-config '{"veniceDiscoveryUrl":"http://venice-controller:5555","storeName":"t1_n1_s1","kafkaSaslMechanism":"PLAIN","kafkaSecurityProtocol":"SASL_PLAINTEXT","kafkaSaslConfig":"org.apache.kafka.common.security.plain.PlainLoginModule required username=\"public\" password=\"token:eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdXBlcnVzZXIifQ.JQpDWJ9oHD743ZyuIw55Qp0bb8xzP6gK0KIWRniF2WnJB1m3v5MsrpfMlmRIlFc3-htWRAFHCc4E0ipj7JU8HjBqLIvVErRseRG-UTM1EprVkj0mk37jXV3ef7gER0KHn9CUKEQPfmTACeKlQ2oV4_qPAZ6HiEt51vzANfZH24vLCIjiOG77Z4s_w2sfgpiodRmhBLFOg_qnQTfGs7TBDWgu4DRoJ6CYZSEcp8q7j8xp_zNVIFGTRjWskocUvedHS9ZsCGZjzuPvRPp19B0VvAjEjtwpa6j7Khvjf4imjp2QHDnZwpCIEp4DSicwM48F5q4k722IdiyTTsVBWy8Cyg\"\";\");"}'
@@ -61,7 +61,7 @@ cd ~/src/venice
   docker compose -f clients/venice-pulsar/src/test/resources/docker-compose-pulsar-venice.yaml down
 ```
 
-## Run integration tests 
+## Run integration tests
 
 ```shell
 # build Venice and sink

--- a/internal/alpini/README.md
+++ b/internal/alpini/README.md
@@ -1,5 +1,5 @@
-"Prospero Alpini (also known as Prosper Alpinus, Prospero Alpinio and Latinized as Prosperus Alpinus) (23 November 1553 
-– 6 February 1617) was a Venetian physician and botanist. He travelled around Egypt and served as the fourth prefect in 
-charge of the botanical garden of Padua. He wrote several botanical treatises which covered exotic plants of economic 
-and medicinal value. His description of coffee and banana plants are considered the oldest in European literature." - 
+"Prospero Alpini (also known as Prosper Alpinus, Prospero Alpinio and Latinized as Prosperus Alpinus) (23 November 1553
+– 6 February 1617) was a Venetian physician and botanist. He travelled around Egypt and served as the fourth prefect in
+charge of the botanical garden of Padua. He wrote several botanical treatises which covered exotic plants of economic
+and medicinal value. His description of coffee and banana plants are considered the oldest in European literature." -
 _[Wikipedia](https://en.wikipedia.org/wiki/Prospero_Alpini)_

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2530,9 +2530,24 @@ public class ConfigKeys {
   public static final String CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_HYBRID_USER_STORE_RT =
       "controller.pubsub.alternative.backend.hybrid.user.store.rt";
 
+  /** Create batch job heartbeat system store version topics using alternative pubsub backend. Default: false */
+  public static final String CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_JOB_HEARTBEAT_STORE_VT =
+      "controller.pubsub.alternative.backend.batch.job.heartbeat.store.vt";
+
+  /** Create batch job heartbeat system store RT topics using alternative pubsub backend. Default: false */
+  public static final String CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_JOB_HEARTBEAT_STORE_RT =
+      "controller.pubsub.alternative.backend.batch.job.heartbeat.store.rt";
+
   /** Comma-separated store names excluded from alternative pubsub backend. Default: empty */
   public static final String CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_EXCLUSION_LIST =
       "controller.pubsub.alternative.backend.exclusion.list";
+
+  /**
+   * Comma-separated store names always routed to the alternative pubsub backend, overriding the
+   * per-topic-type flags. The exclusion list takes precedence over this inclusion list. Default: empty
+   */
+  public static final String CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_INCLUSION_LIST =
+      "controller.pubsub.alternative.backend.inclusion.list";
 
   /**
    * This will indicate which ReplicationMetadataSchemaGenerator version to use to generate replication metadata schema.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -1372,16 +1372,30 @@ public class VeniceControllerClusterConfig {
       flags.put(topic, props.getBoolean(topic.configKey, enableAll));
     }
     this.alternativePubSubBackendEnabled = flags;
-    String exclusionListStr = props.getString(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_EXCLUSION_LIST, "");
-    this.alternativeBackendExclusionList = exclusionListStr.isEmpty()
-        ? Collections.emptySet()
-        : Collections.unmodifiableSet(new HashSet<>(Arrays.asList(exclusionListStr.split("\\s*,\\s*"))));
-    String inclusionListStr = props.getString(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_INCLUSION_LIST, "");
-    this.alternativeBackendInclusionList = inclusionListStr.isEmpty()
-        ? Collections.emptySet()
-        : Collections.unmodifiableSet(new HashSet<>(Arrays.asList(inclusionListStr.split("\\s*,\\s*"))));
+    this.alternativeBackendExclusionList =
+        parseStoreNameSet(props.getString(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_EXCLUSION_LIST, ""));
+    this.alternativeBackendInclusionList =
+        parseStoreNameSet(props.getString(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_INCLUSION_LIST, ""));
 
     this.logClusterConfig();
+  }
+
+  /**
+   * Parses a comma-separated store-name list into an immutable set, trimming whitespace around each entry and
+   * dropping empty values so leading/trailing whitespace or stray commas do not cause silent match failures.
+   */
+  private static Set<String> parseStoreNameSet(String csv) {
+    if (csv == null || csv.isEmpty()) {
+      return Collections.emptySet();
+    }
+    Set<String> result = new HashSet<>();
+    for (String entry: csv.split(",")) {
+      String trimmed = entry.trim();
+      if (!trimmed.isEmpty()) {
+        result.add(trimmed);
+      }
+    }
+    return result.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(result);
   }
 
   private void logClusterConfig() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -1445,7 +1445,12 @@ public class VeniceControllerClusterConfig {
       String storeName,
       boolean isRealTime,
       boolean isHybridStore) {
-    VeniceSystemStoreType systemStoreType = VeniceSystemStoreType.getSystemStoreType(storeName);
+    // BATCH_JOB_HEARTBEAT_STORE is a non-per-user shared system store whose full name is its prefix, for which
+    // VeniceSystemStoreType.getSystemStoreType() returns null; detect it explicitly here.
+    VeniceSystemStoreType systemStoreType =
+        VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE.getPrefix().equals(storeName)
+            ? VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE
+            : VeniceSystemStoreType.getSystemStoreType(storeName);
     if (systemStoreType != null) {
       switch (systemStoreType) {
         case META_STORE:

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -91,10 +91,13 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_SYSTEM_STORE_VERS
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PROTOCOL_VERSION_AUTO_DETECTION_SERVICE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PROTOCOL_VERSION_AUTO_DETECTION_SLEEP_MS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_ALL;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_JOB_HEARTBEAT_STORE_RT;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_JOB_HEARTBEAT_STORE_VT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_USER_STORE_VT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_EXCLUSION_LIST;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_HYBRID_USER_STORE_RT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_HYBRID_USER_STORE_VT;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_INCLUSION_LIST;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_META_SYSTEM_STORE_RT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_META_SYSTEM_STORE_VT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_PUSH_STATUS_SYSTEM_STORE_RT;
@@ -741,6 +744,8 @@ public class VeniceControllerClusterConfig {
     META_STORE_RT(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_META_SYSTEM_STORE_RT),
     PUSH_STATUS_STORE_VT(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_PUSH_STATUS_SYSTEM_STORE_VT),
     PUSH_STATUS_STORE_RT(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_PUSH_STATUS_SYSTEM_STORE_RT),
+    BATCH_JOB_HEARTBEAT_STORE_VT(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_JOB_HEARTBEAT_STORE_VT),
+    BATCH_JOB_HEARTBEAT_STORE_RT(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_JOB_HEARTBEAT_STORE_RT),
     BATCH_USER_STORE_VT(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_USER_STORE_VT),
     HYBRID_USER_STORE_VT(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_HYBRID_USER_STORE_VT),
     HYBRID_USER_STORE_RT(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_HYBRID_USER_STORE_RT);
@@ -754,6 +759,7 @@ public class VeniceControllerClusterConfig {
 
   private final EnumMap<AlternativePubSubBackendTopic, Boolean> alternativePubSubBackendEnabled;
   private final Set<String> alternativeBackendExclusionList;
+  private final Set<String> alternativeBackendInclusionList;
 
   public VeniceControllerClusterConfig(VeniceProperties props) {
     this.props = props;
@@ -1370,6 +1376,10 @@ public class VeniceControllerClusterConfig {
     this.alternativeBackendExclusionList = exclusionListStr.isEmpty()
         ? Collections.emptySet()
         : Collections.unmodifiableSet(new HashSet<>(Arrays.asList(exclusionListStr.split("\\s*,\\s*"))));
+    String inclusionListStr = props.getString(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_INCLUSION_LIST, "");
+    this.alternativeBackendInclusionList = inclusionListStr.isEmpty()
+        ? Collections.emptySet()
+        : Collections.unmodifiableSet(new HashSet<>(Arrays.asList(inclusionListStr.split("\\s*,\\s*"))));
 
     this.logClusterConfig();
   }
@@ -1394,33 +1404,64 @@ public class VeniceControllerClusterConfig {
   }
 
   /**
-   * Whether to use alternative pubsub backend for this store/topic combination.
-   * Checks the exact store name against the exclusion list, then resolves the appropriate
-   * {@link AlternativePubSubBackendTopic} flag via {@link #resolveAlternativePubSubBackendTopic}.
+   * Whether to use the alternative pubsub backend for this store/topic combination. Resolves the
+   * {@link AlternativePubSubBackendTopic} for the store + topic role, then applies the per-store overrides via
+   * {@link #shouldUseAlternativePubSubBackend(String, AlternativePubSubBackendTopic)}.
    * Excluding a user store does not affect its system stores; each must be excluded independently.
    *
    * <p>For user store VTs, {@code isHybridStore} selects between {@link AlternativePubSubBackendTopic#BATCH_USER_STORE_VT}
    * and {@link AlternativePubSubBackendTopic#HYBRID_USER_STORE_VT}. It is ignored for RT topics and system stores.
+   * Callers must derive {@code isHybridStore} from the store (e.g. {@code store.isHybrid()}), not from a freshly
+   * constructed version whose hybrid config is not yet populated, otherwise a hybrid store's VT is misrouted to the
+   * batch backend.
    */
   public boolean shouldUseAlternativePubSubBackend(String storeName, boolean isRealTime, boolean isHybridStore) {
+    return shouldUseAlternativePubSubBackend(
+        storeName,
+        resolveAlternativePubSubBackendTopic(storeName, isRealTime, isHybridStore));
+  }
+
+  /**
+   * Whether to use the alternative pubsub backend for an explicitly resolved {@link AlternativePubSubBackendTopic}.
+   * Precedence: exclusion list (deny) &gt; inclusion list (force on) &gt; per-topic-type flag.
+   */
+  public boolean shouldUseAlternativePubSubBackend(String storeName, AlternativePubSubBackendTopic topicType) {
     if (alternativeBackendExclusionList.contains(storeName)) {
       return false;
     }
-    return alternativePubSubBackendEnabled
-        .get(resolveAlternativePubSubBackendTopic(storeName, isRealTime, isHybridStore));
+    if (alternativeBackendInclusionList.contains(storeName)) {
+      return true;
+    }
+    return alternativePubSubBackendEnabled.get(topicType);
   }
 
-  private AlternativePubSubBackendTopic resolveAlternativePubSubBackendTopic(
+  /**
+   * Maps a store name + topic role to its {@link AlternativePubSubBackendTopic}. System stores are distinguished by
+   * name first (each system store type has its own topic type); {@code isHybridStore} only affects user store VTs.
+   * The switch is exhaustive over {@link VeniceSystemStoreType} so a newly added system store type fails fast here
+   * instead of silently falling through to the user-store routing.
+   */
+  AlternativePubSubBackendTopic resolveAlternativePubSubBackendTopic(
       String storeName,
       boolean isRealTime,
       boolean isHybridStore) {
     VeniceSystemStoreType systemStoreType = VeniceSystemStoreType.getSystemStoreType(storeName);
-    if (systemStoreType == VeniceSystemStoreType.META_STORE) {
-      return isRealTime ? AlternativePubSubBackendTopic.META_STORE_RT : AlternativePubSubBackendTopic.META_STORE_VT;
-    } else if (systemStoreType == VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE) {
-      return isRealTime
-          ? AlternativePubSubBackendTopic.PUSH_STATUS_STORE_RT
-          : AlternativePubSubBackendTopic.PUSH_STATUS_STORE_VT;
+    if (systemStoreType != null) {
+      switch (systemStoreType) {
+        case META_STORE:
+          return isRealTime ? AlternativePubSubBackendTopic.META_STORE_RT : AlternativePubSubBackendTopic.META_STORE_VT;
+        case DAVINCI_PUSH_STATUS_STORE:
+          return isRealTime
+              ? AlternativePubSubBackendTopic.PUSH_STATUS_STORE_RT
+              : AlternativePubSubBackendTopic.PUSH_STATUS_STORE_VT;
+        case BATCH_JOB_HEARTBEAT_STORE:
+          return isRealTime
+              ? AlternativePubSubBackendTopic.BATCH_JOB_HEARTBEAT_STORE_RT
+              : AlternativePubSubBackendTopic.BATCH_JOB_HEARTBEAT_STORE_VT;
+        default:
+          throw new IllegalStateException(
+              "Unhandled system store type for alternative pubsub backend routing: " + systemStoreType);
+      }
     }
     if (isRealTime) {
       return AlternativePubSubBackendTopic.HYBRID_USER_STORE_RT;
@@ -1428,12 +1469,6 @@ public class VeniceControllerClusterConfig {
     return isHybridStore
         ? AlternativePubSubBackendTopic.HYBRID_USER_STORE_VT
         : AlternativePubSubBackendTopic.BATCH_USER_STORE_VT;
-  }
-
-  /** @deprecated use {@link #shouldUseAlternativePubSubBackend(String, boolean, boolean)} */
-  @Deprecated
-  public boolean shouldUseAlternativePubSubBackend(String storeName, boolean isRealTime) {
-    return shouldUseAlternativePubSubBackend(storeName, isRealTime, false);
   }
 
   public VeniceProperties getProps() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2833,7 +2833,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
   }
 
-  private void createBatchTopics(
+  void createBatchTopics(
       Version version,
       PushType pushType,
       TopicManager topicManager,
@@ -2841,9 +2841,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       VeniceControllerClusterConfig clusterConfig,
       boolean useFastKafkaOperationTimeout) {
     List<PubSubTopic> topicNamesToCreate = new ArrayList<>(2);
-    topicNamesToCreate.add(pubSubTopicRepository.getTopic(version.kafkaTopicName()));
+    topicNamesToCreate.add(getPubSubTopicRepository().getTopic(version.kafkaTopicName()));
     if (pushType.isStreamReprocessing()) {
-      PubSubTopic streamReprocessingTopic = pubSubTopicRepository
+      PubSubTopic streamReprocessingTopic = getPubSubTopicRepository()
           .getTopic(Version.composeStreamReprocessingTopic(version.getStoreName(), version.getNumber()));
       topicNamesToCreate.add(streamReprocessingTopic);
     }
@@ -2854,7 +2854,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
      * batch backend.
      */
     Store store = getStore(clusterConfig.getClusterName(), version.getStoreName());
-    boolean isHybridStore = store != null && store.isHybrid();
+    if (store == null) {
+      throw new VeniceNoStoreException(version.getStoreName(), clusterConfig.getClusterName());
+    }
+    boolean isHybridStore = store.isHybrid();
     boolean useAltBackend =
         clusterConfig.shouldUseAlternativePubSubBackend(version.getStoreName(), false, isHybridStore);
     topicNamesToCreate.forEach(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2847,8 +2847,16 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           .getTopic(Version.composeStreamReprocessingTopic(version.getStoreName(), version.getNumber()));
       topicNamesToCreate.add(streamReprocessingTopic);
     }
+    /**
+     * Resolve the alternative-backend decision from the authoritative store hybrid status rather than
+     * {@code version.isHybrid()}: a freshly constructed {@link Version} may not have its hybrid config populated yet
+     * when this runs (see the version-supplied addVersion path), which would misroute a hybrid store's VT to the
+     * batch backend.
+     */
+    Store store = getStore(clusterConfig.getClusterName(), version.getStoreName());
+    boolean isHybridStore = store != null && store.isHybrid();
     boolean useAltBackend =
-        clusterConfig.shouldUseAlternativePubSubBackend(version.getStoreName(), false, version.isHybrid());
+        clusterConfig.shouldUseAlternativePubSubBackend(version.getStoreName(), false, isHybridStore);
     topicNamesToCreate.forEach(
         topicNameToCreate -> topicManager.createTopic(
             topicNameToCreate,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
@@ -22,10 +22,12 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_SERVER_CLUSTER_TOP
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_SERVER_CLUSTER_TOPOLOGY_AWARE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_MODE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_ALL;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_JOB_HEARTBEAT_STORE_VT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_USER_STORE_VT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_EXCLUSION_LIST;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_HYBRID_USER_STORE_RT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_HYBRID_USER_STORE_VT;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_INCLUSION_LIST;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_META_SYSTEM_STORE_RT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_META_SYSTEM_STORE_VT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_PUSH_STATUS_SYSTEM_STORE_RT;
@@ -623,12 +625,12 @@ public class TestVeniceControllerClusterConfig {
     String pushStatusStoreName = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName("MY_STORE");
 
     // All topic types should default to false
-    assertFalse(config.shouldUseAlternativePubSubBackend(metaStoreName, false));
-    assertFalse(config.shouldUseAlternativePubSubBackend(metaStoreName, true));
-    assertFalse(config.shouldUseAlternativePubSubBackend(pushStatusStoreName, false));
-    assertFalse(config.shouldUseAlternativePubSubBackend(pushStatusStoreName, true));
-    assertFalse(config.shouldUseAlternativePubSubBackend("userStore", false));
-    assertFalse(config.shouldUseAlternativePubSubBackend("userStore", true));
+    assertFalse(config.shouldUseAlternativePubSubBackend(metaStoreName, false, false));
+    assertFalse(config.shouldUseAlternativePubSubBackend(metaStoreName, true, false));
+    assertFalse(config.shouldUseAlternativePubSubBackend(pushStatusStoreName, false, false));
+    assertFalse(config.shouldUseAlternativePubSubBackend(pushStatusStoreName, true, false));
+    assertFalse(config.shouldUseAlternativePubSubBackend("userStore", false, false));
+    assertFalse(config.shouldUseAlternativePubSubBackend("userStore", true, false));
   }
 
   /**
@@ -678,10 +680,10 @@ public class TestVeniceControllerClusterConfig {
 
     String metaStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName("MY_STORE");
     String pushStatusStoreName = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName("MY_STORE");
-    assertTrue(config.shouldUseAlternativePubSubBackend(metaStoreName, false));
-    assertTrue(config.shouldUseAlternativePubSubBackend(metaStoreName, true));
-    assertTrue(config.shouldUseAlternativePubSubBackend(pushStatusStoreName, false));
-    assertTrue(config.shouldUseAlternativePubSubBackend(pushStatusStoreName, true));
+    assertTrue(config.shouldUseAlternativePubSubBackend(metaStoreName, false, false));
+    assertTrue(config.shouldUseAlternativePubSubBackend(metaStoreName, true, false));
+    assertTrue(config.shouldUseAlternativePubSubBackend(pushStatusStoreName, false, false));
+    assertTrue(config.shouldUseAlternativePubSubBackend(pushStatusStoreName, true, false));
     assertTrue(config.shouldUseAlternativePubSubBackend("userStore", false, false));
     assertTrue(config.shouldUseAlternativePubSubBackend("userStore", false, true));
     assertTrue(config.shouldUseAlternativePubSubBackend("userStore", true, true));
@@ -702,9 +704,9 @@ public class TestVeniceControllerClusterConfig {
     VeniceControllerClusterConfig config = new VeniceControllerClusterConfig(new VeniceProperties(baseProps));
 
     // Excluded store should return false even though user store RT is enabled
-    assertFalse(config.shouldUseAlternativePubSubBackend("excludedStore", true));
+    assertFalse(config.shouldUseAlternativePubSubBackend("excludedStore", true, false));
     // Non-excluded store should still work
-    assertTrue(config.shouldUseAlternativePubSubBackend("notExcluded", true));
+    assertTrue(config.shouldUseAlternativePubSubBackend("notExcluded", true, false));
 
     // Excluding a user store should NOT affect its system stores
     Properties baseProps2 = getBaseSingleRegionProperties(false);
@@ -715,10 +717,79 @@ public class TestVeniceControllerClusterConfig {
     String metaStoreOfExcluded = VeniceSystemStoreType.META_STORE.getSystemStoreName("excludedStore");
     String metaStoreOfAllowed = VeniceSystemStoreType.META_STORE.getSystemStoreName("allowedStore");
     // System store is not in the exclusion list, so it should still use alternative backend
-    assertTrue(config2.shouldUseAlternativePubSubBackend(metaStoreOfExcluded, false));
-    assertTrue(config2.shouldUseAlternativePubSubBackend(metaStoreOfAllowed, false));
+    assertTrue(config2.shouldUseAlternativePubSubBackend(metaStoreOfExcluded, false, false));
+    assertTrue(config2.shouldUseAlternativePubSubBackend(metaStoreOfAllowed, false, false));
     // The user store itself should be excluded
-    assertFalse(config2.shouldUseAlternativePubSubBackend("excludedStore", false));
+    assertFalse(config2.shouldUseAlternativePubSubBackend("excludedStore", false, false));
+  }
+
+  @Test
+  public void testShouldUseAlternativePubSubBackend_InclusionList() {
+    // Inclusion list forces the alternative backend on for matched stores even when the per-topic-type flag is off.
+    Properties baseProps = getBaseSingleRegionProperties(false);
+    baseProps.put(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_INCLUSION_LIST, "includedStore, anotherIncluded");
+    VeniceControllerClusterConfig config = new VeniceControllerClusterConfig(new VeniceProperties(baseProps));
+
+    // Batch and hybrid user-store VTs are disabled by default, but the included store is forced on for both.
+    assertTrue(config.shouldUseAlternativePubSubBackend("includedStore", false, false));
+    assertTrue(config.shouldUseAlternativePubSubBackend("includedStore", false, true));
+    assertTrue(config.shouldUseAlternativePubSubBackend("anotherIncluded", true, true));
+    // A store not in the inclusion list still follows the (disabled) per-topic-type flags.
+    assertFalse(config.shouldUseAlternativePubSubBackend("notIncluded", false, false));
+  }
+
+  @Test
+  public void testShouldUseAlternativePubSubBackend_ExclusionOverridesInclusion() {
+    // Exclusion (deny) takes precedence over inclusion (force on) for the same store.
+    Properties baseProps = getBaseSingleRegionProperties(false);
+    baseProps.put(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_INCLUSION_LIST, "bothLists");
+    baseProps.put(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_EXCLUSION_LIST, "bothLists");
+    VeniceControllerClusterConfig config = new VeniceControllerClusterConfig(new VeniceProperties(baseProps));
+    assertFalse(config.shouldUseAlternativePubSubBackend("bothLists", false, false));
+    assertFalse(config.shouldUseAlternativePubSubBackend("bothLists", false, true));
+  }
+
+  @Test
+  public void testShouldUseAlternativePubSubBackend_BatchJobHeartbeatStore() {
+    // The batch-job-heartbeat system store must route through its own topic type, not the user-store batch/hybrid
+    // config. Enabling the user-store batch VT flag alone must NOT enable the heartbeat store's VT.
+    String heartbeatStore =
+        VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE.getSystemStoreName("BATCH_JOB_HEARTBEAT_STORE");
+    Properties userBatchOnly = getBaseSingleRegionProperties(false);
+    userBatchOnly.put(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_USER_STORE_VT, "true");
+    VeniceControllerClusterConfig config = new VeniceControllerClusterConfig(new VeniceProperties(userBatchOnly));
+    assertFalse(config.shouldUseAlternativePubSubBackend(heartbeatStore, false, false));
+    assertFalse(config.shouldUseAlternativePubSubBackend(heartbeatStore, true, false));
+
+    // Enabling the dedicated heartbeat flags routes only that store.
+    Properties heartbeatOn = getBaseSingleRegionProperties(false);
+    heartbeatOn.put(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_JOB_HEARTBEAT_STORE_VT, "true");
+    VeniceControllerClusterConfig config2 = new VeniceControllerClusterConfig(new VeniceProperties(heartbeatOn));
+    assertTrue(config2.shouldUseAlternativePubSubBackend(heartbeatStore, false, false));
+    assertFalse(config2.shouldUseAlternativePubSubBackend(heartbeatStore, true, false));
+    // A user store must not be affected by the heartbeat flag.
+    assertFalse(config2.shouldUseAlternativePubSubBackend("userStore", false, false));
+  }
+
+  @Test
+  public void testResolveAlternativePubSubBackendTopic_HybridUserStoreVtRoutesToHybridType() {
+    // Regression: a hybrid user store's VT must resolve to HYBRID_USER_STORE_VT (not BATCH_USER_STORE_VT), so that
+    // enabling only batch.user.store.vt does NOT drag hybrid stores' VTs onto the alternative backend.
+    Properties batchVtOn = getBaseSingleRegionProperties(false);
+    batchVtOn.put(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_USER_STORE_VT, "true");
+    VeniceControllerClusterConfig config = new VeniceControllerClusterConfig(new VeniceProperties(batchVtOn));
+
+    // Batch user store VT (isHybridStore=false) -> alternative backend on.
+    assertEquals(
+        config.resolveAlternativePubSubBackendTopic("userStore", false, false),
+        VeniceControllerClusterConfig.AlternativePubSubBackendTopic.BATCH_USER_STORE_VT);
+    assertTrue(config.shouldUseAlternativePubSubBackend("userStore", false, false));
+
+    // Hybrid user store VT (isHybridStore=true) -> resolves to the hybrid type, which is disabled -> stays off.
+    assertEquals(
+        config.resolveAlternativePubSubBackendTopic("userStore", false, true),
+        VeniceControllerClusterConfig.AlternativePubSubBackendTopic.HYBRID_USER_STORE_VT);
+    assertFalse(config.shouldUseAlternativePubSubBackend("userStore", false, true));
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
@@ -753,8 +753,8 @@ public class TestVeniceControllerClusterConfig {
   public void testShouldUseAlternativePubSubBackend_BatchJobHeartbeatStore() {
     // The batch-job-heartbeat system store must route through its own topic type, not the user-store batch/hybrid
     // config. Enabling the user-store batch VT flag alone must NOT enable the heartbeat store's VT.
-    String heartbeatStore =
-        VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE.getSystemStoreName("BATCH_JOB_HEARTBEAT_STORE");
+    // The batch-job-heartbeat system store is a non-per-user shared store whose full name is its prefix.
+    String heartbeatStore = VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE.getPrefix();
     Properties userBatchOnly = getBaseSingleRegionProperties(false);
     userBatchOnly.put(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_USER_STORE_VT, "true");
     VeniceControllerClusterConfig config = new VeniceControllerClusterConfig(new VeniceProperties(userBatchOnly));

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
@@ -22,6 +22,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_SERVER_CLUSTER_TOP
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HELIX_SERVER_CLUSTER_TOPOLOGY_AWARE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_MODE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_ALL;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_JOB_HEARTBEAT_STORE_RT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_JOB_HEARTBEAT_STORE_VT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_USER_STORE_VT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_EXCLUSION_LIST;
@@ -769,6 +770,32 @@ public class TestVeniceControllerClusterConfig {
     assertFalse(config2.shouldUseAlternativePubSubBackend(heartbeatStore, true, false));
     // A user store must not be affected by the heartbeat flag.
     assertFalse(config2.shouldUseAlternativePubSubBackend("userStore", false, false));
+
+    // Symmetric case: enabling only the heartbeat RT flag routes the heartbeat RT while its VT stays disabled.
+    Properties heartbeatRtOn = getBaseSingleRegionProperties(false);
+    heartbeatRtOn.put(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_JOB_HEARTBEAT_STORE_RT, "true");
+    VeniceControllerClusterConfig config3 = new VeniceControllerClusterConfig(new VeniceProperties(heartbeatRtOn));
+    assertTrue(config3.shouldUseAlternativePubSubBackend(heartbeatStore, true, false));
+    assertFalse(config3.shouldUseAlternativePubSubBackend(heartbeatStore, false, false));
+    // A user store must not be affected by the heartbeat RT flag.
+    assertFalse(config3.shouldUseAlternativePubSubBackend("userStore", true, false));
+  }
+
+  @Test
+  public void testShouldUseAlternativePubSubBackend_ListEntriesAreTrimmedAndEmptiesDropped() {
+    // Leading/trailing whitespace around entries (and stray empty entries) must not cause silent match failures.
+    Properties baseProps = getBaseSingleRegionProperties(false);
+    baseProps.put(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_INCLUSION_LIST, "  includedStore ,, ,  anotherIncluded  ");
+    baseProps.put(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_EXCLUSION_LIST, " excludedStore ,");
+    VeniceControllerClusterConfig config = new VeniceControllerClusterConfig(new VeniceProperties(baseProps));
+
+    // Both inclusion entries match despite surrounding whitespace and the empty tokens between commas.
+    assertTrue(config.shouldUseAlternativePubSubBackend("includedStore", false, false));
+    assertTrue(config.shouldUseAlternativePubSubBackend("anotherIncluded", true, true));
+    // The trailing-comma exclusion entry still matches after trimming.
+    assertFalse(config.shouldUseAlternativePubSubBackend("excludedStore", true, false));
+    // The empty token must not have been added as a matchable (blank) store name.
+    assertFalse(config.shouldUseAlternativePubSubBackend("", false, false));
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controller;
 
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_USER_STORE_VT;
 import static com.linkedin.venice.meta.Version.PushType.INCREMENTAL;
 import static com.linkedin.venice.meta.Version.PushType.STREAM;
 import static com.linkedin.venice.pubsub.PubSubUtil.getPubSubPositionGrpcWireFormat;
@@ -87,6 +88,7 @@ import com.linkedin.venice.utils.RegionUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
 import com.linkedin.venice.views.MaterializedView;
 import com.linkedin.venice.views.ViewUtils;
@@ -344,6 +346,77 @@ public class TestVeniceHelixAdmin {
         anyBoolean(),
         anyBoolean(),
         eq(Optional.empty()));
+  }
+
+  @Test
+  public void testCreateBatchTopicsUsesStoreHybridStatusNotVersion() {
+    // Regression (NG routing): createBatchTopics must resolve the alternative-backend decision from the store's hybrid
+    // status, not from the freshly constructed Version (whose isHybrid() is not yet populated in the version-supplied
+    // addVersion path). With only batch.user.store.vt enabled, a hybrid store's VT must STAY on the primary backend,
+    // while a batch store's VT moves to the alternative backend.
+    int partitionCount = 10;
+    Properties props = TestVeniceControllerClusterConfig.getBaseSingleRegionProperties(false);
+    props.put(CONTROLLER_PUBSUB_ALTERNATIVE_BACKEND_BATCH_USER_STORE_VT, "true");
+    VeniceControllerClusterConfig clusterConfig = new VeniceControllerClusterConfig(new VeniceProperties(props));
+    String configCluster = clusterConfig.getClusterName();
+
+    TopicManager topicManager = mock(TopicManager.class);
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    when(veniceHelixAdmin.getPubSubTopicRepository()).thenReturn(PUB_SUB_TOPIC_REPOSITORY);
+    doCallRealMethod().when(veniceHelixAdmin)
+        .createBatchTopics(
+            any(Version.class),
+            any(PushType.class),
+            eq(topicManager),
+            anyInt(),
+            eq(clusterConfig),
+            anyBoolean());
+
+    // Case 1: hybrid store, fresh version reports non-hybrid (mock default) -> HYBRID_USER_STORE_VT (disabled) ->
+    // primary.
+    Version hybridVersion = mock(Version.class);
+    when(hybridVersion.getStoreName()).thenReturn(storeName);
+    when(hybridVersion.kafkaTopicName()).thenReturn(storeName + "_v1");
+    PubSubTopic hybridVt = PUB_SUB_TOPIC_REPOSITORY.getTopic(storeName + "_v1");
+    Store hybridStore = mock(Store.class);
+    when(hybridStore.isHybrid()).thenReturn(true);
+    doReturn(hybridStore).when(veniceHelixAdmin).getStore(configCluster, storeName);
+
+    veniceHelixAdmin
+        .createBatchTopics(hybridVersion, PushType.BATCH, topicManager, partitionCount, clusterConfig, false);
+    verify(topicManager).createTopic(
+        eq(hybridVt),
+        eq(partitionCount),
+        anyInt(),
+        anyBoolean(),
+        anyBoolean(),
+        any(Optional.class),
+        anyBoolean(),
+        eq(false));
+
+    // Case 2 (positive control): a non-hybrid store under the same config -> BATCH_USER_STORE_VT (enabled) ->
+    // alternative.
+    reset(topicManager);
+    String batchStoreName = "batch-store";
+    Version batchVersion = mock(Version.class);
+    when(batchVersion.getStoreName()).thenReturn(batchStoreName);
+    when(batchVersion.kafkaTopicName()).thenReturn(batchStoreName + "_v1");
+    PubSubTopic batchVt = PUB_SUB_TOPIC_REPOSITORY.getTopic(batchStoreName + "_v1");
+    Store batchStore = mock(Store.class);
+    when(batchStore.isHybrid()).thenReturn(false);
+    doReturn(batchStore).when(veniceHelixAdmin).getStore(configCluster, batchStoreName);
+
+    veniceHelixAdmin
+        .createBatchTopics(batchVersion, PushType.BATCH, topicManager, partitionCount, clusterConfig, false);
+    verify(topicManager).createTopic(
+        eq(batchVt),
+        eq(partitionCount),
+        anyInt(),
+        anyBoolean(),
+        anyBoolean(),
+        any(Optional.class),
+        anyBoolean(),
+        eq(true));
   }
 
   @Test

--- a/specs/fizzbee/README.md
+++ b/specs/fizzbee/README.md
@@ -1,10 +1,10 @@
 This directory contains the formal specs for the FizzBee model checker.
 
-More about the tool and the instructions: [https://github.com/fizzbee-io/fizzbee?tab=readme-ov-file#run-a-model-checker](Run the model checker)
+More about the tool and the instructions:
+[https://github.com/fizzbee-io/fizzbee?tab=readme-ov-file#run-a-model-checker](Run the model checker)
 
 Once installed from source and set the PATH, you can run with
 
 ```
-fizz specs/fizzbee/LeaderFollower/VeniceLeaderFollower.fizz 
+fizz specs/fizzbee/LeaderFollower/VeniceLeaderFollower.fizz
 ```
-


### PR DESCRIPTION
## Problem Statement

Hybrid user-store version topics (VTs) can be created on the alternative pubsub backend even when only `controller.pubsub.alternative.backend.batch.user.store.vt` is enabled and `...hybrid.user.store.vt` is off.

`VeniceHelixAdmin.createBatchTopics` selects the VT backend from `version.isHybrid()`. In the version-supplied `addVersion` path the `VersionImpl` is freshly constructed and its hybrid config is populated only later (via `store.addVersion(...)`), so `version.isHybrid()` returns `false` when the VT is created. A hybrid store's VT is therefore routed through `BATCH_USER_STORE_VT` and lands on the alternative backend.

The RT topic is unaffected because it is created via a separate call that already passes `store.isHybrid()` — so the symptom is "hybrid store, VT on the alternative backend, RT on the primary backend."

Two adjacent gaps in the same routing code:
- `resolveAlternativePubSubBackendTopic` handles only `META_STORE` and `DAVINCI_PUSH_STATUS_STORE`; `BATCH_JOB_HEARTBEAT_STORE` falls through to user-store routing.
- There is no way to opt a single store onto the alternative backend; the only lever is the coarse per-cluster, per-topic-type flag.

## Solution

- `createBatchTopics` resolves the decision from the authoritative store hybrid status (`getStore(...).isHybrid()`) instead of the not-yet-populated version, fixing all VT-creation call sites uniformly.
- Make the `VeniceSystemStoreType` routing exhaustive and add dedicated `BATCH_JOB_HEARTBEAT_STORE_VT` / `BATCH_JOB_HEARTBEAT_STORE_RT` topic types + config keys, so the heartbeat system store routes independently and a newly added system store type fails fast instead of silently using user-store routing.
- Add a per-store inclusion list to force specific stores onto the alternative backend regardless of the per-topic-type flags. Precedence: exclusion (deny) > inclusion (force on) > per-topic-type flag.
- Add an `AlternativePubSubBackendTopic`-typed `shouldUseAlternativePubSubBackend` overload and remove the deprecated 2-arg overload that hardcoded `isHybridStore=false`.

### Code changes

- [x] Added new code behind **a config**. New configs (defaults preserve current behavior):
  - `controller.pubsub.alternative.backend.batch.job.heartbeat.store.vt` — default `false`
  - `controller.pubsub.alternative.backend.batch.job.heartbeat.store.rt` — default `false`
  - `controller.pubsub.alternative.backend.inclusion.list` — default empty
- [ ] Introduced new **log lines**.

## How was this PR tested?

- [x] New unit tests added.
- [x] Modified or extended existing tests.

Added to `TestVeniceControllerClusterConfig`:
- a hybrid user-store VT resolves to `HYBRID_USER_STORE_VT` (regression for the leak),
- the batch-job-heartbeat store routes via its own topic type and is unaffected by the user-store batch flag,
- the inclusion list forces the backend on, and exclusion takes precedence over inclusion.

`./gradlew :services:venice-controller:test --tests "com.linkedin.venice.controller.TestVeniceControllerClusterConfig"` passes; the module compiles and is spotless-clean.

## Does this PR introduce any user-facing or breaking changes?

No data-plane or user-facing behavior change. New configs default to off/empty. The removed deprecated 2-arg `shouldUseAlternativePubSubBackend(String, boolean)` overload had no production callers (only tests, updated here).
