### PR TITLE
feat(server): add request-triggered thread pool metrics

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/ThreadPoolOtelMetricEntity.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/ThreadPoolOtelMetricEntity.java
@@ -28,6 +28,11 @@ public enum ThreadPoolOtelMetricEntity implements ModuleMetricEntityInterface {
   THREAD_POOL_QUEUE_TASK_DISTRIBUTION(
       "thread_pool.queue.task_distribution", MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS, MetricUnit.NUMBER,
       "Distribution of queued task count over time", Collections.singleton(VENICE_THREAD_POOL_NAME)
+  ),
+  THREAD_POOL_ACTIVE_THREAD_DISTRIBUTION(
+      "thread_pool.thread.active_count_distribution", MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS, MetricUnit.NUMBER,
+      "Distribution of active thread count sampled at request submission time",
+      Collections.singleton(VENICE_THREAD_POOL_NAME)
   );
 
   private final MetricEntity metricEntity;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/ThreadPoolStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/ThreadPoolStats.java
@@ -11,13 +11,15 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 
 /**
- * Stats used to collect the usage of a thread pool including: 1. active thread number, 2. max thread number and 3.
- * queued task number.
+ * Stats used to collect the usage of a thread pool including: 1. active thread number, 2. max thread number, 3.
+ * queued task number and 4. a request-triggered avg/max distribution of active thread count and queued task count.
  */
 public class ThreadPoolStats extends AbstractVeniceStats {
   private final ThreadPoolExecutor threadPoolExecutor;
 
   private final MetricEntityStateBase queuedTasksCountMetric;
+
+  private final MetricEntityStateBase activeThreadCountMetric;
 
   public ThreadPoolStats(MetricsRepository metricsRepository, ThreadPoolExecutor threadPoolExecutor, String name) {
     super(metricsRepository, name);
@@ -72,6 +74,22 @@ public class ThreadPoolStats extends AbstractVeniceStats {
         Arrays.asList(new Avg(), new Max()),
         otelData.getBaseDimensionsMap(),
         otelData.getBaseAttributes());
+
+    /**
+     * The periodic async gauge above reports the active thread count only at metric collection time, which can
+     * miss short-lived bursts of activity between collection intervals. To get a better signal on utilization, we
+     * additionally allow callers to explicitly record the active thread count whenever a new request is submitted
+     * to the thread pool. Recording on every request submission (rather than relying purely on the collection-time
+     * gauge) gives us more data points to compute avg/max active thread count within the metric reporting window.
+     */
+    activeThreadCountMetric = MetricEntityStateBase.create(
+        ThreadPoolOtelMetricEntity.THREAD_POOL_ACTIVE_THREAD_DISTRIBUTION.getMetricEntity(),
+        otelData.getOtelRepository(),
+        this::registerSensor,
+        ThreadPoolTehutiMetricNameEnum.ACTIVE_THREAD_COUNT,
+        Arrays.asList(new Avg(), new Max()),
+        otelData.getBaseDimensionsMap(),
+        otelData.getBaseAttributes());
   }
 
   /**
@@ -83,7 +101,19 @@ public class ThreadPoolStats extends AbstractVeniceStats {
     queuedTasksCountMetric.record(this.threadPoolExecutor.getQueue().size());
   }
 
+  /**
+   * Records the current active thread count as a distribution data point for the active thread count metric.
+   * Callers should invoke this once per incoming request, at the point where the request's work is submitted to
+   * this thread pool, to capture avg/max active thread utilization within the metric reporting window. This is a
+   * best-effort, request-triggered sample: it does not rely on periodic metric collection, so it can surface
+   * utilization spikes that a collection-time gauge would otherwise miss, at the cost of not being a fully
+   * accurate point-in-time measurement.
+   */
+  public void recordActiveThreadCount() {
+    activeThreadCountMetric.record(this.threadPoolExecutor.getActiveCount());
+  }
+
   enum ThreadPoolTehutiMetricNameEnum implements TehutiMetricNameEnum {
-    QUEUED_TASK_COUNT
+    QUEUED_TASK_COUNT, ACTIVE_THREAD_COUNT
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/ThreadPoolOtelMetricEntityTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/ThreadPoolOtelMetricEntityTest.java
@@ -47,6 +47,14 @@ public class ThreadPoolOtelMetricEntityTest {
             MetricUnit.NUMBER,
             "Distribution of queued task count over time",
             Collections.singleton(VENICE_THREAD_POOL_NAME)));
+    map.put(
+        ThreadPoolOtelMetricEntity.THREAD_POOL_ACTIVE_THREAD_DISTRIBUTION,
+        new MetricEntityExpectation(
+            "thread_pool.thread.active_count_distribution",
+            MetricType.MIN_MAX_COUNT_SUM_AGGREGATIONS,
+            MetricUnit.NUMBER,
+            "Distribution of active thread count sampled at request submission time",
+            Collections.singleton(VENICE_THREAD_POOL_NAME)));
     return map;
   }
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/ThreadPoolStatsOtelTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/ThreadPoolStatsOtelTest.java
@@ -129,6 +129,69 @@ public class ThreadPoolStatsOtelTest {
   }
 
   @Test
+  public void testRecordActiveThreadCount() {
+    Mockito.doReturn(6).when(mockThreadPool).getActiveCount();
+    stats.recordActiveThreadCount();
+
+    // OTel histogram
+    validateHistogram(
+        ThreadPoolOtelMetricEntity.THREAD_POOL_ACTIVE_THREAD_DISTRIBUTION.getMetricEntity().getMetricName(),
+        6.0,
+        6.0,
+        1,
+        6.0,
+        threadPoolAttributes());
+
+    // Tehuti
+    validateTehutiMetric("active_thread_count", "Avg", 6.0);
+    validateTehutiMetric("active_thread_count", "Max", 6.0);
+  }
+
+  @Test
+  public void testRecordMultipleActiveThreadCounts() {
+    Mockito.doReturn(2).when(mockThreadPool).getActiveCount();
+    stats.recordActiveThreadCount();
+    Mockito.doReturn(9).when(mockThreadPool).getActiveCount();
+    stats.recordActiveThreadCount();
+
+    // OTel histogram: min=2, max=9, count=2, sum=11
+    validateHistogram(
+        ThreadPoolOtelMetricEntity.THREAD_POOL_ACTIVE_THREAD_DISTRIBUTION.getMetricEntity().getMetricName(),
+        2.0,
+        9.0,
+        2,
+        11.0,
+        threadPoolAttributes());
+
+    // Tehuti Avg/Max independently confirm the distribution.
+    validateTehutiMetric("active_thread_count", "Avg", 5.5);
+    validateTehutiMetric("active_thread_count", "Max", 9.0);
+  }
+
+  /**
+   * Edge case: recording the active thread count must not perturb the periodic, collection-time async gauge for
+   * the same underlying value (active thread count). The two metrics are independent views of the same raw signal:
+   * one is sampled on a timer, the other is sampled on request submission.
+   */
+  @Test
+  public void testRecordActiveThreadCountDoesNotAffectAsyncGauge() {
+    Mockito.doReturn(4).when(mockThreadPool).getActiveCount();
+    stats.recordActiveThreadCount();
+    stats.recordActiveThreadCount();
+    stats.recordActiveThreadCount();
+
+    // The async gauge still reflects the live thread pool state, independent of how many times we recorded.
+    validateAsyncGauge(ThreadPoolOtelMetricEntity.THREAD_POOL_THREAD_ACTIVE_COUNT.getMetricEntity().getMetricName(), 4);
+    validateHistogram(
+        ThreadPoolOtelMetricEntity.THREAD_POOL_ACTIVE_THREAD_DISTRIBUTION.getMetricEntity().getMetricName(),
+        4.0,
+        4.0,
+        3,
+        12.0,
+        threadPoolAttributes());
+  }
+
+  @Test
   public void testBlankThreadPoolNameSanitizedToUnknown() {
     verifyThreadPoolNameDimension("   ", "unknown");
   }
@@ -235,5 +298,6 @@ public class ThreadPoolStatsOtelTest {
 
     ThreadPoolStats localStats = new ThreadPoolStats(repo, pool, poolName);
     localStats.recordQueuedTasksCount();
+    localStats.recordActiveThreadCount();
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/ThreadPoolStatsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/ThreadPoolStatsTest.java
@@ -44,4 +44,63 @@ public class ThreadPoolStatsTest {
       metricsRepository.close();
     }
   }
+
+  @Test
+  public void testRecordActiveThreadCountReportsAvgAndMax() {
+    MetricsRepository metricsRepository = MetricsRepositoryUtils.createSingleThreadedMetricsRepository();
+    try {
+      MockTehutiReporter reporter = new MockTehutiReporter();
+      metricsRepository.addReporter(reporter);
+
+      ThreadPoolExecutor threadPool = Mockito.mock(ThreadPoolExecutor.class);
+      BlockingQueue<Runnable> queue = Mockito.mock(BlockingQueue.class);
+      Mockito.doReturn(queue).when(threadPool).getQueue();
+      Mockito.doReturn(0).when(queue).size();
+      String name = "test_pool_active_thread_count";
+      ThreadPoolStats stats = new ThreadPoolStats(metricsRepository, threadPool, name);
+
+      // Simulate two request submissions observing different active thread counts.
+      Mockito.doReturn(2).when(threadPool).getActiveCount();
+      stats.recordActiveThreadCount();
+      Mockito.doReturn(8).when(threadPool).getActiveCount();
+      stats.recordActiveThreadCount();
+
+      Assert.assertEquals(reporter.query("." + name + "--active_thread_count.Avg").value(), 5.0);
+      Assert.assertEquals(reporter.query("." + name + "--active_thread_count.Max").value(), 8.0);
+    } finally {
+      metricsRepository.close();
+    }
+  }
+
+  /**
+   * Edge case: a thread pool that has never had any active threads (e.g. immediately after construction, before any
+   * request has been submitted) should still be able to record a zero active thread count without error, and the
+   * gauge-based "active_thread_number" (collection-time) metric must remain independent of the request-triggered
+   * "active_thread_count" (Avg/Max) metric.
+   */
+  @Test
+  public void testRecordActiveThreadCountWithZeroActiveThreadsDoesNotThrow() {
+    MetricsRepository metricsRepository = MetricsRepositoryUtils.createSingleThreadedMetricsRepository();
+    try {
+      MockTehutiReporter reporter = new MockTehutiReporter();
+      metricsRepository.addReporter(reporter);
+
+      ThreadPoolExecutor threadPool = Mockito.mock(ThreadPoolExecutor.class);
+      BlockingQueue<Runnable> queue = Mockito.mock(BlockingQueue.class);
+      Mockito.doReturn(queue).when(threadPool).getQueue();
+      Mockito.doReturn(0).when(queue).size();
+      Mockito.doReturn(0).when(threadPool).getActiveCount();
+      String name = "test_pool_idle";
+      ThreadPoolStats stats = new ThreadPoolStats(metricsRepository, threadPool, name);
+
+      stats.recordActiveThreadCount();
+
+      Assert.assertEquals(reporter.query("." + name + "--active_thread_count.Avg").value(), 0.0);
+      Assert.assertEquals(reporter.query("." + name + "--active_thread_count.Max").value(), 0.0);
+      // The collection-time gauge is unaffected by the request-triggered recording.
+      Assert.assertEquals((int) reporter.query("." + name + "--active_thread_number.LambdaStat").value(), 0);
+    } finally {
+      metricsRepository.close();
+    }
+  }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/TestVeniceServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/TestVeniceServer.java
@@ -18,6 +18,7 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.server.VeniceServer;
 import com.linkedin.venice.server.VeniceServerContext;
+import com.linkedin.venice.stats.ThreadPoolStats;
 import io.netty.channel.ChannelHandlerContext;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.Optional;
@@ -82,7 +83,9 @@ public class TestVeniceServer extends VeniceServer {
           ReadMetadataRetriever readMetadataRetriever,
           DiskHealthCheckService diskHealthService,
           StorageEngineBackedCompressorFactory compressorFactory,
-          Optional<ResourceReadUsageTracker> resourceReadUsageTracker) {
+          Optional<ResourceReadUsageTracker> resourceReadUsageTracker,
+          ThreadPoolStats executorThreadPoolStats,
+          ThreadPoolStats computeExecutorThreadPoolStats) {
 
         return new StorageReadRequestHandler(
             serverConfig,
@@ -95,7 +98,9 @@ public class TestVeniceServer extends VeniceServer {
             readMetadataRetriever,
             diskHealthService,
             compressorFactory,
-            resourceReadUsageTracker) {
+            resourceReadUsageTracker,
+            executorThreadPoolStats,
+            computeExecutorThreadPoolStats) {
           @Override
           public void channelRead(ChannelHandlerContext context, Object message) throws Exception {
             RequestHandler handler = requestHandler.get();

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
@@ -62,6 +62,8 @@ public class ListenerService extends AbstractVeniceService {
   private final VeniceServerConfig serverConfig;
   private final ThreadPoolExecutor executor;
   private final ThreadPoolExecutor computeExecutor;
+  private final ThreadPoolStats executorThreadPoolStats;
+  private final ThreadPoolStats computeExecutorThreadPoolStats;
   private final ThreadPoolExecutor grpcExecutor;
   private ThreadPoolExecutor sslHandshakeExecutor;
 
@@ -94,13 +96,14 @@ public class ListenerService extends AbstractVeniceService {
         serverConfig.getRestServiceStorageThreadNum(),
         "StorageExecutionThread",
         serverConfig.getDatabaseLookupQueueCapacity());
-    new ThreadPoolStats(metricsRepository, executor, "storage_execution_thread_pool");
+    executorThreadPoolStats = new ThreadPoolStats(metricsRepository, executor, "storage_execution_thread_pool");
 
     computeExecutor = createThreadPool(
         serverConfig.getServerComputeThreadNum(),
         "StorageComputeThread",
         serverConfig.getComputeQueueCapacity());
-    new ThreadPoolStats(metricsRepository, computeExecutor, "storage_compute_thread_pool");
+    computeExecutorThreadPoolStats =
+        new ThreadPoolStats(metricsRepository, computeExecutor, "storage_compute_thread_pool");
 
     if (sslFactory.isPresent() && serverConfig.getSslHandshakeThreadPoolSize() > 0) {
       this.sslHandshakeExecutor = createThreadPool(
@@ -120,7 +123,9 @@ public class ListenerService extends AbstractVeniceService {
         readMetadataRetriever,
         diskHealthService,
         compressorFactory,
-        resourceReadUsageTracker);
+        resourceReadUsageTracker,
+        executorThreadPoolStats,
+        computeExecutorThreadPoolStats);
 
     HttpChannelInitializer channelInitializer = new HttpChannelInitializer(
         storeMetadataRepository,
@@ -263,7 +268,9 @@ public class ListenerService extends AbstractVeniceService {
       ReadMetadataRetriever readMetadataRetriever,
       DiskHealthCheckService diskHealthService,
       StorageEngineBackedCompressorFactory compressorFactory,
-      Optional<ResourceReadUsageTracker> resourceReadUsageTracker) {
+      Optional<ResourceReadUsageTracker> resourceReadUsageTracker,
+      ThreadPoolStats executorThreadPoolStats,
+      ThreadPoolStats computeExecutorThreadPoolStats) {
     return new StorageReadRequestHandler(
         serverConfig,
         executor,
@@ -275,6 +282,8 @@ public class ListenerService extends AbstractVeniceService {
         readMetadataRetriever,
         diskHealthService,
         compressorFactory,
-        resourceReadUsageTracker);
+        resourceReadUsageTracker,
+        executorThreadPoolStats,
+        computeExecutorThreadPoolStats);
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestHandler.java
@@ -72,6 +72,7 @@ import com.linkedin.venice.serialization.StoreDeserializerCache;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
+import com.linkedin.venice.stats.ThreadPoolStats;
 import com.linkedin.venice.streaming.StreamingConstants;
 import com.linkedin.venice.streaming.StreamingUtils;
 import com.linkedin.venice.utils.AvroRecordUtils;
@@ -119,6 +120,8 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
   private final DiskHealthCheckService diskHealthCheckService;
   private final ThreadPoolExecutor executor;
   private final ThreadPoolExecutor computeExecutor;
+  private final ThreadPoolStats executorThreadPoolStats;
+  private final ThreadPoolStats computeExecutorThreadPoolStats;
   private final StorageEngineRepository storageEngineRepository;
   private final ReadOnlyStoreRepository metadataRepository;
   private final ReadOnlySchemaRepository schemaRepository;
@@ -206,7 +209,9 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
       ReadMetadataRetriever readMetadataRetriever,
       DiskHealthCheckService healthCheckService,
       StorageEngineBackedCompressorFactory compressorFactory,
-      Optional<ResourceReadUsageTracker> optionalResourceReadUsageTracker) {
+      Optional<ResourceReadUsageTracker> optionalResourceReadUsageTracker,
+      ThreadPoolStats executorThreadPoolStats,
+      ThreadPoolStats computeExecutorThreadPoolStats) {
     this(
         serverConfig,
         executor,
@@ -219,6 +224,8 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
         healthCheckService,
         compressorFactory,
         optionalResourceReadUsageTracker,
+        executorThreadPoolStats,
+        computeExecutorThreadPoolStats,
         serverConfig.isKeyValueProfilingEnabled()
             ? s -> new MultiGetResponseWrapper(s, new MultiGetResponseStatsWithSizeProfiling(s))
             : MultiGetResponseWrapper::new,
@@ -246,6 +253,8 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
       DiskHealthCheckService healthCheckService,
       StorageEngineBackedCompressorFactory compressorFactory,
       Optional<ResourceReadUsageTracker> optionalResourceReadUsageTracker,
+      ThreadPoolStats executorThreadPoolStats,
+      ThreadPoolStats computeExecutorThreadPoolStats,
       IntFunction<MultiGetResponseWrapper> multiGetResponseProvider,
       IntFunction<ComputeResponseWrapper> computeResponseProvider) {
     this(
@@ -260,6 +269,8 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
         healthCheckService,
         compressorFactory,
         optionalResourceReadUsageTracker,
+        executorThreadPoolStats,
+        computeExecutorThreadPoolStats,
         multiGetResponseProvider,
         computeResponseProvider,
         new KeyPartitionProfilerManager(
@@ -283,11 +294,15 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
       DiskHealthCheckService healthCheckService,
       StorageEngineBackedCompressorFactory compressorFactory,
       Optional<ResourceReadUsageTracker> optionalResourceReadUsageTracker,
+      ThreadPoolStats executorThreadPoolStats,
+      ThreadPoolStats computeExecutorThreadPoolStats,
       IntFunction<MultiGetResponseWrapper> multiGetResponseProvider,
       IntFunction<ComputeResponseWrapper> computeResponseProvider,
       KeyPartitionProfilerManager keyPartitionProfilerManager) {
     this.executor = executor;
     this.computeExecutor = computeExecutor;
+    this.executorThreadPoolStats = executorThreadPoolStats;
+    this.computeExecutorThreadPoolStats = computeExecutorThreadPoolStats;
     this.storageEngineRepository = storageEngineRepository;
     this.metadataRepository = metadataStoreRepository;
     this.schemaRepository = schemaRepository;
@@ -538,6 +553,7 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
 
   public CompletableFuture<ReadResponse> handleSingleGetRequest(GetRouterRequest request) {
     final int queueLen = this.executor.getQueue().size();
+    this.executorThreadPoolStats.recordActiveThreadCount();
     final long preSubmissionTimeNs = System.nanoTime();
     return CompletableFuture.supplyAsync(() -> {
       if (request.shouldRequestBeTerminatedEarly()) {
@@ -590,6 +606,7 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
         ParallelMultiKeyResponseWrapper::multiGet,
         this.multiGetResponseProvider,
         this.executor,
+        this.executorThreadPoolStats,
         requestContext,
         this::processMultiGet);
   }
@@ -609,6 +626,7 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
       ParallelResponseProvider<R> parallelResponseProvider,
       IntFunction<R> individualResponseProvider,
       ThreadPoolExecutor threadPoolExecutor,
+      ThreadPoolStats threadPoolStats,
       C requestContext,
       SingleBatchProcessor<K, C, R> batchProcessor) {
     int totalKeyNum = keys.size();
@@ -620,6 +638,7 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
     CompletableFuture<Void>[] chunkFutures = new CompletableFuture[chunkCount];
 
     final int queueLen = threadPoolExecutor.getQueue().size();
+    threadPoolStats.recordActiveThreadCount();
     final long preSubmissionTimeNs = System.nanoTime();
     for (int cur = 0; cur < chunkCount; ++cur) {
       final int finalCur = cur;
@@ -698,6 +717,7 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
 
   public CompletableFuture<ReadResponse> handleMultiGetRequest(MultiGetRouterRequestWrapper request) {
     final int queueLen = this.executor.getQueue().size();
+    this.executorThreadPoolStats.recordActiveThreadCount();
     final long preSubmissionTimeNs = System.nanoTime();
     return CompletableFuture.supplyAsync(() -> {
       double submissionWaitTime = LatencyUtils.getElapsedTimeFromNSToMS(preSubmissionTimeNs);
@@ -705,7 +725,6 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
       if (request.shouldRequestBeTerminatedEarly()) {
         throw new VeniceRequestEarlyTerminationException(request.getStoreName());
       }
-
       List<MultiGetRouterRequestKeyV1> keys = request.getKeys();
       MultiGetResponseWrapper responseWrapper = this.multiGetResponseProvider.apply(request.getKeyCount());
       RequestContext requestContext = new RequestContext(request, this);
@@ -729,6 +748,7 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
     }
 
     final int queueLen = this.computeExecutor.getQueue().size();
+    this.computeExecutorThreadPoolStats.recordActiveThreadCount();
     final long preSubmissionTimeNs = System.nanoTime();
     return CompletableFuture.supplyAsync(() -> {
       if (request.shouldRequestBeTerminatedEarly()) {
@@ -768,6 +788,7 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
         ParallelMultiKeyResponseWrapper::compute,
         this.computeResponseProvider,
         this.computeExecutor,
+        this.computeExecutorThreadPoolStats,
         requestContext,
         this::processCompute);
   }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -110,6 +110,7 @@ import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import com.linkedin.venice.stats.ServerHttpRequestStats;
+import com.linkedin.venice.stats.ThreadPoolStats;
 import com.linkedin.venice.stats.dimensions.HttpResponseStatusCodeCategory;
 import com.linkedin.venice.stats.dimensions.HttpResponseStatusEnum;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
@@ -195,6 +196,8 @@ public class StorageReadRequestHandlerTest {
   private final IngestionMetadataRetriever ingestionMetadataRetriever = mock(IngestionMetadataRetriever.class);
   private final ReadMetadataRetriever readMetadataRetriever = mock(ReadMetadataRetriever.class);
   private final VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+  private final ThreadPoolStats executorThreadPoolStats = mock(ThreadPoolStats.class);
+  private final ThreadPoolStats computeExecutorThreadPoolStats = mock(ThreadPoolStats.class);
   private final VenicePartitioner partitioner = new SimplePartitioner();
   private final ChunkedValueManifestSerializer chunkedValueManifestSerializer =
       new ChunkedValueManifestSerializer(true);
@@ -235,7 +238,9 @@ public class StorageReadRequestHandlerTest {
         ingestionMetadataRetriever,
         readMetadataRetriever,
         serverConfig,
-        context);
+        context,
+        executorThreadPoolStats,
+        computeExecutorThreadPoolStats);
   }
 
   private enum ParallelQueryProcessing {
@@ -281,6 +286,8 @@ public class StorageReadRequestHandlerTest {
         healthCheckService,
         compressorFactory,
         Optional.empty(),
+        executorThreadPoolStats,
+        computeExecutorThreadPoolStats,
         multiGetResponseProvider,
         ComputeResponseWrapper::new);
   }
@@ -760,7 +767,9 @@ public class StorageReadRequestHandlerTest {
     if (!readComputationEnabled) {
       HttpShortcutResponse errorResponse = (HttpShortcutResponse) argumentCaptor.getValue();
       assertEquals(errorResponse.getStatus(), HttpResponseStatus.METHOD_NOT_ALLOWED);
+      verify(computeExecutorThreadPoolStats, never()).recordActiveThreadCount();
     } else {
+      verify(computeExecutorThreadPoolStats, times(1)).recordActiveThreadCount();
       ComputeResponseWrapper computeResponse = (ComputeResponseWrapper) argumentCaptor.getValue();
       assertEquals(computeResponse.isStreamingResponse(), request.isStreamingRequest());
       assertEquals(computeResponse.getCompressionStrategy(), CompressionStrategy.NO_OP);
@@ -1101,6 +1110,7 @@ public class StorageReadRequestHandlerTest {
       AdminResponse startResp = (AdminResponse) argumentCaptor.getValue();
       assertEquals(startResp.isError(), false, startResp.getMessage());
       assertTrue(startResp.getMessage().contains("status=STARTED"), startResp.getMessage());
+      assertTrue(startResp.serializedResponse().length > 0, "START response should serialize");
       assertTrue(manager.isAnyProfilingActive(), "fast-path flag should flip after START");
 
       // Step 2: send a handful of single-get reads that should all flow through the profiler.
@@ -1139,6 +1149,7 @@ public class StorageReadRequestHandlerTest {
       AdminResponse stopResp = (AdminResponse) stopCaptor.getValue();
       assertEquals(stopResp.isError(), false, stopResp.getMessage());
       assertTrue(stopResp.getMessage().contains("stopped active profiling session"), stopResp.getMessage());
+      assertTrue(stopResp.serializedResponse().length > 0, "STOP response should serialize");
       assertTrue(!manager.isAnyProfilingActive(), "fast-path flag should clear after STOP");
       assertNull(manager.getProfiler(storeName), null);
     } finally {
@@ -1191,6 +1202,196 @@ public class StorageReadRequestHandlerTest {
     } finally {
       manager.shutdown();
     }
+  }
+
+  /**
+   * VENG-11686: whenever a request is submitted to a storage-engine thread pool, we should record exactly one
+   * request-triggered active thread count sample on the {@link ThreadPoolStats} retained for that pool, and we
+   * should never record on the other pool's stats. These tests cover the single-get, sequential multi-get/compute,
+   * and parallel multi-get/compute submission points, plus the edge case of a parallel batch spanning multiple
+   * chunks, which must still record exactly once per request (not once per chunk).
+   */
+  @Test
+  public void testRecordActiveThreadCountOnSingleGet() throws Exception {
+    String keyString = "test-key";
+    GetRouterRequest request = mock(GetRouterRequest.class);
+    doReturn(false).when(request).shouldRequestBeTerminatedEarly();
+    doReturn(SINGLE_GET).when(request).getRequestType();
+    doReturn(version.kafkaTopicName()).when(request).getResourceName();
+    doReturn(keyString.getBytes()).when(request).getKeyBytes();
+
+    StorageReadRequestHandler requestHandler = createStorageReadRequestHandler();
+    requestHandler.channelRead(context, request);
+
+    verify(context, times(1)).writeAndFlush(any());
+    verify(executorThreadPoolStats, times(1)).recordActiveThreadCount();
+    verify(computeExecutorThreadPoolStats, never()).recordActiveThreadCount();
+  }
+
+  @Test
+  public void testRecordActiveThreadCountOnSequentialMultiGet() throws Exception {
+    doReturn(false).when(serverConfig).isEnableParallelBatchGet();
+
+    MultiGetRouterRequestWrapper request = mock(MultiGetRouterRequestWrapper.class);
+    doReturn(false).when(request).shouldRequestBeTerminatedEarly();
+    doReturn(RequestType.MULTI_GET).when(request).getRequestType();
+    doReturn(version.kafkaTopicName()).when(request).getResourceName();
+    doReturn(false).when(request).isStreamingRequest();
+    doReturn(Collections.emptyList()).when(request).getKeys();
+    doReturn(0).when(request).getKeyCount();
+
+    StorageReadRequestHandler requestHandler = createStorageReadRequestHandler();
+    requestHandler.channelRead(context, request);
+
+    verify(context, times(1)).writeAndFlush(any());
+    verify(executorThreadPoolStats, times(1)).recordActiveThreadCount();
+    verify(computeExecutorThreadPoolStats, never()).recordActiveThreadCount();
+  }
+
+  @Test
+  public void testSequentialMultiGetContextFailureIsTranslatedAsynchronously() throws Exception {
+    doReturn(false).when(serverConfig).isEnableParallelBatchGet();
+    doReturn(null).when(storageEngineRepository).getLocalStorageEngine(any());
+
+    MultiGetRouterRequestWrapper request = mock(MultiGetRouterRequestWrapper.class);
+    doReturn(false).when(request).shouldRequestBeTerminatedEarly();
+    doReturn(RequestType.MULTI_GET).when(request).getRequestType();
+    doReturn("missing-store_v1").when(request).getResourceName();
+    doReturn("missing-store").when(request).getStoreName();
+    doReturn(Collections.emptyList()).when(request).getKeys();
+    doReturn(0).when(request).getKeyCount();
+
+    StorageReadRequestHandler requestHandler = createStorageReadRequestHandler();
+    requestHandler.channelRead(context, request);
+
+    verify(context, times(1)).writeAndFlush(argumentCaptor.capture());
+    assertTrue(argumentCaptor.getValue() instanceof HttpShortcutResponse);
+    assertTrue(((HttpShortcutResponse) argumentCaptor.getValue()).getMessage().contains("missing-store_v1"));
+    verify(executorThreadPoolStats, times(1)).recordActiveThreadCount();
+  }
+
+  /**
+   * Edge case: a parallel multi-get spanning several chunks must still record the active thread count exactly once
+   * per request submission, not once per chunk, even though the work fans out into multiple parallel tasks.
+   */
+  @Test
+  public void testRecordActiveThreadCountOnParallelMultiGetRecordsOnceAcrossChunks() throws Exception {
+    doReturn(true).when(serverConfig).isEnableParallelBatchGet();
+    doReturn(1).when(serverConfig).getParallelBatchGetChunkSize();
+
+    RecordSerializer<MultiGetRouterRequestKeyV1> serializer =
+        SerializerDeserializerFactory.getAvroGenericSerializer(MultiGetRouterRequestKeyV1.SCHEMA$);
+    VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer("\"string\"");
+    List<MultiGetRouterRequestKeyV1> keys = new ArrayList<>();
+    int recordCount = 5; // with chunk size 1, this yields 5 parallel chunks
+    for (int i = 0; i < recordCount; ++i) {
+      MultiGetRouterRequestKeyV1 requestKey = new MultiGetRouterRequestKeyV1();
+      requestKey.keyBytes = ByteBuffer.wrap(keySerializer.serialize(null, "key_" + i));
+      requestKey.keyIndex = i;
+      requestKey.partitionId = 0;
+      keys.add(requestKey);
+    }
+
+    String uri = "/" + TYPE_STORAGE + "/test-topic_v1";
+    FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, uri);
+    httpRequest.headers()
+        .set(
+            HttpConstants.VENICE_API_VERSION,
+            ReadAvroProtocolDefinition.MULTI_GET_ROUTER_REQUEST_V1.getProtocolVersion());
+    httpRequest.content().writeBytes(serializer.serializeObjects(keys));
+    MultiGetRouterRequestWrapper request = MultiGetRouterRequestWrapper
+        .parseMultiGetHttpRequest(httpRequest, RequestHelper.getRequestParts(URI.create(uri)));
+
+    StorageReadRequestHandler requestHandler = createStorageReadRequestHandler(true, MultiGetResponseWrapper::new);
+    requestHandler.channelRead(context, request);
+
+    verify(context, timeout(1000).times(1)).writeAndFlush(any());
+    // Exactly one sample for the whole request, regardless of the 5 parallel chunks it fanned out into.
+    verify(executorThreadPoolStats, times(1)).recordActiveThreadCount();
+    verify(computeExecutorThreadPoolStats, never()).recordActiveThreadCount();
+  }
+
+  private ComputeRouterRequestWrapper buildComputeRequestForActiveThreadCountTests(
+      List<ComputeRouterRequestKeyV1> keys) {
+    String valueSchemaStr =
+        "{\"type\": \"record\", \"name\": \"User\"," + " \"fields\": [{\"name\": \"name\", \"type\": \"string\"}]}";
+    Schema valueSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(valueSchemaStr);
+    SchemaEntry valueSchemaEntry = new SchemaEntry(1, valueSchema);
+    doReturn(valueSchemaEntry).when(schemaRepository).getValueSchema(any(), anyInt());
+
+    ComputeRequest computeRequest = new ComputeRequest();
+    computeRequest.setOperations(Collections.emptyList());
+    computeRequest.setResultSchemaStr(new org.apache.avro.util.Utf8(valueSchemaStr));
+
+    ComputeRouterRequestWrapper request = mock(ComputeRouterRequestWrapper.class);
+    doReturn(keys).when(request).getKeys();
+    doReturn(keys.size()).when(request).getKeyCount();
+    doReturn("test-store_v1").when(request).getResourceName();
+    doReturn("test-store").when(request).getStoreName();
+    doReturn(RequestType.COMPUTE).when(request).getRequestType();
+    doReturn(computeRequest).when(request).getComputeRequest();
+    doReturn(1).when(request).getValueSchemaId();
+    doReturn(false).when(request).shouldRequestBeTerminatedEarly();
+    doReturn(false).when(request).isStreamingRequest();
+    return request;
+  }
+
+  @Test
+  public void testRecordActiveThreadCountOnSequentialCompute() throws Exception {
+    doReturn(false).when(serverConfig).isEnableParallelBatchGet();
+    doReturn(true).when(storeRepository).isReadComputationEnabled(any());
+
+    ComputeRouterRequestWrapper request = buildComputeRequestForActiveThreadCountTests(Collections.emptyList());
+
+    StorageReadRequestHandler requestHandler = createStorageReadRequestHandler();
+    requestHandler.channelRead(context, request);
+
+    verify(context, timeout(1000).times(1)).writeAndFlush(any());
+    verify(computeExecutorThreadPoolStats, times(1)).recordActiveThreadCount();
+    verify(executorThreadPoolStats, never()).recordActiveThreadCount();
+  }
+
+  @Test
+  public void testSequentialComputeContextFailureIsTranslatedAsynchronously() throws Exception {
+    doReturn(false).when(serverConfig).isEnableParallelBatchGet();
+    doReturn(true).when(storeRepository).isReadComputationEnabled(any());
+    doReturn(null).when(storageEngineRepository).getLocalStorageEngine(any());
+
+    ComputeRouterRequestWrapper request = buildComputeRequestForActiveThreadCountTests(Collections.emptyList());
+
+    StorageReadRequestHandler requestHandler = createStorageReadRequestHandler();
+    requestHandler.channelRead(context, request);
+
+    verify(context, times(1)).writeAndFlush(argumentCaptor.capture());
+    assertTrue(argumentCaptor.getValue() instanceof HttpShortcutResponse);
+    assertTrue(((HttpShortcutResponse) argumentCaptor.getValue()).getMessage().contains("test-store_v1"));
+    verify(computeExecutorThreadPoolStats, times(1)).recordActiveThreadCount();
+  }
+
+  /**
+   * Edge case: a parallel compute request spanning several chunks must still record the active thread count exactly
+   * once per request submission, not once per chunk.
+   */
+  @Test
+  public void testRecordActiveThreadCountOnParallelComputeRecordsOnceAcrossChunks() throws Exception {
+    doReturn(true).when(serverConfig).isEnableParallelBatchGet();
+    doReturn(1).when(serverConfig).getParallelBatchGetChunkSize();
+    doReturn(true).when(storeRepository).isReadComputationEnabled(any());
+
+    int recordCount = 5; // with chunk size 1, this yields 5 parallel chunks
+    List<ComputeRouterRequestKeyV1> keys = new ArrayList<>();
+    for (int i = 0; i < recordCount; ++i) {
+      keys.add(new ComputeRouterRequestKeyV1(i, ByteBuffer.wrap(("key_" + i).getBytes()), 0));
+    }
+    ComputeRouterRequestWrapper request = buildComputeRequestForActiveThreadCountTests(keys);
+
+    StorageReadRequestHandler requestHandler = createStorageReadRequestHandler();
+    requestHandler.channelRead(context, request);
+
+    verify(context, timeout(1000).times(1)).writeAndFlush(any());
+    // Exactly one sample for the whole request, regardless of the 5 parallel chunks it fanned out into.
+    verify(computeExecutorThreadPoolStats, times(1)).recordActiveThreadCount();
+    verify(executorThreadPoolStats, never()).recordActiveThreadCount();
   }
 
   private SchemaReader getMockSchemaReader(Schema keySchema, Schema valueSchema) {


### PR DESCRIPTION
## Summary

Add request-triggered active-thread sampling for the Venice server storage and compute thread pools. This captures short-lived utilization spikes that can occur between periodic gauge collection intervals.

Related issue: [VENG-11686](https://linkedin.atlassian.net/browse/VENG-11686)

## Implementation

- Add the `thread_pool.thread.active_count_distribution` OpenTelemetry metric with min, max, count, and sum aggregations.
- Record the current active-thread count at request submission time for single-get, multi-get, and compute requests.
- Report average and maximum samples through the corresponding Tehuti sensor.
- Sample parallel multi-key requests once per logical request before chunk submission, rather than once per chunk.

The existing collection-time active-thread and queue gauges remain unchanged. Their semantics are still instantaneous snapshots taken when metrics are collected. The new distribution is a best-effort, request-triggered view intended to surface activity between collection intervals. This change does not modify connection metrics.

## Testing

Ran the targeted unit tests with JDK 17:

```shell
./gradlew --no-daemon \
  :internal:venice-client-common:test \
  --tests com.linkedin.venice.stats.ThreadPoolOtelMetricEntityTest \
  --tests com.linkedin.venice.stats.ThreadPoolStatsOtelTest \
  --tests com.linkedin.venice.stats.ThreadPoolStatsTest \
  :services:venice-server:test \
  --tests com.linkedin.venice.listener.StorageReadRequestHandlerTest
```

The tests cover metric registration and aggregation, preservation of the existing gauges, idle pools, request routing to the correct pool, failure paths, and once-per-logical-request sampling for parallel multi-get and compute requests.

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated, not required for this metric-only change
- [ ] CI passing
- [x] No breaking changes