### PR TITLE
[protocol][build] Stage PushJobDetails v6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -330,9 +330,9 @@ subprojects {
       // project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
       def versionOverrides = [
           // PushJobDetails v6 stages externalStorageWriteTimeMs + veniceWriteTimeMs. Pinned to the current active
-          // version so controllers register v6 in the push job details system store while the code keeps
-          // serializing v5. The override is removed and PUSH_JOB_DETAILS is bumped to v6 in the follow-up PR that
-          // actually populates the two fields from the push job.
+          // version so the generated classes stay on v5 and no code path can serialize v6 yet. The override is
+          // removed and PUSH_JOB_DETAILS is bumped to v6 in the follow-up PR that actually populates the two fields
+          // from the push job, which is also what makes the controllers register v6.
           project(':internal:venice-common').file('src/main/resources/avro/PushJobDetails/v5', PathValidation.DIRECTORY),
       ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -328,7 +328,13 @@ subprojects {
       // Protocol changes should pin the current version via this override and remove the override in a follow-up PR
       // when actually using the new protocol. Example to pin KME to v12 when introducing v13:
       // project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
-      def versionOverrides = []
+      def versionOverrides = [
+          // PushJobDetails v6 stages externalStorageWriteTimeMs + veniceWriteTimeMs. Pinned to the current active
+          // version so controllers register v6 in the push job details system store while the code keeps
+          // serializing v5. The override is removed and PUSH_JOB_DETAILS is bumped to v6 in the follow-up PR that
+          // actually populates the two fields from the push job.
+          project(':internal:venice-common').file('src/main/resources/avro/PushJobDetails/v5', PathValidation.DIRECTORY),
+      ]
 
       def schemaDirs = [sourceDir]
       sourceDir.eachDir { typeDir ->

--- a/build.gradle
+++ b/build.gradle
@@ -329,9 +329,9 @@ subprojects {
       // when actually using the new protocol. Example to pin KME to v12 when introducing v13:
       // project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
       def versionOverrides = [
-          // PushJobDetails v6 stages externalStorageWriteTimeMs + veniceWriteTimeMs. Pinned to the current active
+          // PushJobDetails v6 stages the additionalPushMetrics map field. Pinned to the current active
           // version so the generated classes stay on v5 and no code path can serialize v6 yet. The override is
-          // removed and PUSH_JOB_DETAILS is bumped to v6 in the follow-up PR that actually populates the two fields
+          // removed and PUSH_JOB_DETAILS is bumped to v6 in the follow-up PR that actually populates the map
           // from the push job, which is also what makes the controllers register v6.
           project(':internal:venice-common').file('src/main/resources/avro/PushJobDetails/v5', PathValidation.DIRECTORY),
       ]

--- a/internal/venice-common/src/main/resources/avro/PushJobDetails/v6/PushJobDetails.avsc
+++ b/internal/venice-common/src/main/resources/avro/PushJobDetails/v6/PushJobDetails.avsc
@@ -82,7 +82,7 @@
     },
     {
       "name": "additionalPushMetrics",
-      "doc": "Extensible map of additional push-job metrics keyed by metric name, so new metrics (e.g. per-destination write timings, error-retry counts, per-batch latency) can be added without evolving this schema again. Values reported so far: 'externalStorageWriteTimeMs' - total elapsed time in milliseconds, summed across all successful data writer task outputs of this push, spent in the external storage write path (throttling wait, batch write calls including retries and retry backoff, flush and close); 'veniceWriteTimeMs' - total elapsed time in milliseconds, summed across all successful data writer task outputs of this push, spent invoking the Venice/Kafka writes and flushing/closing the Venice writer. Both are sums of per-task wall-clock durations, NOT the push job's overall wall-clock duration, so with N parallel tasks they can be up to N times the push duration. A missing key means the push did not report that metric (no dual write configured, or an older push job version). Null when no additional metrics were reported.",
+      "doc": "Additional push-job metrics keyed by metric name. Current keys are 'externalStorageWriteTimeMs' for the external write path, including throttling, retries, flush, and close, and 'veniceWriteTimeMs' for Venice writes, flush, and close. Values are summed task wall-clock milliseconds, not overall push duration. A missing key means the metric was not reported; null means no additional metrics were reported.",
       "type": ["null", {"type": "map", "values": "long"}],
       "default": null
     }

--- a/internal/venice-common/src/main/resources/avro/PushJobDetails/v6/PushJobDetails.avsc
+++ b/internal/venice-common/src/main/resources/avro/PushJobDetails/v6/PushJobDetails.avsc
@@ -1,0 +1,96 @@
+{
+  "name": "PushJobDetails",
+  "namespace": "com.linkedin.venice.status.protocol",
+  "type": "record",
+  "fields": [
+    {"name": "clusterName", "type": "string"},
+    {"name": "reportTimestamp", "type": "long", "doc": "timestamp for when the reported details were collected"},
+    {
+      "name": "overallStatus",
+      "type": {
+        "type":"array",
+        "items":{
+          "name": "PushJobDetailsStatusTuple",
+          "type": "record",
+          "fields": [
+            {"name": "status", "type": "int"},
+            {"name": "timestamp", "type": "long"}
+          ],
+          "doc": "0 => STARTED, 1 => COMPLETED, 2 => ERROR, 3 => NOT_CREATED, 4 => UNKNOWN, 5 => TOPIC_CREATED, 6 => WRITE_TO_KAFKA_COMPLETED, 7 => KILLED, 8 => END_OF_PUSH_RECEIVED, 9 => START_OF_INCREMENTAL_PUSH_RECEIVED, 10 => END_OF_INCREMENTAL_PUSH_RECEIVED"
+        }
+      }
+    },
+    {
+      "name": "coloStatus",
+      "type": [
+        "null",
+        {
+          "type" : "map",
+          "values": {
+            "type": "array",
+            "items": "com.linkedin.venice.status.protocol.PushJobDetailsStatusTuple"
+          }
+        }
+      ],
+      "default": null
+    },
+    {"name": "pushId", "type": "string", "default": ""},
+    {"name": "partitionCount", "type": "int", "default": -1},
+    {"name": "valueCompressionStrategy", "type": "int", "doc": "0 => NO_OP, 1 => GZIP", "default": 0},
+    {"name": "chunkingEnabled", "type": "boolean", "default": false},
+    {"name": "jobDurationInMs", "type": "long", "default": -1},
+    {"name": "totalNumberOfRecords", "type": "long", "doc": "total number of key value pairs pushed", "default": -1},
+    {"name": "totalKeyBytes", "type": "long", "doc": "total amount of key bytes pushed", "default": -1},
+    {"name": "totalRawValueBytes", "type": "long", "doc": "total amount of uncompressed value bytes", "default": -1},
+    {"name": "totalCompressedValueBytes", "type": "long", "doc": "total amount of compressed value bytes stored", "default": -1},
+    {"name": "totalGzipCompressedValueBytes", "type": "long", "doc": "total amount of Gzip compressed value bytes", "default": -1},
+    {"name": "totalZstdWithDictCompressedValueBytes", "type": "long", "doc": "total amount of Zstd with Dictionary compressed value bytes", "default": -1},
+    {"name": "totalUncompressedRecordTooLargeFailures", "type": "long", "doc": "total number of records exceeding size limit before compression", "default": -1},
+    {"name": "largestUncompressedValueSizeBytes", "type": "int", "doc": "largest uncompressed value size bytes", "default": -1},
+    {"name": "pushJobConfigs",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "string"
+        }
+      ],
+      "default": null
+    },
+    {"name": "producerConfigs",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "string"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "pushJobLatestCheckpoint",
+      "doc": "Latest checkpoint reached by the push job if available, negative values are known error checkpoints. Refer to {@link com.linkedin.venice.hadoop.VenicePushJob.PushJobCheckpoints}",
+      "type": ["null", "int"],
+      "default":  null
+    },
+    {"name": "failureDetails", "type": "string", "default":  ""},
+    {
+      "name": "sendLivenessHeartbeatFailureDetails",
+      "doc": "Failure details of sending liveness heartbeat from the push job. If no failure or the job is not enabled to send liveness heartbeat, this field is null",
+      "type": ["null", "string"],
+      "default":  null
+    },
+    {
+      "name": "externalStorageWriteTimeMs",
+      "doc": "Total elapsed time in milliseconds, summed across all successful data writer task outputs of this push, spent in the external storage (Spaniel/TiKV) write path: throttling wait, batchPut calls including retries and retry backoff, external flush and external close. This is a sum of per-task wall-clock durations, NOT the push job's overall wall-clock duration, so with N parallel tasks it can be up to N times the push duration. -1 when the push did not report it (no dual write configured, or an older push job version).",
+      "type": "long",
+      "default": -1
+    },
+    {
+      "name": "veniceWriteTimeMs",
+      "doc": "Total elapsed time in milliseconds, summed across all successful data writer task outputs of this push, spent invoking the Venice/Kafka writes and flushing/closing the Venice writer. This is a sum of per-task wall-clock durations, NOT the push job's overall wall-clock duration. -1 when the push did not report it.",
+      "type": "long",
+      "default": -1
+    }
+  ]
+}

--- a/internal/venice-common/src/main/resources/avro/PushJobDetails/v6/PushJobDetails.avsc
+++ b/internal/venice-common/src/main/resources/avro/PushJobDetails/v6/PushJobDetails.avsc
@@ -81,16 +81,10 @@
       "default":  null
     },
     {
-      "name": "externalStorageWriteTimeMs",
-      "doc": "Total elapsed time in milliseconds, summed across all successful data writer task outputs of this push, spent in the external storage (Spaniel/TiKV) write path: throttling wait, batchPut calls including retries and retry backoff, external flush and external close. This is a sum of per-task wall-clock durations, NOT the push job's overall wall-clock duration, so with N parallel tasks it can be up to N times the push duration. -1 when the push did not report it (no dual write configured, or an older push job version).",
-      "type": "long",
-      "default": -1
-    },
-    {
-      "name": "veniceWriteTimeMs",
-      "doc": "Total elapsed time in milliseconds, summed across all successful data writer task outputs of this push, spent invoking the Venice/Kafka writes and flushing/closing the Venice writer. This is a sum of per-task wall-clock durations, NOT the push job's overall wall-clock duration. -1 when the push did not report it.",
-      "type": "long",
-      "default": -1
+      "name": "additionalPushMetrics",
+      "doc": "Extensible map of additional push-job metrics keyed by metric name, so new metrics (e.g. per-destination write timings, error-retry counts, per-batch latency) can be added without evolving this schema again. Values reported so far: 'externalStorageWriteTimeMs' - total elapsed time in milliseconds, summed across all successful data writer task outputs of this push, spent in the external storage write path (throttling wait, batch write calls including retries and retry backoff, flush and close); 'veniceWriteTimeMs' - total elapsed time in milliseconds, summed across all successful data writer task outputs of this push, spent invoking the Venice/Kafka writes and flushing/closing the Venice writer. Both are sums of per-task wall-clock durations, NOT the push job's overall wall-clock duration, so with N parallel tasks they can be up to N times the push duration. A missing key means the push did not report that metric (no dual write configured, or an older push job version). Null when no additional metrics were reported.",
+      "type": ["null", {"type": "map", "values": "long"}],
+      "default": null
     }
   ]
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/status/protocol/TestPushJobDetailsSchemaCompatibility.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/status/protocol/TestPushJobDetailsSchemaCompatibility.java
@@ -1,36 +1,15 @@
 package com.linkedin.venice.status.protocol;
 
-import static java.util.Collections.emptyList;
-
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.Utils;
-import it.unimi.dsi.fastutil.ints.IntSet;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaCompatibility;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericDatumWriter;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.BinaryEncoder;
-import org.apache.avro.io.DatumReader;
-import org.apache.avro.io.DatumWriter;
-import org.apache.avro.io.DecoderFactory;
-import org.apache.avro.io.EncoderFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
 public class TestPushJobDetailsSchemaCompatibility {
-  private static final int STAGED_SCHEMA_ID = 6;
-  private static final int ACTIVE_SCHEMA_ID = STAGED_SCHEMA_ID - 1;
-  private static final List<String> STAGED_FIELDS = Arrays.asList("externalStorageWriteTimeMs", "veniceWriteTimeMs");
-
   private Map<Integer, Schema> schemaVersionMap =
       Utils.getAllSchemasFromResources(AvroProtocolDefinition.PUSH_JOB_DETAILS);
 
@@ -51,110 +30,5 @@ public class TestPushJobDetailsSchemaCompatibility {
           "PushJobDetails schema version " + schemaId + " is incompatible with the latest schema " + "version of "
               + latestSchemaId);
     });
-  }
-
-  /**
-   * v6 is staged, which means it is inert: the {@code versionOverrides} pin in the root build.gradle keeps the
-   * generated classes on v5, and {@link Utils#getAllSchemasFromResources(AvroProtocolDefinition)} stops at the
-   * compiled version, so no runtime path in this build reads, writes or registers v6. Controllers register value
-   * schemas only up to {@link AvroProtocolDefinition#currentProtocolVersion}, and the serializer only caches
-   * readers for the versions resource discovery returned, so both stop at v5 too.
-   *
-   * That inertness is the point of staging: the schema is frozen in the resources and reviewed on its own, while
-   * no code path can emit it. The follow-up PR removes the pin and bumps the protocol definition, which is what
-   * actually registers v6 on the controllers and starts serializing it.
-   */
-  @Test
-  public void testStagedV6IsNotActivatedAndNotVisibleAtRuntime() throws IOException {
-    Assert.assertEquals(
-        AvroProtocolDefinition.PUSH_JOB_DETAILS.currentProtocolVersion.get().intValue(),
-        ACTIVE_SCHEMA_ID,
-        "PushJobDetails v6 must stay staged until the push job actually populates the new fields");
-    Assert.assertNull(
-        schemaVersionMap.get(STAGED_SCHEMA_ID),
-        "The compiled PushJobDetails class must still be v5 while v6 is only staged");
-    IntSet knownProtocols = AvroProtocolDefinition.PUSH_JOB_DETAILS.getSerializer().knownProtocols();
-    Assert.assertTrue(
-        knownProtocols.contains(ACTIVE_SCHEMA_ID),
-        "The runtime serializer must know the active version v5, got: " + knownProtocols);
-    Assert.assertFalse(
-        knownProtocols.contains(STAGED_SCHEMA_ID),
-        "A staged schema must stay invisible to the runtime serializer, otherwise a v6 payload could be emitted "
-            + "before the controllers have registered v6, got: " + knownProtocols);
-
-    Schema activeSchema = schemaVersionMap.get(ACTIVE_SCHEMA_ID);
-    Schema stagedSchema = getStagedSchema();
-    List<String> addedFields = stagedSchema.getFields()
-        .stream()
-        .map(Schema.Field::name)
-        .filter(name -> activeSchema.getField(name) == null)
-        .collect(Collectors.toList());
-    Assert.assertEquals(addedFields, STAGED_FIELDS, "v6 must only append the two timing fields on top of v5");
-    for (String addedField: STAGED_FIELDS) {
-      Schema.Field field = stagedSchema.getField(addedField);
-      Assert.assertEquals(field.schema().getType(), Schema.Type.LONG);
-      Assert.assertTrue(field.hasDefaultValue(), addedField + " must carry a default so v5 records stay readable");
-      Assert.assertEquals(GenericData.get().getDefaultValue(field), -1L, addedField + " must default to -1");
-    }
-
-    // When the follow-up PR activates v6, the controllers register it against v5, which is the version still being
-    // written by push jobs that have not picked up the new VPJ yet. That registration only succeeds if the two are
-    // compatible in both directions.
-    assertCompatible(stagedSchema, activeSchema);
-    assertCompatible(activeSchema, stagedSchema);
-  }
-
-  /**
-   * A controller running the v6 reader must be able to read records still produced by push jobs that serialize v5,
-   * resolving the two appended duration fields to their -1 defaults. That is what makes the "deploy controllers
-   * before push jobs" ordering safe, and what lets the controller treat -1 as "not reported" instead of recording a
-   * bogus zero-millisecond observation.
-   */
-  @Test
-  public void testV6ReaderResolvesMissingDurationsFromV5WriterToDefaults() throws IOException {
-    Schema v5Schema = schemaVersionMap.get(ACTIVE_SCHEMA_ID);
-    Schema v6Schema = getStagedSchema();
-
-    GenericRecord v5Record = new GenericData.Record(v5Schema);
-    for (Schema.Field field: v5Schema.getFields()) {
-      if (field.hasDefaultValue()) {
-        v5Record.put(field.name(), GenericData.get().getDefaultValue(field));
-      }
-    }
-    // The v5 fields without a default must be populated explicitly.
-    v5Record.put("clusterName", "cluster0");
-    v5Record.put("reportTimestamp", 1234L);
-    v5Record.put("overallStatus", new GenericData.Array<>(v5Schema.getField("overallStatus").schema(), emptyList()));
-    v5Record.put("pushId", "push-from-an-older-vpj");
-    v5Record.put("jobDurationInMs", 60000L);
-
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
-    DatumWriter<GenericRecord> writer = new GenericDatumWriter<>(v5Schema);
-    BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(output, null);
-    writer.write(v5Record, encoder);
-    encoder.flush();
-
-    DatumReader<GenericRecord> reader = new GenericDatumReader<>(v5Schema, v6Schema);
-    GenericRecord v6Record = reader.read(null, DecoderFactory.get().binaryDecoder(output.toByteArray(), null));
-
-    Assert.assertEquals(v6Record.get("externalStorageWriteTimeMs"), -1L);
-    Assert.assertEquals(v6Record.get("veniceWriteTimeMs"), -1L);
-    Assert.assertEquals(v6Record.get("jobDurationInMs"), 60000L);
-  }
-
-  /**
-   * {@link Utils#getAllSchemasFromResources(AvroProtocolDefinition)} stops at the compiled version, so a staged
-   * schema has to be read straight out of the resources.
-   */
-  private Schema getStagedSchema() throws IOException {
-    return Utils.getSchemaFromResource("avro/PushJobDetails/v" + STAGED_SCHEMA_ID + "/PushJobDetails.avsc");
-  }
-
-  private void assertCompatible(Schema reader, Schema writer) {
-    Assert.assertEquals(
-        SchemaCompatibility.checkReaderWriterCompatibility(reader, writer).getType(),
-        SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE,
-        "PushJobDetails v" + STAGED_SCHEMA_ID + " must be compatible with v" + ACTIVE_SCHEMA_ID
-            + " in both directions");
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/status/protocol/TestPushJobDetailsSchemaCompatibility.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/status/protocol/TestPushJobDetailsSchemaCompatibility.java
@@ -1,15 +1,35 @@
 package com.linkedin.venice.status.protocol;
 
+import static java.util.Collections.emptyList;
+
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.Utils;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaCompatibility;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
 public class TestPushJobDetailsSchemaCompatibility {
+  private static final int STAGED_SCHEMA_ID = 6;
+  private static final int ACTIVE_SCHEMA_ID = STAGED_SCHEMA_ID - 1;
+  private static final List<String> STAGED_FIELDS = Arrays.asList("externalStorageWriteTimeMs", "veniceWriteTimeMs");
+
   private Map<Integer, Schema> schemaVersionMap =
       Utils.getAllSchemasFromResources(AvroProtocolDefinition.PUSH_JOB_DETAILS);
 
@@ -30,5 +50,96 @@ public class TestPushJobDetailsSchemaCompatibility {
           "PushJobDetails schema version " + schemaId + " is incompatible with the latest schema " + "version of "
               + latestSchemaId);
     });
+  }
+
+  /**
+   * v6 is registered but not activated: the schema ships in the resources so controllers register it in the push job
+   * details system store, while {@link AvroProtocolDefinition#PUSH_JOB_DETAILS} and the generated classes (pinned to
+   * v5 through the {@code versionOverrides} entry in the root build.gradle) stay on v5, so the code keeps
+   * serializing v5. The follow-up PR that populates the new fields removes the pin and bumps the protocol
+   * definition.
+   */
+  @Test
+  public void testStagedV6IsRegisteredButNotActivated() throws IOException {
+    Assert.assertEquals(
+        AvroProtocolDefinition.PUSH_JOB_DETAILS.currentProtocolVersion.get().intValue(),
+        ACTIVE_SCHEMA_ID,
+        "PushJobDetails v6 must stay staged until the push job actually populates the new fields");
+    Assert.assertNull(
+        schemaVersionMap.get(STAGED_SCHEMA_ID),
+        "The compiled PushJobDetails class must still be v5 while v6 is only staged");
+
+    Schema activeSchema = schemaVersionMap.get(ACTIVE_SCHEMA_ID);
+    Schema stagedSchema = getStagedSchema();
+    List<String> addedFields = stagedSchema.getFields()
+        .stream()
+        .map(Schema.Field::name)
+        .filter(name -> activeSchema.getField(name) == null)
+        .collect(Collectors.toList());
+    Assert.assertEquals(addedFields, STAGED_FIELDS, "v6 must only append the two timing fields on top of v5");
+    for (String addedField: STAGED_FIELDS) {
+      Schema.Field field = stagedSchema.getField(addedField);
+      Assert.assertEquals(field.schema().getType(), Schema.Type.LONG);
+      Assert.assertTrue(field.hasDefaultValue(), addedField + " must carry a default so v5 records stay readable");
+      Assert.assertEquals(GenericData.get().getDefaultValue(field), -1L, addedField + " must default to -1");
+    }
+
+    // Registration only succeeds if v6 is compatible in both directions with the version currently being written.
+    assertCompatible(stagedSchema, activeSchema);
+    assertCompatible(activeSchema, stagedSchema);
+  }
+
+  /**
+   * A controller running the v6 reader must be able to read records still produced by push jobs that serialize v5,
+   * resolving the two appended duration fields to their -1 defaults. That is what makes the "deploy controllers
+   * before push jobs" ordering safe, and what lets the controller treat -1 as "not reported" instead of recording a
+   * bogus zero-millisecond observation.
+   */
+  @Test
+  public void testV6ReaderResolvesMissingDurationsFromV5WriterToDefaults() throws IOException {
+    Schema v5Schema = schemaVersionMap.get(ACTIVE_SCHEMA_ID);
+    Schema v6Schema = getStagedSchema();
+
+    GenericRecord v5Record = new GenericData.Record(v5Schema);
+    for (Schema.Field field: v5Schema.getFields()) {
+      if (field.hasDefaultValue()) {
+        v5Record.put(field.name(), GenericData.get().getDefaultValue(field));
+      }
+    }
+    // The v5 fields without a default must be populated explicitly.
+    v5Record.put("clusterName", "cluster0");
+    v5Record.put("reportTimestamp", 1234L);
+    v5Record.put("overallStatus", new GenericData.Array<>(v5Schema.getField("overallStatus").schema(), emptyList()));
+    v5Record.put("pushId", "push-from-an-older-vpj");
+    v5Record.put("jobDurationInMs", 60000L);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DatumWriter<GenericRecord> writer = new GenericDatumWriter<>(v5Schema);
+    BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(output, null);
+    writer.write(v5Record, encoder);
+    encoder.flush();
+
+    DatumReader<GenericRecord> reader = new GenericDatumReader<>(v5Schema, v6Schema);
+    GenericRecord v6Record = reader.read(null, DecoderFactory.get().binaryDecoder(output.toByteArray(), null));
+
+    Assert.assertEquals(v6Record.get("externalStorageWriteTimeMs"), -1L);
+    Assert.assertEquals(v6Record.get("veniceWriteTimeMs"), -1L);
+    Assert.assertEquals(v6Record.get("jobDurationInMs"), 60000L);
+  }
+
+  /**
+   * {@link Utils#getAllSchemasFromResources(AvroProtocolDefinition)} stops at the compiled version, so a staged
+   * schema has to be read straight out of the resources.
+   */
+  private Schema getStagedSchema() throws IOException {
+    return Utils.getSchemaFromResource("avro/PushJobDetails/v" + STAGED_SCHEMA_ID + "/PushJobDetails.avsc");
+  }
+
+  private void assertCompatible(Schema reader, Schema writer) {
+    Assert.assertEquals(
+        SchemaCompatibility.checkReaderWriterCompatibility(reader, writer).getType(),
+        SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE,
+        "PushJobDetails v" + STAGED_SCHEMA_ID + " must be compatible with v" + ACTIVE_SCHEMA_ID
+            + " in both directions");
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/status/protocol/TestPushJobDetailsSchemaCompatibility.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/status/protocol/TestPushJobDetailsSchemaCompatibility.java
@@ -4,6 +4,7 @@ import static java.util.Collections.emptyList;
 
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.Utils;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
@@ -53,14 +54,18 @@ public class TestPushJobDetailsSchemaCompatibility {
   }
 
   /**
-   * v6 is registered but not activated: the schema ships in the resources so controllers register it in the push job
-   * details system store, while {@link AvroProtocolDefinition#PUSH_JOB_DETAILS} and the generated classes (pinned to
-   * v5 through the {@code versionOverrides} entry in the root build.gradle) stay on v5, so the code keeps
-   * serializing v5. The follow-up PR that populates the new fields removes the pin and bumps the protocol
-   * definition.
+   * v6 is staged, which means it is inert: the {@code versionOverrides} pin in the root build.gradle keeps the
+   * generated classes on v5, and {@link Utils#getAllSchemasFromResources(AvroProtocolDefinition)} stops at the
+   * compiled version, so no runtime path in this build reads, writes or registers v6. Controllers register value
+   * schemas only up to {@link AvroProtocolDefinition#currentProtocolVersion}, and the serializer only caches
+   * readers for the versions resource discovery returned, so both stop at v5 too.
+   *
+   * That inertness is the point of staging: the schema is frozen in the resources and reviewed on its own, while
+   * no code path can emit it. The follow-up PR removes the pin and bumps the protocol definition, which is what
+   * actually registers v6 on the controllers and starts serializing it.
    */
   @Test
-  public void testStagedV6IsRegisteredButNotActivated() throws IOException {
+  public void testStagedV6IsNotActivatedAndNotVisibleAtRuntime() throws IOException {
     Assert.assertEquals(
         AvroProtocolDefinition.PUSH_JOB_DETAILS.currentProtocolVersion.get().intValue(),
         ACTIVE_SCHEMA_ID,
@@ -68,6 +73,14 @@ public class TestPushJobDetailsSchemaCompatibility {
     Assert.assertNull(
         schemaVersionMap.get(STAGED_SCHEMA_ID),
         "The compiled PushJobDetails class must still be v5 while v6 is only staged");
+    IntSet knownProtocols = AvroProtocolDefinition.PUSH_JOB_DETAILS.getSerializer().knownProtocols();
+    Assert.assertTrue(
+        knownProtocols.contains(ACTIVE_SCHEMA_ID),
+        "The runtime serializer must know the active version v5, got: " + knownProtocols);
+    Assert.assertFalse(
+        knownProtocols.contains(STAGED_SCHEMA_ID),
+        "A staged schema must stay invisible to the runtime serializer, otherwise a v6 payload could be emitted "
+            + "before the controllers have registered v6, got: " + knownProtocols);
 
     Schema activeSchema = schemaVersionMap.get(ACTIVE_SCHEMA_ID);
     Schema stagedSchema = getStagedSchema();
@@ -84,7 +97,9 @@ public class TestPushJobDetailsSchemaCompatibility {
       Assert.assertEquals(GenericData.get().getDefaultValue(field), -1L, addedField + " must default to -1");
     }
 
-    // Registration only succeeds if v6 is compatible in both directions with the version currently being written.
+    // When the follow-up PR activates v6, the controllers register it against v5, which is the version still being
+    // written by push jobs that have not picked up the new VPJ yet. That registration only succeeds if the two are
+    // compatible in both directions.
     assertCompatible(stagedSchema, activeSchema);
     assertCompatible(activeSchema, stagedSchema);
   }


### PR DESCRIPTION
## Summary

Stage `PushJobDetails` v6 with an extensible `additionalPushMetrics` map.

The map stores optional `long` metrics by name. The first consumers are:

- `externalStorageWriteTimeMs`: summed task time for external writes, including throttling, retries, flush, and close.
- `veniceWriteTimeMs`: summed task time for Venice writes, flush, and close.

These values are sums across successful data-writer task outputs, not the push job's overall duration. Missing keys mean the metric was not reported, and `null` means no additional metrics were reported.

## Staged rollout

This PR adds the v6 schema and pins generated `PushJobDetails` classes to v5 through `versionOverrides`. It does not activate v6 or change runtime serialization.

Follow-up PR #2972 removes the pin, activates v6, and adds VPJ collection and controller metric emission. Controllers must deploy with v6 support before upgraded push jobs send v6 payloads.

## Testing Done

```text
./gradlew :internal:venice-common:test --tests "com.linkedin.venice.status.protocol.TestPushJobDetailsSchemaCompatibility"
BUILD SUCCESSFUL
```

No existing tests were changed.
