### PR TITLE
[vpj] Materialize SSL properties for Spark TTL filters

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/ssl/UserCredentialsFactory.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/ssl/UserCredentialsFactory.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.hadoop.ssl;
 
+import com.linkedin.venice.exceptions.VeniceException;
 import java.io.File;
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
@@ -27,14 +28,23 @@ public class UserCredentialsFactory {
    * Get user's credentials from the the Hadoop token file
    */
   public static Credentials getUserCredentialsFromTokenFile() throws IOException {
-    String tokenFilePath = System.getenv(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
-    if (tokenFilePath == null) {
-      tokenFilePath = System.getProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
-    }
+    String tokenFilePath = getTokenFilePath(
+        System.getenv(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION),
+        System.getProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION));
     File tokenFile = new File(tokenFilePath);
     Credentials credentials = Credentials.readTokenStorageFile(tokenFile, new Configuration());
     verifyCredentials(credentials);
     return credentials;
+  }
+
+  static String getTokenFilePath(String environmentValue, String systemPropertyValue) {
+    String tokenFilePath = environmentValue != null ? environmentValue : systemPropertyValue;
+    if (tokenFilePath == null) {
+      throw new VeniceException(
+          "Hadoop token file location is not configured. Set " + UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION
+              + " as an environment variable or system property.");
+    }
+    return tokenFilePath;
   }
 
   private static void verifyCredentials(Credentials credentials) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/VPJSSLUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/VPJSSLUtils.java
@@ -21,6 +21,7 @@ import com.linkedin.venice.utils.lazy.Lazy;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.Properties;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -61,10 +62,17 @@ public class VPJSSLUtils {
       return config;
     }
     try {
+      String tokenFilePath = System.getenv(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
+      if (tokenFilePath == null) {
+        tokenFilePath = System.getProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
+      }
+      if (tokenFilePath == null) {
+        throw new VeniceException("Hadoop token file location is not configured");
+      }
       Properties mergedProperties = config.toProperties();
       mergedProperties.putAll(getSslProperties(config));
       return new VeniceProperties(mergedProperties);
-    } catch (IOException | VeniceException | NullPointerException e) {
+    } catch (IOException | VeniceException e) {
       throw new VeniceException(
           "Failed to setup SSL for executor-side PubSub client creation. "
               + "Ensure the Hadoop token file is accessible and SSL certificates are valid. SSL configurator class: "

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/VPJSSLUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/VPJSSLUtils.java
@@ -53,6 +53,26 @@ public class VPJSSLUtils {
     return newSslProperties;
   }
 
+  /**
+   * Materializes executor-local SSL properties from Hadoop credentials when an SSL configurator is present.
+   */
+  public static VeniceProperties setupSSLForExecutor(VeniceProperties config) {
+    if (!config.containsKey(SSL_CONFIGURATOR_CLASS_CONFIG)) {
+      return config;
+    }
+    try {
+      Properties mergedProperties = config.toProperties();
+      mergedProperties.putAll(getSslProperties(config));
+      return new VeniceProperties(mergedProperties);
+    } catch (IOException | VeniceException | NullPointerException e) {
+      throw new VeniceException(
+          "Failed to setup SSL for executor-side PubSub client creation. "
+              + "Ensure the Hadoop token file is accessible and SSL certificates are valid. SSL configurator class: "
+              + config.getString(SSL_CONFIGURATOR_CLASS_CONFIG),
+          e);
+    }
+  }
+
   public static void validateSslProperties(VeniceProperties props) {
     String[] requiredSSLPropertiesNames = new String[] { SSL_KEY_PASSWORD_PROPERTY_NAME,
         SSL_KEY_STORE_PASSWORD_PROPERTY_NAME, SSL_KEY_STORE_PROPERTY_NAME, SSL_TRUST_STORE_PROPERTY_NAME };

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/VPJSSLUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/VPJSSLUtils.java
@@ -21,7 +21,6 @@ import com.linkedin.venice.utils.lazy.Lazy;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.Properties;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -62,13 +61,6 @@ public class VPJSSLUtils {
       return config;
     }
     try {
-      String tokenFilePath = System.getenv(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
-      if (tokenFilePath == null) {
-        tokenFilePath = System.getProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
-      }
-      if (tokenFilePath == null) {
-        throw new VeniceException("Hadoop token file location is not configured");
-      }
       Properties mergedProperties = config.toProperties();
       mergedProperties.putAll(getSslProperties(config));
       return new VeniceProperties(mergedProperties);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/chunk/SparkChunkAssembler.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/chunk/SparkChunkAssembler.java
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
  * Converts Spark Rows to the format expected by ChunkAssembler, assembles chunks,
  * and returns the result as a Spark Row.
  */
-public class SparkChunkAssembler implements Serializable {
+public class SparkChunkAssembler implements Serializable, AutoCloseable {
   private static final long serialVersionUID = 1L;
 
   private static final RecordSerializer<KafkaInputMapperValue> SERIALIZER =
@@ -146,6 +146,19 @@ public class SparkChunkAssembler implements Serializable {
     }
 
     return assembledRow;
+  }
+
+  /**
+   * The assembler is safe to reuse sequentially across key groups because all record-specific
+   * assembly state is local to {@link ChunkAssembler#assembleAndGetValue(byte[], Iterator)}.
+   */
+  @Override
+  public void close() {
+    if (ttlFilter != null) {
+      ttlFilter.close();
+      ttlFilter = null;
+    }
+    chunkAssembler = null;
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -135,6 +135,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
+import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapGroupsFunction;
 import org.apache.spark.api.java.function.MapFunction;
@@ -155,6 +156,7 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.util.AccumulatorV2;
 import org.apache.spark.util.LongAccumulator;
+import org.apache.spark.util.TaskCompletionListener;
 
 
 /**
@@ -716,50 +718,124 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     dataFrame = dataFrame
         // Group by key
         .groupByKey((MapFunction<Row, byte[]>) row -> row.getAs(KEY_COLUMN_NAME), Encoders.BINARY())
-        // For each key group, sort by offset DESC and assemble
-        .flatMapGroups((FlatMapGroupsFunction<byte[], Row, Row>) (keyBytes, rowsIterator) -> {
-          long groupStartNs = System.nanoTime();
-          // Collect rows and sort by offset DESC (highest first)
-          List<Row> rowsList = new ArrayList<>();
-          rowsIterator.forEachRemaining(row -> {
-            chunkMetrics.recordsIn.add(1);
-            chunkMetrics.bytesIn.add(CountingIterator.computeByteSizeByIndices(row, inKeyIdx, inValIdx, inRmdIdx));
-            rowsList.add(row);
-          });
-
-          if (rowsList.isEmpty()) {
-            chunkMetrics.timeNs.add(System.nanoTime() - groupStartNs);
-            return Collections.emptyIterator();
-          }
-
-          // Sort by offset DESC
-          rowsList.sort((r1, r2) -> {
-            long offset1 = r1.getAs(OFFSET_COLUMN_NAME);
-            long offset2 = r2.getAs(OFFSET_COLUMN_NAME);
-            return Long.compare(offset2, offset1);
-          });
-
-          // Assemble chunks (and apply TTL filtering if enabled)
-          SparkChunkAssembler assembler =
-              new SparkChunkAssembler(isRmdChunkingEnabled, isTTLEnabled, broadcastFilterProps);
-          Row assembled = assembler.assembleChunks(keyBytes, rowsList.iterator());
-
-          if (assembled == null) {
-            // Latest record is DELETE, chunks incomplete, or filtered by TTL
-            emptyRecordAcc.add(1);
-            chunkMetrics.timeNs.add(System.nanoTime() - groupStartNs);
-            return Collections.emptyIterator();
-          }
-
-          chunkMetrics.recordsOut.add(1);
-          chunkMetrics.bytesOut
-              .add(CountingIterator.computeByteSizeByIndices(assembled, outKeyIdx, outValIdx, outRmdIdx));
-          chunkMetrics.timeNs.add(System.nanoTime() - groupStartNs);
-          return Collections.singletonList(assembled).iterator();
-        }, encoder);
+        // Reuse executor-local SSL and TTL/compressor state across key groups in the same Spark task.
+        .flatMapGroups(
+            new ChunkAssemblyFunction(
+                isRmdChunkingEnabled,
+                isTTLEnabled,
+                broadcastFilterProps,
+                emptyRecordAcc,
+                chunkMetrics,
+                inKeyIdx,
+                inValIdx,
+                inRmdIdx,
+                outKeyIdx,
+                outValIdx,
+                outRmdIdx),
+            encoder);
 
     LOGGER.info("Chunk assembly completed. Output schema: {}", dataFrame.schema());
     return dataFrame;
+  }
+
+  private static class ChunkAssemblyFunction implements FlatMapGroupsFunction<byte[], Row, Row> {
+    private static final long serialVersionUID = 1L;
+
+    private final boolean isRmdChunkingEnabled;
+    private final boolean isTTLEnabled;
+    private final VeniceProperties filterProperties;
+    private final LongAccumulator emptyRecordAcc;
+    private final StageMetrics chunkMetrics;
+    private final int inKeyIdx;
+    private final int inValIdx;
+    private final int inRmdIdx;
+    private final int outKeyIdx;
+    private final int outValIdx;
+    private final int outRmdIdx;
+
+    private transient SparkChunkAssembler assembler;
+
+    ChunkAssemblyFunction(
+        boolean isRmdChunkingEnabled,
+        boolean isTTLEnabled,
+        VeniceProperties filterProperties,
+        LongAccumulator emptyRecordAcc,
+        StageMetrics chunkMetrics,
+        int inKeyIdx,
+        int inValIdx,
+        int inRmdIdx,
+        int outKeyIdx,
+        int outValIdx,
+        int outRmdIdx) {
+      this.isRmdChunkingEnabled = isRmdChunkingEnabled;
+      this.isTTLEnabled = isTTLEnabled;
+      this.filterProperties = filterProperties;
+      this.emptyRecordAcc = emptyRecordAcc;
+      this.chunkMetrics = chunkMetrics;
+      this.inKeyIdx = inKeyIdx;
+      this.inValIdx = inValIdx;
+      this.inRmdIdx = inRmdIdx;
+      this.outKeyIdx = outKeyIdx;
+      this.outValIdx = outValIdx;
+      this.outRmdIdx = outRmdIdx;
+    }
+
+    @Override
+    public Iterator<Row> call(byte[] keyBytes, Iterator<Row> rowsIterator) {
+      long groupStartNs = System.nanoTime();
+      List<Row> rowsList = new ArrayList<>();
+      rowsIterator.forEachRemaining(row -> {
+        chunkMetrics.recordsIn.add(1);
+        chunkMetrics.bytesIn.add(CountingIterator.computeByteSizeByIndices(row, inKeyIdx, inValIdx, inRmdIdx));
+        rowsList.add(row);
+      });
+
+      if (rowsList.isEmpty()) {
+        chunkMetrics.timeNs.add(System.nanoTime() - groupStartNs);
+        return Collections.emptyIterator();
+      }
+
+      rowsList.sort((r1, r2) -> {
+        long offset1 = r1.getAs(OFFSET_COLUMN_NAME);
+        long offset2 = r2.getAs(OFFSET_COLUMN_NAME);
+        return Long.compare(offset2, offset1);
+      });
+
+      Row assembled = getAssembler().assembleChunks(keyBytes, rowsList.iterator());
+      if (assembled == null) {
+        emptyRecordAcc.add(1);
+        chunkMetrics.timeNs.add(System.nanoTime() - groupStartNs);
+        return Collections.emptyIterator();
+      }
+
+      chunkMetrics.recordsOut.add(1);
+      chunkMetrics.bytesOut.add(CountingIterator.computeByteSizeByIndices(assembled, outKeyIdx, outValIdx, outRmdIdx));
+      chunkMetrics.timeNs.add(System.nanoTime() - groupStartNs);
+      return Collections.singletonList(assembled).iterator();
+    }
+
+    private SparkChunkAssembler getAssembler() {
+      if (assembler == null) {
+        VeniceProperties executorFilterProperties = filterProperties;
+        if (isTTLEnabled) {
+          executorFilterProperties = VPJSSLUtils.setupSSLForExecutor(filterProperties);
+        }
+        assembler = new SparkChunkAssembler(isRmdChunkingEnabled, isTTLEnabled, executorFilterProperties);
+
+        TaskContext taskContext = TaskContext.get();
+        if (taskContext != null) {
+          taskContext.addTaskCompletionListener((TaskCompletionListener) context -> closeAssembler());
+        }
+      }
+      return assembler;
+    }
+
+    private void closeAssembler() {
+      if (assembler != null) {
+        assembler.close();
+        assembler = null;
+      }
+    }
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -86,6 +86,7 @@ import com.linkedin.venice.hadoop.input.kafka.ttl.TTLResolutionPolicy;
 import com.linkedin.venice.hadoop.ssl.TempFileSSLConfigurator;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
 import com.linkedin.venice.hadoop.task.datawriter.IncrementalPushWriteQuotaUtils;
+import com.linkedin.venice.hadoop.utils.VPJSSLUtils;
 import com.linkedin.venice.jobs.DataWriterComputeJob;
 import com.linkedin.venice.jobs.StageMetricsSnapshot;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
@@ -522,8 +523,9 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
 
     // Apply filter using mapPartitions for efficiency (one filter instance per partition)
     dataFrame = dataFrame.mapPartitions((MapPartitionsFunction<Row, Row>) iterator -> {
-      SparkKafkaInputTTLFilter ttlFilter =
-          new SparkKafkaInputTTLFilter(new VeniceProperties(broadcastFilterProps.value()));
+      VeniceProperties filterProperties =
+          VPJSSLUtils.setupSSLForExecutor(new VeniceProperties(broadcastFilterProps.value()));
+      SparkKafkaInputTTLFilter ttlFilter = new SparkKafkaInputTTLFilter(filterProperties);
       try {
         CountingIterator countedInput = new CountingIterator(
             iterator,

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/input/pubsub/SparkPubSubPartitionReaderFactory.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/input/pubsub/SparkPubSubPartitionReaderFactory.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.spark.input.pubsub;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_PUBSUB_INPUT_SECONDARY_COMPARATOR_USE_LOCAL_LOGICAL_INDEX;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_FABRIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUBSUB_INPUT_SECONDARY_COMPARATOR_USE_LOCAL_LOGICAL_INDEX;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
 
 import com.linkedin.venice.chunking.ChunkKeyValueTransformer;
@@ -19,7 +18,6 @@ import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.vpj.VenicePushJobConstants;
 import com.linkedin.venice.vpj.pubsub.input.PubSubPartitionSplit;
-import java.util.Properties;
 import org.apache.avro.Schema;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -52,7 +50,7 @@ public class SparkPubSubPartitionReaderFactory implements PartitionReaderFactory
     }
 
     // Setup SSL on the executor side
-    VeniceProperties configWithSsl = setupSSLForExecutor(jobConfig);
+    VeniceProperties configWithSsl = VPJSSLUtils.setupSSLForExecutor(jobConfig);
 
     final SparkPubSubInputPartition inputPartition = (SparkPubSubInputPartition) genericInputPartition;
     final PubSubPartitionSplit partitionSplit = inputPartition.getPubSubPartitionSplit();
@@ -103,27 +101,6 @@ public class SparkPubSubPartitionReaderFactory implements PartitionReaderFactory
         regionName,
         isChunkingEnabled);
     return reader;
-  }
-
-  /**
-   * Sets up SSL on the executor side before creating the PubSub consumer.
-   */
-  private VeniceProperties setupSSLForExecutor(VeniceProperties config) {
-    if (!config.containsKey(SSL_CONFIGURATOR_CLASS_CONFIG)) {
-      return config;
-    }
-    try {
-      Properties sslProps = VPJSSLUtils.getSslProperties(config);
-      Properties merged = config.toProperties();
-      merged.putAll(sslProps);
-      return new VeniceProperties(merged);
-    } catch (Exception e) {
-      String msg = "Failed to setup SSL for executor-side consumer creation. "
-          + "Ensure the Hadoop token file is accessible and SSL certificates are valid. " + "SSL configurator class: "
-          + config.getString(SSL_CONFIGURATOR_CLASS_CONFIG);
-      LOGGER.error(msg, e);
-      throw new RuntimeException(msg, e);
-    }
   }
 
   // Make it explicit that this reader does not support columnar reads.

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/ssl/UserCredentialsFactoryTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/ssl/UserCredentialsFactoryTest.java
@@ -1,0 +1,60 @@
+package com.linkedin.venice.hadoop.ssl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.testng.annotations.Test;
+
+
+public class UserCredentialsFactoryTest {
+  @Test
+  public void testTokenFilePathPrefersEnvironmentValue() {
+    assertEquals(
+        UserCredentialsFactory.getTokenFilePath("/environment/token-file", "/system-property/token-file"),
+        "/environment/token-file");
+  }
+
+  @Test
+  public void testTokenFilePathFallsBackToSystemPropertyValue() {
+    assertEquals(
+        UserCredentialsFactory.getTokenFilePath(null, "/system-property/token-file"),
+        "/system-property/token-file");
+  }
+
+  @Test
+  public void testTokenFilePathFailsWhenLocationIsMissing() {
+    VeniceException exception =
+        expectThrows(VeniceException.class, () -> UserCredentialsFactory.getTokenFilePath(null, null));
+
+    assertEquals(
+        exception.getMessage(),
+        "Hadoop token file location is not configured. Set " + UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION
+            + " as an environment variable or system property.");
+  }
+
+  @Test
+  public void testGetUserCredentialsFromTokenFileFailsForMalformedFile() throws Exception {
+    File tokenFile = Files.createTempFile("user-credentials-factory-invalid", ".tokens").toFile();
+    String tokenFileProperty = UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
+    String previousTokenFile = System.getProperty(tokenFileProperty);
+    try {
+      Files.write(tokenFile.toPath(), "not-a-token-file".getBytes(StandardCharsets.UTF_8));
+      System.setProperty(tokenFileProperty, tokenFile.getAbsolutePath());
+
+      expectThrows(IOException.class, UserCredentialsFactory::getUserCredentialsFromTokenFile);
+    } finally {
+      if (previousTokenFile == null) {
+        System.clearProperty(tokenFileProperty);
+      } else {
+        System.setProperty(tokenFileProperty, previousTokenFile);
+      }
+      Files.deleteIfExists(tokenFile.toPath());
+    }
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/VPJSSLUtilsTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/VPJSSLUtilsTest.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_TYPE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.expectThrows;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.ssl.SSLConfigurator;
@@ -53,6 +54,41 @@ public class VPJSSLUtilsTest {
     });
   }
 
+  @Test
+  public void testSetupSSLForExecutorFailsWhenTokenFileIsMissing() {
+    String tokenFileProperty = UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
+    String previousTokenFile = System.getProperty(tokenFileProperty);
+    try {
+      System.clearProperty(tokenFileProperty);
+      VeniceException exception =
+          expectThrows(VeniceException.class, () -> VPJSSLUtils.setupSSLForExecutor(configWithTestConfigurator()));
+      assertEquals(exception.getMessage().contains("Hadoop token file is accessible"), true);
+    } finally {
+      restoreSystemProperty(tokenFileProperty, previousTokenFile);
+    }
+  }
+
+  @Test
+  public void testSetupSSLForExecutorFailsWhenTokenFileIsInvalid() throws Exception {
+    File tokenFile = Files.createTempFile("vpj-ssl-utils-invalid", ".tokens").toFile();
+    String tokenFileProperty = UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
+    String previousTokenFile = System.getProperty(tokenFileProperty);
+    try {
+      Files.write(tokenFile.toPath(), "not-a-token-file".getBytes(StandardCharsets.UTF_8));
+      System.setProperty(tokenFileProperty, tokenFile.getAbsolutePath());
+      expectThrows(VeniceException.class, () -> VPJSSLUtils.setupSSLForExecutor(configWithTestConfigurator()));
+    } finally {
+      restoreSystemProperty(tokenFileProperty, previousTokenFile);
+      Files.deleteIfExists(tokenFile.toPath());
+    }
+  }
+
+  private VeniceProperties configWithTestConfigurator() {
+    Properties properties = new Properties();
+    properties.setProperty(SSL_CONFIGURATOR_CLASS_CONFIG, TestSSLConfigurator.class.getName());
+    return new VeniceProperties(properties);
+  }
+
   private void withTokenFile(ThrowingRunnable runnable) throws Exception {
     File tokenFile = Files.createTempFile("vpj-ssl-utils", ".tokens").toFile();
     String tokenFileProperty = UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
@@ -72,6 +108,14 @@ public class VPJSSLUtilsTest {
         System.setProperty(tokenFileProperty, previousTokenFile);
       }
       Files.deleteIfExists(tokenFile.toPath());
+    }
+  }
+
+  private void restoreSystemProperty(String propertyName, String previousValue) {
+    if (previousValue == null) {
+      System.clearProperty(propertyName);
+    } else {
+      System.setProperty(propertyName, previousValue);
     }
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/VPJSSLUtilsTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/VPJSSLUtilsTest.java
@@ -1,0 +1,98 @@
+package com.linkedin.venice.hadoop.utils;
+
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_TYPE;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.hadoop.ssl.SSLConfigurator;
+import com.linkedin.venice.hadoop.ssl.UserCredentialsFactory;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Properties;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.testng.annotations.Test;
+
+
+public class VPJSSLUtilsTest {
+  @Test
+  public void testSetupSSLForExecutorWithoutConfiguratorReturnsOriginalConfig() {
+    VeniceProperties config = new VeniceProperties(new Properties());
+
+    assertSame(VPJSSLUtils.setupSSLForExecutor(config), config);
+  }
+
+  @Test
+  public void testSetupSSLForExecutorMergesGeneratedProperties() throws Exception {
+    withTokenFile(() -> {
+      Properties properties = new Properties();
+      properties.setProperty(SSL_CONFIGURATOR_CLASS_CONFIG, TestSSLConfigurator.class.getName());
+      properties.setProperty("existing.property", "existing-value");
+
+      VeniceProperties result = VPJSSLUtils.setupSSLForExecutor(new VeniceProperties(properties));
+
+      assertEquals(result.getString(SSL_KEYSTORE_TYPE), "PKCS12");
+      assertEquals(result.getString("existing.property"), "existing-value");
+      assertEquals(result.getString(SSL_CONFIGURATOR_CLASS_CONFIG), TestSSLConfigurator.class.getName());
+    });
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Failed to setup SSL for executor-side PubSub client creation.*")
+  public void testSetupSSLForExecutorSurfacesConfiguratorFailure() throws Exception {
+    withTokenFile(() -> {
+      Properties properties = new Properties();
+      properties.setProperty(SSL_CONFIGURATOR_CLASS_CONFIG, FailingSSLConfigurator.class.getName());
+      VPJSSLUtils.setupSSLForExecutor(new VeniceProperties(properties));
+    });
+  }
+
+  private void withTokenFile(ThrowingRunnable runnable) throws Exception {
+    File tokenFile = Files.createTempFile("vpj-ssl-utils", ".tokens").toFile();
+    String tokenFileProperty = UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
+    String previousTokenFile = System.getProperty(tokenFileProperty);
+    try {
+      Credentials credentials = new Credentials();
+      for (int i = 0; i < UserCredentialsFactory.REQUIRED_SECRET_KEY_COUNT; i++) {
+        credentials.addSecretKey(new Text("secret-" + i), ("value-" + i).getBytes(StandardCharsets.UTF_8));
+      }
+      credentials.writeTokenStorageFile(new Path(tokenFile.toURI()), new Configuration());
+      System.setProperty(tokenFileProperty, tokenFile.getAbsolutePath());
+      runnable.run();
+    } finally {
+      if (previousTokenFile == null) {
+        System.clearProperty(tokenFileProperty);
+      } else {
+        System.setProperty(tokenFileProperty, previousTokenFile);
+      }
+      Files.deleteIfExists(tokenFile.toPath());
+    }
+  }
+
+  public static class TestSSLConfigurator implements SSLConfigurator {
+    @Override
+    public Properties setupSSLConfig(Properties properties, Credentials userCredentials) {
+      Properties sslProperties = new Properties();
+      sslProperties.setProperty(SSL_KEYSTORE_TYPE, "PKCS12");
+      return sslProperties;
+    }
+  }
+
+  public static class FailingSSLConfigurator implements SSLConfigurator {
+    @Override
+    public Properties setupSSLConfig(Properties properties, Credentials userCredentials) {
+      throw new VeniceException("Test SSL setup failure");
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/VPJSSLUtilsTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/VPJSSLUtilsTest.java
@@ -4,7 +4,6 @@ import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_TYPE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
-import static org.testng.Assert.expectThrows;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.ssl.SSLConfigurator;
@@ -54,41 +53,6 @@ public class VPJSSLUtilsTest {
     });
   }
 
-  @Test
-  public void testSetupSSLForExecutorFailsWhenTokenFileIsMissing() {
-    String tokenFileProperty = UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
-    String previousTokenFile = System.getProperty(tokenFileProperty);
-    try {
-      System.clearProperty(tokenFileProperty);
-      VeniceException exception =
-          expectThrows(VeniceException.class, () -> VPJSSLUtils.setupSSLForExecutor(configWithTestConfigurator()));
-      assertEquals(exception.getMessage().contains("Hadoop token file is accessible"), true);
-    } finally {
-      restoreSystemProperty(tokenFileProperty, previousTokenFile);
-    }
-  }
-
-  @Test
-  public void testSetupSSLForExecutorFailsWhenTokenFileIsInvalid() throws Exception {
-    File tokenFile = Files.createTempFile("vpj-ssl-utils-invalid", ".tokens").toFile();
-    String tokenFileProperty = UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
-    String previousTokenFile = System.getProperty(tokenFileProperty);
-    try {
-      Files.write(tokenFile.toPath(), "not-a-token-file".getBytes(StandardCharsets.UTF_8));
-      System.setProperty(tokenFileProperty, tokenFile.getAbsolutePath());
-      expectThrows(VeniceException.class, () -> VPJSSLUtils.setupSSLForExecutor(configWithTestConfigurator()));
-    } finally {
-      restoreSystemProperty(tokenFileProperty, previousTokenFile);
-      Files.deleteIfExists(tokenFile.toPath());
-    }
-  }
-
-  private VeniceProperties configWithTestConfigurator() {
-    Properties properties = new Properties();
-    properties.setProperty(SSL_CONFIGURATOR_CLASS_CONFIG, TestSSLConfigurator.class.getName());
-    return new VeniceProperties(properties);
-  }
-
   private void withTokenFile(ThrowingRunnable runnable) throws Exception {
     File tokenFile = Files.createTempFile("vpj-ssl-utils", ".tokens").toFile();
     String tokenFileProperty = UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
@@ -108,14 +72,6 @@ public class VPJSSLUtilsTest {
         System.setProperty(tokenFileProperty, previousTokenFile);
       }
       Files.deleteIfExists(tokenFile.toPath());
-    }
-  }
-
-  private void restoreSystemProperty(String propertyName, String previousValue) {
-    if (previousValue == null) {
-      System.clearProperty(propertyName);
-    } else {
-      System.setProperty(propertyName, previousValue);
     }
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/SparkExecutorTestUtils.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/SparkExecutorTestUtils.java
@@ -1,0 +1,184 @@
+package com.linkedin.venice.spark;
+
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_LOCATION;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_PASSWORD;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_TYPE;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEY_PASSWORD;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_LOCATION;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_PASSWORD;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_TYPE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.hadoop.ssl.SSLConfigurator;
+import com.linkedin.venice.hadoop.ssl.UserCredentialsFactory;
+import com.linkedin.venice.kafka.protocol.ControlMessage;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.StartOfPush;
+import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
+import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
+import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
+import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+
+
+public final class SparkExecutorTestUtils {
+  public static final String TEST_KEYSTORE_TYPE = "PKCS12";
+  public static final String TEST_TRUSTSTORE_TYPE = "JKS";
+  private static final byte[] TEST_DICTIONARY = "spark-ttl-test-dictionary".getBytes(StandardCharsets.UTF_8);
+  private static final AtomicInteger SSL_CONFIGURATOR_INVOCATIONS = new AtomicInteger();
+  private static final AtomicInteger CONSUMER_FACTORY_INVOCATIONS = new AtomicInteger();
+  private static final AtomicInteger DICTIONARY_CONSUMER_INVOCATIONS = new AtomicInteger();
+
+  private SparkExecutorTestUtils() {
+  }
+
+  public static void resetInvocations() {
+    SSL_CONFIGURATOR_INVOCATIONS.set(0);
+    CONSUMER_FACTORY_INVOCATIONS.set(0);
+    DICTIONARY_CONSUMER_INVOCATIONS.set(0);
+  }
+
+  public static int getSslConfiguratorInvocations() {
+    return SSL_CONFIGURATOR_INVOCATIONS.get();
+  }
+
+  public static int getConsumerFactoryInvocations() {
+    return CONSUMER_FACTORY_INVOCATIONS.get();
+  }
+
+  public static int getDictionaryConsumerInvocations() {
+    return DICTIONARY_CONSUMER_INVOCATIONS.get();
+  }
+
+  public static void withTokenFile(ThrowingRunnable runnable) throws Exception {
+    synchronized (SparkExecutorTestUtils.class) {
+      File tokenFile = Files.createTempFile("spark-executor-ssl", ".tokens").toFile();
+      String tokenFileProperty = UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
+      String previousTokenFile = System.getProperty(tokenFileProperty);
+      try {
+        Credentials credentials = new Credentials();
+        for (int i = 0; i < UserCredentialsFactory.REQUIRED_SECRET_KEY_COUNT; i++) {
+          credentials.addSecretKey(new Text("secret-" + i), ("value-" + i).getBytes(StandardCharsets.UTF_8));
+        }
+        credentials.writeTokenStorageFile(new Path(tokenFile.toURI()), new Configuration());
+        System.setProperty(tokenFileProperty, tokenFile.getAbsolutePath());
+        runnable.run();
+      } finally {
+        if (previousTokenFile == null) {
+          System.clearProperty(tokenFileProperty);
+        } else {
+          System.setProperty(tokenFileProperty, previousTokenFile);
+        }
+        Files.deleteIfExists(tokenFile.toPath());
+      }
+    }
+  }
+
+  public static class RecordingSSLConfigurator implements SSLConfigurator {
+    @Override
+    public Properties setupSSLConfig(Properties properties, Credentials userCredentials) {
+      SSL_CONFIGURATOR_INVOCATIONS.incrementAndGet();
+      Properties sslProperties = new Properties();
+      sslProperties.setProperty(SSL_KEYSTORE_TYPE, TEST_KEYSTORE_TYPE);
+      sslProperties.setProperty(SSL_TRUSTSTORE_TYPE, TEST_TRUSTSTORE_TYPE);
+      sslProperties.setProperty(SSL_KEYSTORE_LOCATION, "/tmp/test-keystore");
+      sslProperties.setProperty(SSL_TRUSTSTORE_LOCATION, "/tmp/test-truststore");
+      sslProperties.setProperty(SSL_KEYSTORE_PASSWORD, "test-password");
+      sslProperties.setProperty(SSL_TRUSTSTORE_PASSWORD, "test-password");
+      sslProperties.setProperty(SSL_KEY_PASSWORD, "test-password");
+      return sslProperties;
+    }
+  }
+
+  public static class AssertingPubSubConsumerAdapterFactory
+      extends PubSubConsumerAdapterFactory<PubSubConsumerAdapter> {
+    @Override
+    public PubSubConsumerAdapter create(PubSubConsumerAdapterContext context) {
+      VeniceProperties properties = context.getVeniceProperties();
+      assertEquals(properties.getString(SSL_KEYSTORE_TYPE), TEST_KEYSTORE_TYPE);
+      assertEquals(properties.getString(SSL_TRUSTSTORE_TYPE), TEST_TRUSTSTORE_TYPE);
+      CONSUMER_FACTORY_INVOCATIONS.incrementAndGet();
+
+      PubSubConsumerAdapter consumer = mock(PubSubConsumerAdapter.class);
+      when(consumer.getAssignment()).thenReturn(Collections.emptySet());
+      if (context.getConsumerName().contains("DictionaryUtilsConsumer")) {
+        DICTIONARY_CONSUMER_INVOCATIONS.incrementAndGet();
+        configureDictionaryConsumer(consumer);
+      }
+      return consumer;
+    }
+
+    private static void configureDictionaryConsumer(PubSubConsumerAdapter consumer) {
+      AtomicReference<PubSubTopicPartition> subscribedPartition = new AtomicReference<>();
+      doAnswer(invocation -> {
+        subscribedPartition.set(invocation.getArgument(0));
+        return null;
+      }).when(consumer).subscribe(any(PubSubTopicPartition.class), any(PubSubPosition.class));
+      doAnswer(invocation -> {
+        PubSubTopicPartition topicPartition = subscribedPartition.get();
+        return Collections
+            .singletonMap(topicPartition, Collections.singletonList(createStartOfPushMessage(topicPartition)));
+      }).when(consumer).poll(anyLong());
+    }
+
+    private static DefaultPubSubMessage createStartOfPushMessage(PubSubTopicPartition topicPartition) {
+      StartOfPush startOfPush = new StartOfPush();
+      startOfPush.compressionStrategy = CompressionStrategy.ZSTD_WITH_DICT.getValue();
+      startOfPush.compressionDictionary = ByteBuffer.wrap(TEST_DICTIONARY);
+
+      ControlMessage controlMessage = new ControlMessage();
+      controlMessage.controlMessageType = ControlMessageType.START_OF_PUSH.getValue();
+      controlMessage.controlMessageUnion = startOfPush;
+      KafkaMessageEnvelope envelope =
+          new KafkaMessageEnvelope(MessageType.CONTROL_MESSAGE.getValue(), null, controlMessage, null);
+      return new ImmutablePubSubMessage(
+          new KafkaKey(MessageType.CONTROL_MESSAGE, new byte[0]),
+          envelope,
+          topicPartition,
+          ApacheKafkaOffsetPosition.of(0),
+          0L,
+          0);
+    }
+
+    @Override
+    public String getName() {
+      return AssertingPubSubConsumerAdapterFactory.class.getSimpleName();
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+  }
+
+  @FunctionalInterface
+  public interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/SparkExecutorTestUtils.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/SparkExecutorTestUtils.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.compression.ZstdWithDictCompressor;
 import com.linkedin.venice.hadoop.ssl.SSLConfigurator;
 import com.linkedin.venice.hadoop.ssl.UserCredentialsFactory;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
@@ -37,6 +38,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -51,7 +53,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 public final class SparkExecutorTestUtils {
   public static final String TEST_KEYSTORE_TYPE = "PKCS12";
   public static final String TEST_TRUSTSTORE_TYPE = "JKS";
-  private static final byte[] TEST_DICTIONARY = "spark-ttl-test-dictionary".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] TEST_DICTIONARY = ZstdWithDictCompressor.buildDictionaryOnSyntheticAvroData();
   private static final AtomicInteger SSL_CONFIGURATOR_INVOCATIONS = new AtomicInteger();
   private static final AtomicInteger CONSUMER_FACTORY_INVOCATIONS = new AtomicInteger();
   private static final AtomicInteger DICTIONARY_CONSUMER_INVOCATIONS = new AtomicInteger();
@@ -75,6 +77,10 @@ public final class SparkExecutorTestUtils {
 
   public static int getDictionaryConsumerInvocations() {
     return DICTIONARY_CONSUMER_INVOCATIONS.get();
+  }
+
+  public static byte[] getTestDictionary() {
+    return Arrays.copyOf(TEST_DICTIONARY, TEST_DICTIONARY.length);
   }
 
   public static void withTokenFile(ThrowingRunnable runnable) throws Exception {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJobRepushTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJobRepushTest.java
@@ -2,9 +2,14 @@ package com.linkedin.venice.spark.datawriter.jobs;
 
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.spark.SparkConstants.RAW_PUBSUB_INPUT_TABLE_SCHEMA;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PARTITION_COUNT;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_PASSWORD_PROPERTY_NAME;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_STORE_PROPERTY_NAME;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_TRUST_STORE_PROPERTY_NAME;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TOPIC_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_PUSH_DESTINATION_PUBSUB_BROKER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
@@ -18,6 +23,7 @@ import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
+import com.linkedin.venice.spark.SparkExecutorTestUtils;
 import com.linkedin.venice.spark.datawriter.task.DataWriterAccumulators;
 import com.linkedin.venice.spark.datawriter.writer.TestSparkPartitionWriter;
 import com.linkedin.venice.utils.ByteUtils;
@@ -214,30 +220,21 @@ public class DataWriterSparkJobRepushTest {
     assertTrue(Arrays.equals(record.rmd, "rmd".getBytes()), "DELETE RMD should match");
   }
 
-  /**
-   * Test applyTTLFilter with TTL enabled to verify the transformation is set up correctly.
-   * This exercises the enabled path in AbstractDataWriterSparkJob.applyTTLFilter().
-   * We verify the filter transformation is applied (returns a transformed Dataset) without
-   * executing the full Spark pipeline to avoid test infrastructure conflicts.
-   */
   @Test
-  public void testApplyTTLFilterEnabledSetup() throws Exception {
-    String testName = "testApplyTTLFilterEnabledSetup";
+  public void testApplyTTLFilterMaterializesSSLBeforeReadingZstdDictionary() throws Exception {
+    String testName = "testApplyTTLFilterMaterializesSSLBeforeReadingZstdDictionary";
 
-    // Create temp directories and schema files
     File valueSchemaTempDir = Files.createTempDirectory("value-schemas").toFile();
     File rmdSchemaTempDir = Files.createTempDirectory("rmd-schemas").toFile();
 
     try {
-      // Create simple schemas for testing
       String valueSchemaStr =
           "{\"type\":\"record\",\"name\":\"TestValue\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"}]}";
       String rmdSchemaStr =
           "{\"type\":\"record\",\"name\":\"RmdRecord\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\"}]}";
 
-      // Write schema files (schema ID 1, RMD version 1)
       File valueSchemaFile = new File(valueSchemaTempDir, "1");
-      File rmdSchemaFile = new File(rmdSchemaTempDir, "1");
+      File rmdSchemaFile = new File(rmdSchemaTempDir, "1_1");
 
       Files.write(valueSchemaFile.toPath(), valueSchemaStr.getBytes());
       Files.write(rmdSchemaFile.toPath(), rmdSchemaStr.getBytes());
@@ -252,10 +249,20 @@ public class DataWriterSparkJobRepushTest {
       props.setProperty("repush.ttl.start.timestamp", String.valueOf(ttlStartTime));
       props.setProperty("value.schema.dir", valueSchemaTempDir.getAbsolutePath());
       props.setProperty("rmd.schema.dir", rmdSchemaTempDir.getAbsolutePath());
-      props.setProperty("kafka.input.source.compression.strategy", "NO_OP");
+      props.setProperty("kafka.input.source.compression.strategy", CompressionStrategy.ZSTD_WITH_DICT.name());
+      props.setProperty(SSL_CONFIGURATOR_CLASS_CONFIG, SparkExecutorTestUtils.RecordingSSLConfigurator.class.getName());
+      props.setProperty(
+          PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS,
+          SparkExecutorTestUtils.AssertingPubSubConsumerAdapterFactory.class.getName());
+      props.setProperty("pass.through.config.prefixes.list", "pubsub.");
+      props.setProperty(SSL_KEY_STORE_PROPERTY_NAME, "test-keystore-credential");
+      props.setProperty(SSL_TRUST_STORE_PROPERTY_NAME, "test-truststore-credential");
+      props.setProperty(SSL_KEY_PASSWORD_PROPERTY_NAME, "test-key-password-credential");
 
       PushJobSetting setting = new PushJobSetting();
       setting.isSourceKafka = true;
+      setting.enableSSL = true;
+      setting.sslToKafka = true;
       setting.kafkaInputTopic = "test_store_v1";
       setting.repushSourcePubsubBroker = "localhost:9092";
       setting.repushTTLEnabled = true; // TTL enabled
@@ -266,25 +273,25 @@ public class DataWriterSparkJobRepushTest {
       setting.pushDestinationPubsubBroker = "localhost:9092";
       setting.partitionerClass = DefaultVenicePartitioner.class.getName();
       setting.partitionCount = 1;
-      setting.sourceKafkaInputVersionInfo = new VersionImpl("test_store", 1, "test-push-id");
+      Version sourceVersion = new VersionImpl("test_store", 1, "test-push-id");
+      sourceVersion.setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT);
+      setting.sourceKafkaInputVersionInfo = sourceVersion;
 
       job.configure(new VeniceProperties(props), setting);
 
-      // Create test DataFrame with chunked records (these skip TTL filtering)
       List<Row> rows =
           Arrays.asList(createChunkedRow("key1", "chunk1", -1, 1L), createChunkedRow("key2", "chunk2", -20, 2L));
       Dataset<Row> inputDF = job.getSparkSession().createDataFrame(rows, RAW_PUBSUB_INPUT_TABLE_SCHEMA);
 
-      // Apply TTL filter - should return a transformed Dataset
-      Dataset<Row> outputDF = job.testableApplyTTLFilter(inputDF);
-
-      // Verify the transformation was applied (outputDF is not null and is a different object)
-      assertNotNull(outputDF, "TTL filter should return a DataFrame");
-      // Don't call count() to avoid Spark execution issues in test environment
-      // The transformation setup itself provides code coverage
-
+      SparkExecutorTestUtils.resetInvocations();
+      SparkExecutorTestUtils.withTokenFile(() -> {
+        List<Row> outputRows = job.testableApplyTTLFilter(inputDF).collectAsList();
+        assertEquals(outputRows.size(), rows.size());
+        assertTrue(SparkExecutorTestUtils.getSslConfiguratorInvocations() > 0);
+        assertTrue(SparkExecutorTestUtils.getConsumerFactoryInvocations() > 0);
+        assertTrue(SparkExecutorTestUtils.getDictionaryConsumerInvocations() > 0);
+      });
     } finally {
-      // Cleanup temp directories
       deleteDirectory(valueSchemaTempDir);
       deleteDirectory(rmdSchemaTempDir);
     }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJobRepushTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJobRepushTest.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.spark.SparkConstants.RAW_PUBSUB_INPUT_TABLE_SCHEMA;
+import static com.linkedin.venice.spark.SparkConstants.SCHEMA_FOR_CHUNK_ASSEMBLY;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PARTITION_COUNT;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
@@ -19,22 +20,37 @@ import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.CompressorFactory;
 import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.hadoop.PushJobSetting;
+import com.linkedin.venice.kafka.protocol.GUID;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
+import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.ChunkedKeySuffixSerializer;
+import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.spark.SparkExecutorTestUtils;
 import com.linkedin.venice.spark.datawriter.task.DataWriterAccumulators;
 import com.linkedin.venice.spark.datawriter.writer.TestSparkPartitionWriter;
+import com.linkedin.venice.storage.protocol.ChunkId;
+import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
+import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.spark.api.java.function.MapPartitionsFunction;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.Dataset;
@@ -297,11 +313,173 @@ public class DataWriterSparkJobRepushTest {
     }
   }
 
+  @Test
+  public void testApplyChunkAssemblyReusesExecutorSSLForPostAssemblyTTL() throws Exception {
+    String testName = "testApplyChunkAssemblyReusesExecutorSSLForPostAssemblyTTL";
+
+    File valueSchemaTempDir = Files.createTempDirectory("value-schemas").toFile();
+    File rmdSchemaTempDir = Files.createTempDirectory("rmd-schemas").toFile();
+
+    try {
+      Schema valueSchema = new Schema.Parser()
+          .parse("{\"type\":\"record\",\"name\":\"TestValue\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"}]}");
+      Schema rmdSchema = new Schema.Parser().parse(
+          "{\"type\":\"record\",\"name\":\"RmdRecord\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\"}]}");
+      Files.write(new File(valueSchemaTempDir, "1").toPath(), valueSchema.toString().getBytes());
+      Files.write(new File(rmdSchemaTempDir, "1_1").toPath(), rmdSchema.toString().getBytes());
+
+      long ttlStartTime = System.currentTimeMillis();
+      GenericRecord valueRecord = new GenericData.Record(valueSchema);
+      valueRecord.put("id", "fresh-value");
+      GenericRecord rmdRecord = new GenericData.Record(rmdSchema);
+      rmdRecord.put("timestamp", ttlStartTime + 1_000);
+
+      RecordSerializer<GenericRecord> valueSerializer =
+          FastSerializerDeserializerFactory.getFastAvroGenericSerializer(valueSchema);
+      RecordSerializer<GenericRecord> rmdSerializer =
+          FastSerializerDeserializerFactory.getFastAvroGenericSerializer(rmdSchema);
+      byte[] serializedValue = valueSerializer.serialize(valueRecord);
+      byte[] serializedRmd = rmdSerializer.serialize(rmdRecord);
+
+      CompressorFactory compressorFactory = new CompressorFactory();
+      VeniceCompressor zstdCompressor = compressorFactory.createVersionSpecificCompressorIfNotExist(
+          CompressionStrategy.ZSTD_WITH_DICT,
+          "spark-chunked-ttl-test",
+          SparkExecutorTestUtils.getTestDictionary());
+      byte[] compressedValue = ByteUtils.extractByteArray(zstdCompressor.compress(ByteBuffer.wrap(serializedValue), 0));
+
+      TestableDataWriterSparkJob job = new TestableDataWriterSparkJob(testName);
+      currentTestJob = job;
+
+      Properties props = createDefaultTestProperties();
+      props.setProperty("repush.ttl.policy", "0");
+      props.setProperty("repush.ttl.start.timestamp", String.valueOf(ttlStartTime));
+      props.setProperty("value.schema.dir", valueSchemaTempDir.getAbsolutePath());
+      props.setProperty("rmd.schema.dir", rmdSchemaTempDir.getAbsolutePath());
+      props.setProperty("kafka.input.source.compression.strategy", CompressionStrategy.ZSTD_WITH_DICT.name());
+      props.setProperty(SSL_CONFIGURATOR_CLASS_CONFIG, SparkExecutorTestUtils.RecordingSSLConfigurator.class.getName());
+      props.setProperty(
+          PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS,
+          SparkExecutorTestUtils.AssertingPubSubConsumerAdapterFactory.class.getName());
+      props.setProperty("pass.through.config.prefixes.list", "pubsub.");
+      props.setProperty(SSL_KEY_STORE_PROPERTY_NAME, "test-keystore-credential");
+      props.setProperty(SSL_TRUST_STORE_PROPERTY_NAME, "test-truststore-credential");
+      props.setProperty(SSL_KEY_PASSWORD_PROPERTY_NAME, "test-key-password-credential");
+
+      PushJobSetting setting = new PushJobSetting();
+      setting.isSourceKafka = true;
+      setting.enableSSL = true;
+      setting.sslToKafka = true;
+      setting.kafkaInputTopic = "test_store_v1";
+      setting.repushSourcePubsubBroker = "localhost:9092";
+      setting.repushTTLEnabled = true;
+      setting.repushTTLStartTimeMs = ttlStartTime;
+      setting.valueSchemaDir = valueSchemaTempDir.getAbsolutePath();
+      setting.rmdSchemaDir = rmdSchemaTempDir.getAbsolutePath();
+      setting.topic = "test_store_v1";
+      setting.pushDestinationPubsubBroker = "localhost:9092";
+      setting.partitionerClass = DefaultVenicePartitioner.class.getName();
+      setting.partitionCount = 1;
+      Version sourceVersion = new VersionImpl("test_store", 1, "test-push-id");
+      sourceVersion.setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT);
+      sourceVersion.setChunkingEnabled(true);
+      setting.sourceKafkaInputVersionInfo = sourceVersion;
+
+      job.configure(new VeniceProperties(props), setting);
+      job.getSparkSession().conf().set("spark.sql.shuffle.partitions", "1");
+
+      byte[] chunkedKey = "chunked-key".getBytes();
+      byte[] regularKey = "regular-key".getBytes();
+      List<Row> rows = new ArrayList<>();
+      rows.addAll(createSingleChunkRows(chunkedKey, compressedValue, serializedRmd));
+      rows.add(createAssemblyRow(regularKey, compressedValue, serializedRmd, 1, 1, 3L, null));
+      Dataset<Row> inputDF = job.getSparkSession().createDataFrame(rows, SCHEMA_FOR_CHUNK_ASSEMBLY);
+
+      SparkExecutorTestUtils.resetInvocations();
+      SparkExecutorTestUtils.withTokenFile(() -> {
+        List<Row> outputRows = job.testableApplyChunkAssembly(inputDF).collectAsList();
+
+        assertEquals(outputRows.size(), 2);
+        Row assembledChunk = outputRows.stream()
+            .filter(row -> Arrays.equals((byte[]) row.getAs("key"), chunkedKey))
+            .findFirst()
+            .orElse(null);
+        assertNotNull(assembledChunk, "Chunked value should survive post-assembly TTL filtering");
+        assertTrue(Arrays.equals((byte[]) assembledChunk.getAs("value"), compressedValue));
+        assertEquals(
+            SparkExecutorTestUtils.getSslConfiguratorInvocations(),
+            1,
+            "Executor SSL should be materialized once for both key groups in the task");
+        assertEquals(
+            SparkExecutorTestUtils.getConsumerFactoryInvocations(),
+            1,
+            "Only one task-local dictionary consumer should be created");
+        assertEquals(SparkExecutorTestUtils.getDictionaryConsumerInvocations(), 1);
+      });
+    } finally {
+      deleteDirectory(valueSchemaTempDir);
+      deleteDirectory(rmdSchemaTempDir);
+    }
+  }
+
   private Row createChunkedRow(String key, String chunkData, int negativeSchemaId, long offset) {
     return new GenericRowWithSchema(
         new Object[] { "region1", 0, offset, MessageType.PUT.getValue(), negativeSchemaId, key.getBytes(),
             chunkData.getBytes(), -1, new byte[0], null },
         RAW_PUBSUB_INPUT_TABLE_SCHEMA);
+  }
+
+  private List<Row> createSingleChunkRows(byte[] key, byte[] value, byte[] rmd) {
+    ChunkId chunkId = new ChunkId();
+    chunkId.segmentNumber = 1;
+    chunkId.messageSequenceNumber = 1;
+    chunkId.chunkIndex = 0;
+    chunkId.producerGUID = new GUID();
+
+    ChunkedKeySuffix suffix = new ChunkedKeySuffix();
+    suffix.chunkId = chunkId;
+    suffix.isChunk = true;
+
+    ChunkedKeySuffixSerializer suffixSerializer = new ChunkedKeySuffixSerializer();
+    byte[] suffixBytes = suffixSerializer.serialize("ignored", suffix);
+
+    ChunkedValueManifest manifest = new ChunkedValueManifest();
+    manifest.keysWithChunkIdSuffix =
+        Collections.singletonList(new KeyWithChunkingSuffixSerializer().serializeChunkedKey(key, suffix));
+    manifest.schemaId = 1;
+    manifest.size = value.length;
+    byte[] manifestBytes = ByteUtils.extractByteArray(new ChunkedValueManifestSerializer(true).serialize(manifest));
+
+    Row manifestRow = createAssemblyRow(
+        key,
+        manifestBytes,
+        rmd,
+        AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion(),
+        1,
+        2L,
+        null);
+    Row chunkRow = createAssemblyRow(
+        key,
+        value,
+        new byte[0],
+        AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion(),
+        -1,
+        1L,
+        suffixBytes);
+    return Arrays.asList(manifestRow, chunkRow);
+  }
+
+  private Row createAssemblyRow(
+      byte[] key,
+      byte[] value,
+      byte[] rmd,
+      int schemaId,
+      int rmdVersionId,
+      long offset,
+      byte[] chunkedKeySuffix) {
+    return new GenericRowWithSchema(
+        new Object[] { key, value, rmd, schemaId, rmdVersionId, offset, MessageType.PUT.getValue(), chunkedKeySuffix },
+        SCHEMA_FOR_CHUNK_ASSEMBLY);
   }
 
   /**
@@ -753,6 +931,10 @@ public class DataWriterSparkJobRepushTest {
 
     public Dataset<Row> testableApplyTTLFilter(Dataset<Row> dataFrame) {
       return super.applyTTLFilter(dataFrame);
+    }
+
+    public Dataset<Row> testableApplyChunkAssembly(Dataset<Row> dataFrame) {
+      return super.applyChunkAssembly(dataFrame);
     }
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/input/pubsub/SparkPubSubPartitionReaderFactoryTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/input/pubsub/SparkPubSubPartitionReaderFactoryTest.java
@@ -1,12 +1,23 @@
 package com.linkedin.venice.spark.input.pubsub;
 
+import static com.linkedin.venice.ConfigKeys.PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_TOPIC_CHUNKING_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
+import static org.testng.Assert.assertTrue;
 
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.spark.SparkExecutorTestUtils;
 import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.vpj.pubsub.input.PubSubPartitionSplit;
 import java.util.Properties;
 import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.connector.read.PartitionReader;
 import org.testng.annotations.Test;
 
 
@@ -24,5 +35,35 @@ public class SparkPubSubPartitionReaderFactoryTest {
     InputPartition invalidPartition = new InputPartition() {
     };
     factory.createReader(invalidPartition);
+  }
+
+  @Test
+  public void testCreateReaderMaterializesExecutorSSL() throws Exception {
+    Properties properties = new Properties();
+    properties.setProperty(VENICE_REPUSH_SOURCE_PUBSUB_BROKER, "localhost:9092");
+    properties.setProperty(KAFKA_INPUT_TOPIC, "test-topic");
+    properties.setProperty(KAFKA_INPUT_SOURCE_TOPIC_CHUNKING_ENABLED, "false");
+    properties
+        .setProperty(SSL_CONFIGURATOR_CLASS_CONFIG, SparkExecutorTestUtils.RecordingSSLConfigurator.class.getName());
+    properties.setProperty(
+        PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS,
+        SparkExecutorTestUtils.AssertingPubSubConsumerAdapterFactory.class.getName());
+
+    PubSubTopicRepository topicRepository = new PubSubTopicRepository();
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(topicRepository.getTopic("test-topic"), 0);
+    PubSubPosition position = ApacheKafkaOffsetPosition.of(0);
+    SparkPubSubInputPartition inputPartition = new SparkPubSubInputPartition(
+        new PubSubPartitionSplit(topicRepository, topicPartition, position, position, 0, 0, 0));
+
+    SparkExecutorTestUtils.resetInvocations();
+    SparkExecutorTestUtils.withTokenFile(() -> {
+      SparkPubSubPartitionReaderFactory factory =
+          new SparkPubSubPartitionReaderFactory(new VeniceProperties(properties));
+      try (PartitionReader<?> reader = factory.createReader(inputPartition)) {
+        assertTrue(reader instanceof SparkPubSubInputPartitionReader);
+      }
+      assertTrue(SparkExecutorTestUtils.getSslConfiguratorInvocations() > 0);
+      assertTrue(SparkExecutorTestUtils.getConsumerFactoryInvocations() > 0);
+    });
   }
 }


### PR DESCRIPTION
## Problem Statement

Spark repushes with TTL filtering create a second PubSub consumer on executors when a source version uses dictionary compression. The regular Spark input reader materializes executor-local SSL properties from Hadoop credentials before creating its consumer, but the TTL filter previously constructed its dictionary consumer directly from the broadcast job properties.

As a result, adapters that require standard keystore and truststore properties can fail during TTL filter initialization even though the main Spark input consumer is configured correctly.

## Solution

Reuse `VPJSSLUtils.setupSSLForExecutor` in both Spark TTL paths. The raw `mapPartitions` filter materializes SSL once per partition before creating `SparkKafkaInputTTLFilter`.

For chunked sources, replace the per-key `flatMapGroups` lambda with a named task-local function object. It lazily materializes executor SSL and creates one `SparkChunkAssembler` per Spark task, then reuses its chunk assembler and post-assembly TTL/compressor state across sequential key groups. Per-key assembly state remains local to each `assembleAndGetValue` call, and a task-completion listener closes the reusable TTL filter. This avoids per-key credential materialization and dictionary-consumer creation.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

Added focused executor-path coverage that:

- executes the raw Spark TTL `mapPartitions` closure via `collectAsList`;
- executes chunk assembly through `flatMapGroups` with source chunking, TTL, SSL, and `ZSTD_WITH_DICT` enabled;
- assembles a real chunk manifest and chunk, runs post-assembly TTL filtering, and keeps a fresh record;
- verifies executor SSL and the dictionary consumer are initialized exactly once for two key groups in one task;
- verifies the regular `SparkPubSubPartitionReaderFactory` path still materializes executor SSL; and
- covers missing and invalid Hadoop token-file failures while restoring the system property.

The new chunked regression test was run against the previous PR HEAD (`f5aceaf1a`) and failed with `Missing required property ssl.keystore.type`, confirming it covers the reported gap.

An SSL-enabled `TestRepushTTLSpark` variant was not added. The focused action-triggering Spark test covers the exact raw and chunked executor paths without broad multi-region SSL client wiring.

Ran:

```text
./gradlew spotlessApply --no-daemon

./gradlew :clients:venice-push-job:test \
  --tests com.linkedin.venice.hadoop.utils.VPJSSLUtilsTest \
  --tests com.linkedin.venice.spark.chunk.SparkChunkAssemblerTest \
  --tests com.linkedin.venice.spark.datawriter.jobs.DataWriterSparkJobRepushTest \
  --tests com.linkedin.venice.spark.input.pubsub.SparkPubSubPartitionReaderFactoryTest \
  --no-daemon

./gradlew :clients:venice-push-job:spotbugsMain --no-daemon
```

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
