### PR TITLE
[client] Remove dead router-fallback path from ControllerClient.discoverCluster

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -86,6 +86,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.LastSucceedExecutionIdResponse;
 import com.linkedin.venice.controllerapi.routes.AdminCommandExecutionResponse;
+import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceHttpException;
 import com.linkedin.venice.helix.VeniceJsonSerializer;
@@ -1395,12 +1396,25 @@ public class ControllerClient implements Closeable {
     try (ControllerTransport transport = new ControllerTransport(sslFactory)) {
       for (String url: urls) {
         try {
-          // ControllerClient and D2ControllerClient only target VeniceController hosts via controller discovery URLs,
-          // so the legacy router-style /discover_cluster/{storeName} fallback is dead code here.
-          QueryParams params = getQueryParamsToDiscoverCluster(storeName);
-          return transport.request(url, ControllerRoute.CLUSTER_DISCOVERY, params, D2ServiceDiscoveryResponse.class);
+          try {
+            QueryParams params = getQueryParamsToDiscoverCluster(storeName);
+            return transport.request(url, ControllerRoute.CLUSTER_DISCOVERY, params, D2ServiceDiscoveryResponse.class);
+          } catch (VeniceHttpException e) {
+            if (e.getErrorType() == ErrorType.STORE_NOT_FOUND) {
+              lastException = e;
+              break;
+            }
+
+            if (e.getErrorType() == ErrorType.GENERAL_ERROR && e.getHttpStatusCode() == 404) {
+              lastException =
+                  new VeniceHttpException(e.getHttpStatusCode(), e.getMessage(), e, ErrorType.STORE_NOT_FOUND);
+              break;
+            }
+
+            throw e;
+          }
         } catch (Exception e) {
-          LOGGER.warn("Unable to discover cluster for store {} from {}", storeName, url);
+          LOGGER.warn("Unable to discover cluster for store {} from {}", storeName, url, e);
           if (ExceptionUtils.recursiveClassEquals(e, ConnectException.class)) {
             lastConnectException = e;
           } else {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -86,7 +86,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.LastSucceedExecutionIdResponse;
 import com.linkedin.venice.controllerapi.routes.AdminCommandExecutionResponse;
-import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceHttpException;
 import com.linkedin.venice.helix.VeniceJsonSerializer;
@@ -1396,35 +1395,10 @@ public class ControllerClient implements Closeable {
     try (ControllerTransport transport = new ControllerTransport(sslFactory)) {
       for (String url: urls) {
         try {
-          // Because the way to get parameter is different between controller and router, in order to support query
-          // cluster from both cluster and router, we send the path "/discover_cluster?storename=$storeName" at first,
-          // if it does not work, try "/discover_cluster/$storeName"
-          try {
-            QueryParams params = getQueryParamsToDiscoverCluster(storeName);
-            return transport.request(url, ControllerRoute.CLUSTER_DISCOVERY, params, D2ServiceDiscoveryResponse.class);
-          } catch (VeniceHttpException e) {
-            // TODO: Routers also support fetching the store name via query params. So, once sufficient time has passed,
-            // this check can be changed to break out of the loop on non-5XX errors.
-
-            // Do not attempt querying further if host explicitly returns that store was not found.
-            // If Controllers have been upgraded to recent versions, they will return the proper STORE_NOT_FOUND
-            // ErrorType.
-            if (e.getErrorType() == ErrorType.STORE_NOT_FOUND) {
-              lastException = e;
-              break;
-            }
-
-            // If Controllers have not been upgraded recently, they will return a 404 status with GENERAL_ERROR as the
-            // ErrorType.
-            if (e.getErrorType() == ErrorType.GENERAL_ERROR && e.getHttpStatusCode() == 404) {
-              lastException =
-                  new VeniceHttpException(e.getHttpStatusCode(), e.getMessage(), e, ErrorType.STORE_NOT_FOUND);
-              break;
-            }
-
-            String routerPath = ControllerRoute.CLUSTER_DISCOVERY.getPath() + "/" + storeName;
-            return transport.executeGet(url, routerPath, new QueryParams(), D2ServiceDiscoveryResponse.class);
-          }
+          // ControllerClient and D2ControllerClient only target VeniceController hosts via controller discovery URLs,
+          // so the legacy router-style /discover_cluster/{storeName} fallback is dead code here.
+          QueryParams params = getQueryParamsToDiscoverCluster(storeName);
+          return transport.request(url, ControllerRoute.CLUSTER_DISCOVERY, params, D2ServiceDiscoveryResponse.class);
         } catch (Exception e) {
           LOGGER.warn("Unable to discover cluster for store {} from {}", storeName, url);
           if (ExceptionUtils.recursiveClassEquals(e, ConnectException.class)) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
@@ -209,7 +209,8 @@ public class TestControllerClient {
         Assert.assertTrue(nonExistentStoreDiscoResponseInvalidAndLegacy.isError());
         Assert.assertEquals(nonExistentStoreDiscoResponseInvalidAndLegacy.getErrorType(), ErrorType.STORE_NOT_FOUND);
 
-        // Non-store-not-found controller errors still surface as errors after trying the available controller URLs.
+        // Backward compatibility test. Errors which cannot be identified as STORE_NOT_FOUND still surface as the
+        // original request-path failure, even though the legacy router-style path fallback is no longer attempted.
         D2ServiceDiscoveryResponse errorDiscoResponseInvalidAndLegacy = ControllerClient.discoverCluster(
             nonExistentControllerUrl1 + "," + validControllerUrl,
             errorResponseStoreName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
@@ -209,15 +209,14 @@ public class TestControllerClient {
         Assert.assertTrue(nonExistentStoreDiscoResponseInvalidAndLegacy.isError());
         Assert.assertEquals(nonExistentStoreDiscoResponseInvalidAndLegacy.getErrorType(), ErrorType.STORE_NOT_FOUND);
 
-        // Backward compatibility test. When the controller/router doesn't return STORE_NOT_FOUND, and the client cannot
-        // identify it as a STORE_NOT_FOUND error, try to query routers using the path param type of cluster discovery
+        // Non-store-not-found controller errors still surface as errors after trying the available controller URLs.
         D2ServiceDiscoveryResponse errorDiscoResponseInvalidAndLegacy = ControllerClient.discoverCluster(
             nonExistentControllerUrl1 + "," + validControllerUrl,
             errorResponseStoreName,
             Optional.empty(),
             1);
         Assert.assertTrue(errorDiscoResponseInvalidAndLegacy.isError());
-        Assert.assertEquals(errorDiscoResponseInvalidAndLegacy.getErrorType(), ErrorType.BAD_REQUEST);
+        Assert.assertEquals(errorDiscoResponseInvalidAndLegacy.getErrorType(), ErrorType.GENERAL_ERROR);
       });
 
       try (ControllerClient controllerClient =


### PR DESCRIPTION
## Problem Statement

`ControllerClient.discoverCluster(String storeName)` sends the `/discover_cluster?store_name=X` query-param request first, then falls back to a router-style path-form request (`/discover_cluster/X`) on any non-`STORE_NOT_FOUND` `VeniceHttpException`. That fallback exists to let the same code path work against both controllers and routers.

However, `ControllerClient` (and its D2-based subclass `D2ControllerClient`) only ever construct URLs/D2 service names pointing at controller hosts — `VeniceController`, never `VeniceRouter`. So the router-style fallback path is dead code for every real caller (admin-tool, `StoreMigrationTask`, controller-client factories, samza) and only adds an extra request on the retry path for genuine (non-router) controller errors.

## Solution

- Removed the router-style path-form fallback (`transport.executeGet(url, routerPath, ...)`) from `discoverCluster`, since `ControllerClient`/`D2ControllerClient` never target routers.
- Kept the existing legacy backward-compatibility inference intact: if a controller returns `ErrorType.STORE_NOT_FOUND` directly, or a 404 with `ErrorType.GENERAL_ERROR` (older controllers predating the `STORE_NOT_FOUND` error type), the client still infers `STORE_NOT_FOUND` and exits the per-URL retry loop early, matching prior behavior for real controllers.
- Preserved the outer per-URL retry loop and final exception-aggregation logic (`lastConnectException` / `lastException`) unchanged.
- Included the causing exception in the per-URL `LOGGER.warn` call so stack traces are no longer dropped.

### Code changes

- [ ] Added new code behind a config. N/A — no new config.
- [x] Introduced new log lines. Existing `LOGGER.warn` per-URL failure log now includes the exception (`e`) as an argument to preserve the stack trace; no new distinct log lines added.

## How was this PR tested?

- [ ] New unit tests added.
- [x] New integration tests added. N/A — reused/updated existing coverage below.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

Updated `TestControllerClient#testControllerClientDiscoversCorrectCluster` (formerly relying on the router-path fallback for one branch) — all cases still pass:
- All controllers unreachable -> `ConnectException` bubbles up.
- Some controllers unreachable, one valid -> succeeds.
- Real controller returns `STORE_NOT_FOUND` -> surfaced as `STORE_NOT_FOUND`.
- Legacy controller returns 404 + `GENERAL_ERROR` -> still inferred as `STORE_NOT_FOUND` (backward-compat preserved).
- Controller returns an unrelated `GENERAL_ERROR` (e.g. 500) -> surfaced as `GENERAL_ERROR`, no longer attempting the (dead) router-path fallback.

Verified locally with JDK 17:
```
./gradlew :internal:venice-common:compileJava
./gradlew :internal:venice-test-common:integrationTest --tests "*TestControllerClient*"
```

## Does this PR introduce any user-facing or breaking changes?

- [x] No. `ControllerClient` callers see identical behavior for all real (non-router) controller responses; only the dead router-fallback code path is removed.
- [ ] Yes.
