### PR TITLE
[da-vinci] Fix NullPointerException in HeartbeatMonitoringService lag cleanup

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -10,6 +10,7 @@ import com.linkedin.davinci.stats.HeartbeatMonitoringServiceStats;
 import com.linkedin.venice.exceptions.VeniceNoHelixResourceException;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.meta.Instance;
+import com.linkedin.venice.meta.Partition;
 import com.linkedin.venice.meta.PartitionAssignment;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
@@ -891,16 +892,21 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
           boolean lingerReplica = isResourceDeleted;
           String replicaId = Utils.getReplicaId(Version.composeKafkaTopic(storeName, versionNum), partition);
           if (!isResourceDeleted) {
-            Set<String> instanceIdSet = partitionAssignment.getPartition(partition)
-                .getAllInstancesSet()
-                .stream()
-                .map(Instance::getNodeId)
-                .collect(Collectors.toSet());
-            if (instanceIdSet.contains(nodeId)) {
-              // Replica is still assigned to this node based on locally cached customized view
-              cleanupHeartbeatMap.remove(replicaId);
-            } else {
+            Partition assignedPartition = partitionAssignment.getPartition(partition);
+            if (assignedPartition == null) {
+              // Partition has not been populated in the customized view yet (e.g. resource exists but this
+              // partition has no reported replicas). Treat the same as "not assigned to this node" rather than
+              // dereferencing a null partition, which previously threw a NullPointerException here.
               lingerReplica = true;
+            } else {
+              Set<String> instanceIdSet =
+                  assignedPartition.getAllInstancesSet().stream().map(Instance::getNodeId).collect(Collectors.toSet());
+              if (instanceIdSet.contains(nodeId)) {
+                // Replica is still assigned to this node based on locally cached customized view
+                cleanupHeartbeatMap.remove(replicaId);
+              } else {
+                lingerReplica = true;
+              }
             }
           }
           if (lingerReplica) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
@@ -993,6 +993,73 @@ public class HeartbeatMonitoringServiceTest {
   }
 
   @Test
+  public void testCleanupLagMonitorHandlesUnpopulatedPartitionWithoutNpe() {
+    // Regression test: PartitionAssignment#getPartition(partitionId) returns null when that partition slot
+    // has not been populated in the customized view yet (e.g. resource exists but this partition has no
+    // reported replicas). checkAndMaybeCleanupLagMonitor previously dereferenced that null Partition directly,
+    // throwing a NullPointerException from the Ingestion-Heartbeat-Lag-Logging-Service-Thread. It should
+    // instead treat the replica as unassigned/lingering, same as the resource-deleted case.
+    HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(1L, 1L, 1L, BufferReplayPolicy.REWIND_FROM_SOP);
+    Version currentVersion = new VersionImpl(TEST_STORE, 1, "1");
+    currentVersion.setHybridStoreConfig(hybridStoreConfig);
+    Store mockStore = mock(Store.class);
+    Mockito.when(mockStore.getName()).thenReturn(TEST_STORE);
+    Mockito.when(mockStore.getCurrentVersion()).thenReturn(currentVersion.getNumber());
+    Mockito.when(mockStore.getHybridStoreConfig()).thenReturn(hybridStoreConfig);
+    Mockito.when(mockStore.getVersion(1)).thenReturn(currentVersion);
+
+    MetricsRepository mockMetricsRepository = new MetricsRepository();
+    ReadOnlyStoreRepository mockReadOnlyRepository = mock(ReadOnlyStoreRepository.class);
+    Mockito.when(mockReadOnlyRepository.getStoreOrThrow(TEST_STORE)).thenReturn(mockStore);
+    doReturn(new StoreVersionInfo(mockStore, currentVersion)).when(mockReadOnlyRepository)
+        .waitVersion(eq(TEST_STORE), eq(1), any(), anyLong());
+
+    Set<String> regions = new HashSet<>();
+    regions.add(LOCAL_FABRIC);
+    String hostname = "localhost";
+    int port = 123;
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(regions).when(serverConfig).getRegionNames();
+    doReturn(LOCAL_FABRIC).when(serverConfig).getRegionName();
+    doReturn(Duration.ofSeconds(5)).when(serverConfig).getServerMaxWaitForVersionInfo();
+    doReturn(hostname).when(serverConfig).getListenerHostname();
+    doReturn(port).when(serverConfig).getListenerPort();
+    doReturn(5).when(serverConfig).getLagMonitorCleanupCycle();
+    String versionTopic = Version.composeKafkaTopic(mockStore.getName(), 1);
+
+    HelixCustomizedViewOfflinePushRepository mockCustomizedViewOfflinePushRepository =
+        mock(HelixCustomizedViewOfflinePushRepository.class);
+    // p0 has no reported replicas yet: getPartition(0) returns null, matching the real
+    // PartitionAssignment#getPartition behavior for an unpopulated slot.
+    PartitionAssignment mockPartitionAssignment = mock(PartitionAssignment.class);
+    doReturn(null).when(mockPartitionAssignment).getPartition(0);
+    doReturn(mockPartitionAssignment).when(mockCustomizedViewOfflinePushRepository)
+        .getPartitionAssignments(versionTopic);
+
+    CompletableFuture<HelixCustomizedViewOfflinePushRepository> mockCVRepositoryFuture =
+        CompletableFuture.completedFuture(mockCustomizedViewOfflinePushRepository);
+
+    HeartbeatMonitoringService heartbeatMonitoringService = new HeartbeatMonitoringService(
+        mockMetricsRepository,
+        mockReadOnlyRepository,
+        serverConfig,
+        mock(HeartbeatMonitoringServiceStats.class),
+        mockCVRepositoryFuture);
+    heartbeatMonitoringService.updateLagMonitor(
+        versionTopic,
+        0,
+        HeartbeatLagMonitorAction.SET_LEADER_MONITOR,
+        Utils.getReplicaId(versionTopic, 0));
+
+    // Must not throw NullPointerException, and the replica should be treated as lingering/unassigned.
+    heartbeatMonitoringService.checkAndMaybeCleanupLagMonitor();
+    Assert.assertEquals(heartbeatMonitoringService.getCleanupHeartbeatMap().size(), 1);
+    Assert.assertEquals(
+        heartbeatMonitoringService.getCleanupHeartbeatMap().get(Utils.getReplicaId(versionTopic, 0)).intValue(),
+        1);
+  }
+
+  @Test
   public void testLargestHeartbeatLag() {
     HeartbeatMonitoringService heartbeatMonitoringService = mock(HeartbeatMonitoringService.class);
     doCallRealMethod().when(heartbeatMonitoringService).getMaxHeartbeatLag(anyLong(), anyMap());


### PR DESCRIPTION
## Problem Statement

`HeartbeatMonitoringService`'s `Ingestion-Heartbeat-Lag-Logging-Service-Thread` was throwing repeated `NullPointerException`s in production (observed thousands of times/day on venice-1). Root cause: `PartitionAssignment.getPartition(partitionId)` returns `null` when that partition slot has not yet been populated in the customized view (e.g. the resource/version exists but no replica has been reported for that specific partition yet). `cleanupStoreVersionPartitionMap` dereferenced the returned `Partition` unconditionally with `.getAllInstancesSet()`, crashing the cleanup/logging cycle for that iteration and leaving stale entries in the heartbeat lag maps mislabeled with whatever `Venice.Version.Role` they were created with — degrading the reliability of both `Venice.Server.Ingestion.Replication.Heartbeat.Delay` and `.Record.Delay` metrics/SLOs.

## Solution

Guard against a `null` return from `PartitionAssignment#getPartition(int)` in `cleanupStoreVersionPartitionMap`, treating it the same as the existing "resource deleted" / unassigned-replica path (mark the replica as lingering) instead of crashing. This mirrors the existing handling for `VeniceNoHelixResourceException` just above it in the same method.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).
- [x] Local code review completed

Added `testCleanupLagMonitorHandlesUnpopulatedPartitionWithoutNpe`, which mocks `PartitionAssignment#getPartition` to return `null` for a partition — reproducing the exact production `NullPointerException` stack trace against the pre-fix code, and passing cleanly with the fix. Ran the full `HeartbeatMonitoringServiceTest` suite (28 tests) — all pass. Also verified `:clients:da-vinci-client:compileJava` succeeds.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
