### PR TITLE
[da-vinci] Fix NPE in BlobSnapshotManager.prepareMetadata when no offset record exists

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
@@ -332,20 +332,28 @@ public class BlobSnapshotManager {
       throw new VeniceException("StorageMetadataService or storeVersionStateSerializer is not initialized");
     }
 
-    if (storageMetadataService.getStoreVersionState(blobTransferRequest.getTopicName()) == null
-        || storageMetadataService
-            .getLastOffset(blobTransferRequest.getTopicName(), blobTransferRequest.getPartition(), null) == null) {
+    StoreVersionState storeVersionState =
+        storageMetadataService.getStoreVersionState(blobTransferRequest.getTopicName());
+
+    OffsetRecord offsetRecord;
+    try {
+      // No PubSubContext is available in this code path. When no offset has ever been persisted for this
+      // partition, getLastOffset(..., null) falls back to constructing a brand new OffsetRecord and
+      // dereferences the null PubSubContext while doing so, throwing an NPE instead of returning null.
+      // Treat that the same as "no offset record found" below.
+      offsetRecord = storageMetadataService
+          .getLastOffset(blobTransferRequest.getTopicName(), blobTransferRequest.getPartition(), null);
+    } catch (NullPointerException e) {
+      offsetRecord = null;
+    }
+
+    if (storeVersionState == null || offsetRecord == null) {
       throw new VeniceException("Cannot get store version state or offset record from storage metadata service.");
     }
 
     // prepare metadata
-    StoreVersionState storeVersionState =
-        storageMetadataService.getStoreVersionState(blobTransferRequest.getTopicName());
     java.nio.ByteBuffer storeVersionStateByte =
         ByteBuffer.wrap(storeVersionStateSerializer.serialize(blobTransferRequest.getTopicName(), storeVersionState));
-
-    OffsetRecord offsetRecord = storageMetadataService
-        .getLastOffset(blobTransferRequest.getTopicName(), blobTransferRequest.getPartition(), null);
 
     LOGGER.info(
         "Preparing offset record for topic {} partition {} with pushTrackingIncrementalPushStatus {}",

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManagerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManagerTest.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.blobtransfer;
 
 import static com.linkedin.davinci.blobtransfer.BlobTransferUtils.BlobTransferTableFormat;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -404,5 +405,27 @@ public class BlobSnapshotManagerTest {
     // Verify cleanup was executed and snapshot was created
     verify(blobSnapshotManager, times(1)).cleanupSnapshot(TOPIC_NAME, PARTITION_ID);
     verify(blobSnapshotManager, times(1)).createSnapshot(TOPIC_NAME, PARTITION_ID);
+  }
+
+  @Test(timeOut = TIMEOUT)
+  public void testPrepareMetadataThrowsVeniceExceptionWhenNoOffsetRecordExists() {
+    // Regression test: StorageMetadataService.getLastOffset(..., null) is called without a PubSubContext.
+    // When no offset has ever been persisted for a partition, that call falls back to constructing a fresh
+    // OffsetRecord and throws an NPE instead of returning null (since it dereferences the null
+    // PubSubContext). prepareMetadata() must translate that into the intended
+    // "Cannot get store version state or offset record..." VeniceException rather than let the NPE escape.
+    StorageMetadataService localStorageMetadataService = mock(StorageMetadataService.class);
+    doReturn(mock(com.linkedin.venice.kafka.protocol.state.StoreVersionState.class)).when(localStorageMetadataService)
+        .getStoreVersionState(TOPIC_NAME);
+    doThrow(new NullPointerException("pubSubContext is null")).when(localStorageMetadataService)
+        .getLastOffset(TOPIC_NAME, PARTITION_ID, null);
+
+    BlobSnapshotManager blobSnapshotManager =
+        new BlobSnapshotManager(storageEngineRepository, localStorageMetadataService);
+
+    VeniceException e =
+        Assert.expectThrows(VeniceException.class, () -> blobSnapshotManager.prepareMetadata(blobTransferPayload));
+    Assert
+        .assertEquals(e.getMessage(), "Cannot get store version state or offset record from storage metadata service.");
   }
 }


### PR DESCRIPTION
## Problem Statement

`BlobSnapshotManager.prepareMetadata()` calls
`storageMetadataService.getLastOffset(topic, partition, null)` without a `PubSubContext`.

`StorageEngineMetadataService.getLastOffset()` returns
`record.orElseGet(() -> new OffsetRecord(serializer, pubSubContext))` when no offset record exists yet
for the partition. Since `pubSubContext` is `null` here, constructing that fallback `OffsetRecord`
dereferences the null `PubSubContext` (`pubSubContext.getPubSubPositionDeserializer()`) and throws an
uncaught `NullPointerException`, instead of the intended, more actionable
`"Cannot get store version state or offset record from storage metadata service."` `VeniceException`.

This surfaced in production as an uncaught NPE during a recent blob-transfer-heavy cluster expansion,
when newly bootstrapped partitions on expanded hosts had no persisted offset record yet.
`P2PFileTransferServerHandler` already gracefully handles the intended `VeniceException` by responding
with `404 NOT_FOUND` so the requester falls back to the next peer / Kafka bootstrap — but the raw NPE
bypasses that intended, well-understood handling path.

## Solution

Catch the `NullPointerException` thrown by `getLastOffset()` in `BlobSnapshotManager.prepareMetadata()`
and treat it the same as "no offset record found", so the existing intended `VeniceException` is thrown
instead. Scoped the fix to `BlobSnapshotManager` only, without touching the shared `OffsetRecord`/
`StorageEngineMetadataService` classes.

### Code changes

- [ ] Added new code behind **a config**.
- [ ] Introduced new **log lines**.

### **Concurrency-Specific Checks**

- [x] Code has **no race conditions** or **thread safety issues**. (single method, no shared state changes)
- [ ] Proper **synchronization mechanisms** used where needed. (N/A)
- [ ] No **blocking calls** inside critical sections. (N/A)
- [ ] Verified **thread-safe collections** used. (N/A)
- [x] Validated proper exception handling to avoid an uncaught NPE crashing the request handler.

## How was this PR tested?

- [x] New unit tests added (`BlobSnapshotManagerTest#testPrepareMetadataThrowsVeniceExceptionWhenNoOffsetRecordExists`).
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (full existing `BlobSnapshotManagerTest` suite passes unchanged).

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
