### PR TITLE
[vpj][controller] Allow regional external write fail-open

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -947,6 +947,7 @@ public class VenicePushJob implements AutoCloseable {
            */
         }
         runJobWithKillDetection();
+        downgradeFailedExternalStorageRegionsToInternalBeforeEndOfPush();
 
         if (!pushJobSetting.suppressEndOfPushMessage) {
           Map<Integer, Long> partitionRecordCounts = getPerPartitionRecordCounts();
@@ -1825,6 +1826,62 @@ public class VenicePushJob implements AutoCloseable {
       return Collections.emptyMap();
     }
     return dataWriterComputeJob.getTaskTracker().getPerPartitionRecordCounts();
+  }
+
+  private Set<String> getFailedExternalStorageRegions() {
+    String topicName = Version.composeKafkaTopic(pushJobSetting.storeName, pushJobSetting.version);
+    if (dataWriterComputeJob == null || dataWriterComputeJob.getTaskTracker() == null) {
+      LOGGER
+          .warn("Cannot retrieve failed external-storage regions for topic: {}: no task tracker available", topicName);
+      return Collections.emptySet();
+    }
+    Set<String> failedRegions = dataWriterComputeJob.getTaskTracker().getFailedExternalStorageRegions();
+    return failedRegions == null ? Collections.emptySet() : failedRegions;
+  }
+
+  private void downgradeFailedExternalStorageRegionsToInternalBeforeEndOfPush() {
+    Set<String> failedRegions = getFailedExternalStorageRegions();
+    if (failedRegions.isEmpty()) {
+      return;
+    }
+    List<String> sortedFailedRegions = new ArrayList<>(failedRegions);
+    Collections.sort(sortedFailedRegions);
+    String regionsFilter = String.join(",", sortedFailedRegions);
+    LOGGER.warn(
+        "External-storage dual-write exhausted retries in regions {} for store {} v{}. "
+            + "Downgrading those version storage modes to INTERNAL before EOP.",
+        sortedFailedRegions,
+        pushJobSetting.storeName,
+        pushJobSetting.version);
+    String failureContext = "Failed to downgrade version storage mode to INTERNAL for store " + pushJobSetting.storeName
+        + " v" + pushJobSetting.version + " in regions " + sortedFailedRegions;
+    ControllerResponse response;
+    try {
+      response = ControllerClient.retryableRequest(
+          controllerClient,
+          pushJobSetting.controllerRetries,
+          client -> client.updateStoreVersionStorageMode(
+              pushJobSetting.storeName,
+              pushJobSetting.version,
+              StorageMode.INTERNAL,
+              regionsFilter));
+    } catch (Exception e) {
+      throw new VeniceException(
+          failureContext + ". The controller API may be unavailable or not deployed. Root cause: "
+              + getRootCauseMessage(e),
+          e);
+    }
+    if (response.isError()) {
+      throw new VeniceException(failureContext + ". Controller error: " + response.getError());
+    }
+  }
+
+  private static String getRootCauseMessage(Throwable throwable) {
+    Throwable rootCause = throwable;
+    while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+      rootCause = rootCause.getCause();
+    }
+    return rootCause.getMessage() == null ? rootCause.toString() : rootCause.getMessage();
   }
 
   private void updatePushJobDetailsWithDataWriterTracker() {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
@@ -1,5 +1,8 @@
 package com.linkedin.venice.hadoop.mapreduce.counter;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.mapred.Reporter;
 
@@ -260,14 +263,14 @@ public class MRJobCounterHelper {
     return getCountFromCounters(counters, INCREMENTAL_PUSH_THROTTLE_TIME_GROUP_COUNTER_NAME);
   }
 
-  public static java.util.Set<String> getFailedExternalStorageRegions(Counters counters) {
+  public static Set<String> getFailedExternalStorageRegions(Counters counters) {
     if (counters == null) {
-      return java.util.Collections.emptySet();
+      return Collections.emptySet();
     }
-    java.util.Set<String> regions = new java.util.HashSet<>();
+    Set<String> regions = new HashSet<>();
     Counters.Group group = counters.getGroup(COUNTER_GROUP_EXTERNAL_STORAGE);
     if (group == null) {
-      return java.util.Collections.emptySet();
+      return Collections.emptySet();
     }
     for (Counters.Counter counter: group) {
       if (counter.getCounter() > 0
@@ -275,7 +278,7 @@ public class MRJobCounterHelper {
         regions.add(counter.getName().substring(EXTERNAL_STORAGE_FAILED_REGION_COUNTER_NAME_PREFIX.length()));
       }
     }
-    return java.util.Collections.unmodifiableSet(regions);
+    return Collections.unmodifiableSet(regions);
   }
 
   private static long getCountFromCounters(Counters counters, GroupAndCounterNames groupAndCounterNames) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
@@ -38,6 +38,8 @@ public class MRJobCounterHelper {
       "Mapper spray all partitions triggered count";
   private static final String COUNTER_GROUP_KAFKA_INPUT_FORMAT = "KafkaInputFormat";
   private static final String COUNTER_PUT_OR_DELETE_RECORDS = "put or delete records";
+  private static final String COUNTER_GROUP_EXTERNAL_STORAGE = "External storage";
+  private static final String EXTERNAL_STORAGE_FAILED_REGION_COUNTER_NAME_PREFIX = "failed region: ";
 
   private static final String REPUSH_TTL_FILTERED_COUNT = "Repush ttl filtered count";
 
@@ -160,6 +162,16 @@ public class MRJobCounterHelper {
     incrAmountWithGroupCounterName(reporter, INCREMENTAL_PUSH_THROTTLE_TIME_GROUP_COUNTER_NAME, amount);
   }
 
+  public static void incrFailedExternalStorageRegionCount(Reporter reporter, String regionName, long amount) {
+    if (regionName == null || regionName.isEmpty()) {
+      return;
+    }
+    incrAmountWithGroupCounterName(
+        reporter,
+        new GroupAndCounterNames(COUNTER_GROUP_EXTERNAL_STORAGE, getFailedExternalStorageRegionCounterName(regionName)),
+        amount);
+  }
+
   public static long getWriteAclAuthorizationFailureCount(Reporter reporter) {
     return getCountWithGroupCounterName(reporter, WRITE_ACL_FAILURE_GROUP_COUNTER_NAME);
   }
@@ -248,6 +260,21 @@ public class MRJobCounterHelper {
     return getCountFromCounters(counters, INCREMENTAL_PUSH_THROTTLE_TIME_GROUP_COUNTER_NAME);
   }
 
+  public static java.util.Set<String> getFailedExternalStorageRegions(Counters counters) {
+    if (counters == null) {
+      return java.util.Collections.emptySet();
+    }
+    java.util.Set<String> regions = new java.util.HashSet<>();
+    Counters.Group group = counters.getGroup(COUNTER_GROUP_EXTERNAL_STORAGE);
+    for (Counters.Counter counter: group) {
+      if (counter.getCounter() > 0
+          && counter.getName().startsWith(EXTERNAL_STORAGE_FAILED_REGION_COUNTER_NAME_PREFIX)) {
+        regions.add(counter.getName().substring(EXTERNAL_STORAGE_FAILED_REGION_COUNTER_NAME_PREFIX.length()));
+      }
+    }
+    return java.util.Collections.unmodifiableSet(regions);
+  }
+
   private static long getCountFromCounters(Counters counters, GroupAndCounterNames groupAndCounterNames) {
     if (counters == null) {
       return 0;
@@ -278,6 +305,10 @@ public class MRJobCounterHelper {
 
   public static void incrRepushTtlFilterCount(Reporter reporter, long amount) {
     incrAmountWithGroupCounterName(reporter, REPUSH_TTL_FILTER_COUNT_GROUP_COUNTER_NAME, amount);
+  }
+
+  private static String getFailedExternalStorageRegionCounterName(String regionName) {
+    return EXTERNAL_STORAGE_FAILED_REGION_COUNTER_NAME_PREFIX + regionName;
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
@@ -266,6 +266,9 @@ public class MRJobCounterHelper {
     }
     java.util.Set<String> regions = new java.util.HashSet<>();
     Counters.Group group = counters.getGroup(COUNTER_GROUP_EXTERNAL_STORAGE);
+    if (group == null) {
+      return java.util.Collections.emptySet();
+    }
     for (Counters.Counter counter: group) {
       if (counter.getCounter() > 0
           && counter.getName().startsWith(EXTERNAL_STORAGE_FAILED_REGION_COUNTER_NAME_PREFIX)) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/CounterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/CounterBackedMapReduceDataWriterTaskTracker.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.hadoop.mapreduce.datawriter.task;
 
 import com.linkedin.venice.hadoop.mapreduce.counter.MRJobCounterHelper;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import java.util.Set;
 import org.apache.hadoop.mapred.Counters;
 
 
@@ -88,5 +89,10 @@ public class CounterBackedMapReduceDataWriterTaskTracker implements DataWriterTa
   @Override
   public long getIncrementalPushThrottledTimeMs() {
     return MRJobCounterHelper.getIncrementalPushThrottleTimeMs(counters);
+  }
+
+  @Override
+  public Set<String> getFailedExternalStorageRegions() {
+    return MRJobCounterHelper.getFailedExternalStorageRegions(counters);
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
@@ -2,6 +2,9 @@ package com.linkedin.venice.hadoop.mapreduce.datawriter.task;
 
 import com.linkedin.venice.hadoop.mapreduce.counter.MRJobCounterHelper;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.hadoop.mapred.Reporter;
 
 
@@ -10,6 +13,7 @@ import org.apache.hadoop.mapred.Reporter;
  */
 public class ReporterBackedMapReduceDataWriterTaskTracker implements DataWriterTaskTracker {
   private final Reporter reporter;
+  private final Set<String> failedExternalStorageRegions = new HashSet<>();
 
   public ReporterBackedMapReduceDataWriterTaskTracker(Reporter reporter) {
     if (reporter != null) {
@@ -119,6 +123,15 @@ public class ReporterBackedMapReduceDataWriterTaskTracker implements DataWriterT
   }
 
   @Override
+  public void trackFailedExternalStorageRegion(String regionName) {
+    if (regionName == null || regionName.isEmpty()) {
+      return;
+    }
+    failedExternalStorageRegions.add(regionName);
+    MRJobCounterHelper.incrFailedExternalStorageRegionCount(reporter, regionName, 1);
+  }
+
+  @Override
   public long getIncrementalPushThrottledTimeMs() {
     return MRJobCounterHelper.getIncrementalPushThrottleTimeMs(reporter);
   }
@@ -156,5 +169,10 @@ public class ReporterBackedMapReduceDataWriterTaskTracker implements DataWriterT
   @Override
   public long getTotalPutOrDeleteRecordsCount() {
     return MRJobCounterHelper.getTotalPutOrDeleteRecordsCount(reporter);
+  }
+
+  @Override
+  public Set<String> getFailedExternalStorageRegions() {
+    return Collections.unmodifiableSet(new HashSet<>(failedExternalStorageRegions));
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
@@ -127,8 +127,9 @@ public class ReporterBackedMapReduceDataWriterTaskTracker implements DataWriterT
     if (regionName == null || regionName.isEmpty()) {
       return;
     }
-    failedExternalStorageRegions.add(regionName);
-    MRJobCounterHelper.incrFailedExternalStorageRegionCount(reporter, regionName, 1);
+    if (failedExternalStorageRegions.add(regionName)) {
+      MRJobCounterHelper.incrFailedExternalStorageRegionCount(reporter, regionName, 1);
+    }
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -11,6 +11,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_IS_DUPLICAT
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_FAIL_OPEN_ON_REGION_FAILURE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DERIVED_SCHEMA_ID_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.ENABLE_WRITE_COMPUTE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.INCREMENTAL_PUSH_RATE_LIMITER_TYPE;
@@ -21,6 +22,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_FAIL_OPEN_ON_REGION_FAILURE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_DIR;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.RMD_SCHEMA_ID_PROP;
@@ -628,6 +630,9 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
         throw new VeniceException(
             PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS + " must be >= 0, got " + batchPutRetryBackoffMs);
       }
+      boolean failOpenOnRegionFailure = props.getBoolean(
+          PUSH_JOB_EXTERNAL_STORAGE_FAIL_OPEN_ON_REGION_FAILURE,
+          DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_FAIL_OPEN_ON_REGION_FAILURE);
       String writerClassName = props.getString(PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS);
       int partitionId = getEngineTaskConfigProvider().getTaskId();
       // One external writer per DUAL_WRITE region; each is configured with its region name so the impl
@@ -650,23 +655,28 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
           buildExternalStorageThrottlers(externalRecordRate, externalByteRate, dualWriteRegions.size());
       LOGGER.info(
           "Dual-write to external storage enabled for replica {} via impl {} for regions {} "
-              + "(batchSize={}, batchPutRetries={}, batchPutRetryBackoffMs={}, recordThrottle={}, byteThrottle={})",
+              + "(batchSize={}, batchPutRetries={}, batchPutRetryBackoffMs={}, failOpenOnRegionFailure={}, "
+              + "recordThrottle={}, byteThrottle={})",
           Utils.getReplicaId(topicName, partitionId),
           writerClassName,
           dualWriteRegions,
           batchSize,
           batchPutRetries,
           batchPutRetryBackoffMs,
+          failOpenOnRegionFailure,
           describeThrottle(externalRecordRate, "records/sec"),
           describeThrottle(externalByteRate, "bytes/sec"));
       return new DualWriteVeniceWriter(
           topicName,
           baseWriter,
           externalWriters,
+          dualWriteRegions,
           throttlers,
           batchSize,
           batchPutRetries,
-          batchPutRetryBackoffMs);
+          batchPutRetryBackoffMs,
+          failOpenOnRegionFailure,
+          getDataWriterTaskTracker());
     } catch (RuntimeException t) {
       for (ExternalStorageWriter externalWriter: externalWriters) {
         Utils.closeQuietlyWithErrorLogged(externalWriter);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.hadoop.task.datawriter;
 import com.linkedin.venice.hadoop.task.TaskTracker;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -65,6 +66,13 @@ public interface DataWriterTaskTracker extends TaskTracker {
   }
 
   default void trackIncrementalPushThrottledTime(long timeMs) {
+  }
+
+  /**
+   * Report that the external writer for {@code regionName} exhausted its retry budget and was disabled for
+   * the remainder of the task. Callers should report each region at most once per task.
+   */
+  default void trackFailedExternalStorageRegion(String regionName) {
   }
 
   default long getSprayAllPartitionsCount() {
@@ -143,5 +151,13 @@ public interface DataWriterTaskTracker extends TaskTracker {
    */
   default Map<Integer, Long> getPerPartitionRecordCounts() {
     return Collections.emptyMap();
+  }
+
+  /**
+   * Returns the set of regions whose external writers exhausted retries and were reported by one or more
+   * data-writer tasks. Implementations should return an immutable or defensive-copy snapshot.
+   */
+  default Set<String> getFailedExternalStorageRegions() {
+    return Collections.emptySet();
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriter.java
@@ -26,12 +26,13 @@ import org.apache.logging.log4j.Logger;
  *
  * <p>When the push targets multiple regions, the same record is fanned out to every regional writer before
  * the Kafka produce. The guarantee is that <em>no Kafka produce happens for a batch until every regional
- * external write for that batch has succeeded</em>: if any regional write fails (after its bounded retry) the
- * exception propagates before the produce and fails the Spark task. Note this is not an all-or-nothing write
- * across the external sinks within a failed attempt — an earlier region in the fan-out may already hold the
- * batch while a later one failed. Consistency is restored by the whole-partition retry: external writes are
- * idempotent on key, so the next attempt overwrites the partially-written region rather than leaving it
- * divergent.
+ * external write for that batch has succeeded</em> by default: if any regional write fails (after its bounded
+ * retry) the exception propagates before the produce and fails the Spark task. When the optional fail-open
+ * mode is enabled, only the region that exhausted retries is disabled and reported; healthy external regions
+ * and Kafka continue. Note this is not an all-or-nothing write across the external sinks within a failed
+ * attempt — an earlier region in the fan-out may already hold the batch while a later one failed.
+ * Consistency is restored either by the whole-partition retry (fail-fast) or by flipping the failed
+ * region's version {@code storageMode} back to {@code INTERNAL} before EOP (fail-open mode).
  *
  * <p><b>Region fan-out is sequential.</b> Each region's {@code batchPut} (including its bounded retries and
  * backoff) completes before the next region's begins, on the single partition-writer task thread. This keeps
@@ -55,6 +56,7 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
 
   private final AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter;
   private final List<ExternalStorageWriter> externalWriters;
+  private final List<String> externalWriterRegions;
   /**
    * Per-region rate limiters, index-aligned with {@link #externalWriters}. {@code null} when throttling is off
    * for the whole task; individual entries may be {@code null} to leave a single region unthrottled.
@@ -66,6 +68,9 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
   private final int batchPutRetries;
   private final long batchPutRetryBackoffMs;
   private final List<BufferedPut> putBuffer;
+  private final boolean failOpenOnExternalStorageRegionFailure;
+  private final DataWriterTaskTracker dataWriterTaskTracker;
+  private final boolean[] disabledExternalWriters;
 
   /**
    * Convenience constructor for callers that don't need the buffered retry policy (e.g. unit tests that
@@ -104,7 +109,17 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
       int batchSize,
       int batchPutRetries,
       long batchPutRetryBackoffMs) {
-    this(topicName, kafkaWriter, externalWriters, null, batchSize, batchPutRetries, batchPutRetryBackoffMs);
+    this(
+        topicName,
+        kafkaWriter,
+        externalWriters,
+        defaultExternalWriterRegions(externalWriters.size()),
+        null,
+        batchSize,
+        batchPutRetries,
+        batchPutRetryBackoffMs,
+        false,
+        null);
   }
 
   /**
@@ -120,9 +135,38 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
       int batchSize,
       int batchPutRetries,
       long batchPutRetryBackoffMs) {
+    this(
+        topicName,
+        kafkaWriter,
+        externalWriters,
+        defaultExternalWriterRegions(externalWriters.size()),
+        throttlers,
+        batchSize,
+        batchPutRetries,
+        batchPutRetryBackoffMs,
+        false,
+        null);
+  }
+
+  DualWriteVeniceWriter(
+      String topicName,
+      AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter,
+      List<ExternalStorageWriter> externalWriters,
+      List<String> externalWriterRegions,
+      List<ExternalStorageWriteThrottler> throttlers,
+      int batchSize,
+      int batchPutRetries,
+      long batchPutRetryBackoffMs,
+      boolean failOpenOnExternalStorageRegionFailure,
+      DataWriterTaskTracker dataWriterTaskTracker) {
     super(topicName);
     if (externalWriters == null || externalWriters.isEmpty()) {
       throw new IllegalArgumentException("externalWriters must be non-empty");
+    }
+    if (externalWriterRegions == null || externalWriterRegions.size() != externalWriters.size()) {
+      throw new IllegalArgumentException(
+          "externalWriterRegions size " + (externalWriterRegions == null ? 0 : externalWriterRegions.size())
+              + " must match externalWriters size " + externalWriters.size());
     }
     if (throttlers != null && throttlers.size() != externalWriters.size()) {
       throw new IllegalArgumentException(
@@ -137,14 +181,23 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
     if (batchPutRetryBackoffMs < 0) {
       throw new IllegalArgumentException("batchPutRetryBackoffMs must be >= 0, got " + batchPutRetryBackoffMs);
     }
+    for (String externalWriterRegion: externalWriterRegions) {
+      if (externalWriterRegion == null || externalWriterRegion.isEmpty()) {
+        throw new IllegalArgumentException("externalWriterRegions must not contain null/empty values");
+      }
+    }
     this.kafkaWriter = kafkaWriter;
     this.externalWriters = new ArrayList<>(externalWriters);
+    this.externalWriterRegions = new ArrayList<>(externalWriterRegions);
     this.throttlers = throttlers == null ? null : new ArrayList<>(throttlers);
     this.anyByteThrottling = anyByteThrottling(this.throttlers);
     this.batchSize = batchSize;
     this.batchPutRetries = batchPutRetries;
     this.batchPutRetryBackoffMs = batchPutRetryBackoffMs;
     this.putBuffer = new ArrayList<>(batchSize);
+    this.failOpenOnExternalStorageRegionFailure = failOpenOnExternalStorageRegionFailure;
+    this.dataWriterTaskTracker = dataWriterTaskTracker;
+    this.disabledExternalWriters = new boolean[externalWriters.size()];
   }
 
   @Override
@@ -239,8 +292,19 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
   @Override
   public void flush() {
     drainBuffer();
-    for (ExternalStorageWriter externalWriter: externalWriters) {
-      externalWriter.flush();
+    for (int i = 0; i < externalWriters.size(); i++) {
+      try {
+        externalWriters.get(i).flush();
+      } catch (RuntimeException e) {
+        if (shouldSuppressDisabledWriterFailure(i)) {
+          LOGGER.warn(
+              "Suppressing flush failure from disabled external writer for region {} because fail-open is enabled",
+              externalWriterRegions.get(i),
+              e);
+          continue;
+        }
+        throw e;
+      }
     }
     kafkaWriter.flush();
   }
@@ -262,10 +326,17 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
     } catch (RuntimeException e) {
       firstError = new IOException("Failed to flush before close", e);
     }
-    for (ExternalStorageWriter externalWriter: externalWriters) {
+    for (int i = 0; i < externalWriters.size(); i++) {
       try {
-        externalWriter.close();
+        externalWriters.get(i).close();
       } catch (IOException | RuntimeException e) {
+        if (shouldSuppressDisabledWriterFailure(i)) {
+          LOGGER.warn(
+              "Suppressing close failure from disabled external writer for region {} because fail-open is enabled",
+              externalWriterRegions.get(i),
+              e);
+          continue;
+        }
         // External impls are pluggable — an unchecked throw from one regional writer must not skip closing
         // the remaining regional writers or kafkaWriter.close() below, otherwise resources leak during task
         // shutdown.
@@ -331,23 +402,35 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
     long byteCount = anyByteThrottling ? totalBytes(externalRecords) : 0L;
     CompletableFuture<PubSubProduceResult> last = null;
     try {
-      // Fan out the same batch to every regional external sink before any Kafka produce. A failure on any
-      // region (after its bounded retry) propagates before any produce and fails the push. Earlier regions in
-      // the fan-out may already hold the batch when a later one fails; that partial state is reconciled by the
-      // idempotent whole-partition retry (see the class-level contract), not prevented here.
+      // Fan out the same batch to every regional external sink before any Kafka produce. In fail-fast mode a
+      // regional failure (after its bounded retry) propagates before any produce and fails the push. In
+      // fail-open mode the failed region is disabled and future batches skip it, while healthy regions and
+      // Kafka continue. Earlier regions in the fan-out may already hold the batch when a later one failed;
+      // that partial state is reconciled either by the idempotent whole-partition retry (fail-fast) or by
+      // downgrading the failed region's version back to INTERNAL before EOP (fail-open).
       //
       // Each region is rate limited (when a throttler is configured) immediately before its own write: the
       // blocking limiter waits until the per-region budget admits the batch, enforcing independent per-region
       // budgets without reordering the external-first writes. (If a limiter threw instead of blocking it would
       // propagate before the write; the GuavaRateLimiter used here blocks rather than rejecting.)
       for (int i = 0; i < externalWriters.size(); i++) {
+        if (shouldSkipExternalWriter(i)) {
+          continue;
+        }
         if (throttlers != null) {
           ExternalStorageWriteThrottler throttler = throttlers.get(i);
           if (throttler != null) {
             throttler.throttle(recordCount, byteCount);
           }
         }
-        batchPutWithRetry(externalWriters.get(i), externalRecords);
+        try {
+          batchPutWithRetry(externalWriters.get(i), externalWriterRegions.get(i), externalRecords);
+        } catch (RuntimeException e) {
+          if (!failOpenOnExternalStorageRegionFailure || Thread.currentThread().isInterrupted()) {
+            throw e;
+          }
+          disableFailedExternalWriter(i, e);
+        }
       }
       for (BufferedPut buffered: putBuffer) {
         CompletableFuture<PubSubProduceResult> kafkaFuture = invokeKafkaPut(buffered);
@@ -385,14 +468,18 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
    * <p>Interruption during the backoff sleep aborts the retry — the executor wants to shut down — and
    * surfaces the original failure with the {@link InterruptedException} suppressed.
    */
-  private void batchPutWithRetry(ExternalStorageWriter externalWriter, List<ExternalStorageRecord> records) {
+  private void batchPutWithRetry(
+      ExternalStorageWriter externalWriter,
+      String regionName,
+      List<ExternalStorageRecord> records) {
     int attempts = batchPutRetries + 1;
     RuntimeException lastError = null;
     for (int attempt = 1; attempt <= attempts; attempt++) {
       try {
         externalWriter.batchPut(records);
         if (attempt > 1) {
-          LOGGER.info("externalWriter.batchPut succeeded on attempt {}/{}", attempt, attempts);
+          LOGGER
+              .info("externalWriter.batchPut for region {} succeeded on attempt {}/{}", regionName, attempt, attempts);
         }
         return;
       } catch (RuntimeException e) {
@@ -403,7 +490,8 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
         }
         if (attempt < attempts) {
           LOGGER.warn(
-              "externalWriter.batchPut failed on attempt {}/{}; retrying after {}ms",
+              "externalWriter.batchPut failed for region {} on attempt {}/{}; retrying after {}ms",
+              regionName,
               attempt,
               attempts,
               batchPutRetryBackoffMs,
@@ -454,6 +542,39 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
       }
     }
     return false;
+  }
+
+  private boolean shouldSkipExternalWriter(int writerIndex) {
+    return failOpenOnExternalStorageRegionFailure && disabledExternalWriters[writerIndex];
+  }
+
+  private boolean shouldSuppressDisabledWriterFailure(int writerIndex) {
+    return failOpenOnExternalStorageRegionFailure && disabledExternalWriters[writerIndex];
+  }
+
+  private void disableFailedExternalWriter(int writerIndex, RuntimeException failure) {
+    if (disabledExternalWriters[writerIndex]) {
+      return;
+    }
+    disabledExternalWriters[writerIndex] = true;
+    String regionName = externalWriterRegions.get(writerIndex);
+    if (dataWriterTaskTracker != null) {
+      dataWriterTaskTracker.trackFailedExternalStorageRegion(regionName);
+    }
+    LOGGER.warn(
+        "Fail-open is enabled; disabling external writer for region {} after {} failed batchPut attempt(s). "
+            + "Future batches will skip this region while Kafka and healthy external regions continue.",
+        regionName,
+        batchPutRetries + 1,
+        failure);
+  }
+
+  private static List<String> defaultExternalWriterRegions(int writerCount) {
+    List<String> regions = new ArrayList<>(writerCount);
+    for (int i = 0; i < writerCount; i++) {
+      regions.add("external-region-" + i);
+    }
+    return regions;
   }
 
   private CompletableFuture<PubSubProduceResult> invokeKafkaPut(BufferedPut bp) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/SparkConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/SparkConstants.java
@@ -5,6 +5,7 @@ import static org.apache.spark.sql.types.DataTypes.IntegerType;
 import static org.apache.spark.sql.types.DataTypes.LongType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
 
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -19,6 +20,7 @@ public class SparkConstants {
   // Internal column names, hence begins with "_"
   public static final String PARTITION_COLUMN_NAME = "__partition__";
   public static final String RECORD_COUNT_COLUMN_NAME = "__record_count__";
+  public static final String FAILED_EXTERNAL_STORAGE_REGIONS_COLUMN_NAME = "__failed_external_storage_regions__";
   public static final String SCHEMA_ID_COLUMN_NAME = "__schema_id__";
   public static final String RMD_VERSION_ID_COLUMN_NAME = "__replication_metadata_version_id__";
   public static final String OFFSET_COLUMN_NAME = "__offset__";
@@ -32,7 +34,12 @@ public class SparkConstants {
 
   public static final StructType PARTITION_RECORD_COUNT_SCHEMA = new StructType(
       new StructField[] { new StructField(PARTITION_COLUMN_NAME, IntegerType, false, Metadata.empty()),
-          new StructField(RECORD_COUNT_COLUMN_NAME, LongType, false, Metadata.empty()) });
+          new StructField(RECORD_COUNT_COLUMN_NAME, LongType, false, Metadata.empty()),
+          new StructField(
+              FAILED_EXTERNAL_STORAGE_REGIONS_COLUMN_NAME,
+              DataTypes.createArrayType(StringType),
+              false,
+              Metadata.empty()) });
 
   public static final StructType DEFAULT_SCHEMA_WITH_PARTITION = new StructType(
       new StructField[] { new StructField(KEY_COLUMN_NAME, BinaryType, false, Metadata.empty()),

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -890,7 +890,7 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     validateRmdSchema(pushJobSetting);
 
     ExpressionEncoder<Row> rowEncoder = RowEncoder.apply(DEFAULT_SCHEMA);
-    ExpressionEncoder<Row> partitionRecordCountEncoder = RowEncoder.apply(PARTITION_RECORD_COUNT_SCHEMA);
+    ExpressionEncoder<Row> partitionWriterTaskOutputEncoder = RowEncoder.apply(PARTITION_RECORD_COUNT_SCHEMA);
     int numOutputPartitions = pushJobSetting.partitionCount;
 
     Properties jobProps = new Properties();
@@ -967,26 +967,33 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
         } finally {
           kafkaWriteMetrics.timeNs.add(System.nanoTime() - startNs);
         }
-      }, partitionRecordCountEncoder);
+      }, partitionWriterTaskOutputEncoder);
 
       /*
-       * collect() returns exactly one (partitionId, recordCount) row per Spark partition. With
-       * speculative execution, if the original task and a speculative attempt both finish at the
-       * same time, Spark's TaskScheduler accepts the result from whichever one successfully
-       * communicates completion first and immediately kills the other; the duplicate's work is
-       * discarded to prevent duplicate data processing. So no two rows in the collected list will
-       * ever share the same partition id, and we can populate the map directly via put().
+       * collect() returns exactly one successful task-output row per Spark partition:
+       * (partitionId, recordCount, failedExternalStorageRegions). With speculative execution, if
+       * the original task and a speculative attempt both finish at the same time, Spark's
+       * TaskScheduler accepts the result from whichever one successfully communicates completion
+       * first and immediately kills the other; the duplicate's work is discarded to prevent
+       * duplicate data processing. So no two rows in the collected list will ever share the same
+       * partition id, and only the winning task's final disabled-region set contributes here.
        *
-       * The collected data volume is bounded by numPartitions (e.g. 10K partitions = ~160KB) so
-       * collectAsList() is safe.
+       * The collected data volume is bounded by numPartitions plus a small failed-region list per
+       * partition (e.g. 10K partitions with record counts only is ~160KB), so collectAsList() is
+       * safe.
        */
       String topicName = pushJobSetting.topic;
-      List<Row> partitionCountRows = dataFrame.collectAsList();
-      Map<Integer, Long> perPartitionRecordCounts = new HashMap<>(partitionCountRows.size());
-      for (Row row: partitionCountRows) {
+      List<Row> taskOutputRows = dataFrame.collectAsList();
+      Map<Integer, Long> perPartitionRecordCounts = new HashMap<>(taskOutputRows.size());
+      Set<String> failedExternalStorageRegions = new HashSet<>();
+      for (Row row: taskOutputRows) {
         perPartitionRecordCounts.put(row.getInt(0), row.getLong(1));
+        if (!row.isNullAt(2)) {
+          failedExternalStorageRegions.addAll(row.getList(2));
+        }
       }
       taskTracker.setPerPartitionRecordCounts(perPartitionRecordCounts);
+      taskTracker.setFailedExternalStorageRegions(failedExternalStorageRegions);
       LOGGER.info(
           "Collected per-partition record counts for topic: {} ({} partitions)",
           topicName,

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
@@ -3,7 +3,9 @@ package com.linkedin.venice.spark.datawriter.task;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -12,6 +14,7 @@ import java.util.Map;
 public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   private final DataWriterAccumulators accumulators;
   private Map<Integer, Long> perPartitionRecordCounts = Collections.emptyMap();
+  private final Set<String> failedExternalStorageRegions = new HashSet<>();
 
   public SparkDataWriterTaskTracker(DataWriterAccumulators accumulators) {
     this.accumulators = accumulators;
@@ -95,6 +98,14 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   @Override
   public void trackIncrementalPushThrottledTime(long timeMs) {
     accumulators.incrementalPushThrottleTimeCounter.add(timeMs);
+  }
+
+  @Override
+  public void trackFailedExternalStorageRegion(String regionName) {
+    if (regionName == null || regionName.isEmpty()) {
+      return;
+    }
+    failedExternalStorageRegions.add(regionName);
   }
 
   @Override
@@ -186,8 +197,25 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
         : Collections.unmodifiableMap(new HashMap<>(counts));
   }
 
+  /**
+   * Sets the deduplicated failed external-storage regions collected from successful Spark task output.
+   */
+  public void setFailedExternalStorageRegions(Set<String> failedRegions) {
+    failedExternalStorageRegions.clear();
+    if (failedRegions != null) {
+      failedExternalStorageRegions.addAll(failedRegions);
+    }
+  }
+
   @Override
   public Map<Integer, Long> getPerPartitionRecordCounts() {
     return perPartitionRecordCounts;
+  }
+
+  @Override
+  public Set<String> getFailedExternalStorageRegions() {
+    return failedExternalStorageRegions.isEmpty()
+        ? Collections.emptySet()
+        : Collections.unmodifiableSet(new HashSet<>(failedExternalStorageRegions));
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/writer/SparkPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/writer/SparkPartitionWriter.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.spark.sql.Row;
@@ -91,5 +92,9 @@ public class SparkPartitionWriter extends AbstractPartitionWriter {
    */
   long getRecordCount() {
     return getMessageSent();
+  }
+
+  Set<String> getFailedExternalStorageRegions() {
+    return dataWriterTaskTracker.getFailedExternalStorageRegions();
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/writer/SparkPartitionWriterFactory.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/writer/SparkPartitionWriterFactory.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.spark.datawriter.writer;
 
 import com.linkedin.venice.spark.datawriter.task.DataWriterAccumulators;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Properties;
@@ -9,6 +10,7 @@ import org.apache.spark.api.java.function.MapPartitionsFunction;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
+import scala.collection.JavaConverters;
 
 
 public class SparkPartitionWriterFactory implements MapPartitionsFunction<Row, Row> {
@@ -23,12 +25,18 @@ public class SparkPartitionWriterFactory implements MapPartitionsFunction<Row, R
 
   @Override
   public Iterator<Row> call(Iterator<Row> rows) throws Exception {
+    SparkPartitionWriter partitionWriter = new SparkPartitionWriter(jobProps.getValue(), accumulators);
     long recordCount;
-    try (SparkPartitionWriter partitionWriter = new SparkPartitionWriter(jobProps.getValue(), accumulators)) {
+    try (SparkPartitionWriter ignored = partitionWriter) {
       partitionWriter.processRows(rows);
       recordCount = partitionWriter.getRecordCount();
     }
+    // Read this after close so the task output reflects any regions disabled while flushing or closing the writer.
+    ArrayList<String> failedExternalStorageRegions = new ArrayList<>(partitionWriter.getFailedExternalStorageRegions());
+    Collections.sort(failedExternalStorageRegions);
     int partitionId = TaskContext.get().partitionId();
-    return Collections.singletonList(RowFactory.create(partitionId, recordCount)).iterator();
+    return Collections.singletonList(
+        RowFactory.create(partitionId, recordCount, JavaConverters.asScalaBuffer(failedExternalStorageRegions).toSeq()))
+        .iterator();
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/VenicePushJobConstants.java
@@ -524,6 +524,7 @@ public final class VenicePushJobConstants {
    *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE} — buffer threshold for the dual-write wrapper</li>
    *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES} — bounded retry count for {@code batchPut}</li>
    *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS} — sleep between retry attempts</li>
+   *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_FAIL_OPEN_ON_REGION_FAILURE} — optionally disable a region after retry exhaustion and continue the push</li>
    *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND} — per-region global record-rate cap</li>
    *   <li>{@link #PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND} — per-region global byte-rate cap</li>
    * </ul>
@@ -567,6 +568,18 @@ public final class VenicePushJobConstants {
   public static final String PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS =
       "push.job.external.storage.batchput.retry.backoff.ms";
   public static final long DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS = 1000L;
+
+  /**
+   * Whether VPJ should fail open when one region's external writer keeps failing after exhausting
+   * {@link #PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES}. Default {@code false} preserves the historical
+   * fail-fast behavior: any regional external-write failure aborts the push before Kafka produce. When set
+   * to {@code true}, the failed region is reported once, its external writer is disabled for the rest of the
+   * task, healthy external regions continue receiving writes, Kafka produce continues, and the VPJ driver is
+   * expected to flip that region's current version {@code storageMode} to {@code INTERNAL} before EOP.
+   */
+  public static final String PUSH_JOB_EXTERNAL_STORAGE_FAIL_OPEN_ON_REGION_FAILURE =
+      "push.job.external.storage.fail.open.on.region.failure";
+  public static final boolean DEFAULT_PUSH_JOB_EXTERNAL_STORAGE_FAIL_OPEN_ON_REGION_FAILURE = false;
 
   /**
    * Global write quota in records per second for the external-storage dual-write path, applied <em>per target

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobLifecycleTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobLifecycleTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.hadoop;
 
+import static com.linkedin.venice.vpj.VenicePushJobConstants.CONTROLLER_REQUEST_RETRY_ATTEMPTS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DATA_WRITER_COMPUTE_JOB_CLASS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
@@ -8,12 +9,15 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_TIMEOUT_OV
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VALUE_FIELD_PROP;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -26,6 +30,7 @@ import static org.testng.Assert.fail;
 
 import com.linkedin.venice.PushJobCheckpoints;
 import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
@@ -33,19 +38,24 @@ import com.linkedin.venice.etl.ETLValueSchemaTransformation;
 import com.linkedin.venice.exceptions.ConcurrentBatchPushException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceStoreAclException;
+import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
 import com.linkedin.venice.jobs.DataWriterComputeJob;
+import com.linkedin.venice.meta.StorageMode;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.File;
+import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
+import org.mockito.InOrder;
 import org.mockito.stubbing.Answer;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -314,6 +324,85 @@ public class VenicePushJobLifecycleTest extends VenicePushJobTestBase {
       assertEquals(dataWriterKilledLatch.getCount(), 0, "Data writer job should have been killed");
       verify(dataWriterJob, times(1)).kill();
       verify(client, atLeastOnce()).queryOverallJobStatus(anyString(), any(), any(), anyBoolean());
+    }
+  }
+
+  @Test
+  public void testFailedExternalStorageRegionsDowngradeBeforeEndOfPush() throws Exception {
+    Properties props = getVpjRequiredProperties();
+    props.put(KEY_FIELD_PROP, "id");
+    props.put(VALUE_FIELD_PROP, "name");
+    ControllerClient client = getClient();
+    doReturn(mockJobStatusQuery()).when(client).queryOverallJobStatus(anyString(), any(), any(), anyBoolean());
+    ControllerResponse versionUpdateResponse = new ControllerResponse();
+    doReturn(versionUpdateResponse).when(client)
+        .updateStoreVersionStorageMode(TEST_STORE, 1, StorageMode.INTERNAL, "dc-1");
+
+    try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
+      skipVPJValidation(pushJob);
+      doNothing().when(pushJob).runJobWithKillDetection();
+
+      DataWriterTaskTracker tracker = mock(DataWriterTaskTracker.class);
+      doReturn(Collections.singleton("dc-1")).when(tracker).getFailedExternalStorageRegions();
+      doReturn(Collections.emptyMap()).when(tracker).getPerPartitionRecordCounts();
+
+      DataWriterComputeJob dataWriterJob = mock(DataWriterComputeJob.class);
+      doReturn(tracker).when(dataWriterJob).getTaskTracker();
+      pushJob.setDataWriterComputeJob(dataWriterJob);
+
+      pushJob.run();
+
+      InOrder inOrder = inOrder(client);
+      inOrder.verify(client).updateStoreVersionStorageMode(TEST_STORE, 1, StorageMode.INTERNAL, "dc-1");
+      inOrder.verify(client).writeEndOfPush(TEST_STORE, 1, Collections.emptyMap());
+    }
+  }
+
+  @DataProvider(name = "versionStorageModeUpdateFailure")
+  public Object[][] versionStorageModeUpdateFailure() {
+    return new Object[][] { { false, "simulated regional version update failure" },
+        { true, "404 Not Found: /update_store_version_storage_mode" } };
+  }
+
+  @Test(dataProvider = "versionStorageModeUpdateFailure")
+  public void testFailedExternalStorageRegionDowngradeFailureBlocksEndOfPush(
+      boolean throwException,
+      String expectedReason) throws Exception {
+    Properties props = getVpjRequiredProperties();
+    props.put(KEY_FIELD_PROP, "id");
+    props.put(VALUE_FIELD_PROP, "name");
+    props.put(CONTROLLER_REQUEST_RETRY_ATTEMPTS, "1");
+    ControllerClient client = getClient();
+    if (throwException) {
+      doThrow(new VeniceException(expectedReason)).when(client)
+          .updateStoreVersionStorageMode(TEST_STORE, 1, StorageMode.INTERNAL, "dc-1");
+    } else {
+      ControllerResponse errorResponse = new ControllerResponse();
+      errorResponse.setError(expectedReason);
+      doReturn(errorResponse).when(client).updateStoreVersionStorageMode(TEST_STORE, 1, StorageMode.INTERNAL, "dc-1");
+    }
+
+    try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
+      skipVPJValidation(pushJob);
+      doNothing().when(pushJob).runJobWithKillDetection();
+
+      DataWriterTaskTracker tracker = mock(DataWriterTaskTracker.class);
+      doReturn(Collections.singleton("dc-1")).when(tracker).getFailedExternalStorageRegions();
+      DataWriterComputeJob dataWriterJob = mock(DataWriterComputeJob.class);
+      doReturn(tracker).when(dataWriterJob).getTaskTracker();
+      pushJob.setDataWriterComputeJob(dataWriterJob);
+
+      try {
+        pushJob.run();
+        fail("Expected VeniceException when regional version storage-mode downgrade fails");
+      } catch (VeniceException e) {
+        assertTrue(
+            e.getMessage().contains(TEST_STORE) && e.getMessage().contains("v1") && e.getMessage().contains("dc-1")
+                && e.getMessage().contains(expectedReason),
+            "Unexpected error message: " + e.getMessage());
+      }
+
+      verify(client, never()).writeEndOfPush(anyString(), anyInt(), any());
     }
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/MapReduceDataWriterTaskTrackerTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/MapReduceDataWriterTaskTrackerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
@@ -51,6 +52,16 @@ public class MapReduceDataWriterTaskTrackerTest {
   public void testFailedExternalStorageRegionsDefaultToEmpty() {
     CounterBackedMapReduceDataWriterTaskTracker counterTracker =
         new CounterBackedMapReduceDataWriterTaskTracker(new Counters());
+    assertEquals(counterTracker.getFailedExternalStorageRegions(), Collections.emptySet());
+  }
+
+  @Test
+  public void testFailedExternalStorageRegionsDefaultToEmptyWhenCounterGroupIsMissing() {
+    Counters counters = mock(Counters.class);
+    when(counters.getGroup(anyString())).thenReturn(null);
+
+    CounterBackedMapReduceDataWriterTaskTracker counterTracker =
+        new CounterBackedMapReduceDataWriterTaskTracker(counters);
     assertEquals(counterTracker.getFailedExternalStorageRegions(), Collections.emptySet());
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/MapReduceDataWriterTaskTrackerTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/MapReduceDataWriterTaskTrackerTest.java
@@ -4,6 +4,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
@@ -39,6 +41,7 @@ public class MapReduceDataWriterTaskTrackerTest {
     expected.add("dc-0");
     expected.add("dc-1");
     assertEquals(reporterTracker.getFailedExternalStorageRegions(), expected);
+    verify(reporter, times(2)).incrCounter(anyString(), anyString(), anyLong());
 
     CounterBackedMapReduceDataWriterTaskTracker counterTracker =
         new CounterBackedMapReduceDataWriterTaskTracker(counters);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/MapReduceDataWriterTaskTrackerTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/MapReduceDataWriterTaskTrackerTest.java
@@ -1,0 +1,56 @@
+package com.linkedin.venice.hadoop.mapreduce.datawriter.task;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.hadoop.mapred.Counters;
+import org.apache.hadoop.mapred.Reporter;
+import org.testng.annotations.Test;
+
+
+public class MapReduceDataWriterTaskTrackerTest {
+  @Test
+  public void testFailedExternalStorageRegionsAggregateFromReporterIntoCounters() {
+    Counters counters = new Counters();
+    Reporter reporter = mock(Reporter.class);
+    doAnswer(invocation -> {
+      counters.incrCounter(
+          (String) invocation.getArgument(0),
+          (String) invocation.getArgument(1),
+          (Long) invocation.getArgument(2));
+      return null;
+    }).when(reporter).incrCounter(anyString(), anyString(), anyLong());
+
+    ReporterBackedMapReduceDataWriterTaskTracker reporterTracker =
+        new ReporterBackedMapReduceDataWriterTaskTracker(reporter);
+    reporterTracker.trackFailedExternalStorageRegion("dc-0");
+    reporterTracker.trackFailedExternalStorageRegion("dc-1");
+    reporterTracker.trackFailedExternalStorageRegion("dc-0");
+
+    Set<String> expected = new HashSet<>();
+    expected.add("dc-0");
+    expected.add("dc-1");
+    assertEquals(reporterTracker.getFailedExternalStorageRegions(), expected);
+
+    CounterBackedMapReduceDataWriterTaskTracker counterTracker =
+        new CounterBackedMapReduceDataWriterTaskTracker(counters);
+    assertEquals(counterTracker.getFailedExternalStorageRegions(), expected);
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> counterTracker.getFailedExternalStorageRegions().add("dc-2"));
+  }
+
+  @Test
+  public void testFailedExternalStorageRegionsDefaultToEmpty() {
+    CounterBackedMapReduceDataWriterTaskTracker counterTracker =
+        new CounterBackedMapReduceDataWriterTaskTracker(new Counters());
+    assertEquals(counterTracker.getFailedExternalStorageRegions(), Collections.emptySet());
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriterTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriterTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -262,6 +263,71 @@ public class DualWriteVeniceWriterTest {
       } catch (Exception ignored) {
       }
     }
+  }
+
+  @Test
+  public void failOpenDisablesOnlyTheFailedRegionAndContinuesKafkaAndHealthyRegions() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter failing = new RecordingExternalStorageWriter();
+    RecordingExternalStorageWriter healthy = new RecordingExternalStorageWriter();
+    failing.failBatchPutTimes = Integer.MAX_VALUE;
+    RecordingDataWriterTaskTracker tracker = new RecordingDataWriterTaskTracker();
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(
+        TOPIC,
+        kafkaWriter,
+        Arrays.asList(failing, healthy),
+        Arrays.asList("dc-fail", "dc-healthy"),
+        null,
+        1,
+        2,
+        0L,
+        true,
+        tracker)) {
+      writer.put(key(1), value(1), SCHEMA_ID, null);
+      writer.put(key(2), value(2), SCHEMA_ID, null);
+    }
+
+    assertEquals(
+        failing.batchPutAttempts,
+        3,
+        "Failed region should exhaust the initial attempt plus 2 retries exactly once, then be skipped");
+    assertEquals(
+        healthy.batchPutInvocations.size(),
+        2,
+        "Healthy region should continue receiving every batch after the other region is disabled");
+    assertTrue(failing.flushCount > 0, "Disabled writer must still be flushed before close");
+    assertTrue(failing.closed, "Disabled writer must still be closed");
+    assertEquals(tracker.failedExternalStorageRegions, Collections.singleton("dc-fail"));
+    verify(kafkaWriter, times(2)).put(any(), any(), anyInt(), any());
+  }
+
+  @Test
+  public void transientRetrySuccessDoesNotMarkOrDisableTheRegion() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter recovering = new RecordingExternalStorageWriter();
+    recovering.failBatchPutTimes = 2;
+    RecordingDataWriterTaskTracker tracker = new RecordingDataWriterTaskTracker();
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(
+        TOPIC,
+        kafkaWriter,
+        Arrays.asList(recovering),
+        Arrays.asList("dc-recovering"),
+        null,
+        1,
+        3,
+        0L,
+        true,
+        tracker)) {
+      writer.put(key(1), value(1), SCHEMA_ID, null);
+      writer.put(key(2), value(2), SCHEMA_ID, null);
+    }
+
+    assertEquals(recovering.batchPutAttempts, 4, "Writer should retry through success and remain enabled afterwards");
+    assertEquals(recovering.batchPutInvocations.size(), 2, "Both puts should eventually reach the recovering region");
+    assertTrue(
+        tracker.failedExternalStorageRegions.isEmpty(),
+        "A transient failure that recovers within retry budget must not disable or report the region");
+    verify(kafkaWriter, times(2)).put(any(), any(), anyInt(), any());
   }
 
   // --- Failure-mode tests --------------------------------------------------------------------------
@@ -610,6 +676,15 @@ public class DualWriteVeniceWriterTest {
       if (throwOnClose != null) {
         throw throwOnClose;
       }
+    }
+  }
+
+  private static final class RecordingDataWriterTaskTracker implements DataWriterTaskTracker {
+    final java.util.Set<String> failedExternalStorageRegions = new java.util.HashSet<>();
+
+    @Override
+    public void trackFailedExternalStorageRegion(String regionName) {
+      failedExternalStorageRegions.add(regionName);
     }
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriterTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriterTest.java
@@ -24,7 +24,9 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.testng.annotations.Test;
@@ -680,7 +682,7 @@ public class DualWriteVeniceWriterTest {
   }
 
   private static final class RecordingDataWriterTaskTracker implements DataWriterTaskTracker {
-    final java.util.Set<String> failedExternalStorageRegions = new java.util.HashSet<>();
+    final Set<String> failedExternalStorageRegions = new HashSet<>();
 
     @Override
     public void trackFailedExternalStorageRegion(String regionName) {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJobTest.java
@@ -50,15 +50,21 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.fs.Path;
+import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.MapPartitionsFunction;
 import org.apache.spark.broadcast.Broadcast;
@@ -75,6 +81,7 @@ import org.apache.spark.sql.types.StructType;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import scala.collection.JavaConverters;
 
 
 public class AbstractDataWriterSparkJobTest {
@@ -481,8 +488,33 @@ public class AbstractDataWriterSparkJobTest {
     }
   }
 
+  @Test
+  public void testRunComputeJobAggregatesFailedExternalStorageRegionsFromTaskOutput() throws IOException {
+    PushJobSetting setting = getDefaultKafkaInputPushJobSetting();
+    setting.partitionCount = 2;
+
+    try (TaskOutputTestingDataWriterSparkJob job = new TaskOutputTestingDataWriterSparkJob()) {
+      job.configure(new VeniceProperties(new Properties()), setting);
+      job.runComputeJob();
+
+      Map<Integer, Long> expectedCounts = new HashMap<>();
+      expectedCounts.put(0, 3L);
+      expectedCounts.put(1, 5L);
+      Assert.assertEquals(job.getTaskTracker().getPerPartitionRecordCounts(), expectedCounts);
+
+      Set<String> expectedFailedRegions = new HashSet<>();
+      expectedFailedRegions.add("dc-0");
+      expectedFailedRegions.add("dc-1");
+      Assert.assertEquals(job.getTaskTracker().getFailedExternalStorageRegions(), expectedFailedRegions);
+    }
+  }
+
   private static long getTotalInputDataSize(QuotaTestingDataWriterSparkJob job) {
     return job.getTaskTracker().getTotalKeySize() + job.getTaskTracker().getTotalValueSize();
+  }
+
+  private static scala.collection.Seq<String> toScalaSeq(String... values) {
+    return JavaConverters.asScalaBuffer(new ArrayList<>(Arrays.asList(values))).toSeq();
   }
 
   private PushJobSetting getDefaultKafkaInputPushJobSetting() {
@@ -713,7 +745,44 @@ public class AbstractDataWriterSparkJobTest {
           accumulators.outputRecordCounter.add(1);
         }
         accumulators.partitionWriterCloseCounter.add(1);
-        return Collections.singletonList(RowFactory.create(partitionId, recordCount)).iterator();
+        return Collections.singletonList(RowFactory.create(partitionId, recordCount, toScalaSeq())).iterator();
+      };
+    }
+  }
+
+  private static class TaskOutputTestingDataWriterSparkJob extends DataWriterSparkJob {
+    @Override
+    protected Dataset<Row> getKafkaInputDataFrame() {
+      List<Row> rows = Arrays.asList(
+          new GenericRowWithSchema(
+              new Object[] { "region1", 0, 100L, MessageType.PUT.getValue(), 1, "test-key-1".getBytes(),
+                  "test-value-1".getBytes(), 1, "rmd".getBytes(), null },
+              RAW_PUBSUB_INPUT_TABLE_SCHEMA),
+          new GenericRowWithSchema(
+              new Object[] { "region1", 1, 101L, MessageType.PUT.getValue(), 1, "test-key-2".getBytes(),
+                  "test-value-2".getBytes(), 1, "rmd".getBytes(), null },
+              RAW_PUBSUB_INPUT_TABLE_SCHEMA));
+      return getSparkSession().createDataFrame(rows, RAW_PUBSUB_INPUT_TABLE_SCHEMA);
+    }
+
+    @Override
+    protected MapPartitionsFunction<Row, Row> createPartitionWriterFactory(
+        Broadcast<Properties> broadcastProperties,
+        DataWriterAccumulators accumulators) {
+      return iterator -> {
+        while (iterator.hasNext()) {
+          iterator.next();
+        }
+
+        int partitionId = TaskContext.get().partitionId();
+        switch (partitionId) {
+          case 0:
+            return Collections.singletonList(RowFactory.create(0, 3L, toScalaSeq("dc-1", "dc-0"))).iterator();
+          case 1:
+            return Collections.singletonList(RowFactory.create(1, 5L, toScalaSeq("dc-1"))).iterator();
+          default:
+            return Collections.singletonList(RowFactory.create(partitionId, 0L, toScalaSeq())).iterator();
+        }
       };
     }
   }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTrackerTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTrackerTest.java
@@ -1,8 +1,11 @@
 package com.linkedin.venice.spark.datawriter.task;
 
 import com.linkedin.venice.spark.SparkConstants;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import org.apache.spark.sql.SparkSession;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -268,6 +271,57 @@ public class SparkDataWriterTaskTrackerTest {
     Assert.assertEquals((long) result.get(0), 100L);
     Assert.assertEquals((long) result.get(1), 200L);
     Assert.assertEquals((long) result.get(2), 50L);
+  }
+
+  @Test
+  public void testFailedExternalStorageRegionsTrackPerTaskTracker() {
+    DataWriterAccumulators accumulators = new DataWriterAccumulators(spark);
+    SparkDataWriterTaskTracker tracker1 = new SparkDataWriterTaskTracker(accumulators);
+    SparkDataWriterTaskTracker tracker2 = new SparkDataWriterTaskTracker(accumulators);
+
+    tracker1.trackFailedExternalStorageRegion("dc-0");
+    tracker1.trackFailedExternalStorageRegion("dc-0");
+    tracker1.trackFailedExternalStorageRegion("dc-1");
+    tracker1.trackFailedExternalStorageRegion(null);
+    tracker1.trackFailedExternalStorageRegion("");
+    tracker2.trackFailedExternalStorageRegion("dc-2");
+
+    Set<String> tracker1Expected = new HashSet<>();
+    tracker1Expected.add("dc-0");
+    tracker1Expected.add("dc-1");
+    Assert.assertEquals(tracker1.getFailedExternalStorageRegions(), tracker1Expected);
+    Assert.assertEquals(tracker2.getFailedExternalStorageRegions(), Collections.singleton("dc-2"));
+
+    verifyAllAccumulators(accumulators, new DataWriterAccumulators(spark));
+  }
+
+  @Test
+  public void testSetAndGetFailedExternalStorageRegions() {
+    DataWriterAccumulators accumulators = new DataWriterAccumulators(spark);
+    SparkDataWriterTaskTracker tracker = new SparkDataWriterTaskTracker(accumulators);
+
+    tracker.trackFailedExternalStorageRegion("dc-stale");
+
+    Set<String> failedRegions = new HashSet<>();
+    failedRegions.add("dc-0");
+    failedRegions.add("dc-1");
+
+    tracker.setFailedExternalStorageRegions(failedRegions);
+    failedRegions.add("dc-2");
+
+    Set<String> expected = new HashSet<>();
+    expected.add("dc-0");
+    expected.add("dc-1");
+    Assert.assertEquals(tracker.getFailedExternalStorageRegions(), expected);
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testFailedExternalStorageRegionsIsUnmodifiable() {
+    DataWriterAccumulators accumulators = new DataWriterAccumulators(spark);
+    SparkDataWriterTaskTracker tracker = new SparkDataWriterTaskTracker(accumulators);
+    tracker.setFailedExternalStorageRegions(Collections.singleton("dc-0"));
+
+    tracker.getFailedExternalStorageRegions().add("dc-1");
   }
 
   @Test(expectedExceptions = UnsupportedOperationException.class)

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -66,6 +66,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.SOURCE_FA
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SOURCE_FABRIC_VERSION_INCLUDED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SOURCE_GRID_FABRIC;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STATUS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_MODE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_NODE_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_CONFIG_NAME_FILTER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_CONFIG_VALUE_FILTER;
@@ -90,6 +91,7 @@ import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceHttpException;
 import com.linkedin.venice.helix.VeniceJsonSerializer;
+import com.linkedin.venice.meta.StorageMode;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.schema.avro.DirectionalSchemaCompatibilityType;
@@ -1159,6 +1161,22 @@ public class ControllerClient implements Closeable {
   public ControllerResponse updateStore(String storeName, UpdateStoreQueryParams queryParams) {
     QueryParams params = addCommonParams(queryParams).add(NAME, storeName);
     return request(ControllerRoute.UPDATE_STORE, params, ControllerResponse.class);
+  }
+
+  public ControllerResponse updateStoreVersionStorageMode(String storeName, int version, StorageMode storageMode) {
+    return updateStoreVersionStorageMode(storeName, version, storageMode, null);
+  }
+
+  public ControllerResponse updateStoreVersionStorageMode(
+      String storeName,
+      int version,
+      StorageMode storageMode,
+      String regionsFilter) {
+    QueryParams params = newParams().add(NAME, storeName).add(VERSION, version).add(STORAGE_MODE, storageMode.name());
+    if (StringUtils.isNotEmpty(regionsFilter)) {
+      params.add(REGIONS_FILTER, regionsFilter);
+    }
+    return request(ControllerRoute.UPDATE_STORE_VERSION_STORAGE_MODE, params, ControllerResponse.class);
   }
 
   public SchemaResponse getValueSchema(String storeName, int valueSchemaId) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -84,6 +84,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.SINGLE_GE
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SOURCE_FABRIC;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SOURCE_FABRIC_VERSION_INCLUDED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STATUS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_MODE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_NODE_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_QUOTA_IN_BYTE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORES_TO_REPLICATE;
@@ -285,6 +286,9 @@ public enum ControllerRoute implements VeniceDimensionInterface {
 
   GET_DEAD_STORES(
       "/get_dead_stores", HttpMethod.GET, Arrays.asList(CLUSTER), NAME, INCLUDE_SYSTEM_STORES, LOOK_BACK_MS
+  ),
+  UPDATE_STORE_VERSION_STORAGE_MODE(
+      "/update_store_version_storage_mode", HttpMethod.POST, Arrays.asList(NAME, VERSION, STORAGE_MODE), REGIONS_FILTER
   ),
   LIST_STORE_PUSH_INFO("/list_store_push_info", HttpMethod.GET, Arrays.asList(CLUSTER, NAME, PARTITION_DETAIL_ENABLED)),
   GET_REGION_PUSH_DETAILS(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -288,7 +288,8 @@ public enum ControllerRoute implements VeniceDimensionInterface {
       "/get_dead_stores", HttpMethod.GET, Arrays.asList(CLUSTER), NAME, INCLUDE_SYSTEM_STORES, LOOK_BACK_MS
   ),
   UPDATE_STORE_VERSION_STORAGE_MODE(
-      "/update_store_version_storage_mode", HttpMethod.POST, Arrays.asList(NAME, VERSION, STORAGE_MODE), REGIONS_FILTER
+      "/update_store_version_storage_mode", HttpMethod.POST, Arrays.asList(CLUSTER, NAME, VERSION, STORAGE_MODE),
+      REGIONS_FILTER
   ),
   LIST_STORE_PUSH_INFO("/list_store_push_info", HttpMethod.GET, Arrays.asList(CLUSTER, NAME, PARTITION_DETAIL_ENABLED)),
   GET_REGION_PUSH_DETAILS(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
@@ -254,6 +254,19 @@ public abstract class AbstractStore implements Store {
   }
 
   @Override
+  public void setVersionStorageMode(int versionNumber, StorageMode storageMode) {
+    checkVersionSupplier();
+    for (int i = storeVersionsSupplier.getForUpdate().size() - 1; i >= 0; i--) {
+      Version version = new VersionImpl(storeVersionsSupplier.getForUpdate().get(i));
+      if (version.getNumber() == versionNumber) {
+        version.setStorageMode(storageMode);
+        return;
+      }
+    }
+    throw new VeniceException("Version:" + versionNumber + " does not exist");
+  }
+
+  @Override
   public int peekNextVersionNumber() {
     int nextVersionNumber = getLargestUsedVersionNumber() + 1;
     checkDisableStoreWrite("increase", nextVersionNumber);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -1640,6 +1640,11 @@ public class ReadOnlyStore implements Store {
   }
 
   @Override
+  public void setVersionStorageMode(int versionNumber, StorageMode storageMode) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   @Nonnull
   public Version getVersionOrThrow(int versionNumber) throws StoreVersionNotFoundException {
     return new ReadOnlyVersion(this.delegate.getVersionOrThrow(versionNumber));

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
@@ -315,6 +315,12 @@ public interface Store {
     // ReadOnlyStore overrides to throw UnsupportedOperationException.
   }
 
+  default void setVersionStorageMode(int versionNumber, StorageMode storageMode) {
+    // No-op default. AbstractStore overrides this using storeVersionsSupplier.getForUpdate() to bypass the
+    // ReadOnlyVersion wrapper returned by getVersion(). ReadOnlyStore overrides to throw
+    // UnsupportedOperationException.
+  }
+
   int peekNextVersionNumber();
 
   /**

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/ControllerRouteDimensionTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/ControllerRouteDimensionTest.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.controllerapi;
 
+import static org.testng.Assert.assertTrue;
+
 import com.linkedin.venice.stats.dimensions.VeniceDimensionTestFixture;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
 import com.linkedin.venice.utils.CollectionUtils;
@@ -8,6 +10,11 @@ import org.testng.annotations.Test;
 
 
 public class ControllerRouteDimensionTest {
+  @Test
+  public void testUpdateStoreVersionStorageModeRequiresCluster() {
+    assertTrue(ControllerRoute.UPDATE_STORE_VERSION_STORAGE_MODE.getParams().contains(ControllerApiConstants.CLUSTER));
+  }
+
   @Test
   public void testDimensionInterface() {
     Map<ControllerRoute, String> expectedValues = CollectionUtils.<ControllerRoute, String>mapBuilder()

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/ControllerRouteDimensionTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/ControllerRouteDimensionTest.java
@@ -25,6 +25,7 @@ public class ControllerRouteDimensionTest {
         .put(ControllerRoute.ABORT_MIGRATION, "abort_migration")
         .put(ControllerRoute.DELETE_STORE, "delete_store")
         .put(ControllerRoute.UPDATE_STORE, "update_store")
+        .put(ControllerRoute.UPDATE_STORE_VERSION_STORAGE_MODE, "update_store_version_storage_mode")
         .put(ControllerRoute.SET_VERSION, "set_version")
         .put(ControllerRoute.ROLLBACK_TO_BACKUP_VERSION, "rollback_to_backup_version")
         .put(ControllerRoute.AGGREGATED_HEALTH_STATUS, "aggregated_health_status")

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/ReadOnlyStoreTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/ReadOnlyStoreTest.java
@@ -5,6 +5,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.systemstore.schemas.StoreETLConfig;
 import com.linkedin.venice.systemstore.schemas.StoreHybridConfig;
 import com.linkedin.venice.systemstore.schemas.StorePartitionerConfig;
@@ -431,5 +432,32 @@ public class ReadOnlyStoreTest {
     }
     // Backing store is unchanged
     assertTrue(store.getVersion(1).isTargetRegionPromoted());
+  }
+
+  @Test
+  public void testSetVersionStorageMode() {
+    ZKStore store = (ZKStore) TestUtils.createTestStore("testStore", "testOwner", System.currentTimeMillis());
+    store.addVersion(new VersionImpl(store.getName(), 1, "push1"));
+    store.addVersion(new VersionImpl(store.getName(), 2, "push2"));
+
+    store.setVersionStorageMode(1, StorageMode.DUAL_WRITE);
+    assertEquals(store.getVersion(1).getStorageMode(), StorageMode.DUAL_WRITE);
+    assertEquals(store.getVersion(2).getStorageMode(), StorageMode.INTERNAL);
+
+    try {
+      store.setVersionStorageMode(99, StorageMode.DUAL_WRITE);
+      throw new AssertionError("Expected VeniceException");
+    } catch (VeniceException e) {
+      assertTrue(e.getMessage().contains("Version:99 does not exist"));
+    }
+
+    ReadOnlyStore readOnlyStore = new ReadOnlyStore(store);
+    try {
+      readOnlyStore.setVersionStorageMode(1, StorageMode.INTERNAL);
+      throw new AssertionError("Expected UnsupportedOperationException");
+    } catch (UnsupportedOperationException e) {
+      // expected
+    }
+    assertEquals(store.getVersion(1).getStorageMode(), StorageMode.DUAL_WRITE);
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/InMemoryExternalStorageWriter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/InMemoryExternalStorageWriter.java
@@ -39,12 +39,22 @@ public class InMemoryExternalStorageWriter implements ExternalStorageWriter {
   private static final ConcurrentMap<String, ConcurrentMap<String, AtomicInteger>> BATCH_PUT_INVOCATIONS =
       new ConcurrentHashMap<>();
 
+  /** region → topic → total number of {@code batchPut} attempts across all tasks, including failed attempts. */
+  private static final ConcurrentMap<String, ConcurrentMap<String, AtomicInteger>> BATCH_PUT_ATTEMPTS =
+      new ConcurrentHashMap<>();
+
   /**
    * Key that the integration test uses to verify the OSS prefix-forwarding rule end-to-end: any
    * {@code push.job.external.storage.*} property set by the test on the driver must reach
    * {@link #configure}'s {@code VeniceProperties} on the executor.
    */
   static final String FORWARDED_CONFIG_PROBE_KEY = "push.job.external.storage.test.forwarded.value";
+
+  /**
+   * Optional integration-test knob: if set to a region name, every writer instance configured for that
+   * region throws from {@link #batchPut(List)} before persisting anything.
+   */
+  static final String FAIL_ALWAYS_IN_REGION_KEY = "push.job.external.storage.test.fail.always.in.region";
 
   /** region → topic → snapshot of {@link #FORWARDED_CONFIG_PROBE_KEY} captured at configure() time. */
   private static final ConcurrentMap<String, ConcurrentMap<String, String>> FORWARDED_CONFIG_OBSERVED =
@@ -53,6 +63,7 @@ public class InMemoryExternalStorageWriter implements ExternalStorageWriter {
   private String region;
   private String topicName;
   private ConcurrentMap<ByteBuffer, byte[]> shard;
+  private boolean failAlways;
 
   public InMemoryExternalStorageWriter() {
   }
@@ -69,12 +80,19 @@ public class InMemoryExternalStorageWriter implements ExternalStorageWriter {
     if (!observed.isEmpty()) {
       FORWARDED_CONFIG_OBSERVED.computeIfAbsent(region, r -> new ConcurrentHashMap<>()).put(topicName, observed);
     }
+    failAlways = region.equals(jobProps.getString(FAIL_ALWAYS_IN_REGION_KEY, ""));
   }
 
   @Override
   public void batchPut(List<ExternalStorageRecord> records) {
     if (records.isEmpty()) {
       return;
+    }
+    BATCH_PUT_ATTEMPTS.computeIfAbsent(region, r -> new ConcurrentHashMap<>())
+        .computeIfAbsent(topicName, k -> new AtomicInteger())
+        .incrementAndGet();
+    if (failAlways) {
+      throw new RuntimeException("Injected external-storage failure for region " + region);
     }
     BATCH_PUT_INVOCATIONS.computeIfAbsent(region, r -> new ConcurrentHashMap<>())
         .computeIfAbsent(topicName, k -> new AtomicInteger())
@@ -155,6 +173,16 @@ public class InMemoryExternalStorageWriter implements ExternalStorageWriter {
     return total;
   }
 
+  /** Total number of {@code batchPut} attempts for {@code (region, topic)}, including failed attempts. */
+  public static int batchPutAttemptsForRegionAndTopic(String region, String topicName) {
+    ConcurrentMap<String, AtomicInteger> byTopic = BATCH_PUT_ATTEMPTS.get(region);
+    if (byTopic == null) {
+      return 0;
+    }
+    AtomicInteger counter = byTopic.get(topicName);
+    return counter == null ? 0 : counter.get();
+  }
+
   /**
    * Value of {@link #FORWARDED_CONFIG_PROBE_KEY} seen by {@code configure()} for {@code topic} in any region.
    * {@code null} if no instance observed it (either because nothing was configured for that topic or because
@@ -175,6 +203,7 @@ public class InMemoryExternalStorageWriter implements ExternalStorageWriter {
     SINK.clear();
     MAX_BATCH_SIZE_OBSERVED.clear();
     BATCH_PUT_INVOCATIONS.clear();
+    BATCH_PUT_ATTEMPTS.clear();
     FORWARDED_CONFIG_OBSERVED.clear();
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVPJDualWriteExternalStorageMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVPJDualWriteExternalStorageMultiRegion.java
@@ -287,9 +287,9 @@ public class TestVPJDualWriteExternalStorageMultiRegion extends AbstractMultiReg
     props.setProperty(InMemoryExternalStorageWriter.FAIL_ALWAYS_IN_REGION_KEY, failedRegion);
 
     try (ControllerClient parentClient = new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl());
-        ControllerClient healthyClient =
+        ControllerClient healthyRegionControllerClient =
             new ControllerClient(CLUSTER_NAME, childDatacenters.get(0).getControllerConnectString());
-        ControllerClient failedClient =
+        ControllerClient failedRegionControllerClient =
             new ControllerClient(CLUSTER_NAME, childDatacenters.get(1).getControllerConnectString())) {
       assertCommand(parentClient.createNewStore(storeName, "owner", stringSchema.toString(), stringSchema.toString()));
       assertCommand(
@@ -300,10 +300,10 @@ public class TestVPJDualWriteExternalStorageMultiRegion extends AbstractMultiReg
                   .setStorageMode(StorageMode.DUAL_WRITE)));
       TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
         assertEquals(
-            assertCommand(healthyClient.getStore(storeName)).getStore().getStorageMode(),
+            assertCommand(healthyRegionControllerClient.getStore(storeName)).getStore().getStorageMode(),
             StorageMode.DUAL_WRITE);
         assertEquals(
-            assertCommand(failedClient.getStore(storeName)).getStore().getStorageMode(),
+            assertCommand(failedRegionControllerClient.getStore(storeName)).getStore().getStorageMode(),
             StorageMode.DUAL_WRITE);
       });
 
@@ -326,19 +326,19 @@ public class TestVPJDualWriteExternalStorageMultiRegion extends AbstractMultiReg
           "The failed region should never persist external-storage records after every batchPut throws");
 
       TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
-        StoreInfo healthyStore = assertCommand(healthyClient.getStore(storeName)).getStore();
-        StoreInfo failedStore = assertCommand(failedClient.getStore(storeName)).getStore();
+        StoreInfo healthyRegionStoreInfo = assertCommand(healthyRegionControllerClient.getStore(storeName)).getStore();
+        StoreInfo failedRegionStoreInfo = assertCommand(failedRegionControllerClient.getStore(storeName)).getStore();
 
-        assertEquals(healthyStore.getCurrentVersion(), 1);
-        assertEquals(failedStore.getCurrentVersion(), 1);
-        assertEquals(healthyStore.getStorageMode(), StorageMode.DUAL_WRITE);
-        assertEquals(failedStore.getStorageMode(), StorageMode.DUAL_WRITE);
+        assertEquals(healthyRegionStoreInfo.getCurrentVersion(), 1);
+        assertEquals(failedRegionStoreInfo.getCurrentVersion(), 1);
+        assertEquals(healthyRegionStoreInfo.getStorageMode(), StorageMode.DUAL_WRITE);
+        assertEquals(failedRegionStoreInfo.getStorageMode(), StorageMode.DUAL_WRITE);
         assertEquals(
-            healthyStore.getVersion(1).get().getStorageMode(),
+            healthyRegionStoreInfo.getVersion(1).get().getStorageMode(),
             StorageMode.DUAL_WRITE,
             "Healthy region should keep the version in DUAL_WRITE mode");
         assertEquals(
-            failedStore.getVersion(1).get().getStorageMode(),
+            failedRegionStoreInfo.getVersion(1).get().getStorageMode(),
             StorageMode.INTERNAL,
             "Failed region should downgrade only that version to INTERNAL before the swap");
       });

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVPJDualWriteExternalStorageMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVPJDualWriteExternalStorageMultiRegion.java
@@ -5,7 +5,10 @@ import static com.linkedin.venice.utils.TestWriteUtils.DEFAULT_USER_DATA_RECORD_
 import static com.linkedin.venice.utils.TestWriteUtils.DEFAULT_USER_DATA_VALUE_PREFIX;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DATA_WRITER_COMPUTE_JOB_CLASS;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_FAIL_OPEN_ON_REGION_FAILURE;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_BYTES_PER_REGION_PER_SECOND;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUSH_JOB_EXTERNAL_STORAGE_WRITE_QUOTA_RECORDS_PER_REGION_PER_SECOND;
@@ -247,6 +250,97 @@ public class TestVPJDualWriteExternalStorageMultiRegion extends AbstractMultiReg
                 veniceValue.toString(),
                 "External-storage value and Venice value diverge for key " + i);
           }
+        });
+      }
+    }
+  }
+
+  @Test(timeOut = 240 * Time.MS_PER_SECOND)
+  public void dualWritePushSucceedsWhenOneRegionExhaustsExternalWriteRetries() throws Exception {
+    String storeName = Utils.getUniqueString("dual_write_fail_open_multi_region");
+    String healthyRegion = multiRegionMultiClusterWrapper.getChildRegionNames().get(0);
+    String failedRegion = multiRegionMultiClusterWrapper.getChildRegionNames().get(1);
+
+    File inputDir = Utils.getTempDataDirectory();
+    writeSimpleAvroFileWithStringToStringSchema(inputDir);
+    Schema stringSchema = Schema.parse("\"string\"");
+
+    Properties props = IntegrationTestPushUtils
+        .defaultVPJProps(multiRegionMultiClusterWrapper, "file://" + inputDir.getAbsolutePath(), storeName);
+    props.setProperty(DATA_WRITER_COMPUTE_JOB_CLASS, DataWriterSparkJob.class.getCanonicalName());
+    props.setProperty(SPARK_NATIVE_INPUT_FORMAT_ENABLED, "true");
+    props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS, InMemoryExternalStorageWriter.class.getName());
+    props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE, "1");
+    props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES, "2");
+    props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRY_BACKOFF_MS, "0");
+    props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_FAIL_OPEN_ON_REGION_FAILURE, "true");
+    props.setProperty(InMemoryExternalStorageWriter.FAIL_ALWAYS_IN_REGION_KEY, failedRegion);
+
+    try (ControllerClient parentClient = new ControllerClient(CLUSTER_NAME, parentController.getControllerUrl());
+        ControllerClient healthyClient =
+            new ControllerClient(CLUSTER_NAME, childDatacenters.get(0).getControllerConnectString());
+        ControllerClient failedClient =
+            new ControllerClient(CLUSTER_NAME, childDatacenters.get(1).getControllerConnectString())) {
+      assertCommand(parentClient.createNewStore(storeName, "owner", stringSchema.toString(), stringSchema.toString()));
+      assertCommand(
+          parentClient.updateStore(
+              storeName,
+              new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+                  .setPartitionCount(1)
+                  .setStorageMode(StorageMode.DUAL_WRITE)));
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        assertEquals(
+            assertCommand(healthyClient.getStore(storeName)).getStore().getStorageMode(),
+            StorageMode.DUAL_WRITE);
+        assertEquals(
+            assertCommand(failedClient.getStore(storeName)).getStore().getStorageMode(),
+            StorageMode.DUAL_WRITE);
+      });
+
+      IntegrationTestPushUtils.runVPJ(props);
+
+      String topic = Version.composeKafkaTopic(storeName, 1);
+      assertEquals(
+          InMemoryExternalStorageWriter.batchPutAttemptsForRegionAndTopic(failedRegion, topic),
+          3,
+          "Failed region should exhaust the configured initial attempt plus 2 retries exactly once");
+      assertEquals(
+          InMemoryExternalStorageWriter.regionsWithDataForTopic(topic),
+          Collections.singleton(healthyRegion),
+          "Only the healthy region should retain external-storage data after fail-open disables the failed region");
+      assertEquals(
+          InMemoryExternalStorageWriter.snapshotForRegionAndTopic(healthyRegion, topic).size(),
+          DEFAULT_USER_DATA_RECORD_COUNT);
+      assertTrue(
+          InMemoryExternalStorageWriter.snapshotForRegionAndTopic(failedRegion, topic).isEmpty(),
+          "The failed region should never persist external-storage records after every batchPut throws");
+
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+        StoreInfo healthyStore = assertCommand(healthyClient.getStore(storeName)).getStore();
+        StoreInfo failedStore = assertCommand(failedClient.getStore(storeName)).getStore();
+
+        assertEquals(healthyStore.getCurrentVersion(), 1);
+        assertEquals(failedStore.getCurrentVersion(), 1);
+        assertEquals(healthyStore.getStorageMode(), StorageMode.DUAL_WRITE);
+        assertEquals(failedStore.getStorageMode(), StorageMode.DUAL_WRITE);
+        assertEquals(
+            healthyStore.getVersion(1).get().getStorageMode(),
+            StorageMode.DUAL_WRITE,
+            "Healthy region should keep the version in DUAL_WRITE mode");
+        assertEquals(
+            failedStore.getVersion(1).get().getStorageMode(),
+            StorageMode.INTERNAL,
+            "Failed region should downgrade only that version to INTERNAL before the swap");
+      });
+
+      VeniceClusterWrapper failedCluster = getCluster(1);
+      try (AvroGenericStoreClient<String, Object> client = ClientFactory.getAndStartGenericAvroClient(
+          ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(failedCluster.getRandomRouterURL()))) {
+        TestUtils.waitForNonDeterministicAssertion(READ_VERIFICATION_TIMEOUT_SEC, TimeUnit.SECONDS, true, true, () -> {
+          failedCluster.refreshAllRouterMetaData();
+          Object value = client.get("1").get();
+          assertNotNull(value, "Failed region should still serve the new current version");
+          assertEquals(value.toString(), DEFAULT_USER_DATA_VALUE_PREFIX + 1);
         });
       }
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVPJDualWriteExternalStorageMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVPJDualWriteExternalStorageMultiRegion.java
@@ -22,6 +22,7 @@ import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.hadoop.mapreduce.datawriter.jobs.DataWriterMRJob;
 import com.linkedin.venice.hadoop.task.datawriter.ExternalStorageRecord;
 import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
@@ -86,6 +87,11 @@ public class TestVPJDualWriteExternalStorageMultiRegion extends AbstractMultiReg
   @DataProvider(name = "batchSize")
   public Object[][] batchSize() {
     return new Object[][] { { 1 }, { 25 } };
+  }
+
+  @DataProvider(name = "dataWriterComputeJobClass")
+  public Object[][] dataWriterComputeJobClass() {
+    return new Object[][] { { DataWriterSparkJob.class }, { DataWriterMRJob.class } };
   }
 
   @Test(timeOut = 240 * Time.MS_PER_SECOND, dataProvider = "batchSize")
@@ -255,9 +261,11 @@ public class TestVPJDualWriteExternalStorageMultiRegion extends AbstractMultiReg
     }
   }
 
-  @Test(timeOut = 240 * Time.MS_PER_SECOND)
-  public void dualWritePushSucceedsWhenOneRegionExhaustsExternalWriteRetries() throws Exception {
-    String storeName = Utils.getUniqueString("dual_write_fail_open_multi_region");
+  @Test(timeOut = 240 * Time.MS_PER_SECOND, dataProvider = "dataWriterComputeJobClass")
+  public void dualWritePushSucceedsWhenOneRegionExhaustsExternalWriteRetries(Class<?> dataWriterComputeJobClass)
+      throws Exception {
+    String storeName =
+        Utils.getUniqueString("dual_write_fail_open_multi_region_" + dataWriterComputeJobClass.getSimpleName());
     String healthyRegion = multiRegionMultiClusterWrapper.getChildRegionNames().get(0);
     String failedRegion = multiRegionMultiClusterWrapper.getChildRegionNames().get(1);
 
@@ -267,8 +275,10 @@ public class TestVPJDualWriteExternalStorageMultiRegion extends AbstractMultiReg
 
     Properties props = IntegrationTestPushUtils
         .defaultVPJProps(multiRegionMultiClusterWrapper, "file://" + inputDir.getAbsolutePath(), storeName);
-    props.setProperty(DATA_WRITER_COMPUTE_JOB_CLASS, DataWriterSparkJob.class.getCanonicalName());
-    props.setProperty(SPARK_NATIVE_INPUT_FORMAT_ENABLED, "true");
+    props.setProperty(DATA_WRITER_COMPUTE_JOB_CLASS, dataWriterComputeJobClass.getCanonicalName());
+    if (dataWriterComputeJobClass == DataWriterSparkJob.class) {
+      props.setProperty(SPARK_NATIVE_INPUT_FORMAT_ENABLED, "true");
+    }
     props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_WRITER_CLASS, InMemoryExternalStorageWriter.class.getName());
     props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_BATCH_SIZE, "1");
     props.setProperty(PUSH_JOB_EXTERNAL_STORAGE_BATCHPUT_RETRIES, "2");

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -1018,6 +1018,20 @@ public interface Admin extends AutoCloseable, Closeable {
   }
 
   /**
+   * Update a specific version's {@link StorageMode} in the selected region(s) without mutating the
+   * store-level default. Used by VPJ fail-open external dual-write pushes to downgrade only the failed child
+   * colo's current version back to INTERNAL before EOP.
+   */
+  default void updateStoreVersionStorageMode(
+      String clusterName,
+      String storeName,
+      int version,
+      StorageMode storageMode,
+      String regionFilter) {
+    throw new VeniceUnsupportedOperationException("updateStoreVersionStorageMode");
+  }
+
+  /**
    * Return whether the admin consumption task is enabled for the passed cluster.
    */
   default boolean isAdminTopicConsumptionEnabled(String clusterName) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5846,6 +5846,45 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
   }
 
+  @Override
+  public void updateStoreVersionStorageMode(
+      String clusterName,
+      String storeName,
+      int version,
+      StorageMode storageMode,
+      String regionFilter) {
+    if (StringUtils.isNotEmpty(regionFilter) && !isRegionPartOfRegionsFilterList(getRegionName(), regionFilter)) {
+      LOGGER.info(
+          "Skipping version storage-mode update for store {} v{} in cluster {} because region filter {} does not include {}",
+          storeName,
+          version,
+          clusterName,
+          regionFilter,
+          getRegionName());
+      return;
+    }
+
+    storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
+      Version storeVersion = store.getVersion(version);
+      if (storeVersion == null) {
+        throw new VeniceException(
+            "Version " + version + " does not exist for store " + storeName + " in cluster " + clusterName);
+      }
+      if (storeVersion.getStorageMode() == storageMode) {
+        return store;
+      }
+      store.setVersionStorageMode(version, storageMode);
+      LOGGER.info(
+          "Updated store {} v{} storageMode to {} in cluster {} for region {}",
+          storeName,
+          version,
+          storageMode,
+          clusterName,
+          getRegionName());
+      return store;
+    });
+  }
+
   /**
    * Returns true if {@code localFabric} is permitted by an ETL active-fabrics allowlist.
    * {@code null} or empty list means "no restriction; permit every fabric" (default behavior).

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3177,6 +3177,46 @@ public class VeniceParentHelixAdmin implements Admin {
     parentVersionOrchestrator.updateStoreVersionStatus(clusterName, storeName, version, status);
   }
 
+  @Override
+  public void updateStoreVersionStorageMode(
+      String clusterName,
+      String storeName,
+      int version,
+      StorageMode storageMode,
+      String regionFilter) {
+    Map<String, ControllerClient> controllerClientMap = getVeniceHelixAdmin().getControllerClientMap(clusterName);
+    if (controllerClientMap.isEmpty()) {
+      throw new VeniceException("No child controller clients found for cluster " + clusterName);
+    }
+
+    Set<String> targetRegions = StringUtils.isEmpty(regionFilter)
+        ? new TreeSet<>(controllerClientMap.keySet())
+        : new TreeSet<>(parseRegionsFilterList(regionFilter));
+    Set<String> unknownRegions = new HashSet<>(targetRegions);
+    unknownRegions.removeAll(controllerClientMap.keySet());
+    if (!unknownRegions.isEmpty()) {
+      throw new VeniceException(
+          "Unknown regions " + unknownRegions + " requested for store " + storeName + " in cluster " + clusterName);
+    }
+
+    for (String region: targetRegions) {
+      ControllerClient childControllerClient = controllerClientMap.get(region);
+      ControllerResponse response;
+      try {
+        response = childControllerClient.updateStoreVersionStorageMode(storeName, version, storageMode);
+      } catch (Exception e) {
+        throw new VeniceException(
+            "Failed to update version storage mode for store " + storeName + " v" + version + " in region " + region,
+            e);
+      }
+      if (response.isError()) {
+        throw new VeniceException(
+            "Failed to update version storage mode for store " + storeName + " v" + version + " in region " + region
+                + ": " + response.getError());
+      }
+    }
+  }
+
   public void validateActiveActiveReplicationEnableConfigs(
       Optional<Boolean> activeActiveReplicationEnabledOptional,
       Optional<Boolean> nativeReplicationEnabledOptional,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -116,6 +116,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOP
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_UNCLEAN_LEADER_ELECTION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORAGE_PERSONA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORE;
+import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORE_VERSION_STORAGE_MODE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPLOAD_PUSH_JOB_STATUS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.VALIDATE_STORE_DELETED;
 import static com.linkedin.venice.controllerapi.ControllerRoute.WIPE_CLUSTER;
@@ -419,6 +420,9 @@ public class AdminSparkServer extends AbstractVeniceService {
     httpService.post(
         UPDATE_STORE.getPath(),
         new VeniceParentControllerRegionStateHandler(admin, storesRoutes.updateStore(admin)));
+    httpService.post(
+        UPDATE_STORE_VERSION_STORAGE_MODE.getPath(),
+        new VeniceParentControllerRegionStateHandler(admin, storesRoutes.updateStoreVersionStorageMode(admin)));
 
     httpService.post(
         AUTO_MIGRATE_STORE.getPath(),

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -22,6 +22,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.READ_WRIT
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REGIONS_FILTER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SOURCE_REGION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STATUS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_MODE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_CONFIG_NAME_FILTER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_CONFIG_VALUE_FILTER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_NAME;
@@ -63,6 +64,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.SET_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.STORAGE_ENGINE_OVERHEAD_RATIO;
 import static com.linkedin.venice.controllerapi.ControllerRoute.STORE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORE;
+import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORE_VERSION_STORAGE_MODE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.VALIDATE_STORE_DELETED;
 
 import com.linkedin.venice.HttpConstants;
@@ -1111,6 +1113,40 @@ public class StoresRoutes extends AbstractRoute {
         veniceResponse.setName(store);
         veniceResponse.setCluster(cluster);
         veniceResponse.setRegionToStorageMode(serialized);
+      }
+    };
+  }
+
+  /**
+   * @see Admin#updateStoreVersionStorageMode(String, String, int, StorageMode, String)
+   */
+  public Route updateStoreVersionStorageMode(Admin admin) {
+    return new VeniceRouteHandler<ControllerResponse>(ControllerResponse.class) {
+      @Override
+      public void internalHandle(Request request, ControllerResponse veniceResponse) {
+        if (!checkIsAllowListUser(
+            request,
+            veniceResponse,
+            () -> isAllowListUser(request) || hasWriteAccessToTopic(request))) {
+          return;
+        }
+        AdminSparkServer.validateParams(request, UPDATE_STORE_VERSION_STORAGE_MODE.getParams(), admin);
+        String clusterName = request.queryParams(CLUSTER);
+        String storeName = request.queryParams(NAME);
+        veniceResponse.setCluster(clusterName);
+        veniceResponse.setName(storeName);
+
+        try {
+          int version = Integer.parseInt(request.queryParams(VERSION));
+          StorageMode storageMode = StorageMode.valueOf(request.queryParams(STORAGE_MODE));
+          String regionsFilter = request.queryParamOrDefault(REGIONS_FILTER, "");
+          admin.updateStoreVersionStorageMode(clusterName, storeName, version, storageMode, regionsFilter);
+        } catch (Exception e) {
+          veniceResponse.setError(
+              "Failed when updating version storage mode for store " + storeName + ". Exception type: "
+                  + e.getClass().toString() + ". Detailed message = " + e.getMessage(),
+              e);
+        }
       }
     };
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -242,6 +242,42 @@ public class TestVeniceHelixAdmin {
         () -> veniceHelixAdmin.getStorageModePerRegion(clusterName, missingStoreName));
   }
 
+  @Test
+  public void testUpdateStoreVersionStorageModeMutatesOnlyTheVersion() {
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    String storeName = "store_version_storage_mode_update";
+    Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
+    store.setStorageMode(StorageMode.DUAL_WRITE);
+    VersionImpl version = new VersionImpl(storeName, 1, "test-push");
+    version.setStorageMode(StorageMode.DUAL_WRITE);
+    store.addVersion(version);
+    doReturn("dc-0").when(veniceHelixAdmin).getRegionName();
+    doAnswer(invocation -> {
+      VeniceHelixAdmin.StoreMetadataOperation operation = invocation.getArgument(2);
+      operation.update(store, null);
+      return null;
+    }).when(veniceHelixAdmin).storeMetadataUpdate(eq(clusterName), eq(storeName), any());
+    doCallRealMethod().when(veniceHelixAdmin)
+        .updateStoreVersionStorageMode(clusterName, storeName, 1, StorageMode.INTERNAL, "dc-0");
+
+    veniceHelixAdmin.updateStoreVersionStorageMode(clusterName, storeName, 1, StorageMode.INTERNAL, "dc-0");
+
+    assertEquals(store.getStorageMode(), StorageMode.DUAL_WRITE);
+    assertEquals(store.getVersion(1).getStorageMode(), StorageMode.INTERNAL);
+  }
+
+  @Test
+  public void testUpdateStoreVersionStorageModeSkipsWhenRegionFilterDoesNotMatch() {
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    doReturn("dc-0").when(veniceHelixAdmin).getRegionName();
+    doCallRealMethod().when(veniceHelixAdmin)
+        .updateStoreVersionStorageMode(clusterName, "store", 1, StorageMode.INTERNAL, "dc-1");
+
+    veniceHelixAdmin.updateStoreVersionStorageMode(clusterName, "store", 1, StorageMode.INTERNAL, "dc-1");
+
+    verify(veniceHelixAdmin, never()).storeMetadataUpdate(anyString(), anyString(), any());
+  }
+
   /**
    * This test verify that in function {@link VeniceHelixAdmin#setUpMetaStoreAndMayProduceSnapshot},
    * meta store RT topic creation has to happen before any writings to meta store's rt topic.

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -3036,6 +3036,42 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   @Test
+  public void testUpdateStoreVersionStorageModeTargetsOnlyRequestedRegions() {
+    String storeName = "test_store_version_storage_mode_targeted";
+    Map<String, ControllerClient> controllerClientMap = new HashMap<>();
+    ControllerClient dc0Client = mock(ControllerClient.class);
+    ControllerClient dc1Client = mock(ControllerClient.class);
+    controllerClientMap.put("dc-0", dc0Client);
+    controllerClientMap.put("dc-1", dc1Client);
+    doReturn(controllerClientMap).when(internalAdmin).getControllerClientMap(clusterName);
+
+    ControllerResponse response = new ControllerResponse();
+    doReturn(response).when(dc1Client).updateStoreVersionStorageMode(storeName, 1, StorageMode.INTERNAL);
+
+    parentAdmin.updateStoreVersionStorageMode(clusterName, storeName, 1, StorageMode.INTERNAL, "dc-1");
+
+    verify(dc0Client, never()).updateStoreVersionStorageMode(anyString(), anyInt(), any());
+    verify(dc1Client).updateStoreVersionStorageMode(storeName, 1, StorageMode.INTERNAL);
+  }
+
+  @Test
+  public void testUpdateStoreVersionStorageModeThrowsOnChildError() {
+    String storeName = "test_store_version_storage_mode_error";
+    Map<String, ControllerClient> controllerClientMap = new HashMap<>();
+    ControllerClient dc0Client = mock(ControllerClient.class);
+    controllerClientMap.put("dc-0", dc0Client);
+    doReturn(controllerClientMap).when(internalAdmin).getControllerClientMap(clusterName);
+
+    ControllerResponse errorResponse = new ControllerResponse();
+    errorResponse.setError("simulated child failure");
+    doReturn(errorResponse).when(dc0Client).updateStoreVersionStorageMode(storeName, 1, StorageMode.INTERNAL);
+
+    assertThrows(
+        VeniceException.class,
+        () -> parentAdmin.updateStoreVersionStorageMode(clusterName, storeName, 1, StorageMode.INTERNAL, "dc-0"));
+  }
+
+  @Test
   public void checkNewPushCapacityFromChildrenBlocksWhenChildRolledBackWithinRetention() {
     String store = "npc_from_children_rollback_block";
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoresRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoresRoutesTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
@@ -18,6 +19,7 @@ import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.VeniceHelixAdmin;
 import com.linkedin.venice.controller.VeniceParentHelixAdmin;
 import com.linkedin.venice.controllerapi.ControllerApiConstants;
+import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.MultiRegionStorageModeResponse;
 import com.linkedin.venice.controllerapi.MultiStoreInfoResponse;
 import com.linkedin.venice.controllerapi.MultiStoreResponse;
@@ -112,6 +114,60 @@ public class StoresRoutesTest {
     Assert.assertEquals(response.getName(), TEST_STORE_NAME);
     Assert.assertEquals(response.getRegionToStorageMode().get("dc-0"), "DUAL_WRITE");
     Assert.assertEquals(response.getRegionToStorageMode().get("dc-1"), "INTERNAL");
+  }
+
+  @Test
+  public void testUpdateStoreVersionStorageMode() throws Exception {
+    Admin mockAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(true).when(mockAdmin).isLeaderControllerFor(TEST_CLUSTER);
+
+    Request request = mock(Request.class);
+    doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
+    doReturn(TEST_STORE_NAME).when(request).queryParams(eq(ControllerApiConstants.NAME));
+    doReturn("1").when(request).queryParams(eq(ControllerApiConstants.VERSION));
+    doReturn(StorageMode.INTERNAL.name()).when(request).queryParams(eq(ControllerApiConstants.STORAGE_MODE));
+    doReturn("dc-1").when(request).queryParamOrDefault(eq(ControllerApiConstants.REGIONS_FILTER), eq(""));
+
+    Route route =
+        new StoresRoutes(false, Optional.empty(), pubSubTopicRepository).updateStoreVersionStorageMode(mockAdmin);
+    ControllerResponse response = ObjectMapperFactory.getInstance()
+        .readValue(route.handle(request, mock(Response.class)).toString(), ControllerResponse.class);
+
+    Assert.assertFalse(response.isError());
+    Assert.assertEquals(response.getCluster(), TEST_CLUSTER);
+    Assert.assertEquals(response.getName(), TEST_STORE_NAME);
+    verify(mockAdmin).updateStoreVersionStorageMode(TEST_CLUSTER, TEST_STORE_NAME, 1, StorageMode.INTERNAL, "dc-1");
+  }
+
+  @Test
+  public void testUpdateStoreVersionStorageModeAllowsTopicWriter() throws Exception {
+    Admin mockAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(true).when(mockAdmin).isLeaderControllerFor(TEST_CLUSTER);
+
+    Request request = mock(Request.class);
+    doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
+    doReturn(TEST_STORE_NAME).when(request).queryParams(eq(ControllerApiConstants.NAME));
+    doReturn("1").when(request).queryParams(eq(ControllerApiConstants.VERSION));
+    doReturn(StorageMode.INTERNAL.name()).when(request).queryParams(eq(ControllerApiConstants.STORAGE_MODE));
+    doReturn("dc-1").when(request).queryParamOrDefault(eq(ControllerApiConstants.REGIONS_FILTER), eq(""));
+
+    StoresRoutes storesRoutes = new StoresRoutes(false, Optional.empty(), pubSubTopicRepository) {
+      @Override
+      protected boolean isAllowListUser(Request request) {
+        return false;
+      }
+
+      @Override
+      protected boolean hasWriteAccessToTopic(Request request) {
+        return true;
+      }
+    };
+    Route route = storesRoutes.updateStoreVersionStorageMode(mockAdmin);
+    ControllerResponse response = ObjectMapperFactory.getInstance()
+        .readValue(route.handle(request, mock(Response.class)).toString(), ControllerResponse.class);
+
+    Assert.assertFalse(response.isError());
+    verify(mockAdmin).updateStoreVersionStorageMode(TEST_CLUSTER, TEST_STORE_NAME, 1, StorageMode.INTERNAL, "dc-1");
   }
 
   @Test


### PR DESCRIPTION
## Problem Statement

A single regional external storage engine writer exhausting retries currently fails the entire multi-colo VPJ, even when Venice and the other regional external storage engines are healthy.

## Solution

- Add `push.job.external.storage.fail.open.on.region.failure` (default: `false`).
- When enabled, disable only the failed regional external storage engine writer after retry exhaustion and continue healthy regions plus Venice.
- Aggregate failed regions from successful MR/Spark tasks, then set only those child-region versions to `INTERNAL` before EOP. Store-level `storageMode` remains `DUAL_WRITE`.
- Fail the push before EOP with contextual errors if the controller mutation is unavailable or fails.

### Code changes

- [x] Added new code behind **a config**: `push.job.external.storage.fail.open.on.region.failure=false`.
- [x] Introduced new **log lines**.
  - [x] Confirmed logs are bounded to retry attempts and one disable warning per task/region.

### **Concurrency-Specific Checks**

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used where needed.
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [x] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility: the new behavior is disabled by default.

Targeted VPJ/controller unit tests and `TestVPJDualWriteExternalStorageMultiRegion` pass. The integration test runs the same fail-open scenario with both Spark and MapReduce data writers: it consistently fails one region's external storage engine writes, verifies retry exhaustion, successful push completion, and a version-only `INTERNAL` downgrade in that region.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
