### PR TITLE
[protocol][build] Stage MetadataResponseRecord v4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -331,6 +331,10 @@ subprojects {
       def versionOverrides = [
           project(':internal:venice-common').file('src/main/resources/avro/StoreMetaValue/v46', PathValidation.DIRECTORY),
           project(':services:venice-controller').file('src/main/resources/avro/AdminOperation/v101', PathValidation.DIRECTORY),
+          // MetadataResponseRecord v4 stages VersionProperties.storageMode (mirrors StoreVersion.storageMode from
+          // StoreMetaValue v44). Pinned to the current active version until SERVER_METADATA_RESPONSE is bumped and
+          // the server populate + Fast Client read land in a follow-up PR.
+          project(':internal:venice-common').file('src/main/resources/avro/MetadataResponseRecord/v3', PathValidation.DIRECTORY),
       ]
 
       def schemaDirs = [sourceDir]

--- a/build.gradle
+++ b/build.gradle
@@ -328,7 +328,12 @@ subprojects {
       // Protocol changes should pin the current version via this override and remove the override in a follow-up PR
       // when actually using the new protocol. Example to pin KME to v12 when introducing v13:
       // project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
-      def versionOverrides = []
+      def versionOverrides = [
+          // MetadataResponseRecord v4 stages VersionProperties.storageMode (mirrors StoreVersion.storageMode from
+          // StoreMetaValue v44). Pinned to the current active version until SERVER_METADATA_RESPONSE is bumped and
+          // the server populate + Fast Client read land in a follow-up PR.
+          project(':internal:venice-common').file('src/main/resources/avro/MetadataResponseRecord/v3', PathValidation.DIRECTORY),
+      ]
 
       def schemaDirs = [sourceDir]
       sourceDir.eachDir { typeDir ->

--- a/internal/venice-common/src/main/resources/avro/MetadataResponseRecord/v4/MetadataResponseRecord.avsc
+++ b/internal/venice-common/src/main/resources/avro/MetadataResponseRecord/v4/MetadataResponseRecord.avsc
@@ -1,0 +1,144 @@
+{
+  "type": "record",
+  "name": "MetadataResponseRecord",
+  "namespace": "com.linkedin.venice.metadata.response",
+  "doc": "This record will store version properties, key & value schemas, and routing information",
+  "fields": [
+    {
+      "name": "versionMetadata",
+      "doc": "The current version number and other version properties such as the compression strategy",
+      "type": [
+        "null",
+        {
+          "name": "VersionProperties",
+          "type": "record",
+          "fields": [
+            {
+              "name": "currentVersion",
+              "doc": "Current version number",
+              "type": "int"
+            },
+            {
+              "name": "compressionStrategy",
+              "doc": "The current version's compression strategy. 0 -> NO_OP, 1 -> GZIP, 2 -> ZSTD, 3 -> ZSTD_WITH_DICT",
+              "type": {
+                "name": "CompressionStrategy",
+                "type": "int"
+              }
+            },
+            {
+              "name": "partitionCount",
+              "doc": "Partition count of the current version",
+              "type": "int"
+            },
+            {
+              "name": "partitionerClass",
+              "doc": "Partitioner class name",
+              "type": "string"
+            },
+            {
+              "name": "partitionerParams",
+              "doc": "Partitioner parameters",
+              "type": {
+                "type": "map",
+                "values": "string"
+              }
+            },
+            {
+              "name": "amplificationFactor",
+              "doc": "Partitioner amplification factor",
+              "type": "int"
+            },
+            {
+              "name": "storageMode",
+              "doc": "Storage mode of the current version. Controls where data for this version is persisted in addition to (or instead of) Venice local storage. 0 => INTERNAL (default, Venice-only); 1 => DUAL_WRITE (data is written to both Venice local storage and the configured external storage); 2 => EXTERNAL (external-storage-only; Venice's data partition becomes NoOp while metadata partitions are still persisted locally for checkpointing).",
+              "type": "int",
+              "default": 0
+            }
+          ]
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "versions",
+      "doc": "List of all version numbers",
+      "type": {
+        "type": "array",
+        "items": "int"
+      }
+    },
+    {
+      "name": "keySchema",
+      "doc": "Key schema",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "string"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "valueSchemas",
+      "doc": "Value schemas",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "string"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "latestSuperSetValueSchemaId",
+      "doc": "Latest super set value schema ID",
+      "type": [
+        "null",
+        "int"
+      ],
+      "default": null
+    },
+    {
+      "name": "routingInfo",
+      "doc": "Routing table information, maps resource to partition ID to a list of replicas",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "array",
+            "items": "string"
+          }
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "helixGroupInfo",
+      "doc": "Helix group information, maps replicas to their respective groups",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "int"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "batchGetLimit",
+      "doc": "The max key number allowed in a batch get request",
+      "type": "int",
+      "default": 150
+    },
+    {
+      "name": "externalStorageReadMode",
+      "doc": "Store-level read routing for clients backed by both Venice local storage and a configured external storage system. 0 => VENICE_ONLY (default, reads served from Venice local storage only -- current behavior); 1 => DUAL_MODE_CONSISTENCY_CHECK; 2 => DUAL_MODE_EARLY_RETURN; 3 => EXTERNAL_ONLY.",
+      "type": "int",
+      "default": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Stage `MetadataResponseRecord` v4 with a defaulted `storageMode` field in `VersionProperties`. Keep code generation and the runtime protocol pinned to v3 so this change can roll out before activation.

The field defaults to `INTERNAL` (`0`) for compatibility with older writers.

## Testing

- `./gradlew :internal:venice-common:compileJava`
- Confirmed generated `VersionProperties` does not contain `storageMode` while the v3 override is active
- Confirmed `SERVER_METADATA_RESPONSE` remains at version 3