### PR TITLE
[server] Isolate consumers by store encryption policy

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.kafka.consumer;
 
+import static com.linkedin.venice.ConfigKeys.CLUSTER_ENCRYPTION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -25,6 +26,7 @@ import com.linkedin.venice.utils.RedundantExceptionFilter;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
@@ -34,6 +36,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -50,7 +53,8 @@ import org.apache.logging.log4j.Logger;
 
 /**
  * {@link AggKafkaConsumerService} supports Kafka consumer pool for multiple Kafka clusters from different data centers;
- * for each Kafka bootstrap server url, {@link AggKafkaConsumerService} will create one {@link KafkaConsumerService}.
+ * for each Kafka bootstrap server URL and consumer decryption mode, {@link AggKafkaConsumerService} will create one
+ * {@link KafkaConsumerService}.
  */
 public class AggKafkaConsumerService extends AbstractVeniceService {
   private static final Logger LOGGER = LogManager.getLogger(AggKafkaConsumerService.class);
@@ -68,7 +72,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
   private final boolean liveConfigBasedKafkaThrottlingEnabled;
   private final boolean isKafkaConsumerOffsetCollectionEnabled;
   private final KafkaConsumerService.ConsumerAssignmentStrategy sharedConsumerAssignmentStrategy;
-  private final Map<String, AbstractKafkaConsumerService> kafkaServerToConsumerServiceMap =
+  private final Map<ConsumerServiceKey, AbstractKafkaConsumerService> kafkaServerToConsumerServiceMap =
       new VeniceConcurrentHashMap<>();
   private final Map<String, String> kafkaClusterUrlToAliasMap;
   private final Object2IntMap<String> kafkaClusterUrlToIdMap;
@@ -92,6 +96,42 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
   private final VeniceJsonSerializer<Map<String, Map<String, TopicPartitionIngestionInfo>>> topicPartitionIngestionContextJsonSerializer =
       new VeniceJsonSerializer<>(new TypeReference<Map<String, Map<String, TopicPartitionIngestionInfo>>>() {
       });
+
+  static final class ConsumerServiceKey {
+    private final String resolvedKafkaUrl;
+    private final boolean decryptionEnabled;
+
+    ConsumerServiceKey(String resolvedKafkaUrl, boolean decryptionEnabled) {
+      this.resolvedKafkaUrl = Objects.requireNonNull(resolvedKafkaUrl);
+      this.decryptionEnabled = decryptionEnabled;
+    }
+
+    String getResolvedKafkaUrl() {
+      return resolvedKafkaUrl;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof ConsumerServiceKey)) {
+        return false;
+      }
+      ConsumerServiceKey that = (ConsumerServiceKey) o;
+      return decryptionEnabled == that.decryptionEnabled && resolvedKafkaUrl.equals(that.resolvedKafkaUrl);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(resolvedKafkaUrl, decryptionEnabled);
+    }
+
+    @Override
+    public String toString() {
+      return resolvedKafkaUrl + " (decryptionEnabled=" + decryptionEnabled + ")";
+    }
+  }
 
   public AggKafkaConsumerService(
       final PubSubPropertiesSupplier pubSubPropertiesSupplier,
@@ -200,7 +240,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
   protected static Runnable getStuckConsumerDetectionAndRepairRunnable(
       Logger logger,
       Time time,
-      Map<String, AbstractKafkaConsumerService> kafkaServerToConsumerServiceMap,
+      Map<?, AbstractKafkaConsumerService> kafkaServerToConsumerServiceMap,
       Map<String, StoreIngestionTask> versionTopicStoreIngestionTaskMapping,
       long stuckConsumerRepairThresholdMs,
       long nonExistingTopicIngestionTaskKillThresholdMs,
@@ -306,12 +346,12 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
   private static void reportStaleTopicPartitions(
       Logger logger,
       Time time,
-      Map<String, AbstractKafkaConsumerService> kafkaServerToConsumerServiceMap,
+      Map<?, AbstractKafkaConsumerService> kafkaServerToConsumerServiceMap,
       long consumerPollTrackerStaleThresholdMs) {
     StringBuilder stringBuilder = new StringBuilder();
     long now = time.getMilliseconds();
     // Detect and log any subscribed topic partitions that are not polling records
-    for (Map.Entry<String, AbstractKafkaConsumerService> consumerService: kafkaServerToConsumerServiceMap.entrySet()) {
+    for (Map.Entry<?, AbstractKafkaConsumerService> consumerService: kafkaServerToConsumerServiceMap.entrySet()) {
       Map<PubSubTopicPartition, Long> staleTopicPartitions =
           consumerService.getValue().getStaleTopicPartitions(now - consumerPollTrackerStaleThresholdMs);
       if (!staleTopicPartitions.isEmpty()) {
@@ -354,12 +394,16 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
    *         or null if there isn't any.
    */
   AbstractKafkaConsumerService getKafkaConsumerService(final String kafkaURL) {
-    AbstractKafkaConsumerService consumerService = kafkaServerToConsumerServiceMap.get(kafkaURL);
-    if (consumerService == null && kafkaClusterUrlResolver != null) {
-      // The resolver is needed to resolve a special format of kafka URL to the original kafka URL
-      consumerService = kafkaServerToConsumerServiceMap.get(kafkaClusterUrlResolver.apply(kafkaURL));
+    AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaURL, false);
+    if (consumerService == null) {
+      consumerService = getKafkaConsumerService(kafkaURL, true);
     }
     return consumerService;
+  }
+
+  AbstractKafkaConsumerService getKafkaConsumerService(final String kafkaURL, boolean decryptionEnabled) {
+    String resolvedKafkaUrl = kafkaClusterUrlResolver == null ? kafkaURL : kafkaClusterUrlResolver.apply(kafkaURL);
+    return kafkaServerToConsumerServiceMap.get(new ConsumerServiceKey(resolvedKafkaUrl, decryptionEnabled));
   }
 
   /**
@@ -377,9 +421,12 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
       throw new IllegalArgumentException("Kafka URL must be set in the consumer properties config. Got: " + kafkaUrl);
     }
     String resolvedKafkaUrl = kafkaClusterUrlResolver == null ? kafkaUrl : kafkaClusterUrlResolver.apply(kafkaUrl);
-    final AbstractKafkaConsumerService alreadyCreatedConsumerService = getKafkaConsumerService(resolvedKafkaUrl);
+    boolean decryptionEnabled = new VeniceProperties(consumerProperties).getBoolean(CLUSTER_ENCRYPTION_ENABLED, false);
+    ConsumerServiceKey consumerServiceKey = new ConsumerServiceKey(resolvedKafkaUrl, decryptionEnabled);
+    final AbstractKafkaConsumerService alreadyCreatedConsumerService =
+        kafkaServerToConsumerServiceMap.get(consumerServiceKey);
     if (alreadyCreatedConsumerService != null) {
-      LOGGER.info("KafkaConsumerService has already been created for Kafka cluster with URL: {}", resolvedKafkaUrl);
+      LOGGER.info("KafkaConsumerService has already been created for {}", consumerServiceKey);
       return alreadyCreatedConsumerService;
     }
 
@@ -411,7 +458,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
             getCrossTpProcessingPoolForPoolType(poolType));
 
     AbstractKafkaConsumerService consumerService =
-        kafkaServerToConsumerServiceMap.computeIfAbsent(resolvedKafkaUrl, url -> {
+        kafkaServerToConsumerServiceMap.computeIfAbsent(consumerServiceKey, key -> {
           if (serverConfig
               .getConsumerPoolStrategyType() == KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.CURRENT_VERSION_PRIORITIZATION) {
             return new KafkaConsumerServiceDelegator(serverConfig, consumerServiceBuilder);
@@ -452,18 +499,24 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
       final String kafkaURL,
       PubSubTopic versionTopic,
       PubSubTopicPartition pubSubTopicPartition) {
-    AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaURL);
-    if (consumerService == null) {
-      return false;
+    for (boolean decryptionEnabled: new boolean[] { false, true }) {
+      AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaURL, decryptionEnabled);
+      if (consumerService != null) {
+        SharedKafkaConsumer consumer =
+            consumerService.getConsumerAssignedToVersionTopicPartition(versionTopic, pubSubTopicPartition);
+        if (consumer != null && consumer.hasSubscription(pubSubTopicPartition)) {
+          return true;
+        }
+      }
     }
-    SharedKafkaConsumer consumer =
-        consumerService.getConsumerAssignedToVersionTopicPartition(versionTopic, pubSubTopicPartition);
-    return consumer != null && consumer.hasSubscription(pubSubTopicPartition);
+    return false;
   }
 
   boolean hasConsumerAssignedFor(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) {
-    for (String kafkaUrl: kafkaServerToConsumerServiceMap.keySet()) {
-      if (hasConsumerAssignedFor(kafkaUrl, versionTopic, pubSubTopicPartition)) {
+    for (AbstractKafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
+      SharedKafkaConsumer consumer =
+          consumerService.getConsumerAssignedToVersionTopicPartition(versionTopic, pubSubTopicPartition);
+      if (consumer != null && consumer.hasSubscription(pubSubTopicPartition)) {
         return true;
       }
     }
@@ -515,9 +568,28 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
       PubSubPosition lastOffset,
       boolean inclusive) {
     PubSubTopic versionTopic = storeIngestionTask.getVersionTopic();
+    boolean decryptionEnabled = StoreIngestionTask.resolveConsumerEncryptionEnabled(
+        serverConfig.getClusterProperties(),
+        metadataRepository.getStore(versionTopic.getStoreName()));
+    AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaURL, decryptionEnabled);
+    return subscribeConsumerFor(
+        consumerService,
+        kafkaURL,
+        storeIngestionTask,
+        partitionReplicaIngestionContext,
+        lastOffset,
+        inclusive);
+  }
+
+  ConsumedDataReceiver<List<DefaultPubSubMessage>> subscribeConsumerFor(
+      AbstractKafkaConsumerService consumerService,
+      final String kafkaURL,
+      StoreIngestionTask storeIngestionTask,
+      PartitionReplicaIngestionContext partitionReplicaIngestionContext,
+      PubSubPosition lastOffset,
+      boolean inclusive) {
+    PubSubTopic versionTopic = storeIngestionTask.getVersionTopic();
     PubSubTopicPartition pubSubTopicPartition = partitionReplicaIngestionContext.getPubSubTopicPartition();
-    AbstractKafkaConsumerService consumerService =
-        getKafkaConsumerService(kafkaClusterUrlResolver == null ? kafkaURL : kafkaClusterUrlResolver.apply(kafkaURL));
     if (consumerService == null) {
       throw new VeniceException(
           "Kafka consumer service must exist for version topic: " + versionTopic + " in Kafka cluster: " + kafkaURL);
@@ -549,10 +621,14 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
       final String kafkaURL,
       PubSubTopic versionTopic,
       PubSubTopicPartition pubSubTopicPartition) {
-    AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaURL);
-    return consumerService == null
-        ? -1
-        : consumerService.getLatestOffsetBasedOnMetrics(versionTopic, pubSubTopicPartition);
+    for (boolean decryptionEnabled: new boolean[] { false, true }) {
+      AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaURL, decryptionEnabled);
+      if (consumerService != null
+          && consumerService.getConsumerAssignedToVersionTopicPartition(versionTopic, pubSubTopicPartition) != null) {
+        return consumerService.getLatestOffsetBasedOnMetrics(versionTopic, pubSubTopicPartition);
+      }
+    }
+    return -1;
   }
 
   /**
@@ -596,9 +672,10 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
    */
   Set<String> getKafkaUrlsFor(PubSubTopic versionTopic) {
     Set<String> kafkaUrls = new HashSet<>(kafkaServerToConsumerServiceMap.size());
-    for (Map.Entry<String, AbstractKafkaConsumerService> entry: kafkaServerToConsumerServiceMap.entrySet()) {
+    for (Map.Entry<ConsumerServiceKey, AbstractKafkaConsumerService> entry: kafkaServerToConsumerServiceMap
+        .entrySet()) {
       if (entry.getValue().hasAnySubscriptionFor(versionTopic)) {
-        kafkaUrls.add(entry.getKey());
+        kafkaUrls.add(entry.getKey().getResolvedKafkaUrl());
       }
     }
     return kafkaUrls;
@@ -606,8 +683,10 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
 
   byte[] getIngestionInfoFor(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) throws IOException {
     Map<String, Map<String, TopicPartitionIngestionInfo>> topicPartitionIngestionContext = new HashMap<>();
-    for (String kafkaUrl: kafkaServerToConsumerServiceMap.keySet()) {
-      AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaUrl);
+    for (Map.Entry<ConsumerServiceKey, AbstractKafkaConsumerService> consumerServiceEntry: kafkaServerToConsumerServiceMap
+        .entrySet()) {
+      String kafkaUrl = consumerServiceEntry.getKey().getResolvedKafkaUrl();
+      AbstractKafkaConsumerService consumerService = consumerServiceEntry.getValue();
       Map<PubSubTopicPartition, TopicPartitionIngestionInfo> topicPartitionIngestionInfoMap =
           consumerService.getIngestionInfoFor(versionTopic, pubSubTopicPartition, false);
       for (Map.Entry<PubSubTopicPartition, TopicPartitionIngestionInfo> entry: topicPartitionIngestionInfoMap
@@ -629,12 +708,19 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
     if (kafkaUrl == null) {
       return "kafkaUrl is not found for region: " + regionName;
     }
-    AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaUrl);
-    if (consumerService == null) {
+    Map<PubSubTopicPartition, TopicPartitionIngestionInfo> topicPartitionIngestionInfoMap = new HashMap<>();
+    boolean consumerServiceFound = false;
+    for (boolean decryptionEnabled: new boolean[] { false, true }) {
+      AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaUrl, decryptionEnabled);
+      if (consumerService != null) {
+        consumerServiceFound = true;
+        topicPartitionIngestionInfoMap
+            .putAll(consumerService.getIngestionInfoFor(versionTopic, pubSubTopicPartition, true));
+      }
+    }
+    if (!consumerServiceFound) {
       return "Kafka consumer service is not found for kafkaUrl: " + kafkaUrl + ", region: " + regionName;
     }
-    Map<PubSubTopicPartition, TopicPartitionIngestionInfo> topicPartitionIngestionInfoMap =
-        consumerService.getIngestionInfoFor(versionTopic, pubSubTopicPartition, true);
     return KafkaConsumerService.convertTopicPartitionIngestionInfoMapToStr(topicPartitionIngestionInfoMap);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -9,6 +9,7 @@ import static com.linkedin.davinci.kafka.consumer.ConsumerActionType.UNSUBSCRIBE
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.LEADER;
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.STANDBY;
 import static com.linkedin.davinci.validation.DataIntegrityValidator.DISABLED;
+import static com.linkedin.venice.ConfigKeys.CLUSTER_ENCRYPTION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.LogMessages.KILLED_JOB_MESSAGE;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
@@ -4932,7 +4933,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
     final boolean consumeRemotely = !Objects.equals(resolvedKafkaURL, localKafkaServer);
     // TODO: Move remote KafkaConsumerService creating operations into the aggKafkaConsumerService.
-    aggKafkaConsumerService
+    AbstractKafkaConsumerService kafkaConsumerService = aggKafkaConsumerService
         .createKafkaConsumerService(createKafkaConsumerProperties(kafkaProps, resolvedKafkaURL, consumeRemotely));
     PartitionConsumptionState pcs = pubSubTopicPartition == null
         ? null
@@ -4947,6 +4948,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     // localKafkaServer doesn't have suffix but kafkaURL may have suffix,
     // and we don't want to pass the resolvedKafkaURL as it will be passed to data receiver for parsing cluster id
     aggKafkaConsumerService.subscribeConsumerFor(
+        kafkaConsumerService,
         kafkaURL,
         this,
         partitionReplicaIngestionContext,
@@ -5797,7 +5799,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       Properties localConsumerProps,
       String remoteKafkaSourceAddress,
       boolean consumeRemotely) {
-    Properties newConsumerProps = serverConfig.getClusterProperties().getPropertiesCopy();
+    VeniceProperties clusterProperties = serverConfig.getClusterProperties();
+    Properties newConsumerProps = clusterProperties.getPropertiesCopy();
     newConsumerProps.putAll(localConsumerProps);
     newConsumerProps.setProperty(KAFKA_BOOTSTRAP_SERVERS, remoteKafkaSourceAddress);
     VeniceProperties customizedConsumerConfigs = consumeRemotely
@@ -5806,7 +5809,16 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     if (!customizedConsumerConfigs.isEmpty()) {
       newConsumerProps.putAll(customizedConsumerConfigs.toProperties());
     }
+    newConsumerProps.setProperty(
+        CLUSTER_ENCRYPTION_ENABLED,
+        Boolean.toString(resolveConsumerEncryptionEnabled(clusterProperties, storeRepository.getStore(storeName))));
     return newConsumerProps;
+  }
+
+  static boolean resolveConsumerEncryptionEnabled(VeniceProperties clusterProperties, Store store) {
+    return clusterProperties.containsKey(CLUSTER_ENCRYPTION_ENABLED)
+        ? clusterProperties.getBoolean(CLUSTER_ENCRYPTION_ENABLED)
+        : store != null && store.isEncryptionEnabled();
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerServiceTest.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.davinci.kafka.consumer.KafkaConsumerService.ConsumerAssignmentStrategy.PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
 import static com.linkedin.davinci.kafka.consumer.KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.DEFAULT;
+import static com.linkedin.venice.ConfigKeys.CLUSTER_ENCRYPTION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -16,6 +17,7 @@ import static org.mockito.Mockito.when;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.stats.StuckConsumerRepairStats;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
@@ -40,7 +42,9 @@ import io.tehuti.metrics.Sensor;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Consumer;
@@ -91,6 +95,7 @@ public class AggKafkaConsumerServiceTest {
     when(serverConfig.getKafkaClusterUrlToIdMap()).thenReturn(Object2IntMaps.unmodifiable(tmpKafkaClusterUrlToIdMap));
     // note that this isn't the exact same as the one in VeniceClusterConfig, but it should be sufficient for most cases
     when(serverConfig.getKafkaClusterUrlResolver()).thenReturn(Utils::resolveKafkaUrlForSepTopic);
+    when(serverConfig.getClusterProperties()).thenReturn(VeniceProperties.empty());
     when(serverConfig.getConsumerPoolStrategyType()).thenReturn(DEFAULT);
     when(serverConfig.getConsumerPoolSizePerKafkaCluster()).thenReturn(5);
     when(serverConfig.isUnregisterMetricForDeletedStoreEnabled()).thenReturn(Boolean.FALSE);
@@ -123,6 +128,89 @@ public class AggKafkaConsumerServiceTest {
   }
 
   // test subscribeConsumerFor
+  @Test
+  public void testConsumerEncryptionConfigPrecedence() {
+    Store encryptedStore = mock(Store.class);
+    when(encryptedStore.isEncryptionEnabled()).thenReturn(true);
+    Store plaintextStore = mock(Store.class);
+
+    VeniceProperties absentClusterProperty = VeniceProperties.empty();
+    Assert.assertTrue(StoreIngestionTask.resolveConsumerEncryptionEnabled(absentClusterProperty, encryptedStore));
+    Assert.assertFalse(StoreIngestionTask.resolveConsumerEncryptionEnabled(absentClusterProperty, plaintextStore));
+    Assert.assertFalse(StoreIngestionTask.resolveConsumerEncryptionEnabled(absentClusterProperty, null));
+
+    Properties clusterProperties = new Properties();
+    clusterProperties.setProperty(CLUSTER_ENCRYPTION_ENABLED, Boolean.FALSE.toString());
+    Assert.assertFalse(
+        StoreIngestionTask.resolveConsumerEncryptionEnabled(new VeniceProperties(clusterProperties), encryptedStore));
+
+    clusterProperties.setProperty(CLUSTER_ENCRYPTION_ENABLED, Boolean.TRUE.toString());
+    Assert.assertTrue(
+        StoreIngestionTask.resolveConsumerEncryptionEnabled(new VeniceProperties(clusterProperties), plaintextStore));
+  }
+
+  @Test
+  public void testEncryptedAndPlaintextStoresUseIsolatedConsumerServices() throws Exception {
+    doReturn(VeniceProperties.empty()).when(pubSubPropertiesSupplier).get(PUBSUB_URL);
+
+    Properties plaintextProperties = getConsumerProperties(false);
+    Properties encryptedProperties = getConsumerProperties(true);
+
+    AbstractKafkaConsumerService plaintextService =
+        aggKafkaConsumerService.createKafkaConsumerService(plaintextProperties);
+    AbstractKafkaConsumerService encryptedService =
+        aggKafkaConsumerService.createKafkaConsumerService(encryptedProperties);
+
+    Assert.assertNotSame(plaintextService, encryptedService);
+    Assert.assertSame(plaintextService, aggKafkaConsumerService.createKafkaConsumerService(plaintextProperties));
+    Assert.assertSame(encryptedService, aggKafkaConsumerService.createKafkaConsumerService(encryptedProperties));
+    Assert.assertSame(plaintextService, aggKafkaConsumerService.getKafkaConsumerService(PUBSUB_URL, false));
+    Assert.assertSame(encryptedService, aggKafkaConsumerService.getKafkaConsumerService(PUBSUB_URL, true));
+
+    ArgumentCaptor<PubSubConsumerAdapterContext> contextCaptor =
+        ArgumentCaptor.forClass(PubSubConsumerAdapterContext.class);
+    verify(consumerFactory, times(10)).create(contextCaptor.capture());
+    List<PubSubConsumerAdapterContext> contexts = contextCaptor.getAllValues();
+    Assert.assertTrue(
+        contexts.subList(0, 5)
+            .stream()
+            .noneMatch(context -> context.getVeniceProperties().getBoolean(CLUSTER_ENCRYPTION_ENABLED, false)));
+    Assert.assertTrue(
+        contexts.subList(5, 10)
+            .stream()
+            .allMatch(context -> context.getVeniceProperties().getBoolean(CLUSTER_ENCRYPTION_ENABLED, false)));
+
+    aggKafkaConsumerService.stopInner();
+    Assert.assertFalse(plaintextService.isRunning());
+    Assert.assertFalse(encryptedService.isRunning());
+  }
+
+  @Test
+  public void testEncryptedConsumerCreationFailureIsPropagatedAndRetryable() {
+    doReturn(VeniceProperties.empty()).when(pubSubPropertiesSupplier).get(PUBSUB_URL);
+    RuntimeException creationFailure = new RuntimeException("KMS initialization failed");
+    PubSubConsumerAdapter adapter = mock(PubSubConsumerAdapter.class);
+    when(consumerFactory.create(any(PubSubConsumerAdapterContext.class))).thenThrow(creationFailure)
+        .thenReturn(adapter);
+
+    Properties encryptedProperties = getConsumerProperties(true);
+    RuntimeException exception = Assert.expectThrows(
+        RuntimeException.class,
+        () -> aggKafkaConsumerService.createKafkaConsumerService(encryptedProperties));
+    Assert.assertSame(exception, creationFailure);
+    Assert.assertNull(aggKafkaConsumerService.getKafkaConsumerService(PUBSUB_URL, true));
+
+    Assert.assertNotNull(aggKafkaConsumerService.createKafkaConsumerService(encryptedProperties));
+    Assert.assertNotNull(aggKafkaConsumerService.getKafkaConsumerService(PUBSUB_URL, true));
+  }
+
+  private Properties getConsumerProperties(boolean encryptionEnabled) {
+    Properties properties = new Properties();
+    properties.setProperty(KAFKA_BOOTSTRAP_SERVERS, PUBSUB_URL);
+    properties.setProperty(CLUSTER_ENCRYPTION_ENABLED, Boolean.toString(encryptionEnabled));
+    return properties;
+  }
+
   @Test
   public void testSubscribeConsumerFor() {
     doReturn(new VeniceProperties(new Properties())).when(pubSubPropertiesSupplier).get(PUBSUB_URL);
@@ -393,7 +481,8 @@ public class AggKafkaConsumerServiceTest {
     AggKafkaConsumerService serviceSpy = spy(testService);
 
     AbstractKafkaConsumerService mockConsumerService = mock(AbstractKafkaConsumerService.class);
-    doReturn(mockConsumerService).when(serviceSpy).getKafkaConsumerService(kafkaUrl);
+    doReturn(mockConsumerService).when(serviceSpy).getKafkaConsumerService(kafkaUrl, false);
+    doReturn(null).when(serviceSpy).getKafkaConsumerService(kafkaUrl, true);
 
     TopicPartitionIngestionInfo mockIngestionInfo =
         new TopicPartitionIngestionInfo(1000L, 50L, 10.5, 1024.0, "consumer-1", 100L, 200L, topic.getName());
@@ -411,6 +500,39 @@ public class AggKafkaConsumerServiceTest {
     Assert.assertTrue(result.contains("consumer-1"));
 
     verify(mockConsumerService).getIngestionInfoFor(topic, topicPartition, true);
+  }
+
+  @Test
+  public void testGetIngestionInfoReportsBothConsumerModes() {
+    String regionName = "region1";
+    String kafkaUrl = "kafka://test-cluster:9092";
+    PubSubTopicPartition encryptedTopicPartition = new PubSubTopicPartitionImpl(topic, 1);
+
+    Map<String, String> kafkaClusterUrlToAliasMap = new HashMap<>();
+    kafkaClusterUrlToAliasMap.put(kafkaUrl, regionName);
+    when(serverConfig.getKafkaClusterUrlToAliasMap()).thenReturn(kafkaClusterUrlToAliasMap);
+
+    AggKafkaConsumerService serviceSpy = spy(createTestService());
+    AbstractKafkaConsumerService plaintextService = mock(AbstractKafkaConsumerService.class);
+    AbstractKafkaConsumerService encryptedService = mock(AbstractKafkaConsumerService.class);
+    doReturn(plaintextService).when(serviceSpy).getKafkaConsumerService(kafkaUrl, false);
+    doReturn(encryptedService).when(serviceSpy).getKafkaConsumerService(kafkaUrl, true);
+
+    TopicPartitionIngestionInfo plaintextInfo =
+        new TopicPartitionIngestionInfo(10L, 1L, 1.0, 10.0, "plaintext-consumer", 1L, 2L, topic.getName());
+    TopicPartitionIngestionInfo encryptedInfo =
+        new TopicPartitionIngestionInfo(20L, 2L, 2.0, 20.0, "encrypted-consumer", 2L, 3L, topic.getName());
+    when(plaintextService.getIngestionInfoFor(topic, topicPartition, true))
+        .thenReturn(Collections.singletonMap(topicPartition, plaintextInfo));
+    when(encryptedService.getIngestionInfoFor(topic, topicPartition, true))
+        .thenReturn(Collections.singletonMap(encryptedTopicPartition, encryptedInfo));
+
+    String result = serviceSpy.getIngestionInfoFor(topic, topicPartition, regionName);
+
+    Assert.assertTrue(result.contains("plaintext-consumer"));
+    Assert.assertTrue(result.contains("encrypted-consumer"));
+    verify(plaintextService).getIngestionInfoFor(topic, topicPartition, true);
+    verify(encryptedService).getIngestionInfoFor(topic, topicPartition, true);
   }
 
   @Test
@@ -442,7 +564,8 @@ public class AggKafkaConsumerServiceTest {
     AggKafkaConsumerService testService = createTestService();
     AggKafkaConsumerService serviceSpy = spy(testService);
 
-    doReturn(null).when(serviceSpy).getKafkaConsumerService(kafkaUrl);
+    doReturn(null).when(serviceSpy).getKafkaConsumerService(kafkaUrl, false);
+    doReturn(null).when(serviceSpy).getKafkaConsumerService(kafkaUrl, true);
 
     String result = serviceSpy.getIngestionInfoFor(topic, topicPartition, regionName);
     Assert.assertTrue(result.contains("Kafka consumer service is not found"));
@@ -461,7 +584,8 @@ public class AggKafkaConsumerServiceTest {
     AggKafkaConsumerService serviceSpy = spy(testService);
 
     AbstractKafkaConsumerService mockConsumerService = mock(AbstractKafkaConsumerService.class);
-    doReturn(mockConsumerService).when(serviceSpy).getKafkaConsumerService(kafkaUrl);
+    doReturn(mockConsumerService).when(serviceSpy).getKafkaConsumerService(kafkaUrl, false);
+    doReturn(null).when(serviceSpy).getKafkaConsumerService(kafkaUrl, true);
 
     when(mockConsumerService.getIngestionInfoFor(topic, topicPartition, true)).thenReturn(new HashMap<>());
 


### PR DESCRIPTION
## Problem Statement

Server ingestion currently pools shared PubSub consumers only by resolved broker URL. When `cluster.encryption.enabled` is absent, that design cannot honor a target store encryption setting, and the first consumer created for a broker can incorrectly determine decryption behavior for other stores sharing the same broker.

The cluster property must remain authoritative when explicitly set to either `true` or `false`. Store-level fallback applies only when it is absent. Admin topics and metadata fetchers remain plaintext because they do not have a target store.

## Solution

Resolve server-ingestion consumer decryption from the explicit cluster property when present; otherwise fall back to the target `Store.isEncryptionEnabled()` value. A missing store resolves to plaintext.

Shared consumer services are now keyed by a typed key containing the resolved broker URL and decryption mode. Creation returns the exact service selected for that policy, and subscription uses that service directly, preventing policy leakage between encrypted and plaintext stores on the same broker. Lookup, diagnostics, stale-consumer reporting, unsubscribe, and shutdown paths cover both pools.

This change depends on the configured PubSub consumer adapter honoring `cluster.encryption.enabled`: `true` must construct a decrypting/raw consumer path, while `false` must construct the normal plaintext consumer.

### Code changes

- [x] Added new code behind **a config**. Uses existing `cluster.encryption.enabled`; explicit `true` or `false` wins, while an absent property falls back to store encryption and defaults missing stores to plaintext.
- [x] Introduced new **log lines**.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging. The existing duplicate-service creation log now includes the typed pool key and remains on the bounded service-creation path.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Testing Done

- [x] Local code review completed
- [x] `./gradlew :clients:da-vinci-client:test --tests com.linkedin.davinci.kafka.consumer.AggKafkaConsumerServiceTest`
- [x] `./gradlew :clients:da-vinci-client:test --tests com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest --tests com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionServiceTest`
- [x] `./gradlew spotlessJavaCheck :clients:da-vinci-client:assemble`
- [x] Commit hooks: `spotlessApply` and `generateGHCI`

Coverage includes explicit cluster true, explicit cluster false with an encrypted store, absent property with encrypted/plaintext/missing stores, mixed encrypted and plaintext stores sharing one broker, property propagation to consumer creation, reporting and cleanup across both modes, and creation failure propagation with a successful retry.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
