### PR TITLE
[vpj][controller][protocol][build] Report push job write timings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -328,13 +328,7 @@ subprojects {
       // Protocol changes should pin the current version via this override and remove the override in a follow-up PR
       // when actually using the new protocol. Example to pin KME to v12 when introducing v13:
       // project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
-      def versionOverrides = [
-          // PushJobDetails v6 stages the additionalPushMetrics map field. Pinned to the current active
-          // version so the generated classes stay on v5 and no code path can serialize v6 yet. The override is
-          // removed and PUSH_JOB_DETAILS is bumped to v6 in the follow-up PR that actually populates the map
-          // from the push job, which is also what makes the controllers register v6.
-          project(':internal:venice-common').file('src/main/resources/avro/PushJobDetails/v5', PathValidation.DIRECTORY),
-      ]
+      def versionOverrides = []
 
       def schemaDirs = [sourceDir]
       sourceDir.eachDir { typeDir ->

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -10,6 +10,10 @@ import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.VENICE_PARTITIONERS;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENABLED_CONFIG;
+import static com.linkedin.venice.status.protocol.PushJobDetailsAdditionalMetrics.EXTERNAL_STORAGE_WRITE_TIME_MS;
+import static com.linkedin.venice.status.protocol.PushJobDetailsAdditionalMetrics.VENICE_WRITE_TIME_MS;
+import static com.linkedin.venice.status.protocol.PushJobDetailsAdditionalMetrics.getMetric;
+import static com.linkedin.venice.status.protocol.PushJobDetailsAdditionalMetrics.putMetric;
 import static com.linkedin.venice.throttle.VeniceRateLimiter.RateLimiterType.GUAVA_RATE_LIMITER;
 import static com.linkedin.venice.utils.AvroSupersetSchemaUtils.validateSubsetValueSchema;
 import static com.linkedin.venice.utils.AvroSupersetSchemaUtils.validateSubsetValueSchemaForProjection;
@@ -152,6 +156,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.meta.VersionStorageModeUpdateReason;
 import com.linkedin.venice.meta.ViewConfig;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
@@ -1807,6 +1812,10 @@ public class VenicePushJob implements AutoCloseable {
     pushJobDetails.totalKeyBytes = -1;
     pushJobDetails.totalRawValueBytes = -1;
     pushJobDetails.totalCompressedValueBytes = -1;
+    // Left null on purpose, matching the v6 schema default: "this push reported no additional metrics".
+    // Only pushes that actually run the dual-write path populate any key, and leaving the map null keeps the
+    // controller from recording a meaningless zero-millisecond observation for every non-dual-write push.
+    pushJobDetails.additionalPushMetrics = null;
     pushJobDetails.failureDetails = "";
     pushJobDetails.pushJobLatestCheckpoint = PushJobCheckpoints.INITIALIZE_PUSH_JOB.getValue();
     pushJobDetails.pushJobConfigs = Collections.singletonMap(
@@ -1864,7 +1873,8 @@ public class VenicePushJob implements AutoCloseable {
               pushJobSetting.storeName,
               pushJobSetting.version,
               StorageMode.INTERNAL,
-              regionsFilter));
+              regionsFilter,
+              VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE));
     } catch (Exception e) {
       throw new VeniceException(
           failureContext + ". The controller API may be unavailable or not deployed. Root cause: "
@@ -1910,6 +1920,27 @@ public class VenicePushJob implements AutoCloseable {
       pushJobDetails.totalUncompressedRecordTooLargeFailures = taskTracker.getUncompressedRecordTooLargeFailureCount();
       // size of largest uncompressed value
       pushJobDetails.largestUncompressedValueSizeBytes = taskTracker.getLargestUncompressedValueSize();
+      /*
+       * Summed data-writer task durations for the two write legs, reported through the additionalPushMetrics
+       * map. These are NOT the push job's wall-clock duration (that is pushJobDetails.jobDurationInMs): every
+       * successful task contributes its own elapsed time, so with N parallel tasks the totals can be up to N
+       * times the push duration. Only the dual-write path measures them, so a push that never wrote to
+       * external storage leaves the key absent rather than reporting a zero — which is also how a controller
+       * reading an older v5 record sees it, since v5 resolves the whole map to null.
+       *
+       * Caveat: the ">0" gate below conflates "never measured" with "measured, took under a millisecond" —
+       * both currently report as absent. The tracker interface has no explicit "was this leg tracked" signal
+       * (its defaults are 0, same as a genuine sub-millisecond duration), so a real fix needs that signal
+       * threaded through before this can safely become ">=0".
+       */
+      long externalStorageWriteTimeMs = taskTracker.getExternalStorageWriteTimeMs();
+      if (externalStorageWriteTimeMs > 0) {
+        putMetric(pushJobDetails, EXTERNAL_STORAGE_WRITE_TIME_MS, externalStorageWriteTimeMs);
+      }
+      long veniceWriteTimeMs = taskTracker.getVeniceWriteTimeMs();
+      if (veniceWriteTimeMs > 0) {
+        putMetric(pushJobDetails, VENICE_WRITE_TIME_MS, veniceWriteTimeMs);
+      }
       List<String> summaryLogLines = new ArrayList<>();
       summaryLogLines.add("Total number of records: " + pushJobDetails.totalNumberOfRecords);
       summaryLogLines
@@ -1950,6 +1981,15 @@ public class VenicePushJob implements AutoCloseable {
       long taskIncrementalPushThrottledTimeMs = taskTracker.getIncrementalPushThrottledTimeMs();
       if (taskIncrementalPushThrottledTimeMs > 0) {
         summaryLogLines.add("Incremental push total throttle time: " + taskIncrementalPushThrottledTimeMs + " ms");
+      }
+      Long reportedExternalStorageWriteTimeMs = getMetric(pushJobDetails, EXTERNAL_STORAGE_WRITE_TIME_MS);
+      if (reportedExternalStorageWriteTimeMs != null) {
+        summaryLogLines
+            .add("External storage write time (summed across tasks): " + reportedExternalStorageWriteTimeMs + " ms");
+      }
+      Long reportedVeniceWriteTimeMs = getMetric(pushJobDetails, VENICE_WRITE_TIME_MS);
+      if (reportedVeniceWriteTimeMs != null) {
+        summaryLogLines.add("Venice write time (summed across tasks): " + reportedVeniceWriteTimeMs + " ms");
       }
 
       LOGGER.info("Data writer job summary: \n\t{}", StringUtils.join(summaryLogLines, "\n\t"));

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/counter/MRJobCounterHelper.java
@@ -43,6 +43,17 @@ public class MRJobCounterHelper {
   private static final String COUNTER_PUT_OR_DELETE_RECORDS = "put or delete records";
   private static final String COUNTER_GROUP_EXTERNAL_STORAGE = "External storage";
   private static final String EXTERNAL_STORAGE_FAILED_REGION_COUNTER_NAME_PREFIX = "failed region: ";
+  /**
+   * Summed across every successful reducer of the job: wall-clock time spent in the external-storage
+   * write path, including throttling wait, batchPut retries/backoff, flush and close. This is
+   * a sum of per-task durations, not the job's wall-clock duration.
+   */
+  private static final String EXTERNAL_STORAGE_WRITE_TIME_MS = "external storage write time (ms)";
+  /**
+   * Summed across every successful reducer of the job: wall-clock time spent invoking the Venice/Kafka writes
+   * and flushing/closing the Venice writer. Sum of per-task durations, not job wall-clock duration.
+   */
+  private static final String VENICE_WRITE_TIME_MS = "venice write time (ms)";
 
   private static final String REPUSH_TTL_FILTERED_COUNT = "Repush ttl filtered count";
 
@@ -96,6 +107,12 @@ public class MRJobCounterHelper {
 
   public static final GroupAndCounterNames INCREMENTAL_PUSH_THROTTLE_TIME_GROUP_COUNTER_NAME =
       new GroupAndCounterNames(COUNTER_GROUP_KAFKA, INCREMENTAL_PUSH_THROTTLE_TIME_MS);
+
+  public static final GroupAndCounterNames EXTERNAL_STORAGE_WRITE_TIME_GROUP_COUNTER_NAME =
+      new GroupAndCounterNames(COUNTER_GROUP_EXTERNAL_STORAGE, EXTERNAL_STORAGE_WRITE_TIME_MS);
+
+  public static final GroupAndCounterNames VENICE_WRITE_TIME_GROUP_COUNTER_NAME =
+      new GroupAndCounterNames(COUNTER_GROUP_KAFKA, VENICE_WRITE_TIME_MS);
 
   private MRJobCounterHelper() {
     // Util class
@@ -173,6 +190,30 @@ public class MRJobCounterHelper {
         reporter,
         new GroupAndCounterNames(COUNTER_GROUP_EXTERNAL_STORAGE, getFailedExternalStorageRegionCounterName(regionName)),
         amount);
+  }
+
+  public static void incrExternalStorageWriteTime(Reporter reporter, long amount) {
+    incrAmountWithGroupCounterName(reporter, EXTERNAL_STORAGE_WRITE_TIME_GROUP_COUNTER_NAME, amount);
+  }
+
+  public static void incrVeniceWriteTime(Reporter reporter, long amount) {
+    incrAmountWithGroupCounterName(reporter, VENICE_WRITE_TIME_GROUP_COUNTER_NAME, amount);
+  }
+
+  public static long getExternalStorageWriteTimeMs(Reporter reporter) {
+    return getCountWithGroupCounterName(reporter, EXTERNAL_STORAGE_WRITE_TIME_GROUP_COUNTER_NAME);
+  }
+
+  public static long getExternalStorageWriteTimeMs(Counters counters) {
+    return getCountFromCounters(counters, EXTERNAL_STORAGE_WRITE_TIME_GROUP_COUNTER_NAME);
+  }
+
+  public static long getVeniceWriteTimeMs(Reporter reporter) {
+    return getCountWithGroupCounterName(reporter, VENICE_WRITE_TIME_GROUP_COUNTER_NAME);
+  }
+
+  public static long getVeniceWriteTimeMs(Counters counters) {
+    return getCountFromCounters(counters, VENICE_WRITE_TIME_GROUP_COUNTER_NAME);
   }
 
   public static long getWriteAclAuthorizationFailureCount(Reporter reporter) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/CounterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/CounterBackedMapReduceDataWriterTaskTracker.java
@@ -95,4 +95,14 @@ public class CounterBackedMapReduceDataWriterTaskTracker implements DataWriterTa
   public Set<String> getFailedExternalStorageRegions() {
     return MRJobCounterHelper.getFailedExternalStorageRegions(counters);
   }
+
+  @Override
+  public long getExternalStorageWriteTimeMs() {
+    return MRJobCounterHelper.getExternalStorageWriteTimeMs(counters);
+  }
+
+  @Override
+  public long getVeniceWriteTimeMs() {
+    return MRJobCounterHelper.getVeniceWriteTimeMs(counters);
+  }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/ReporterBackedMapReduceDataWriterTaskTracker.java
@@ -138,6 +138,26 @@ public class ReporterBackedMapReduceDataWriterTaskTracker implements DataWriterT
   }
 
   @Override
+  public void trackExternalStorageWriteTime(long timeMs) {
+    MRJobCounterHelper.incrExternalStorageWriteTime(reporter, timeMs);
+  }
+
+  @Override
+  public void trackVeniceWriteTime(long timeMs) {
+    MRJobCounterHelper.incrVeniceWriteTime(reporter, timeMs);
+  }
+
+  @Override
+  public long getExternalStorageWriteTimeMs() {
+    return MRJobCounterHelper.getExternalStorageWriteTimeMs(reporter);
+  }
+
+  @Override
+  public long getVeniceWriteTimeMs() {
+    return MRJobCounterHelper.getVeniceWriteTimeMs(reporter);
+  }
+
+  @Override
   public long getTotalKeySize() {
     return MRJobCounterHelper.getTotalKeySize(reporter);
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DataWriterTaskTracker.java
@@ -69,6 +69,31 @@ public interface DataWriterTaskTracker extends TaskTracker {
   }
 
   /**
+   * Report elapsed wall-clock time this task spent inside the external-storage write path.
+   * This covers the complete external leg: the per-region write throttling wait, the
+   * {@code ExternalStorageWriter.batchPut} calls including their retries and retry backoff sleeps, the
+   * external {@code flush}, and the external {@code close}. It excludes anything spent producing to
+   * Venice/Kafka.
+   *
+   * <p>Callers report monotonic deltas as they accrue, so the aggregate is the <em>sum of per-task
+   * durations</em>, not the push's wall-clock duration: with N concurrent data-writer tasks the total can be
+   * up to N times the push's elapsed time.
+   */
+  default void trackExternalStorageWriteTime(long timeMs) {
+  }
+
+  /**
+   * Report elapsed wall-clock time this task spent invoking the Venice/Kafka write path: the
+   * {@code VeniceWriter.put} invocations plus flushing and closing the Venice writer. It excludes anything
+   * spent in the external-storage path.
+   *
+   * <p>Same aggregation semantics as {@link #trackExternalStorageWriteTime(long)}: summed task durations,
+   * not push wall-clock time.
+   */
+  default void trackVeniceWriteTime(long timeMs) {
+  }
+
+  /**
    * Report that the external writer for {@code regionName} exhausted its retry budget and was disabled for
    * the remainder of the task. Callers should report each region at most once per task.
    */
@@ -140,6 +165,24 @@ public interface DataWriterTaskTracker extends TaskTracker {
   }
 
   default long getIncrementalPushThrottledTimeMs() {
+    return 0;
+  }
+
+  /**
+   * @return the summed per-task duration (ms) spent in the external-storage write path across all successful
+   *         task outputs of this push. See {@link #trackExternalStorageWriteTime(long)} for exactly what is
+   *         included; this is <em>not</em> the push's wall-clock time.
+   */
+  default long getExternalStorageWriteTimeMs() {
+    return 0;
+  }
+
+  /**
+   * @return the summed per-task duration (ms) spent in the Venice/Kafka write path across all successful task
+   *         outputs of this push. See {@link #trackVeniceWriteTime(long)}; this is <em>not</em> the push's
+   *         wall-clock time.
+   */
+  default long getVeniceWriteTimeMs() {
     return 0;
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriter.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -50,6 +51,29 @@ import org.apache.logging.log4j.Logger;
  * <p>{@code update} and {@code delete} are not supported — batch pushes from clean input never call either.
  * Both throw {@link UnsupportedOperationException} so a stray invocation fails the Spark task loudly rather
  * than silently leaving the external sink and Venice in divergent states.
+ *
+ * <p><b>Write-path timing.</b> The wrapper measures how long this task spends in each of the two legs and
+ * reports the accrued time to the {@link DataWriterTaskTracker}:
+ * <ul>
+ *   <li><b>external</b> — per-region throttling wait, {@code batchPut} including its retries and retry
+ *       backoff sleeps, external {@code flush} and external {@code close}.</li>
+ *   <li><b>venice</b> — the {@code kafkaWriter.put} invocations plus {@code kafkaWriter.flush()} and
+ *       {@code kafkaWriter.close()}.</li>
+ * </ul>
+ * The two legs are measured over disjoint intervals on the single partition-writer task thread, so no
+ * wall-clock instant is counted twice. Timing uses {@link System#nanoTime()} (monotonic, immune to wall-clock
+ * adjustments) and is accrued in {@code try/finally} blocks so a failing batch still contributes the time it
+ * burned. Accrued time is published to the tracker as whole-millisecond deltas after every drain, flush and
+ * close, so work done while flushing/closing is always captured even if the task later fails.
+ *
+ * <p><b>Caveat: the two legs are not symmetric cost measurements.</b> {@code kafkaWriter.put(...)} is an
+ * asynchronous enqueue — the actual produce work happens on the producer's background I/O thread and is
+ * mostly captured later, in {@code kafkaWriter.flush()}. Because that background thread keeps draining the
+ * producer's buffer <em>while</em> this task thread is blocked inside the external-write leg, some of the
+ * real Kafka produce cost is hidden from {@code veniceWriteTimeMs} whenever the external leg is the slower
+ * one. Treat {@code externalStorageWriteTimeMs} vs {@code veniceWriteTimeMs} as an indicator of which leg to
+ * look at first, not a precise cost split — it structurally under-reports the Venice leg's true cost, more so
+ * the slower external storage is.
  */
 public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], byte[]> {
   private static final Logger LOGGER = LogManager.getLogger(DualWriteVeniceWriter.class);
@@ -71,6 +95,13 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
   private final boolean failOpenOnExternalStorageRegionFailure;
   private final DataWriterTaskTracker dataWriterTaskTracker;
   private final boolean[] disabledExternalWriters;
+  /** Monotonic nanos accrued in the external-storage leg (throttle + batchPut/retries + flush + close). */
+  private long externalStorageWriteNanos;
+  /** Monotonic nanos accrued in the Venice leg (kafka put + flush + close). */
+  private long veniceWriteNanos;
+  /** Whole milliseconds already handed to the tracker, so republishing only reports the new delta. */
+  private long reportedExternalStorageWriteTimeMs;
+  private long reportedVeniceWriteTimeMs;
 
   /**
    * Convenience constructor for callers that don't need the buffered retry policy (e.g. unit tests that
@@ -291,22 +322,37 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
 
   @Override
   public void flush() {
-    drainBuffer();
-    for (int i = 0; i < externalWriters.size(); i++) {
+    try {
+      // drainBuffer() accrues its own external/venice time, so it stays outside the intervals timed below.
+      drainBuffer();
+      long externalStartNs = System.nanoTime();
       try {
-        externalWriters.get(i).flush();
-      } catch (RuntimeException e) {
-        if (shouldSuppressDisabledWriterFailure(i)) {
-          LOGGER.warn(
-              "Suppressing flush failure from disabled external writer for region {} because fail-open is enabled",
-              externalWriterRegions.get(i),
-              e);
-          continue;
+        for (int i = 0; i < externalWriters.size(); i++) {
+          try {
+            externalWriters.get(i).flush();
+          } catch (RuntimeException e) {
+            if (shouldSuppressDisabledWriterFailure(i)) {
+              LOGGER.warn(
+                  "Suppressing flush failure from disabled external writer for region {} because fail-open is enabled",
+                  externalWriterRegions.get(i),
+                  e);
+              continue;
+            }
+            throw e;
+          }
         }
-        throw e;
+      } finally {
+        externalStorageWriteNanos += System.nanoTime() - externalStartNs;
       }
+      long veniceStartNs = System.nanoTime();
+      try {
+        kafkaWriter.flush();
+      } finally {
+        veniceWriteNanos += System.nanoTime() - veniceStartNs;
+      }
+    } finally {
+      publishAccruedTimings();
     }
-    kafkaWriter.flush();
   }
 
   @Override
@@ -317,46 +363,60 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
   @Override
   public void close(boolean gracefulClose) throws IOException {
     IOException firstError = null;
-    // Self-flush so close() alone is sufficient to meet the ExternalStorageWriter lifecycle contract:
-    // drains the wrapper's buffer and forces every regional externalWriter.flush() + kafkaWriter.flush()
-    // before any of them are closed. AbstractPartitionWriter.close() also calls flush() explicitly before
-    // close(), but self-flushing here protects any caller that uses the wrapper in a different lifecycle.
     try {
-      flush();
-    } catch (RuntimeException e) {
-      firstError = new IOException("Failed to flush before close", e);
-    }
-    for (int i = 0; i < externalWriters.size(); i++) {
+      // Self-flush so close() alone is sufficient to meet the ExternalStorageWriter lifecycle contract:
+      // drains the wrapper's buffer and forces every regional externalWriter.flush() + kafkaWriter.flush()
+      // before any of them are closed. AbstractPartitionWriter.close() also calls flush() explicitly before
+      // close(), but self-flushing here protects any caller that uses the wrapper in a different lifecycle.
       try {
-        externalWriters.get(i).close();
-      } catch (IOException | RuntimeException e) {
-        if (shouldSuppressDisabledWriterFailure(i)) {
-          LOGGER.warn(
-              "Suppressing close failure from disabled external writer for region {} because fail-open is enabled",
-              externalWriterRegions.get(i),
-              e);
-          continue;
+        flush();
+      } catch (RuntimeException e) {
+        firstError = new IOException("Failed to flush before close", e);
+      }
+      long externalStartNs = System.nanoTime();
+      try {
+        for (int i = 0; i < externalWriters.size(); i++) {
+          try {
+            externalWriters.get(i).close();
+          } catch (IOException | RuntimeException e) {
+            if (shouldSuppressDisabledWriterFailure(i)) {
+              LOGGER.warn(
+                  "Suppressing close failure from disabled external writer for region {} because fail-open is enabled",
+                  externalWriterRegions.get(i),
+                  e);
+              continue;
+            }
+            // External impls are pluggable — an unchecked throw from one regional writer must not skip closing
+            // the remaining regional writers or kafkaWriter.close() below, otherwise resources leak during task
+            // shutdown.
+            IOException wrapped = e instanceof IOException ? (IOException) e : new IOException(e);
+            if (firstError == null) {
+              firstError = wrapped;
+            } else {
+              firstError.addSuppressed(wrapped);
+            }
+          }
         }
-        // External impls are pluggable — an unchecked throw from one regional writer must not skip closing
-        // the remaining regional writers or kafkaWriter.close() below, otherwise resources leak during task
-        // shutdown.
+      } finally {
+        externalStorageWriteNanos += System.nanoTime() - externalStartNs;
+      }
+      long veniceStartNs = System.nanoTime();
+      try {
+        kafkaWriter.close(gracefulClose);
+      } catch (IOException | RuntimeException e) {
         IOException wrapped = e instanceof IOException ? (IOException) e : new IOException(e);
         if (firstError == null) {
           firstError = wrapped;
         } else {
           firstError.addSuppressed(wrapped);
         }
+      } finally {
+        veniceWriteNanos += System.nanoTime() - veniceStartNs;
       }
-    }
-    try {
-      kafkaWriter.close(gracefulClose);
-    } catch (IOException | RuntimeException e) {
-      IOException wrapped = e instanceof IOException ? (IOException) e : new IOException(e);
-      if (firstError == null) {
-        firstError = wrapped;
-      } else {
-        firstError.addSuppressed(wrapped);
-      }
+    } finally {
+      // Publish whatever accrued while closing, even when a regional writer or the Kafka writer threw, so the
+      // push still reports the time this task actually burned.
+      publishAccruedTimings();
     }
     if (firstError != null) {
       throw firstError;
@@ -413,35 +473,49 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
       // blocking limiter waits until the per-region budget admits the batch, enforcing independent per-region
       // budgets without reordering the external-first writes. (If a limiter threw instead of blocking it would
       // propagate before the write; the GuavaRateLimiter used here blocks rather than rejecting.)
-      for (int i = 0; i < externalWriters.size(); i++) {
-        if (shouldSkipExternalWriter(i)) {
-          continue;
-        }
-        if (throttlers != null) {
-          ExternalStorageWriteThrottler throttler = throttlers.get(i);
-          if (throttler != null) {
-            throttler.throttle(recordCount, byteCount);
+      //
+      // The whole fan-out is timed as external-storage work: the throttling wait, every batchPut attempt and
+      // the backoff sleeps between retries all happen inside this interval and none of it overlaps the Kafka
+      // produce loop below.
+      long externalStartNs = System.nanoTime();
+      try {
+        for (int i = 0; i < externalWriters.size(); i++) {
+          if (shouldSkipExternalWriter(i)) {
+            continue;
+          }
+          if (throttlers != null) {
+            ExternalStorageWriteThrottler throttler = throttlers.get(i);
+            if (throttler != null) {
+              throttler.throttle(recordCount, byteCount);
+            }
+          }
+          try {
+            batchPutWithRetry(externalWriters.get(i), externalWriterRegions.get(i), externalRecords);
+          } catch (RuntimeException e) {
+            if (!failOpenOnExternalStorageRegionFailure || Thread.currentThread().isInterrupted()) {
+              throw e;
+            }
+            disableFailedExternalWriter(i, e);
           }
         }
-        try {
-          batchPutWithRetry(externalWriters.get(i), externalWriterRegions.get(i), externalRecords);
-        } catch (RuntimeException e) {
-          if (!failOpenOnExternalStorageRegionFailure || Thread.currentThread().isInterrupted()) {
-            throw e;
-          }
-          disableFailedExternalWriter(i, e);
-        }
+      } finally {
+        externalStorageWriteNanos += System.nanoTime() - externalStartNs;
       }
-      for (BufferedPut buffered: putBuffer) {
-        CompletableFuture<PubSubProduceResult> kafkaFuture = invokeKafkaPut(buffered);
-        kafkaFuture.whenComplete((result, error) -> {
-          if (error != null) {
-            buffered.future.completeExceptionally(error);
-          } else {
-            buffered.future.complete(result);
-          }
-        });
-        last = buffered.future;
+      long veniceStartNs = System.nanoTime();
+      try {
+        for (BufferedPut buffered: putBuffer) {
+          CompletableFuture<PubSubProduceResult> kafkaFuture = invokeKafkaPut(buffered);
+          kafkaFuture.whenComplete((result, error) -> {
+            if (error != null) {
+              buffered.future.completeExceptionally(error);
+            } else {
+              buffered.future.complete(result);
+            }
+          });
+          last = buffered.future;
+        }
+      } finally {
+        veniceWriteNanos += System.nanoTime() - veniceStartNs;
       }
       return last;
     } catch (Throwable t) {
@@ -456,6 +530,34 @@ public class DualWriteVeniceWriter extends AbstractVeniceWriter<byte[], byte[], 
       // Always clear the buffer so the next drainBuffer() (e.g. close() self-flushing after this failure)
       // does not replay the same records to the external sink.
       putBuffer.clear();
+      // Report what this batch burned even when it failed, so a fail-open push still accounts for the time
+      // spent on the regions that gave up.
+      publishAccruedTimings();
+    }
+  }
+
+  /**
+   * Hand the newly accrued external/Venice time to the task tracker as whole-millisecond deltas.
+   *
+   * <p>Nanos are accumulated internally and only the difference against what was already reported is
+   * published, so repeated calls (after every drain, flush and close) never double count and sub-millisecond
+   * batches still add up across a task instead of each rounding to zero.
+   */
+  private void publishAccruedTimings() {
+    if (dataWriterTaskTracker == null) {
+      return;
+    }
+    long externalMs = TimeUnit.NANOSECONDS.toMillis(externalStorageWriteNanos);
+    long externalDeltaMs = externalMs - reportedExternalStorageWriteTimeMs;
+    if (externalDeltaMs > 0) {
+      reportedExternalStorageWriteTimeMs = externalMs;
+      dataWriterTaskTracker.trackExternalStorageWriteTime(externalDeltaMs);
+    }
+    long veniceMs = TimeUnit.NANOSECONDS.toMillis(veniceWriteNanos);
+    long veniceDeltaMs = veniceMs - reportedVeniceWriteTimeMs;
+    if (veniceDeltaMs > 0) {
+      reportedVeniceWriteTimeMs = veniceMs;
+      dataWriterTaskTracker.trackVeniceWriteTime(veniceDeltaMs);
     }
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/SparkConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/SparkConstants.java
@@ -5,6 +5,7 @@ import static org.apache.spark.sql.types.DataTypes.IntegerType;
 import static org.apache.spark.sql.types.DataTypes.LongType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
 
+import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
@@ -21,6 +22,8 @@ public class SparkConstants {
   public static final String PARTITION_COLUMN_NAME = "__partition__";
   public static final String RECORD_COUNT_COLUMN_NAME = "__record_count__";
   public static final String FAILED_EXTERNAL_STORAGE_REGIONS_COLUMN_NAME = "__failed_external_storage_regions__";
+  public static final String EXTERNAL_STORAGE_WRITE_TIME_MS_COLUMN_NAME = "__external_storage_write_time_ms__";
+  public static final String VENICE_WRITE_TIME_MS_COLUMN_NAME = "__venice_write_time_ms__";
   public static final String SCHEMA_ID_COLUMN_NAME = "__schema_id__";
   public static final String RMD_VERSION_ID_COLUMN_NAME = "__replication_metadata_version_id__";
   public static final String OFFSET_COLUMN_NAME = "__offset__";
@@ -32,6 +35,17 @@ public class SparkConstants {
           new StructField(VALUE_COLUMN_NAME, BinaryType, true, Metadata.empty()),
           new StructField(RMD_COLUMN_NAME, BinaryType, true, Metadata.empty()) });
 
+  /**
+   * Task output emitted once per Spark partition by the partition writer. Everything the driver needs from a
+   * data-writer task that must not be collected via accumulators travels through these columns: Spark
+   * speculative execution can run two attempts for the same partition and accumulator updates from both
+   * attempts are visible on the driver, which would double count. Exactly one successful task output row per
+   * partition survives {@code collect()}, so the row-based values stay exact.
+   *
+   * <p>The two timing columns are per-task wall-clock durations (see
+   * {@link DataWriterTaskTracker#trackExternalStorageWriteTime}),
+   * summed by the driver across partitions. They are a sum of task durations, not the push's wall-clock time.
+   */
   public static final StructType PARTITION_RECORD_COUNT_SCHEMA = new StructType(
       new StructField[] { new StructField(PARTITION_COLUMN_NAME, IntegerType, false, Metadata.empty()),
           new StructField(RECORD_COUNT_COLUMN_NAME, LongType, false, Metadata.empty()),
@@ -39,7 +53,9 @@ public class SparkConstants {
               FAILED_EXTERNAL_STORAGE_REGIONS_COLUMN_NAME,
               DataTypes.createArrayType(StringType),
               false,
-              Metadata.empty()) });
+              Metadata.empty()),
+          new StructField(EXTERNAL_STORAGE_WRITE_TIME_MS_COLUMN_NAME, LongType, false, Metadata.empty()),
+          new StructField(VENICE_WRITE_TIME_MS_COLUMN_NAME, LongType, false, Metadata.empty()) });
 
   public static final StructType DEFAULT_SCHEMA_WITH_PARTITION = new StructType(
       new StructField[] { new StructField(KEY_COLUMN_NAME, BinaryType, false, Metadata.empty()),

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -971,12 +971,15 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
 
       /*
        * collect() returns exactly one successful task-output row per Spark partition:
-       * (partitionId, recordCount, failedExternalStorageRegions). With speculative execution, if
-       * the original task and a speculative attempt both finish at the same time, Spark's
-       * TaskScheduler accepts the result from whichever one successfully communicates completion
-       * first and immediately kills the other; the duplicate's work is discarded to prevent
-       * duplicate data processing. So no two rows in the collected list will ever share the same
-       * partition id, and only the winning task's final disabled-region set contributes here.
+       * (partitionId, recordCount, failedExternalStorageRegions, externalStorageWriteTimeMs,
+       * veniceWriteTimeMs). With speculative execution, if the original task and a speculative attempt both
+       * finish at the same time, Spark's TaskScheduler accepts the result from whichever one successfully
+       * communicates completion first and immediately kills the other; the duplicate's work is discarded to
+       * prevent duplicate data processing. So no two rows in the collected list will ever share the same
+       * partition id, and only the winning task's final disabled-region set and accrued write times
+       * contribute here. This is exactly why the two duration totals travel as row columns instead of
+       * LongAccumulators: accumulator updates from a killed speculative attempt would still be added on the
+       * driver and inflate the sums.
        *
        * The collected data volume is bounded by numPartitions plus a small failed-region list per
        * partition (e.g. 10K partitions with record counts only is ~160KB), so collectAsList() is
@@ -986,18 +989,28 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
       List<Row> taskOutputRows = dataFrame.collectAsList();
       Map<Integer, Long> perPartitionRecordCounts = new HashMap<>(taskOutputRows.size());
       Set<String> failedExternalStorageRegions = new HashSet<>();
+      // Summed task wall-clock durations across partitions, not the push's wall-clock duration.
+      long externalStorageWriteTimeMs = 0;
+      long veniceWriteTimeMs = 0;
       for (Row row: taskOutputRows) {
         perPartitionRecordCounts.put(row.getInt(0), row.getLong(1));
         if (!row.isNullAt(2)) {
           failedExternalStorageRegions.addAll(row.getList(2));
         }
+        externalStorageWriteTimeMs += row.getLong(3);
+        veniceWriteTimeMs += row.getLong(4);
       }
       taskTracker.setPerPartitionRecordCounts(perPartitionRecordCounts);
       taskTracker.setFailedExternalStorageRegions(failedExternalStorageRegions);
+      taskTracker.setExternalStorageWriteTimeMs(externalStorageWriteTimeMs);
+      taskTracker.setVeniceWriteTimeMs(veniceWriteTimeMs);
       LOGGER.info(
-          "Collected per-partition record counts for topic: {} ({} partitions)",
+          "Collected per-partition record counts for topic: {} ({} partitions). Summed task durations: "
+              + "externalStorageWriteTimeMs={}, veniceWriteTimeMs={}",
           topicName,
-          perPartitionRecordCounts.size());
+          perPartitionRecordCounts.size(),
+          externalStorageWriteTimeMs,
+          veniceWriteTimeMs);
     } finally {
       // Release the DataFrame cached by the pre-write quota check now that the write is done.
       if (quotaCheckedInput != null) {
@@ -1074,6 +1087,13 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
 
   /**
    * Creates the partition writer factory. Can be overridden for testing purposes.
+   *
+   * <p><b>Breaking change note:</b> the returned function's output rows must conform to
+   * {@link com.linkedin.venice.spark.SparkConstants#PARTITION_RECORD_COUNT_SCHEMA}, which this change extends
+   * from 3 columns to 5 by appending {@code externalStorageWriteTimeMs} and {@code veniceWriteTimeMs} (both
+   * non-nullable {@code long}). Any out-of-tree override that still emits the old 3-column shape will fail
+   * row-encoder validation.
+   *
    * @param broadcastProperties the broadcast job properties
    * @param accumulators the data writer accumulators
    * @return the partition writer factory

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTracker.java
@@ -15,6 +15,15 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
   private final DataWriterAccumulators accumulators;
   private Map<Integer, Long> perPartitionRecordCounts = Collections.emptyMap();
   private final Set<String> failedExternalStorageRegions = new HashSet<>();
+  /**
+   * Deliberately plain fields rather than {@code LongAccumulator}s: with speculative execution enabled a
+   * partition can be attempted twice and both attempts' accumulator updates reach the driver, inflating a
+   * summed duration. On an executor these hold this task attempt's own accrued time and are shipped to the
+   * driver as task-output row columns; on the driver they hold the sum over the one surviving row per
+   * partition, set via {@link #setExternalStorageWriteTimeMs}/{@link #setVeniceWriteTimeMs}.
+   */
+  private long externalStorageWriteTimeMs;
+  private long veniceWriteTimeMs;
 
   public SparkDataWriterTaskTracker(DataWriterAccumulators accumulators) {
     this.accumulators = accumulators;
@@ -106,6 +115,22 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
       return;
     }
     failedExternalStorageRegions.add(regionName);
+  }
+
+  @Override
+  public void trackExternalStorageWriteTime(long timeMs) {
+    if (timeMs <= 0) {
+      return;
+    }
+    externalStorageWriteTimeMs += timeMs;
+  }
+
+  @Override
+  public void trackVeniceWriteTime(long timeMs) {
+    if (timeMs <= 0) {
+      return;
+    }
+    veniceWriteTimeMs += timeMs;
   }
 
   @Override
@@ -205,6 +230,30 @@ public class SparkDataWriterTaskTracker implements DataWriterTaskTracker {
     if (failedRegions != null) {
       failedExternalStorageRegions.addAll(failedRegions);
     }
+  }
+
+  /**
+   * Sets the total external-storage write time summed on the driver from the successful task-output rows.
+   */
+  public void setExternalStorageWriteTimeMs(long timeMs) {
+    this.externalStorageWriteTimeMs = timeMs;
+  }
+
+  /**
+   * Sets the total Venice write time summed on the driver from the successful task-output rows.
+   */
+  public void setVeniceWriteTimeMs(long timeMs) {
+    this.veniceWriteTimeMs = timeMs;
+  }
+
+  @Override
+  public long getExternalStorageWriteTimeMs() {
+    return externalStorageWriteTimeMs;
+  }
+
+  @Override
+  public long getVeniceWriteTimeMs() {
+    return veniceWriteTimeMs;
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/writer/SparkPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/writer/SparkPartitionWriter.java
@@ -97,4 +97,14 @@ public class SparkPartitionWriter extends AbstractPartitionWriter {
   Set<String> getFailedExternalStorageRegions() {
     return dataWriterTaskTracker.getFailedExternalStorageRegions();
   }
+
+  /** @return time this task spent in the external-storage write path, in ms. */
+  long getExternalStorageWriteTimeMs() {
+    return dataWriterTaskTracker.getExternalStorageWriteTimeMs();
+  }
+
+  /** @return time this task spent in the Venice/Kafka write path, in ms. */
+  long getVeniceWriteTimeMs() {
+    return dataWriterTaskTracker.getVeniceWriteTimeMs();
+  }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/writer/SparkPartitionWriterFactory.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/writer/SparkPartitionWriterFactory.java
@@ -31,12 +31,20 @@ public class SparkPartitionWriterFactory implements MapPartitionsFunction<Row, R
       partitionWriter.processRows(rows);
       recordCount = partitionWriter.getRecordCount();
     }
-    // Read this after close so the task output reflects any regions disabled while flushing or closing the writer.
+    // Read these after close so the task output reflects any regions disabled while flushing or closing the
+    // writer, and includes the time the flush/close themselves took.
     ArrayList<String> failedExternalStorageRegions = new ArrayList<>(partitionWriter.getFailedExternalStorageRegions());
     Collections.sort(failedExternalStorageRegions);
+    long externalStorageWriteTimeMs = partitionWriter.getExternalStorageWriteTimeMs();
+    long veniceWriteTimeMs = partitionWriter.getVeniceWriteTimeMs();
     int partitionId = TaskContext.get().partitionId();
     return Collections.singletonList(
-        RowFactory.create(partitionId, recordCount, JavaConverters.asScalaBuffer(failedExternalStorageRegions).toSeq()))
+        RowFactory.create(
+            partitionId,
+            recordCount,
+            JavaConverters.asScalaBuffer(failedExternalStorageRegions).toSeq(),
+            externalStorageWriteTimeMs,
+            veniceWriteTimeMs))
         .iterator();
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobLifecycleTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobLifecycleTest.java
@@ -1,5 +1,8 @@
 package com.linkedin.venice.hadoop;
 
+import static com.linkedin.venice.status.protocol.PushJobDetailsAdditionalMetrics.EXTERNAL_STORAGE_WRITE_TIME_MS;
+import static com.linkedin.venice.status.protocol.PushJobDetailsAdditionalMetrics.VENICE_WRITE_TIME_MS;
+import static com.linkedin.venice.status.protocol.PushJobDetailsAdditionalMetrics.getMetric;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.CONTROLLER_REQUEST_RETRY_ATTEMPTS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DATA_WRITER_COMPUTE_JOB_CLASS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
@@ -25,6 +28,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -42,6 +46,7 @@ import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
 import com.linkedin.venice.jobs.DataWriterComputeJob;
 import com.linkedin.venice.meta.StorageMode;
 import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.VersionStorageModeUpdateReason;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
@@ -336,7 +341,12 @@ public class VenicePushJobLifecycleTest extends VenicePushJobTestBase {
     doReturn(mockJobStatusQuery()).when(client).queryOverallJobStatus(anyString(), any(), any(), anyBoolean());
     ControllerResponse versionUpdateResponse = new ControllerResponse();
     doReturn(versionUpdateResponse).when(client)
-        .updateStoreVersionStorageMode(TEST_STORE, 1, StorageMode.INTERNAL, "dc-1");
+        .updateStoreVersionStorageMode(
+            TEST_STORE,
+            1,
+            StorageMode.INTERNAL,
+            "dc-1",
+            VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
 
     try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
       skipVPJValidation(pushJob);
@@ -353,7 +363,13 @@ public class VenicePushJobLifecycleTest extends VenicePushJobTestBase {
       pushJob.run();
 
       InOrder inOrder = inOrder(client);
-      inOrder.verify(client).updateStoreVersionStorageMode(TEST_STORE, 1, StorageMode.INTERNAL, "dc-1");
+      inOrder.verify(client)
+          .updateStoreVersionStorageMode(
+              TEST_STORE,
+              1,
+              StorageMode.INTERNAL,
+              "dc-1",
+              VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
       inOrder.verify(client).writeEndOfPush(TEST_STORE, 1, Collections.emptyMap());
     }
   }
@@ -375,11 +391,22 @@ public class VenicePushJobLifecycleTest extends VenicePushJobTestBase {
     ControllerClient client = getClient();
     if (throwException) {
       doThrow(new VeniceException(expectedReason)).when(client)
-          .updateStoreVersionStorageMode(TEST_STORE, 1, StorageMode.INTERNAL, "dc-1");
+          .updateStoreVersionStorageMode(
+              TEST_STORE,
+              1,
+              StorageMode.INTERNAL,
+              "dc-1",
+              VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
     } else {
       ControllerResponse errorResponse = new ControllerResponse();
       errorResponse.setError(expectedReason);
-      doReturn(errorResponse).when(client).updateStoreVersionStorageMode(TEST_STORE, 1, StorageMode.INTERNAL, "dc-1");
+      doReturn(errorResponse).when(client)
+          .updateStoreVersionStorageMode(
+              TEST_STORE,
+              1,
+              StorageMode.INTERNAL,
+              "dc-1",
+              VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
     }
 
     try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
@@ -403,6 +430,67 @@ public class VenicePushJobLifecycleTest extends VenicePushJobTestBase {
       }
 
       verify(client, never()).writeEndOfPush(anyString(), anyInt(), any());
+    }
+  }
+
+  /**
+   * The two durations reported by the data writer are surfaced in PushJobDetails so the controller can turn
+   * them into a metric. They are summed task durations, unrelated to the push's own wall-clock duration.
+   */
+  @Test
+  public void testPushJobDetailsCarriesDataWriterSinkWriteTimes() throws Exception {
+    Properties props = getVpjRequiredProperties();
+    props.put(KEY_FIELD_PROP, "id");
+    props.put(VALUE_FIELD_PROP, "name");
+    ControllerClient client = getClient();
+    doReturn(mockJobStatusQuery()).when(client).queryOverallJobStatus(anyString(), any(), any(), anyBoolean());
+
+    try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
+      skipVPJValidation(pushJob);
+      doNothing().when(pushJob).runJobWithKillDetection();
+
+      DataWriterTaskTracker tracker = mock(DataWriterTaskTracker.class);
+      doReturn(Collections.emptySet()).when(tracker).getFailedExternalStorageRegions();
+      doReturn(Collections.emptyMap()).when(tracker).getPerPartitionRecordCounts();
+      doReturn(12_345L).when(tracker).getExternalStorageWriteTimeMs();
+      doReturn(678L).when(tracker).getVeniceWriteTimeMs();
+
+      DataWriterComputeJob dataWriterJob = mock(DataWriterComputeJob.class);
+      doReturn(tracker).when(dataWriterJob).getTaskTracker();
+      pushJob.setDataWriterComputeJob(dataWriterJob);
+
+      pushJob.run();
+
+      assertEquals(getMetric(pushJob.getPushJobDetails(), EXTERNAL_STORAGE_WRITE_TIME_MS), Long.valueOf(12_345L));
+      assertEquals(getMetric(pushJob.getPushJobDetails(), VENICE_WRITE_TIME_MS), Long.valueOf(678L));
+    }
+  }
+
+  @Test
+  public void testPushJobDetailsWriteTimesStayUnreportedWhenNotTracked() throws Exception {
+    Properties props = getVpjRequiredProperties();
+    props.put(KEY_FIELD_PROP, "id");
+    props.put(VALUE_FIELD_PROP, "name");
+    ControllerClient client = getClient();
+    doReturn(mockJobStatusQuery()).when(client).queryOverallJobStatus(anyString(), any(), any(), anyBoolean());
+
+    try (VenicePushJob pushJob = getSpyVenicePushJob(props, client)) {
+      skipVPJValidation(pushJob);
+      doNothing().when(pushJob).runJobWithKillDetection();
+
+      // A tracker that never saw a dual write reports the interface defaults of 0.
+      DataWriterTaskTracker tracker = new DataWriterTaskTracker() {
+      };
+      DataWriterComputeJob dataWriterJob = mock(DataWriterComputeJob.class);
+      doReturn(tracker).when(dataWriterJob).getTaskTracker();
+      pushJob.setDataWriterComputeJob(dataWriterJob);
+
+      pushJob.run();
+
+      // Those zeros must not be published as real observations; an entirely absent map says "never measured".
+      assertNull(
+          pushJob.getPushJobDetails().getAdditionalPushMetrics(),
+          "A push that never measured a leg must leave additionalPushMetrics null rather than reporting zeros");
     }
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/MapReduceDataWriterTaskTrackerTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/mapreduce/datawriter/task/MapReduceDataWriterTaskTrackerTest.java
@@ -22,14 +22,7 @@ public class MapReduceDataWriterTaskTrackerTest {
   @Test
   public void testFailedExternalStorageRegionsAggregateFromReporterIntoCounters() {
     Counters counters = new Counters();
-    Reporter reporter = mock(Reporter.class);
-    doAnswer(invocation -> {
-      counters.incrCounter(
-          (String) invocation.getArgument(0),
-          (String) invocation.getArgument(1),
-          (Long) invocation.getArgument(2));
-      return null;
-    }).when(reporter).incrCounter(anyString(), anyString(), anyLong());
+    Reporter reporter = countingReporter(counters);
 
     ReporterBackedMapReduceDataWriterTaskTracker reporterTracker =
         new ReporterBackedMapReduceDataWriterTaskTracker(reporter);
@@ -52,6 +45,46 @@ public class MapReduceDataWriterTaskTrackerTest {
   }
 
   @Test
+  public void testWriteTimesRoundTripFromReporterIntoCounters() {
+    Counters counters = new Counters();
+    Reporter reporter = countingReporter(counters);
+
+    ReporterBackedMapReduceDataWriterTaskTracker reporterTracker =
+        new ReporterBackedMapReduceDataWriterTaskTracker(reporter);
+    when(reporter.getCounter(anyString(), anyString())).thenAnswer(
+        invocation -> counters.findCounter((String) invocation.getArgument(0), (String) invocation.getArgument(1)));
+
+    // Several tasks/batches report incrementally; the counter is the sum of every report.
+    reporterTracker.trackExternalStorageWriteTime(120);
+    reporterTracker.trackExternalStorageWriteTime(30);
+    reporterTracker.trackVeniceWriteTime(7);
+
+    assertEquals(reporterTracker.getExternalStorageWriteTimeMs(), 150L);
+    assertEquals(reporterTracker.getVeniceWriteTimeMs(), 7L);
+
+    CounterBackedMapReduceDataWriterTaskTracker counterTracker =
+        new CounterBackedMapReduceDataWriterTaskTracker(counters);
+    assertEquals(counterTracker.getExternalStorageWriteTimeMs(), 150L);
+    assertEquals(counterTracker.getVeniceWriteTimeMs(), 7L);
+  }
+
+  @Test
+  public void testWriteTimesDefaultToZeroWithoutAnyReport() {
+    CounterBackedMapReduceDataWriterTaskTracker counterTracker =
+        new CounterBackedMapReduceDataWriterTaskTracker(new Counters());
+    assertEquals(counterTracker.getExternalStorageWriteTimeMs(), 0L);
+    assertEquals(counterTracker.getVeniceWriteTimeMs(), 0L);
+
+    ReporterBackedMapReduceDataWriterTaskTracker nullReporterTracker =
+        new ReporterBackedMapReduceDataWriterTaskTracker(null);
+    // Reporter.NULL has no counters to read or write; reporting must be a no-op rather than a failure.
+    nullReporterTracker.trackExternalStorageWriteTime(10);
+    nullReporterTracker.trackVeniceWriteTime(10);
+    assertEquals(nullReporterTracker.getExternalStorageWriteTimeMs(), 0L);
+    assertEquals(nullReporterTracker.getVeniceWriteTimeMs(), 0L);
+  }
+
+  @Test
   public void testFailedExternalStorageRegionsDefaultToEmpty() {
     CounterBackedMapReduceDataWriterTaskTracker counterTracker =
         new CounterBackedMapReduceDataWriterTaskTracker(new Counters());
@@ -66,5 +99,18 @@ public class MapReduceDataWriterTaskTrackerTest {
     CounterBackedMapReduceDataWriterTaskTracker counterTracker =
         new CounterBackedMapReduceDataWriterTaskTracker(counters);
     assertEquals(counterTracker.getFailedExternalStorageRegions(), Collections.emptySet());
+  }
+
+  /** A {@link Reporter} mock whose counter increments land in {@code counters}, like a real MR task's do. */
+  private static Reporter countingReporter(Counters counters) {
+    Reporter reporter = mock(Reporter.class);
+    doAnswer(invocation -> {
+      counters.incrCounter(
+          (String) invocation.getArgument(0),
+          (String) invocation.getArgument(1),
+          (Long) invocation.getArgument(2));
+      return null;
+    }).when(reporter).incrCounter(anyString(), anyString(), anyLong());
+    return reporter;
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriterTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/task/datawriter/DualWriteVeniceWriterTest.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.hadoop.task.datawriter;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -34,6 +35,10 @@ import org.testng.annotations.Test;
 
 public class DualWriteVeniceWriterTest {
   private static final String TOPIC = "test_store_v1";
+  /** Simulated latency for the leg under test; large enough that scheduling noise cannot mask it. */
+  private static final long SLOW_LEG_SLEEP_MS = 120;
+  /** Smaller simulated latency for assertions that sum several sleeps. */
+  private static final long BATCH_SLEEP_MS = 40;
   private static final byte[] KEY_PREFIX = "key_".getBytes();
   private static final byte[] VALUE_PREFIX = "value_".getBytes();
   private static final int SCHEMA_ID = 7;
@@ -608,6 +613,225 @@ public class DualWriteVeniceWriterTest {
         () -> new DualWriteVeniceWriter(TOPIC, kafkaWriter, Arrays.asList(dc0, dc1), oneThrottler, 1, 0, 0L));
   }
 
+  /**
+   * The two legs are timed over disjoint intervals, so a slow external sink must not be charged to the Venice
+   * leg. Timing assertions use generous margins because they measure real elapsed time.
+   */
+  @Test
+  public void externalStorageLatencyIsNotChargedToTheVeniceLeg() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    external.sleepMsPerBatchPut = SLOW_LEG_SLEEP_MS;
+    RecordingDataWriterTaskTracker tracker = new RecordingDataWriterTaskTracker();
+
+    try (DualWriteVeniceWriter writer = newTrackedWriter(kafkaWriter, external, tracker, 1)) {
+      writer.put(key(1), value(1), SCHEMA_ID, null);
+    }
+
+    assertTrue(
+        tracker.externalStorageWriteTimeMs >= SLOW_LEG_SLEEP_MS - 1,
+        "External leg should account for the sink latency, got " + tracker.externalStorageWriteTimeMs + "ms");
+    assertTrue(
+        tracker.veniceWriteTimeMs < SLOW_LEG_SLEEP_MS / 2,
+        "External latency must not leak into the Venice leg, got " + tracker.veniceWriteTimeMs + "ms");
+  }
+
+  @Test
+  public void veniceLatencyIsNotChargedToTheExternalLeg() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    doAnswer(invocation -> {
+      sleepQuietly(SLOW_LEG_SLEEP_MS);
+      return CompletableFuture.completedFuture(null);
+    }).when(kafkaWriter).put(any(), any(), anyInt(), any());
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    RecordingDataWriterTaskTracker tracker = new RecordingDataWriterTaskTracker();
+
+    try (DualWriteVeniceWriter writer = newTrackedWriter(kafkaWriter, external, tracker, 1)) {
+      writer.put(key(1), value(1), SCHEMA_ID, null);
+    }
+
+    assertTrue(
+        tracker.veniceWriteTimeMs >= SLOW_LEG_SLEEP_MS - 1,
+        "Venice leg should account for the Kafka produce latency, got " + tracker.veniceWriteTimeMs + "ms");
+    assertTrue(
+        tracker.externalStorageWriteTimeMs < SLOW_LEG_SLEEP_MS / 2,
+        "Kafka latency must not leak into the external leg, got " + tracker.externalStorageWriteTimeMs + "ms");
+  }
+
+  @Test
+  public void writeTimesAccumulateAcrossBatches() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    external.sleepMsPerBatchPut = BATCH_SLEEP_MS;
+    RecordingDataWriterTaskTracker tracker = new RecordingDataWriterTaskTracker();
+
+    int batches = 3;
+    try (DualWriteVeniceWriter writer = newTrackedWriter(kafkaWriter, external, tracker, 1)) {
+      for (int i = 0; i < batches; i++) {
+        writer.put(key(i), value(i), SCHEMA_ID, null);
+      }
+    }
+
+    assertEquals(external.batchPutInvocations.size(), batches);
+    assertTrue(
+        tracker.externalStorageWriteTimeMs >= batches * BATCH_SLEEP_MS - 1,
+        "Every batch should contribute to the total, got " + tracker.externalStorageWriteTimeMs + "ms for " + batches
+            + " batches");
+    assertTrue(
+        tracker.externalStorageWriteTimeReports > 1,
+        "Time should be published incrementally rather than only once at close");
+  }
+
+  @Test
+  public void externalWriteTimeIncludesThrottlingWait() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    RecordingRateLimiter rateLimiter = new RecordingRateLimiter();
+    rateLimiter.sleepMsPerAcquire = SLOW_LEG_SLEEP_MS;
+    RecordingDataWriterTaskTracker tracker = new RecordingDataWriterTaskTracker();
+
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(
+        TOPIC,
+        kafkaWriter,
+        Collections.singletonList(external),
+        Collections.singletonList("dc-0"),
+        Collections.singletonList(new ExternalStorageWriteThrottler(rateLimiter, null)),
+        1,
+        0,
+        0L,
+        false,
+        tracker)) {
+      writer.put(key(1), value(1), SCHEMA_ID, null);
+    }
+
+    assertEquals(rateLimiter.acquired, Collections.singletonList(1));
+    assertTrue(
+        tracker.externalStorageWriteTimeMs >= SLOW_LEG_SLEEP_MS - 1,
+        "Throttling wait belongs to the external leg, got " + tracker.externalStorageWriteTimeMs + "ms");
+  }
+
+  @Test
+  public void externalWriteTimeIncludesRetriesAndBackoff() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter recovering = new RecordingExternalStorageWriter();
+    recovering.failBatchPutTimes = 2;
+    RecordingDataWriterTaskTracker tracker = new RecordingDataWriterTaskTracker();
+
+    long backoffMs = BATCH_SLEEP_MS;
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(
+        TOPIC,
+        kafkaWriter,
+        Collections.singletonList(recovering),
+        Collections.singletonList("dc-0"),
+        null,
+        1,
+        2,
+        backoffMs,
+        false,
+        tracker)) {
+      writer.put(key(1), value(1), SCHEMA_ID, null);
+    }
+
+    assertEquals(recovering.batchPutAttempts, 3, "Two failures then a success");
+    // Two backoff sleeps sit between the three attempts and are part of the external leg.
+    assertTrue(
+        tracker.externalStorageWriteTimeMs >= 2 * backoffMs - 1,
+        "Retry backoff belongs to the external leg, got " + tracker.externalStorageWriteTimeMs + "ms");
+  }
+
+  @Test
+  public void writeTimesIncludeFlushAndClose() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    doAnswer(invocation -> {
+      sleepQuietly(BATCH_SLEEP_MS);
+      return null;
+    }).when(kafkaWriter).flush();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    external.sleepMsPerFlush = BATCH_SLEEP_MS;
+    external.sleepMsPerClose = BATCH_SLEEP_MS;
+    RecordingDataWriterTaskTracker tracker = new RecordingDataWriterTaskTracker();
+
+    DualWriteVeniceWriter writer = newTrackedWriter(kafkaWriter, external, tracker, 1);
+    writer.put(key(1), value(1), SCHEMA_ID, null);
+    long externalAfterPut = tracker.externalStorageWriteTimeMs;
+    long veniceAfterPut = tracker.veniceWriteTimeMs;
+    writer.close();
+
+    assertTrue(external.closed);
+    // close() self-flushes, so the external total picks up both the flush and the close latency.
+    assertTrue(
+        tracker.externalStorageWriteTimeMs - externalAfterPut >= 2 * BATCH_SLEEP_MS - 1,
+        "External flush and close must be captured, got " + (tracker.externalStorageWriteTimeMs - externalAfterPut)
+            + "ms");
+    assertTrue(
+        tracker.veniceWriteTimeMs - veniceAfterPut >= BATCH_SLEEP_MS - 1,
+        "Venice flush must be captured, got " + (tracker.veniceWriteTimeMs - veniceAfterPut) + "ms");
+  }
+
+  @Test
+  public void failOpenStillReportsAccruedExternalWriteTime() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter failing = new RecordingExternalStorageWriter();
+    failing.failBatchPutTimes = Integer.MAX_VALUE;
+    failing.sleepMsPerBatchPut = BATCH_SLEEP_MS;
+    RecordingDataWriterTaskTracker tracker = new RecordingDataWriterTaskTracker();
+
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(
+        TOPIC,
+        kafkaWriter,
+        Collections.singletonList(failing),
+        Collections.singletonList("dc-fail"),
+        null,
+        1,
+        1,
+        0L,
+        true,
+        tracker)) {
+      writer.put(key(1), value(1), SCHEMA_ID, null);
+      writer.put(key(2), value(2), SCHEMA_ID, null);
+    }
+
+    assertEquals(tracker.failedExternalStorageRegions, Collections.singleton("dc-fail"));
+    // Both attempts ran before the region was disabled; that time is still the push's cost.
+    assertTrue(
+        tracker.externalStorageWriteTimeMs >= 2 * BATCH_SLEEP_MS - 1,
+        "Fail-open must still report the time burned on the failed region, got " + tracker.externalStorageWriteTimeMs
+            + "ms");
+    verify(kafkaWriter, times(2)).put(any(), any(), anyInt(), any());
+  }
+
+  @Test
+  public void writeTimesAreNotReportedWithoutATracker() throws IOException {
+    AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter = mockKafkaWriter();
+    RecordingExternalStorageWriter external = new RecordingExternalStorageWriter();
+    external.sleepMsPerBatchPut = BATCH_SLEEP_MS;
+
+    // No tracker configured (the non-dual-write-aware constructors): must not NPE.
+    try (DualWriteVeniceWriter writer = new DualWriteVeniceWriter(TOPIC, kafkaWriter, external, 1)) {
+      writer.put(key(1), value(1), SCHEMA_ID, null);
+    }
+
+    assertEquals(external.batchPutInvocations.size(), 1);
+  }
+
+  private static DualWriteVeniceWriter newTrackedWriter(
+      AbstractVeniceWriter<byte[], byte[], byte[]> kafkaWriter,
+      ExternalStorageWriter external,
+      DataWriterTaskTracker tracker,
+      int batchSize) {
+    return new DualWriteVeniceWriter(
+        TOPIC,
+        kafkaWriter,
+        Collections.singletonList(external),
+        Collections.singletonList("dc-0"),
+        null,
+        batchSize,
+        0,
+        0L,
+        false,
+        tracker);
+  }
+
   private static int expectedBytes(int i) {
     return key(i).length + ExternalStorageRecord.SCHEMA_ID_PREFIX_LENGTH + value(i).length;
   }
@@ -630,6 +854,18 @@ public class DualWriteVeniceWriterTest {
     return concat(VALUE_PREFIX, Integer.toString(i).getBytes());
   }
 
+  private static void sleepQuietly(long millis) {
+    if (millis <= 0) {
+      return;
+    }
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while simulating latency", e);
+    }
+  }
+
   private static byte[] concat(byte[] a, byte[] b) {
     byte[] out = new byte[a.length + b.length];
     System.arraycopy(a, 0, out, 0, a.length);
@@ -650,6 +886,10 @@ public class DualWriteVeniceWriterTest {
     /** Number of leading {@code batchPut} attempts that should throw before the first success. */
     int failBatchPutTimes = 0;
     IOException throwOnClose = null;
+    /** Simulated per-call latency, so timing assertions have something deterministic to measure. */
+    long sleepMsPerBatchPut = 0;
+    long sleepMsPerFlush = 0;
+    long sleepMsPerClose = 0;
 
     @Override
     public void configure(VeniceProperties jobProps, String topicName, int partitionId) {
@@ -658,6 +898,7 @@ public class DualWriteVeniceWriterTest {
     @Override
     public void batchPut(List<ExternalStorageRecord> records) {
       batchPutAttempts++;
+      sleepQuietly(sleepMsPerBatchPut);
       if (throwOnBatchPut != null) {
         throw throwOnBatchPut;
       }
@@ -670,11 +911,13 @@ public class DualWriteVeniceWriterTest {
     @Override
     public void flush() {
       flushCount++;
+      sleepQuietly(sleepMsPerFlush);
     }
 
     @Override
     public void close() throws IOException {
       closed = true;
+      sleepQuietly(sleepMsPerClose);
       if (throwOnClose != null) {
         throw throwOnClose;
       }
@@ -683,10 +926,36 @@ public class DualWriteVeniceWriterTest {
 
   private static final class RecordingDataWriterTaskTracker implements DataWriterTaskTracker {
     final Set<String> failedExternalStorageRegions = new HashSet<>();
+    long externalStorageWriteTimeMs = 0;
+    long veniceWriteTimeMs = 0;
+    int externalStorageWriteTimeReports = 0;
+    int veniceWriteTimeReports = 0;
 
     @Override
     public void trackFailedExternalStorageRegion(String regionName) {
       failedExternalStorageRegions.add(regionName);
+    }
+
+    @Override
+    public void trackExternalStorageWriteTime(long timeMs) {
+      externalStorageWriteTimeReports++;
+      externalStorageWriteTimeMs += timeMs;
+    }
+
+    @Override
+    public void trackVeniceWriteTime(long timeMs) {
+      veniceWriteTimeReports++;
+      veniceWriteTimeMs += timeMs;
+    }
+
+    @Override
+    public long getExternalStorageWriteTimeMs() {
+      return externalStorageWriteTimeMs;
+    }
+
+    @Override
+    public long getVeniceWriteTimeMs() {
+      return veniceWriteTimeMs;
     }
   }
 
@@ -698,6 +967,8 @@ public class DualWriteVeniceWriterTest {
   private static final class RecordingRateLimiter implements VeniceRateLimiter {
     final List<Integer> acquired = new ArrayList<>();
     RuntimeException throwOnAcquire = null;
+    /** Simulated blocking wait, standing in for a real limiter that makes the caller wait for budget. */
+    long sleepMsPerAcquire = 0;
 
     @Override
     public boolean tryAcquirePermit(int units) {
@@ -710,6 +981,7 @@ public class DualWriteVeniceWriterTest {
 
     @Override
     public void acquirePermit(int units) {
+      sleepQuietly(sleepMsPerAcquire);
       if (throwOnAcquire != null) {
         throw throwOnAcquire;
       }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJobTest.java
@@ -44,6 +44,7 @@ import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.spark.datawriter.task.DataWriterAccumulators;
+import com.linkedin.venice.spark.datawriter.task.SparkDataWriterTaskTracker;
 import com.linkedin.venice.utils.PushInputSchemaBuilder;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Utils;
@@ -506,6 +507,33 @@ public class AbstractDataWriterSparkJobTest {
       expectedFailedRegions.add("dc-0");
       expectedFailedRegions.add("dc-1");
       Assert.assertEquals(job.getTaskTracker().getFailedExternalStorageRegions(), expectedFailedRegions);
+
+      // Durations are summed over one successful row per partition, never via accumulators.
+      Assert.assertEquals(job.getTaskTracker().getExternalStorageWriteTimeMs(), 1000L);
+      Assert.assertEquals(job.getTaskTracker().getVeniceWriteTimeMs(), 42L);
+    }
+  }
+
+  @Test
+  public void testRunComputeJobDoesNotUseAccumulatorsForWriteTimes() throws IOException {
+    PushJobSetting setting = getDefaultKafkaInputPushJobSetting();
+    setting.partitionCount = 2;
+
+    try (TaskOutputTestingDataWriterSparkJob job = new TaskOutputTestingDataWriterSparkJob()) {
+      job.configure(new VeniceProperties(new Properties()), setting);
+      job.runComputeJob();
+
+      /*
+       * The task-output rows above are the only source of the two totals. A tracker built on the very same
+       * accumulator set, but never fed the collected rows, must therefore report nothing: proof that no
+       * LongAccumulator is carrying these durations, which is what makes them safe under speculative
+       * execution.
+       */
+      SparkDataWriterTaskTracker accumulatorOnlyView =
+          new SparkDataWriterTaskTracker(job.getAccumulatorsForDataWriterJob());
+      Assert.assertEquals(accumulatorOnlyView.getExternalStorageWriteTimeMs(), 0L);
+      Assert.assertEquals(accumulatorOnlyView.getVeniceWriteTimeMs(), 0L);
+      Assert.assertEquals(job.getTaskTracker().getExternalStorageWriteTimeMs(), 1000L);
     }
   }
 
@@ -745,7 +773,7 @@ public class AbstractDataWriterSparkJobTest {
           accumulators.outputRecordCounter.add(1);
         }
         accumulators.partitionWriterCloseCounter.add(1);
-        return Collections.singletonList(RowFactory.create(partitionId, recordCount, toScalaSeq())).iterator();
+        return Collections.singletonList(RowFactory.create(partitionId, recordCount, toScalaSeq(), 0L, 0L)).iterator();
       };
     }
   }
@@ -777,11 +805,12 @@ public class AbstractDataWriterSparkJobTest {
         int partitionId = TaskContext.get().partitionId();
         switch (partitionId) {
           case 0:
-            return Collections.singletonList(RowFactory.create(0, 3L, toScalaSeq("dc-1", "dc-0"))).iterator();
+            return Collections.singletonList(RowFactory.create(0, 3L, toScalaSeq("dc-1", "dc-0"), 700L, 40L))
+                .iterator();
           case 1:
-            return Collections.singletonList(RowFactory.create(1, 5L, toScalaSeq("dc-1"))).iterator();
+            return Collections.singletonList(RowFactory.create(1, 5L, toScalaSeq("dc-1"), 300L, 2L)).iterator();
           default:
-            return Collections.singletonList(RowFactory.create(partitionId, 0L, toScalaSeq())).iterator();
+            return Collections.singletonList(RowFactory.create(partitionId, 0L, toScalaSeq(), 0L, 0L)).iterator();
         }
       };
     }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTrackerTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/task/SparkDataWriterTaskTrackerTest.java
@@ -315,6 +315,56 @@ public class SparkDataWriterTaskTrackerTest {
     Assert.assertEquals(tracker.getFailedExternalStorageRegions(), expected);
   }
 
+  @Test
+  public void testWriteTimesAccumulatePerTaskTrackerWithoutAccumulators() {
+    DataWriterAccumulators accumulators = new DataWriterAccumulators(spark);
+    SparkDataWriterTaskTracker tracker1 = new SparkDataWriterTaskTracker(accumulators);
+    SparkDataWriterTaskTracker tracker2 = new SparkDataWriterTaskTracker(accumulators);
+
+    tracker1.trackExternalStorageWriteTime(100);
+    tracker1.trackExternalStorageWriteTime(50);
+    tracker1.trackVeniceWriteTime(7);
+    tracker2.trackExternalStorageWriteTime(1000);
+    tracker2.trackVeniceWriteTime(3);
+
+    Assert.assertEquals(tracker1.getExternalStorageWriteTimeMs(), 150L);
+    Assert.assertEquals(tracker1.getVeniceWriteTimeMs(), 7L);
+    Assert.assertEquals(tracker2.getExternalStorageWriteTimeMs(), 1000L);
+    Assert.assertEquals(tracker2.getVeniceWriteTimeMs(), 3L);
+
+    // Crucially, nothing landed in a shared accumulator: durations travel via task-output rows precisely
+    // because speculative attempts would otherwise both contribute their accumulator updates on the driver.
+    verifyAllAccumulators(accumulators, new DataWriterAccumulators(spark));
+  }
+
+  @Test
+  public void testWriteTimesIgnoreNonPositiveReports() {
+    DataWriterAccumulators accumulators = new DataWriterAccumulators(spark);
+    SparkDataWriterTaskTracker tracker = new SparkDataWriterTaskTracker(accumulators);
+
+    tracker.trackExternalStorageWriteTime(0);
+    tracker.trackExternalStorageWriteTime(-5);
+    tracker.trackVeniceWriteTime(0);
+    tracker.trackVeniceWriteTime(-1);
+
+    Assert.assertEquals(tracker.getExternalStorageWriteTimeMs(), 0L);
+    Assert.assertEquals(tracker.getVeniceWriteTimeMs(), 0L);
+  }
+
+  @Test
+  public void testSetAndGetWriteTimes() {
+    DataWriterAccumulators accumulators = new DataWriterAccumulators(spark);
+    SparkDataWriterTaskTracker tracker = new SparkDataWriterTaskTracker(accumulators);
+
+    // Executor-side accrual is replaced wholesale by the driver-side sum over task-output rows.
+    tracker.trackExternalStorageWriteTime(999);
+    tracker.setExternalStorageWriteTimeMs(42);
+    tracker.setVeniceWriteTimeMs(21);
+
+    Assert.assertEquals(tracker.getExternalStorageWriteTimeMs(), 42L);
+    Assert.assertEquals(tracker.getVeniceWriteTimeMs(), 21L);
+  }
+
   @Test(expectedExceptions = UnsupportedOperationException.class)
   public void testFailedExternalStorageRegionsIsUnmodifiable() {
     DataWriterAccumulators accumulators = new DataWriterAccumulators(spark);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/meta/VersionStorageModeUpdateReason.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/meta/VersionStorageModeUpdateReason.java
@@ -1,0 +1,50 @@
+package com.linkedin.venice.meta;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Why a per-version {@link StorageMode} update was requested. Carried as an optional parameter on the
+ * update-version-storage-mode controller API so the controller that applies the update can tell an automated
+ * fail-open apart from a manual or operational change, without callers having to encode intent in free-form
+ * strings.
+ *
+ * <p>Requests that omit the reason are treated as {@link #UNSPECIFIED}, which keeps older clients working.
+ */
+public enum VersionStorageModeUpdateReason {
+  /** Default. A manual or otherwise unattributed storage-mode change. Not alertable. */
+  UNSPECIFIED,
+
+  /**
+   * The push job exhausted its external-storage write retries in the targeted region(s) and is failing open by
+   * downgrading those regions' version storage mode back to {@link StorageMode#INTERNAL} before end of push. The
+   * push still succeeds, so this is the only signal that the region lost its external-storage copy, and the
+   * controller applying it emits an alertable metric.
+   */
+  EXTERNAL_WRITE_FAILURE;
+
+  private static final Logger LOGGER = LogManager.getLogger(VersionStorageModeUpdateReason.class);
+
+  /**
+   * Parse a reason supplied over the controller API, tolerating {@code null} and blank values so that a newer
+   * client talking to an older controller — or the reverse — never fails the request over telemetry intent. An
+   * unrecognized non-blank value is logged, since it typically means a caller mis-typed the enum name and would
+   * otherwise silently lose the alertable signal this reason exists to carry.
+   *
+   * @return the matching reason, or {@link #UNSPECIFIED} when the value is absent or unrecognized
+   */
+  public static VersionStorageModeUpdateReason parseOrDefault(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return UNSPECIFIED;
+    }
+    String trimmedValue = value.trim();
+    for (VersionStorageModeUpdateReason reason: values()) {
+      if (reason.name().equalsIgnoreCase(trimmedValue)) {
+        return reason;
+      }
+    }
+    LOGGER.warn("Unrecognized VersionStorageModeUpdateReason value '{}', defaulting to {}", trimmedValue, UNSPECIFIED);
+    return UNSPECIFIED;
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensions.java
@@ -104,6 +104,9 @@ public enum VeniceMetricsDimensions {
   /** {@link VenicePushJobStatus} */
   VENICE_PUSH_JOB_STATUS("venice.push_job.status"),
 
+  /** {@link VenicePushJobDataWriterSink} */
+  VENICE_PUSH_JOB_DATA_WRITER_SINK("venice.push_job.data_writer.sink"),
+
   /** {@link VeniceSystemStoreType} */
   VENICE_SYSTEM_STORE_TYPE("venice.system_store.type"),
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VenicePushJobDataWriterSink.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/dimensions/VenicePushJobDataWriterSink.java
@@ -1,0 +1,27 @@
+package com.linkedin.venice.stats.dimensions;
+
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_PUSH_JOB_DATA_WRITER_SINK;
+
+
+/**
+ * Dimension enum identifying which sink a push job's data-writer tasks were writing to when the reported
+ * duration accrued. It lets a single duration metric carry both legs of a dual write instead of needing one
+ * metric per leg.
+ *
+ * Maps to {@link VeniceMetricsDimensions#VENICE_PUSH_JOB_DATA_WRITER_SINK}.
+ */
+public enum VenicePushJobDataWriterSink implements VeniceDimensionInterface {
+  /** Time spent invoking the Venice/Kafka writes and flushing/closing the Venice writer. */
+  VENICE,
+
+  /**
+   * Time spent in the external storage write path: throttling wait, batchPut calls including
+   * retries and retry backoff, external flush and external close.
+   */
+  EXTERNAL_STORAGE;
+
+  @Override
+  public VeniceMetricsDimensions getDimensionName() {
+    return VENICE_PUSH_JOB_DATA_WRITER_SINK;
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/meta/VersionStorageModeUpdateReasonTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/meta/VersionStorageModeUpdateReasonTest.java
@@ -1,0 +1,42 @@
+package com.linkedin.venice.meta;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+
+public class VersionStorageModeUpdateReasonTest {
+  @Test
+  public void testParseOrDefaultWithNull() {
+    assertEquals(VersionStorageModeUpdateReason.parseOrDefault(null), VersionStorageModeUpdateReason.UNSPECIFIED);
+  }
+
+  @Test
+  public void testParseOrDefaultWithEmptyOrBlank() {
+    assertEquals(VersionStorageModeUpdateReason.parseOrDefault(""), VersionStorageModeUpdateReason.UNSPECIFIED);
+    assertEquals(VersionStorageModeUpdateReason.parseOrDefault("   "), VersionStorageModeUpdateReason.UNSPECIFIED);
+  }
+
+  @Test
+  public void testParseOrDefaultWithKnownValue() {
+    assertEquals(
+        VersionStorageModeUpdateReason.parseOrDefault("EXTERNAL_WRITE_FAILURE"),
+        VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
+  }
+
+  @Test
+  public void testParseOrDefaultIsCaseInsensitiveAndTrims() {
+    assertEquals(
+        VersionStorageModeUpdateReason.parseOrDefault("  external_write_failure  "),
+        VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
+  }
+
+  @Test
+  public void testParseOrDefaultWithUnrecognizedValueLogsAndDefaults() {
+    // A typo'd reason (e.g. "EXTERNAL_WRITE_FAILUR") must not be silently mistaken for a recognized reason; it
+    // has to resolve to UNSPECIFIED just like a genuinely unspecified request.
+    assertEquals(
+        VersionStorageModeUpdateReason.parseOrDefault("EXTERNAL_WRITE_FAILUR"),
+        VersionStorageModeUpdateReason.UNSPECIFIED);
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VeniceMetricsDimensionsTest.java
@@ -106,6 +106,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_PUSH_JOB_STATUS:
           assertEquals(dimension.getDimensionName(format), "venice.push_job.status");
           break;
+        case VENICE_PUSH_JOB_DATA_WRITER_SINK:
+          assertEquals(dimension.getDimensionName(format), "venice.push_job.data_writer.sink");
+          break;
         case VENICE_SYSTEM_STORE_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.system_store.type");
           break;
@@ -303,6 +306,9 @@ public class VeniceMetricsDimensionsTest {
         case VENICE_PUSH_JOB_STATUS:
           assertEquals(dimension.getDimensionName(format), "venice.pushJob.status");
           break;
+        case VENICE_PUSH_JOB_DATA_WRITER_SINK:
+          assertEquals(dimension.getDimensionName(format), "venice.pushJob.dataWriter.sink");
+          break;
         case VENICE_SYSTEM_STORE_TYPE:
           assertEquals(dimension.getDimensionName(format), "venice.systemStore.type");
           break;
@@ -499,6 +505,9 @@ public class VeniceMetricsDimensionsTest {
           break;
         case VENICE_PUSH_JOB_STATUS:
           assertEquals(dimension.getDimensionName(format), "Venice.PushJob.Status");
+          break;
+        case VENICE_PUSH_JOB_DATA_WRITER_SINK:
+          assertEquals(dimension.getDimensionName(format), "Venice.PushJob.DataWriter.Sink");
           break;
         case VENICE_SYSTEM_STORE_TYPE:
           assertEquals(dimension.getDimensionName(format), "Venice.SystemStore.Type");

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VenicePushJobDataWriterSinkTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/dimensions/VenicePushJobDataWriterSinkTest.java
@@ -1,0 +1,21 @@
+package com.linkedin.venice.stats.dimensions;
+
+import com.linkedin.venice.utils.CollectionUtils;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+
+public class VenicePushJobDataWriterSinkTest {
+  @Test
+  public void testDimensionInterface() {
+    Map<VenicePushJobDataWriterSink, String> expectedValues =
+        CollectionUtils.<VenicePushJobDataWriterSink, String>mapBuilder()
+            .put(VenicePushJobDataWriterSink.VENICE, "venice")
+            .put(VenicePushJobDataWriterSink.EXTERNAL_STORAGE, "external_storage")
+            .build();
+    new VeniceDimensionTestFixture<>(
+        VenicePushJobDataWriterSink.class,
+        VeniceMetricsDimensions.VENICE_PUSH_JOB_DATA_WRITER_SINK,
+        expectedValues).assertAll();
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -135,6 +135,8 @@ public class ControllerApiConstants {
   public static final String INGESTION_PAUSED_REGIONS = "ingestion_paused_regions";
 
   public static final String STORAGE_MODE = "storage_mode";
+  /** Optional {@link com.linkedin.venice.meta.VersionStorageModeUpdateReason} name; absent means UNSPECIFIED. */
+  public static final String VERSION_STORAGE_MODE_UPDATE_REASON = "version_storage_mode_update_reason";
   public static final String EXTERNAL_STORAGE_READ_MODE = "external_storage_read_mode";
 
   public static final String AUTO_SCHEMA_REGISTER_FOR_PUSHJOB_ENABLED = "auto_auto_register_for_pushjob_enabled";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -78,6 +78,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.TO_BE_STO
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.UPSTREAM_POSITION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VALUE_SCHEMA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION_STORAGE_MODE_UPDATE_REASON;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VOLDEMORT_STORE_NAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.WRITE_OPERATION;
 import static com.linkedin.venice.meta.Version.PushType;
@@ -93,6 +94,7 @@ import com.linkedin.venice.exceptions.VeniceHttpException;
 import com.linkedin.venice.helix.VeniceJsonSerializer;
 import com.linkedin.venice.meta.StorageMode;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStorageModeUpdateReason;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.schema.avro.DirectionalSchemaCompatibilityType;
 import com.linkedin.venice.security.SSLFactory;
@@ -1172,9 +1174,31 @@ public class ControllerClient implements Closeable {
       int version,
       StorageMode storageMode,
       String regionsFilter) {
+    return updateStoreVersionStorageMode(
+        storeName,
+        version,
+        storageMode,
+        regionsFilter,
+        VersionStorageModeUpdateReason.UNSPECIFIED);
+  }
+
+  /**
+   * Update the storage mode of a single store version, optionally restricted to {@code regionsFilter} and
+   * optionally annotated with why the update is being made. The reason is telemetry intent only: it never changes
+   * the resulting storage mode, and a controller that does not understand it simply ignores it.
+   */
+  public ControllerResponse updateStoreVersionStorageMode(
+      String storeName,
+      int version,
+      StorageMode storageMode,
+      String regionsFilter,
+      VersionStorageModeUpdateReason reason) {
     QueryParams params = newParams().add(NAME, storeName).add(VERSION, version).add(STORAGE_MODE, storageMode.name());
     if (StringUtils.isNotEmpty(regionsFilter)) {
       params.add(REGIONS_FILTER, regionsFilter);
+    }
+    if (reason != null && reason != VersionStorageModeUpdateReason.UNSPECIFIED) {
+      params.add(VERSION_STORAGE_MODE_UPDATE_REASON, reason.name());
     }
     return request(ControllerRoute.UPDATE_STORE_VERSION_STORAGE_MODE, params, ControllerResponse.class);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -95,6 +95,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.TO_BE_STO
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.UPSTREAM_POSITION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VALUE_SCHEMA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION_STORAGE_MODE_UPDATE_REASON;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VOLDEMORT_STORE_NAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.WRITE_COMPUTATION_ENABLED;
 
@@ -289,7 +290,7 @@ public enum ControllerRoute implements VeniceDimensionInterface {
   ),
   UPDATE_STORE_VERSION_STORAGE_MODE(
       "/update_store_version_storage_mode", HttpMethod.POST, Arrays.asList(CLUSTER, NAME, VERSION, STORAGE_MODE),
-      REGIONS_FILTER
+      REGIONS_FILTER, VERSION_STORAGE_MODE_UPDATE_REASON
   ),
   LIST_STORE_PUSH_INFO("/list_store_push_info", HttpMethod.GET, Arrays.asList(CLUSTER, NAME, PARTITION_DETAIL_ENABLED)),
   GET_REGION_PUSH_DETAILS(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -60,8 +60,16 @@ public enum AvroProtocolDefinition {
 
   /**
    * Used to encode push job details records to be written to the PushJobDetails system store.
+   *
+   * <p><b>Deployment ordering.</b> This is a system-store value schema, so controllers must have registered
+   * v6 (which they do on startup, from the resources of the venice-common they were built with) <em>before</em>
+   * any push job serializes a v6 payload. Rolling out a VPJ built from this commit against a controller fleet
+   * still on v5 would make the controller reject the write. The safe order is: deploy controllers first, then
+   * the push job. v6 only appends one nullable {@code map<string, long>} field ({@code additionalPushMetrics})
+   * defaulting to {@code null}, so a v5 reader can still read a v6 record (it drops the map) and a v6 reader
+   * resolves a v5 record's missing map to {@code null}.
    */
-  PUSH_JOB_DETAILS(26, 5, PushJobDetails.class),
+  PUSH_JOB_DETAILS(26, 6, PushJobDetails.class),
 
   /**
    * Used to encode metadata changes about the system as a whole. Records of this type

--- a/internal/venice-common/src/main/java/com/linkedin/venice/status/protocol/PushJobDetailsAdditionalMetrics.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/status/protocol/PushJobDetailsAdditionalMetrics.java
@@ -1,0 +1,76 @@
+package com.linkedin.venice.status.protocol;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+
+/**
+ * Keys and accessors for {@link PushJobDetails#additionalPushMetrics}, the open-ended
+ * {@code map<string, long>} the push job uses to report extra per-push measurements.
+ *
+ * <p>Both sides of the protocol go through here so the key strings exist exactly once: the push job writes
+ * them, the controller reads them. Two absence cases are distinguished and both mean "not reported" rather
+ * than zero:
+ * <ul>
+ *   <li>a {@code null} map — the push reported no additional metrics at all, which is also what a v5 record
+ *       resolves to when read by a v6 reader;</li>
+ *   <li>a present map with the key absent — the push reported some metrics but not this one.</li>
+ * </ul>
+ *
+ * <p>Avro deserializes map keys as {@code Utf8}, not {@code String}, so a plain {@code Map#get(Object)} with a
+ * {@code String} key silently misses on a record that came off the wire. {@link #getMetric} compares by
+ * {@link CharSequence#toString()} to work for both freshly built and deserialized records.
+ */
+public final class PushJobDetailsAdditionalMetrics {
+  /**
+   * Summed data-writer task wall-clock milliseconds spent in the external storage write path: throttling wait,
+   * {@code batchPut} calls including retries and retry backoff, external flush and external close.
+   */
+  public static final String EXTERNAL_STORAGE_WRITE_TIME_MS = "externalStorageWriteTimeMs";
+
+  /**
+   * Summed data-writer task wall-clock milliseconds spent invoking the Venice/Kafka writes and flushing and
+   * closing the Venice writer.
+   */
+  public static final String VENICE_WRITE_TIME_MS = "veniceWriteTimeMs";
+
+  private PushJobDetailsAdditionalMetrics() {
+  }
+
+  /**
+   * Read one metric.
+   *
+   * @return the reported value, or {@code null} when the map is {@code null} or does not carry {@code key}.
+   *         A {@code null} return means "not reported" and must not be recorded as a zero observation.
+   */
+  public static Long getMetric(PushJobDetails pushJobDetails, String key) {
+    if (pushJobDetails == null) {
+      return null;
+    }
+    Map<CharSequence, Long> metrics = pushJobDetails.getAdditionalPushMetrics();
+    if (metrics == null) {
+      return null;
+    }
+    for (Map.Entry<CharSequence, Long> entry: metrics.entrySet()) {
+      CharSequence entryKey = entry.getKey();
+      if (entryKey != null && key.equals(entryKey.toString())) {
+        return entry.getValue();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Record one metric, lazily creating the map so a push that reports nothing leaves it {@code null} rather
+   * than serializing an empty map.
+   */
+  public static void putMetric(PushJobDetails pushJobDetails, String key, long value) {
+    Map<CharSequence, Long> metrics = pushJobDetails.getAdditionalPushMetrics();
+    if (metrics == null) {
+      // Insertion ordered so the serialized map and any log line built from it are stable across runs.
+      metrics = new LinkedHashMap<>();
+      pushJobDetails.setAdditionalPushMetrics(metrics);
+    }
+    metrics.put(key, value);
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/ControllerClientTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/ControllerClientTest.java
@@ -1,6 +1,8 @@
 package com.linkedin.venice.controllerapi;
 
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.StorageMode;
+import com.linkedin.venice.meta.VersionStorageModeUpdateReason;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -42,5 +44,56 @@ public class ControllerClientTest {
     }, r -> false));
 
     Assert.assertEquals(attempts.get(), 3, "Should exhaust all attempts before throwing");
+  }
+
+  /**
+   * Callers written against the pre-existing overloads must keep compiling and must land on the same request the
+   * controller already understands, with the reason defaulted rather than invented.
+   */
+  @Test
+  public void testUpdateStoreVersionStorageModeWithoutReasonDefaultsToUnspecified() {
+    ControllerClient client = Mockito.mock(ControllerClient.class);
+    Mockito.doCallRealMethod()
+        .when(client)
+        .updateStoreVersionStorageMode(Mockito.anyString(), Mockito.anyInt(), Mockito.any());
+    Mockito.doCallRealMethod()
+        .when(client)
+        .updateStoreVersionStorageMode(Mockito.anyString(), Mockito.anyInt(), Mockito.any(), Mockito.any());
+
+    client.updateStoreVersionStorageMode("store", 1, StorageMode.INTERNAL);
+    client.updateStoreVersionStorageMode("store", 1, StorageMode.INTERNAL, "dc-1");
+
+    Mockito.verify(client)
+        .updateStoreVersionStorageMode(
+            "store",
+            1,
+            StorageMode.INTERNAL,
+            null,
+            VersionStorageModeUpdateReason.UNSPECIFIED);
+    Mockito.verify(client)
+        .updateStoreVersionStorageMode(
+            "store",
+            1,
+            StorageMode.INTERNAL,
+            "dc-1",
+            VersionStorageModeUpdateReason.UNSPECIFIED);
+  }
+
+  @Test
+  public void testVersionStorageModeUpdateReasonParsing() {
+    Assert.assertEquals(
+        VersionStorageModeUpdateReason.parseOrDefault("EXTERNAL_WRITE_FAILURE"),
+        VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
+    Assert.assertEquals(
+        VersionStorageModeUpdateReason.parseOrDefault("external_write_failure"),
+        VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
+    // Absent, blank or unknown values must never fail the request; they simply are not alertable.
+    Assert
+        .assertEquals(VersionStorageModeUpdateReason.parseOrDefault(null), VersionStorageModeUpdateReason.UNSPECIFIED);
+    Assert
+        .assertEquals(VersionStorageModeUpdateReason.parseOrDefault("  "), VersionStorageModeUpdateReason.UNSPECIFIED);
+    Assert.assertEquals(
+        VersionStorageModeUpdateReason.parseOrDefault("SOMETHING_FROM_A_NEWER_CLIENT"),
+        VersionStorageModeUpdateReason.UNSPECIFIED);
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/status/protocol/TestPushJobDetailsSchemaCompatibility.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/status/protocol/TestPushJobDetailsSchemaCompatibility.java
@@ -1,15 +1,37 @@
 package com.linkedin.venice.status.protocol;
 
+import static java.util.Collections.emptyList;
+
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.Utils;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaCompatibility;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.util.Utf8;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
 public class TestPushJobDetailsSchemaCompatibility {
+  private static final int ACTIVATED_SCHEMA_ID = 6;
+  private static final int PREVIOUS_SCHEMA_ID = ACTIVATED_SCHEMA_ID - 1;
+  private static final String ADDED_FIELD = "additionalPushMetrics";
+
   private Map<Integer, Schema> schemaVersionMap =
       Utils.getAllSchemasFromResources(AvroProtocolDefinition.PUSH_JOB_DETAILS);
 
@@ -30,5 +52,129 @@ public class TestPushJobDetailsSchemaCompatibility {
           "PushJobDetails schema version " + schemaId + " is incompatible with the latest schema " + "version of "
               + latestSchemaId);
     });
+  }
+
+  /**
+   * v6 was registered by #2971 with the generated classes pinned to v5. This PR removes that pin and activates
+   * it, so the compiled class and the protocol definition must now both be on v6, and the nullable
+   * additionalPushMetrics map must be the only addition on top of v5.
+   */
+  @Test
+  public void testV6IsActivatedAndOnlyAppendsTheAdditionalPushMetricsMap() {
+    Assert.assertEquals(
+        AvroProtocolDefinition.PUSH_JOB_DETAILS.currentProtocolVersion.get().intValue(),
+        ACTIVATED_SCHEMA_ID,
+        "PushJobDetails must be activated at v6 for the push job to report the write timings");
+    Schema activeSchema = schemaVersionMap.get(ACTIVATED_SCHEMA_ID);
+    Assert.assertNotNull(activeSchema, "The compiled PushJobDetails class must be v6, i.e. no versionOverrides pin");
+
+    Schema previousSchema = schemaVersionMap.get(PREVIOUS_SCHEMA_ID);
+    List<String> addedFields = activeSchema.getFields()
+        .stream()
+        .map(Schema.Field::name)
+        .filter(name -> previousSchema.getField(name) == null)
+        .collect(Collectors.toList());
+    Assert.assertEquals(
+        addedFields,
+        Collections.singletonList(ADDED_FIELD),
+        "v6 must only append the additionalPushMetrics map on top of v5");
+
+    Schema.Field field = activeSchema.getField(ADDED_FIELD);
+    Assert.assertEquals(field.schema().getType(), Schema.Type.UNION, ADDED_FIELD + " must be nullable");
+    Schema mapBranch = field.schema()
+        .getTypes()
+        .stream()
+        .filter(branch -> branch.getType() == Schema.Type.MAP)
+        .findFirst()
+        .orElse(null);
+    Assert.assertNotNull(mapBranch, ADDED_FIELD + " must carry a map branch");
+    Assert.assertEquals(mapBranch.getValueType().getType(), Schema.Type.LONG, "Metric values must be longs");
+    Assert.assertTrue(field.hasDefaultValue(), ADDED_FIELD + " must carry a default so v5 records stay readable");
+    Assert.assertNull(
+        GenericData.get().getDefaultValue(field),
+        ADDED_FIELD + " must default to null, meaning no additional metrics were reported");
+  }
+
+  /**
+   * The two timing keys are the contract between the push job that writes them and the controller that reads
+   * them, so they must come from one shared place rather than being retyped on either side.
+   */
+  @Test
+  public void testTimingMetricKeysAreShared() {
+    Assert.assertEquals(PushJobDetailsAdditionalMetrics.EXTERNAL_STORAGE_WRITE_TIME_MS, "externalStorageWriteTimeMs");
+    Assert.assertEquals(PushJobDetailsAdditionalMetrics.VENICE_WRITE_TIME_MS, "veniceWriteTimeMs");
+  }
+
+  /**
+   * A null map and a present-but-missing key both mean "not reported" and must be distinguishable from a
+   * reported zero, otherwise the controller records a bogus zero-millisecond observation. Reads must also work
+   * on a record that came off the wire, whose map keys are Utf8 rather than String.
+   */
+  @Test
+  public void testAdditionalPushMetricsAccessorsDistinguishAbsentFromZero() {
+    PushJobDetails details = new PushJobDetails();
+
+    Assert.assertNull(details.getAdditionalPushMetrics(), "A fresh record must report no additional metrics");
+    Assert.assertNull(
+        PushJobDetailsAdditionalMetrics.getMetric(details, PushJobDetailsAdditionalMetrics.VENICE_WRITE_TIME_MS),
+        "A null map must read back as not reported");
+
+    PushJobDetailsAdditionalMetrics
+        .putMetric(details, PushJobDetailsAdditionalMetrics.EXTERNAL_STORAGE_WRITE_TIME_MS, 0L);
+    Assert.assertEquals(
+        PushJobDetailsAdditionalMetrics
+            .getMetric(details, PushJobDetailsAdditionalMetrics.EXTERNAL_STORAGE_WRITE_TIME_MS),
+        Long.valueOf(0L),
+        "Zero is a legitimate reported duration and must not read back as absent");
+    Assert.assertNull(
+        PushJobDetailsAdditionalMetrics.getMetric(details, PushJobDetailsAdditionalMetrics.VENICE_WRITE_TIME_MS),
+        "A key the push never wrote must read back as not reported");
+
+    // Deserialized records carry Utf8 keys, so a String-keyed lookup must still resolve them.
+    PushJobDetails fromTheWire = new PushJobDetails();
+    Map<CharSequence, Long> utf8Keyed = new HashMap<>();
+    utf8Keyed.put(new Utf8(PushJobDetailsAdditionalMetrics.VENICE_WRITE_TIME_MS), 42L);
+    fromTheWire.setAdditionalPushMetrics(utf8Keyed);
+    Assert.assertEquals(
+        PushJobDetailsAdditionalMetrics.getMetric(fromTheWire, PushJobDetailsAdditionalMetrics.VENICE_WRITE_TIME_MS),
+        Long.valueOf(42L),
+        "Utf8 map keys must resolve for a String lookup");
+  }
+
+  /**
+   * A controller running the v6 reader must be able to read records still produced by push jobs that serialize v5,
+   * resolving the appended map to its null default. That is what keeps the rollout safe while older push jobs are
+   * still in flight, and what lets the controller treat a null map as "not reported" instead of recording a bogus
+   * zero-millisecond observation.
+   */
+  @Test
+  public void testV6ReaderResolvesMissingAdditionalPushMetricsFromV5WriterToNull() throws IOException {
+    Schema v5Schema = schemaVersionMap.get(PREVIOUS_SCHEMA_ID);
+    Schema v6Schema = schemaVersionMap.get(ACTIVATED_SCHEMA_ID);
+
+    GenericRecord v5Record = new GenericData.Record(v5Schema);
+    for (Schema.Field field: v5Schema.getFields()) {
+      if (field.hasDefaultValue()) {
+        v5Record.put(field.name(), GenericData.get().getDefaultValue(field));
+      }
+    }
+    // The v5 fields without a default must be populated explicitly.
+    v5Record.put("clusterName", "cluster0");
+    v5Record.put("reportTimestamp", 1234L);
+    v5Record.put("overallStatus", new GenericData.Array<>(v5Schema.getField("overallStatus").schema(), emptyList()));
+    v5Record.put("pushId", "push-from-an-older-vpj");
+    v5Record.put("jobDurationInMs", 60000L);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    DatumWriter<GenericRecord> writer = new GenericDatumWriter<>(v5Schema);
+    BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(output, null);
+    writer.write(v5Record, encoder);
+    encoder.flush();
+
+    DatumReader<GenericRecord> reader = new GenericDatumReader<>(v5Schema, v6Schema);
+    GenericRecord v6Record = reader.read(null, DecoderFactory.get().binaryDecoder(output.toByteArray(), null));
+
+    Assert.assertNull(v6Record.get(ADDED_FIELD), "A v5 record must resolve to a null additionalPushMetrics map");
+    Assert.assertEquals(v6Record.get("jobDurationInMs"), 60000L);
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVPJDualWriteExternalStorageMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVPJDualWriteExternalStorageMultiRegion.java
@@ -26,18 +26,27 @@ import com.linkedin.venice.hadoop.mapreduce.datawriter.jobs.DataWriterMRJob;
 import com.linkedin.venice.hadoop.task.datawriter.ExternalStorageRecord;
 import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.meta.StorageMode;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStorageModeUpdateReason;
 import com.linkedin.venice.serializer.AvroGenericDeserializer;
 import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.spark.datawriter.jobs.DataWriterSparkJob;
+import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricsRepository;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -75,9 +84,18 @@ import org.testng.annotations.Test;
  *       dropping records.</li>
  *   <li><b>Ingestion unaffected:</b> Venice still serves every record in the {@code DUAL_WRITE} region.</li>
  * </ul>
+ *
+ * <p>{@link #dualWritePushSucceedsWhenOneRegionExhaustsExternalWriteRetries} additionally covers the fail-open
+ * path over both data writer engines (Spark and MapReduce): one region's external writes exhaust their retries,
+ * the push still succeeds, only that region's version is downgraded to {@code INTERNAL}, and the affected
+ * region's controller emits {@code push_job.external_storage_write_failure.count} exactly once with that region
+ * as its dimension while the healthy region emits nothing.
  */
 public class TestVPJDualWriteExternalStorageMultiRegion extends AbstractMultiRegionTest {
   private static final int READ_VERIFICATION_TIMEOUT_SEC = 60;
+  /** Matches {@code PushJobStatusStats.PushJobOtelMetricEntity.PUSH_JOB_EXTERNAL_STORAGE_WRITE_FAILURE_COUNT}. */
+  private static final String EXTERNAL_STORAGE_WRITE_FAILURE_METRIC_NAME =
+      "push_job.external_storage_write_failure.count";
 
   @AfterMethod(alwaysRun = true)
   public void resetSink() {
@@ -343,6 +361,51 @@ public class TestVPJDualWriteExternalStorageMultiRegion extends AbstractMultiReg
             "Failed region should downgrade only that version to INTERNAL before the swap");
       });
 
+      // The fail-open is otherwise silent — the push succeeded — so the alertable counter is the only signal
+      // that this fabric's copy of v1 exists in Venice alone. It must be attributed to the region that actually
+      // lost its external-storage copy, and the healthy region must stay clean.
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+        assertEquals(
+            externalStorageWriteFailureCount(1, storeName, failedRegion),
+            1L,
+            "The failed region's controller must count exactly one external-storage write failure");
+        assertEquals(
+            externalStorageWriteFailureCount(0, storeName, healthyRegion),
+            0L,
+            "The healthy region never failed open and must not contribute to the alert");
+      });
+      // Cross-region attribution: the failed region's controller must not attribute the failure to any region
+      // other than its own, which is what makes a per-fabric alert meaningful.
+      assertEquals(
+          externalStorageWriteFailureCount(1, storeName, healthyRegion),
+          0L,
+          "The failed region's controller must not attribute its failure to the healthy region");
+
+      // Idempotent replay through the parent: the push job retries this request, so the same downgrade can be
+      // delivered more than once. The version is already INTERNAL, so nothing transitions and the counter must
+      // not move. This also re-exercises parent -> child reason propagation on its own, outside the push.
+      assertCommand(
+          parentClient.updateStoreVersionStorageMode(
+              storeName,
+              1,
+              StorageMode.INTERNAL,
+              failedRegion,
+              VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE));
+      assertEquals(
+          assertCommand(failedRegionControllerClient.getStore(storeName)).getStore()
+              .getVersion(1)
+              .get()
+              .getStorageMode(),
+          StorageMode.INTERNAL,
+          "The replayed downgrade must leave the version INTERNAL");
+      // Give the child controller room to have (incorrectly) re-emitted before asserting the count held.
+      TestUtils.waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, true, true, () -> {
+        assertEquals(
+            externalStorageWriteFailureCount(1, storeName, failedRegion),
+            1L,
+            "An idempotent replay of the same downgrade must not double count the alert");
+      });
+
       VeniceClusterWrapper failedCluster = getCluster(1);
       try (AvroGenericStoreClient<String, Object> client = ClientFactory.getAndStartGenericAvroClient(
           ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(failedCluster.getRandomRouterURL()))) {
@@ -354,5 +417,48 @@ public class TestVPJDualWriteExternalStorageMultiRegion extends AbstractMultiReg
         });
       }
     }
+  }
+
+  /**
+   * Sum {@code push_job.external_storage_write_failure.count} across the controllers of one child region,
+   * for the given store and {@code venice.region.name} dimension.
+   *
+   * <p>Reads the controllers' own {@link InMemoryMetricReader}s, so this asserts on what the affected region's
+   * controller actually emitted rather than on anything the test computed. Returns 0 when the counter has never
+   * been recorded, since an OTel instrument that was never observed does not materialize at all.
+   */
+  private long externalStorageWriteFailureCount(int dcIndex, String storeName, String regionName) {
+    AttributeKey<String> clusterKey = AttributeKey.stringKey("venice.cluster.name");
+    AttributeKey<String> storeKey = AttributeKey.stringKey("venice.store.name");
+    AttributeKey<String> regionKey = AttributeKey.stringKey("venice.region.name");
+    VeniceMultiClusterWrapper childDatacenter = childDatacenters.get(dcIndex);
+    long total = 0L;
+    for (VeniceControllerWrapper controller: childDatacenter.getControllers().values()) {
+      MetricsRepository repository = controller.getMetricRepository();
+      if (!(repository instanceof VeniceMetricsRepository)) {
+        continue;
+      }
+      InMemoryMetricReader reader =
+          (InMemoryMetricReader) ((VeniceMetricsRepository) repository).getVeniceMetricsConfig()
+              .getOtelAdditionalMetricsReader();
+      if (reader == null) {
+        continue;
+      }
+      for (MetricData metricData: reader.collectAllMetrics()) {
+        if (!metricData.getName().endsWith(EXTERNAL_STORAGE_WRITE_FAILURE_METRIC_NAME)) {
+          continue;
+        }
+        total += metricData.getLongSumData()
+            .getPoints()
+            .stream()
+            .filter(
+                point -> CLUSTER_NAME.equals(point.getAttributes().get(clusterKey))
+                    && storeName.equals(point.getAttributes().get(storeKey))
+                    && regionName.equals(point.getAttributes().get(regionKey)))
+            .mapToLong(LongPointData::getValue)
+            .sum();
+      }
+    }
+    return total;
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -31,6 +31,7 @@ import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.UncompletedPartition;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.meta.VersionStorageModeUpdateReason;
 import com.linkedin.venice.persona.StoragePersona;
 import com.linkedin.venice.protocols.controller.PubSubPositionGrpcWireFormat;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -1028,6 +1029,27 @@ public interface Admin extends AutoCloseable, Closeable {
       int version,
       StorageMode storageMode,
       String regionFilter) {
+    updateStoreVersionStorageMode(
+        clusterName,
+        storeName,
+        version,
+        storageMode,
+        regionFilter,
+        VersionStorageModeUpdateReason.UNSPECIFIED);
+  }
+
+  /**
+   * Same as {@link #updateStoreVersionStorageMode(String, String, int, StorageMode, String)}, plus why the update
+   * was requested. The reason only drives controller telemetry — notably the alertable per-region counter emitted
+   * for {@link VersionStorageModeUpdateReason#EXTERNAL_WRITE_FAILURE} — and never changes the resulting mode.
+   */
+  default void updateStoreVersionStorageMode(
+      String clusterName,
+      String storeName,
+      int version,
+      StorageMode storageMode,
+      String regionFilter,
+      VersionStorageModeUpdateReason reason) {
     throw new VeniceUnsupportedOperationException("updateStoreVersionStorageMode");
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -28,6 +28,9 @@ import static com.linkedin.venice.meta.VersionStatus.ROLLED_BACK;
 import static com.linkedin.venice.meta.VersionStatus.STARTED;
 import static com.linkedin.venice.pushmonitor.OfflinePushStatus.HELIX_ASSIGNMENT_COMPLETED;
 import static com.linkedin.venice.serialization.avro.AvroProtocolDefinition.PARTICIPANT_MESSAGE_SYSTEM_STORE_VALUE;
+import static com.linkedin.venice.status.protocol.PushJobDetailsAdditionalMetrics.EXTERNAL_STORAGE_WRITE_TIME_MS;
+import static com.linkedin.venice.status.protocol.PushJobDetailsAdditionalMetrics.VENICE_WRITE_TIME_MS;
+import static com.linkedin.venice.status.protocol.PushJobDetailsAdditionalMetrics.getMetric;
 import static com.linkedin.venice.utils.RegionUtils.isRegionPartOfRegionsFilterList;
 import static com.linkedin.venice.utils.RegionUtils.parseRegionsFilterList;
 import static com.linkedin.venice.views.ViewUtils.ETERNAL_TOPIC_RETENTION_ENABLED;
@@ -35,6 +38,8 @@ import static com.linkedin.venice.views.ViewUtils.LOG_COMPACTION_ENABLED;
 import static com.linkedin.venice.views.ViewUtils.PARTITION_COUNT;
 import static com.linkedin.venice.views.ViewUtils.USE_FAST_KAFKA_OPERATION_TIMEOUT;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.D2.D2ClientUtils;
@@ -174,6 +179,7 @@ import com.linkedin.venice.meta.VeniceETLStrategy;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.meta.VersionStorageModeUpdateReason;
 import com.linkedin.venice.meta.ViewConfig;
 import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.participant.protocol.KillPushJob;
@@ -218,6 +224,7 @@ import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.stats.AbstractVeniceAggStats;
 import com.linkedin.venice.stats.ZkClientStatusStats;
+import com.linkedin.venice.stats.dimensions.VenicePushJobDataWriterSink;
 import com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory;
 import com.linkedin.venice.status.PushJobDetailsStatus;
 import com.linkedin.venice.status.StatusMessageChannel;
@@ -282,6 +289,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -417,6 +425,20 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   private final Map<String, DisabledPartitionStats> disabledPartitionStatMap = new HashMap<>();
   private final Map<String, PushJobStatusStats> pushJobStatusStatsMap = new HashMap<>();
   private final Map<String, AddVersionLatencyStats> addVersionLatencyStatsMap = new HashMap<>();
+
+  /**
+   * Push jobs whose data-writer sink durations have already been observed, so a re-reported terminal
+   * PushJobDetails does not add a second histogram observation for the same push. A push job sends its
+   * terminal update once, but retries, parent-to-child dual writes and re-sends can deliver the same terminal
+   * record more than once, and unlike the push-status counters a duplicated duration would skew the
+   * distribution.
+   *
+   * <p>Bounded and expiring so a controller that stays up for weeks cannot accumulate push ids forever; a
+   * push that somehow re-reports after the TTL just records once more, which is acceptable for a distribution
+   * metric. Caffeine is already a controller dependency (see {@link DeferredVersionSwapService}).
+   */
+  private final Cache<String, Boolean> dataWriterSinkWriteTimeEmittedPushIds =
+      Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(6, TimeUnit.HOURS).build();
 
   // This map stores the time when topics were created. It only contains topics whose information has not yet been
   // persisted to Zk.
@@ -773,16 +795,21 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         logCompactionStatsMap.putIfAbsent(clusterName, new LogCompactionStats(metricsRepository, clusterName));
       }
 
+      /**
+       * Push job stats are not tied to error-leader-replica fail over: every cluster reports push job status and
+       * the external-storage write failure counter, so register them before the fail-over specific short circuit
+       * below.
+       */
+      pushJobStatusStatsMap.putIfAbsent(clusterName, new PushJobStatusStats(metricsRepository, clusterName));
+
       if (!multiClusterConfigs.getControllerConfig(clusterName).isErrorLeaderReplicaFailOverEnabled()) {
         continue;
       }
 
       HelixLiveInstanceMonitor liveInstanceMonitor = new HelixLiveInstanceMonitor(this.helixZkClient, clusterName);
       DisabledPartitionStats disabledPartitionStats = new DisabledPartitionStats(metricsRepository, clusterName);
-      PushJobStatusStats pushJobStatusStats = new PushJobStatusStats(metricsRepository, clusterName);
       disabledPartitionStatMap.put(clusterName, disabledPartitionStats);
       liveInstanceMonitorMap.put(clusterName, liveInstanceMonitor);
-      pushJobStatusStatsMap.put(clusterName, pushJobStatusStats);
       addVersionLatencyStatsMap.put(clusterName, new AddVersionLatencyStats(metricsRepository, clusterName));
       // Register new instance callback
       liveInstanceMonitor.registerLiveInstanceChangedListener(new LiveInstanceChangedListener() {
@@ -1521,7 +1548,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       Map<String, LogCompactionStats> logCompactionStatsMap,
       PushJobStatusRecordKey pushJobDetailsKey,
       PushJobDetails pushJobDetailsValue,
-      Set<PushJobCheckpoints> pushJobUserErrorCheckpoints) {
+      Set<PushJobCheckpoints> pushJobUserErrorCheckpoints,
+      Cache<String, Boolean> dataWriterSinkWriteTimeEmittedPushIds) {
     List<PushJobDetailsStatusTuple> overallStatuses = pushJobDetailsValue.getOverallStatus();
     if (overallStatuses.isEmpty()) {
       return;
@@ -1576,6 +1604,15 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           if (Version.isPushIdRePush(pushJobDetailsValue.getPushId().toString())) {
             logCompactionStatsMap.get(cluster).setCompactionComplete(storeName.toString());
           }
+          // Only a completed push's data-writer timings are meaningful for "why was this push slow" — a push
+          // that failed partway through would contribute a partial duration to the same histogram as a
+          // completed push, with no status dimension to tell them apart.
+          emitDataWriterSinkWriteTimeMetrics(
+              pushJobStatusStatsMap.get(cluster),
+              pushJobDetailsKey,
+              pushJobDetailsValue,
+              isIncrementalPush,
+              dataWriterSinkWriteTimeEmittedPushIds);
         }
         // Append job duration in minutes to log message
         double jobDurationInMinutes = pushJobDetailsValue.getJobDurationInMs() / 60000.0;
@@ -1593,6 +1630,60 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           pushJobDetailsKey.toString(),
           pushJobDetailsValue.toString(),
           e);
+    }
+  }
+
+  /**
+   * Record one histogram observation per sink for a successfully completed push, using the summed data-writer
+   * task durations the push job reported in {@link PushJobDetails#additionalPushMetrics}.
+   *
+   * <p>Only called for a push whose terminal status is {@link PushJobDetailsStatus#isSucceeded}: a push that
+   * failed partway through would otherwise contribute a partial duration to the same histogram as a completed
+   * push, and the metric carries no status dimension to tell the two apart.
+   *
+   * <p>A null map means the push reported no additional metrics at all — an older push job, whose v5 record a
+   * v6 reader resolves to null — and an absent key means that particular leg was not reported, typically
+   * because no external storage was configured. Both are skipped rather than recorded as zero. The push id —
+   * deliberately never a metric dimension, since it is unbounded cardinality — is only used to dedup: a
+   * terminal push is observed once even if its terminal PushJobDetails record is delivered repeatedly. The
+   * dedup entry is only written once the metric has actually been recorded, so a missing stats registration or
+   * a recording failure does not permanently suppress the (still-unobserved) push.
+   */
+  private static void emitDataWriterSinkWriteTimeMetrics(
+      PushJobStatusStats pushJobStatusStats,
+      PushJobStatusRecordKey pushJobDetailsKey,
+      PushJobDetails pushJobDetailsValue,
+      boolean isIncrementalPush,
+      Cache<String, Boolean> dataWriterSinkWriteTimeEmittedPushIds) {
+    if (pushJobStatusStats == null) {
+      return;
+    }
+    Long externalStorageWriteTimeMs = getMetric(pushJobDetailsValue, EXTERNAL_STORAGE_WRITE_TIME_MS);
+    Long veniceWriteTimeMs = getMetric(pushJobDetailsValue, VENICE_WRITE_TIME_MS);
+    if (externalStorageWriteTimeMs == null && veniceWriteTimeMs == null) {
+      return;
+    }
+    String storeName = pushJobDetailsKey.getStoreName().toString();
+    if (dataWriterSinkWriteTimeEmittedPushIds != null) {
+      String dedupKey = storeName + "_v" + pushJobDetailsKey.getVersionNumber() + "_pushId_"
+          + (pushJobDetailsValue.getPushId() == null ? "unknown" : pushJobDetailsValue.getPushId().toString());
+      // getIfPresent + put is a check-then-act race between concurrent deliveries of the same terminal record;
+      // putIfAbsent on the underlying map makes the check-and-mark atomic.
+      if (dataWriterSinkWriteTimeEmittedPushIds.asMap().putIfAbsent(dedupKey, Boolean.TRUE) != null) {
+        return;
+      }
+    }
+    PushType pushType = isIncrementalPush ? PushType.INCREMENTAL : PushType.BATCH;
+    if (externalStorageWriteTimeMs != null) {
+      pushJobStatusStats.recordDataWriterSinkWriteTime(
+          storeName,
+          pushType,
+          VenicePushJobDataWriterSink.EXTERNAL_STORAGE,
+          externalStorageWriteTimeMs);
+    }
+    if (veniceWriteTimeMs != null) {
+      pushJobStatusStats
+          .recordDataWriterSinkWriteTime(storeName, pushType, VenicePushJobDataWriterSink.VENICE, veniceWriteTimeMs);
     }
   }
 
@@ -1647,7 +1738,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   void sendPushJobDetailsToLocalRT(PushJobStatusRecordKey key, PushJobDetails value) {
-    emitPushJobStatusMetrics(pushJobStatusStatsMap, logCompactionStatsMap, key, value, pushJobUserErrorCheckpoints);
+    emitPushJobStatusMetrics(
+        pushJobStatusStatsMap,
+        logCompactionStatsMap,
+        key,
+        value,
+        pushJobUserErrorCheckpoints,
+        dataWriterSinkWriteTimeEmittedPushIds);
     pushJobDetailsManager.writeToLocalRTTopic(key, value);
   }
 
@@ -5852,37 +5949,80 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       int version,
       StorageMode storageMode,
-      String regionFilter) {
-    if (StringUtils.isNotEmpty(regionFilter) && !isRegionPartOfRegionsFilterList(getRegionName(), regionFilter)) {
+      String regionFilter,
+      VersionStorageModeUpdateReason reason) {
+    String regionName = getRegionName();
+    if (StringUtils.isNotEmpty(regionFilter) && !isRegionPartOfRegionsFilterList(regionName, regionFilter)) {
       LOGGER.info(
           "Skipping version storage-mode update for store {} v{} in cluster {} because region filter {} does not include {}",
           storeName,
           version,
           clusterName,
           regionFilter,
-          getRegionName());
+          regionName);
       return;
     }
 
+    /**
+     * Set only when this call is the one that actually moves the version off an external-write mode. An idempotent
+     * retry of the same request finds the version already INTERNAL, changes nothing, and therefore must not be
+     * counted a second time.
+     */
+    AtomicBoolean downgradedFromExternalWrite = new AtomicBoolean(false);
     storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
       Version storeVersion = store.getVersion(version);
       if (storeVersion == null) {
         throw new VeniceException(
             "Version " + version + " does not exist for store " + storeName + " in cluster " + clusterName);
       }
-      if (storeVersion.getStorageMode() == storageMode) {
+      StorageMode previousStorageMode = storeVersion.getStorageMode();
+      if (previousStorageMode == storageMode) {
         return store;
       }
       store.setVersionStorageMode(version, storageMode);
+      if (storageMode == StorageMode.INTERNAL) {
+        downgradedFromExternalWrite.set(true);
+      }
       LOGGER.info(
-          "Updated store {} v{} storageMode to {} in cluster {} for region {}",
+          "Updated store {} v{} storageMode from {} to {} in cluster {} for region {}",
           storeName,
           version,
+          previousStorageMode,
           storageMode,
           clusterName,
-          getRegionName());
+          regionName);
       return store;
     });
+
+    if (reason == VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE && downgradedFromExternalWrite.get()) {
+      recordExternalStorageWriteFailure(clusterName, storeName, regionName);
+    }
+  }
+
+  /**
+   * Emit the alertable counter for a region whose external-storage writes were given up on. This runs on the
+   * controller of the affected region — the parent fans the request out to one child controller per region in
+   * {@code regionsFilter}, and each child knows its own region — so the region dimension is the region that lost
+   * its external-storage copy, not the controller that first received the push job's request.
+   *
+   * <p>Package private so tests can assert exactly when it fires without reaching into the stats registry.
+   */
+  void recordExternalStorageWriteFailure(String clusterName, String storeName, String regionName) {
+    PushJobStatusStats pushJobStatusStats = pushJobStatusStatsMap.get(clusterName);
+    if (pushJobStatusStats == null) {
+      LOGGER.warn(
+          "No push job status stats registered for cluster {}, skipping the external-storage write failure metric for store {} in region {}",
+          clusterName,
+          storeName,
+          regionName);
+      return;
+    }
+    LOGGER.warn(
+        "External-storage writes failed for store {} in cluster {} region {}; the version storage mode was failed open to INTERNAL",
+        storeName,
+        clusterName,
+        regionName);
+    pushJobStatusStats.recordExternalStorageWriteFailure(storeName, regionName);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -136,6 +136,7 @@ import com.linkedin.venice.meta.StoreVersionInfo;
 import com.linkedin.venice.meta.VeniceETLStrategy;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.meta.VersionStorageModeUpdateReason;
 import com.linkedin.venice.meta.ViewConfig;
 import com.linkedin.venice.persona.StoragePersona;
 import com.linkedin.venice.protocols.controller.PubSubPositionGrpcWireFormat;
@@ -3183,7 +3184,8 @@ public class VeniceParentHelixAdmin implements Admin {
       String storeName,
       int version,
       StorageMode storageMode,
-      String regionFilter) {
+      String regionFilter,
+      VersionStorageModeUpdateReason reason) {
     Map<String, ControllerClient> controllerClientMap = getVeniceHelixAdmin().getControllerClientMap(clusterName);
     if (controllerClientMap.isEmpty()) {
       throw new VeniceException("No child controller clients found for cluster " + clusterName);
@@ -3203,7 +3205,12 @@ public class VeniceParentHelixAdmin implements Admin {
       ControllerClient childControllerClient = controllerClientMap.get(region);
       ControllerResponse response;
       try {
-        response = childControllerClient.updateStoreVersionStorageMode(storeName, version, storageMode);
+        /**
+         * The region filter is already resolved into one request per target region, so the child call carries no
+         * filter of its own. The reason is forwarded so the child — which is the affected region — is the one that
+         * emits the fail-open metric.
+         */
+        response = childControllerClient.updateStoreVersionStorageMode(storeName, version, storageMode, null, reason);
       } catch (Exception e) {
         throw new VeniceException(
             "Failed to update version storage mode for store " + storeName + " v" + version + " in region " + region,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -29,6 +29,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_NAM
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TOPIC;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TOPIC_COMPACTION_POLICY;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION_STORAGE_MODE_UPDATE_REASON;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.WRITE_OPERATION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.ABORT_MIGRATION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.BACKUP_VERSION;
@@ -113,6 +114,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataAudit;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStorageModeUpdateReason;
 import com.linkedin.venice.protocols.controller.ClusterStoreGrpcInfo;
 import com.linkedin.venice.protocols.controller.ListStoresGrpcRequest;
 import com.linkedin.venice.protocols.controller.ListStoresGrpcResponse;
@@ -1118,7 +1120,7 @@ public class StoresRoutes extends AbstractRoute {
   }
 
   /**
-   * @see Admin#updateStoreVersionStorageMode(String, String, int, StorageMode, String)
+   * @see Admin#updateStoreVersionStorageMode(String, String, int, StorageMode, String, VersionStorageModeUpdateReason)
    */
   public Route updateStoreVersionStorageMode(Admin admin) {
     return new VeniceRouteHandler<ControllerResponse>(ControllerResponse.class) {
@@ -1140,7 +1142,10 @@ public class StoresRoutes extends AbstractRoute {
           int version = Integer.parseInt(request.queryParams(VERSION));
           StorageMode storageMode = StorageMode.valueOf(request.queryParams(STORAGE_MODE));
           String regionsFilter = request.queryParamOrDefault(REGIONS_FILTER, "");
-          admin.updateStoreVersionStorageMode(clusterName, storeName, version, storageMode, regionsFilter);
+          // An absent or unrecognized reason resolves to UNSPECIFIED so an older client never fails here.
+          VersionStorageModeUpdateReason reason = VersionStorageModeUpdateReason
+              .parseOrDefault(request.queryParamOrDefault(VERSION_STORAGE_MODE_UPDATE_REASON, ""));
+          admin.updateStoreVersionStorageMode(clusterName, storeName, version, storageMode, regionsFilter, reason);
         } catch (Exception e) {
           veniceResponse.setError(
               "Failed when updating version storage mode for store " + storeName + ". Exception type: "

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/PushJobStatusStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/PushJobStatusStats.java
@@ -2,8 +2,10 @@ package com.linkedin.venice.controller.stats;
 
 import static com.linkedin.venice.controller.stats.ControllerStatsDimensionUtils.dimensionMapBuilder;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_PUSH_JOB_DATA_WRITER_SINK;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_PUSH_JOB_STATUS;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_PUSH_JOB_TYPE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REGION_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
 import static com.linkedin.venice.utils.Utils.setOf;
 
@@ -12,6 +14,7 @@ import com.linkedin.venice.stats.AbstractVeniceStats;
 import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
 import com.linkedin.venice.stats.VeniceOpenTelemetryMetricsRepository;
 import com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions;
+import com.linkedin.venice.stats.dimensions.VenicePushJobDataWriterSink;
 import com.linkedin.venice.stats.dimensions.VenicePushJobStatus;
 import com.linkedin.venice.stats.metrics.MetricEntity;
 import com.linkedin.venice.stats.metrics.MetricEntityStateGeneric;
@@ -20,20 +23,34 @@ import com.linkedin.venice.stats.metrics.MetricUnit;
 import com.linkedin.venice.stats.metrics.ModuleMetricEntityInterface;
 import com.linkedin.venice.stats.metrics.TehutiMetricNameEnum;
 import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.stats.Avg;
 import io.tehuti.metrics.stats.Count;
 import io.tehuti.metrics.stats.CountSinceLastMeasurement;
+import io.tehuti.metrics.stats.Max;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
 public class PushJobStatusStats extends AbstractVeniceStats {
+  private static final Logger LOGGER = LogManager.getLogger(PushJobStatusStats.class);
   private final MetricEntityStateGeneric batchPushSuccessMetric;
   private final MetricEntityStateGeneric batchPushFailureDueToUserErrorMetric;
   private final MetricEntityStateGeneric batchPushFailureDueToNonUserErrorMetric;
   private final MetricEntityStateGeneric incrementalPushSuccessMetric;
   private final MetricEntityStateGeneric incrementalPushFailureDueToUserErrorMetric;
   private final MetricEntityStateGeneric incrementalPushFailureDueToNonUserErrorMetric;
+  /**
+   * Duration a push's data-writer tasks spent writing to the external storage sink and to Venice. Both share
+   * one OTel metric entity and are told apart by the {@link VenicePushJobDataWriterSink} dimension, while
+   * Tehuti gets one sensor per sink because Tehuti sensors carry no dimensions.
+   */
+  private final MetricEntityStateGeneric externalStorageWriteTimeMetric;
+  private final MetricEntityStateGeneric veniceWriteTimeMetric;
+  /** Alertable per-region signal that a push gave up writing to external storage. */
+  private final MetricEntityStateGeneric externalStorageWriteFailureMetric;
 
   public PushJobStatusStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
@@ -90,6 +107,30 @@ public class PushJobStatusStats extends AbstractVeniceStats {
         PushJobTehutiMetricNameEnum.INCREMENTAL_PUSH_JOB_FAILED_NON_USER_ERROR,
         Arrays.asList(new Count(), new CountSinceLastMeasurement()),
         baseDimensionsMap);
+
+    externalStorageWriteTimeMetric = MetricEntityStateGeneric.create(
+        PushJobOtelMetricEntity.PUSH_JOB_DATA_WRITER_SINK_WRITE_TIME.getMetricEntity(),
+        otelRepository,
+        this::registerSensorIfAbsent,
+        PushJobTehutiMetricNameEnum.PUSH_JOB_EXTERNAL_STORAGE_WRITE_TIME,
+        Arrays.asList(new Avg(), new Max()),
+        baseDimensionsMap);
+
+    veniceWriteTimeMetric = MetricEntityStateGeneric.create(
+        PushJobOtelMetricEntity.PUSH_JOB_DATA_WRITER_SINK_WRITE_TIME.getMetricEntity(),
+        otelRepository,
+        this::registerSensorIfAbsent,
+        PushJobTehutiMetricNameEnum.PUSH_JOB_VENICE_WRITE_TIME,
+        Arrays.asList(new Avg(), new Max()),
+        baseDimensionsMap);
+
+    externalStorageWriteFailureMetric = MetricEntityStateGeneric.create(
+        PushJobOtelMetricEntity.PUSH_JOB_EXTERNAL_STORAGE_WRITE_FAILURE_COUNT.getMetricEntity(),
+        otelRepository,
+        this::registerSensorIfAbsent,
+        PushJobTehutiMetricNameEnum.PUSH_JOB_EXTERNAL_STORAGE_WRITE_FAILURE,
+        Arrays.asList(new Count(), new CountSinceLastMeasurement()),
+        baseDimensionsMap);
   }
 
   public void recordBatchPushSuccessSensor(String storeName) {
@@ -121,6 +162,55 @@ public class PushJobStatusStats extends AbstractVeniceStats {
         .record(1, pushJobDimensions(storeName, PushType.INCREMENTAL, VenicePushJobStatus.SYSTEM_ERROR));
   }
 
+  /**
+   * Record how long a terminal push's data-writer tasks spent writing to one of the two sinks.
+   *
+   * <p>{@code timeMs} is the sum of the per-task wall-clock durations reported by the push job, not the
+   * push's own wall-clock duration. Negative values mean the push did not report the duration (older push job
+   * or no dual write configured) and are dropped rather than recorded as a bogus observation. Callers are
+   * responsible for invoking this at most once per push per sink; see the dedup in
+   * {@code VeniceHelixAdmin#emitPushJobStatusMetrics}.
+   */
+  public void recordDataWriterSinkWriteTime(
+      String storeName,
+      PushType pushType,
+      VenicePushJobDataWriterSink sink,
+      long timeMs) {
+    if (timeMs < 0) {
+      return;
+    }
+    Map<VeniceMetricsDimensions, String> dimensions = dimensionMapBuilder().store(storeName)
+        .add(VENICE_PUSH_JOB_TYPE, pushType.getDimensionValue())
+        .add(VENICE_PUSH_JOB_DATA_WRITER_SINK, sink.getDimensionValue())
+        .build();
+    switch (sink) {
+      case EXTERNAL_STORAGE:
+        externalStorageWriteTimeMetric.record(timeMs, dimensions);
+        break;
+      case VENICE:
+        veniceWriteTimeMetric.record(timeMs, dimensions);
+        break;
+      default:
+        // Metrics recording should never fail the caller; a future sink value that isn't wired up here should
+        // be dropped with a loud warning instead of throwing on a hot metrics path.
+        LOGGER.warn("Unsupported data writer sink: {}, dropping data writer sink write time observation", sink);
+    }
+  }
+
+  /**
+   * Record that a push exhausted its external-storage write retries in {@code regionName} and that the region's
+   * version storage mode was consequently failed open to {@code INTERNAL}. This is a counter rather than a
+   * duration: it exists to be alerted on, since the push itself still succeeds and would otherwise look healthy.
+   *
+   * <p>Emitted by the controller of the affected region, once per region per accepted downgrade. Push type is
+   * deliberately not a dimension because the controller applying the downgrade does not know it, and neither push
+   * id nor version number are dimensions because they are unbounded.
+   */
+  public void recordExternalStorageWriteFailure(String storeName, String regionName) {
+    externalStorageWriteFailureMetric
+        .record(1, dimensionMapBuilder().store(storeName).add(VENICE_REGION_NAME, regionName).build());
+  }
+
   private static Map<VeniceMetricsDimensions, String> pushJobDimensions(
       String storeName,
       PushType pushType,
@@ -133,7 +223,8 @@ public class PushJobStatusStats extends AbstractVeniceStats {
 
   enum PushJobTehutiMetricNameEnum implements TehutiMetricNameEnum {
     BATCH_PUSH_JOB_SUCCESS, BATCH_PUSH_JOB_FAILED_USER_ERROR, BATCH_PUSH_JOB_FAILED_NON_USER_ERROR,
-    INCREMENTAL_PUSH_JOB_SUCCESS, INCREMENTAL_PUSH_JOB_FAILED_USER_ERROR, INCREMENTAL_PUSH_JOB_FAILED_NON_USER_ERROR
+    INCREMENTAL_PUSH_JOB_SUCCESS, INCREMENTAL_PUSH_JOB_FAILED_USER_ERROR, INCREMENTAL_PUSH_JOB_FAILED_NON_USER_ERROR,
+    PUSH_JOB_EXTERNAL_STORAGE_WRITE_TIME, PUSH_JOB_VENICE_WRITE_TIME, PUSH_JOB_EXTERNAL_STORAGE_WRITE_FAILURE
   }
 
   public enum PushJobOtelMetricEntity implements ModuleMetricEntityInterface {
@@ -142,6 +233,29 @@ public class PushJobStatusStats extends AbstractVeniceStats {
         "push_job.count", MetricType.COUNTER, MetricUnit.NUMBER,
         "Push job completions, differentiated by push type and status",
         setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME, VENICE_PUSH_JOB_TYPE, VENICE_PUSH_JOB_STATUS)
+    ),
+
+    /**
+     * PushJobStatusStats: Time a terminal push's data writer tasks spent writing to each sink. This is the
+     * sum of the per-task wall-clock durations reported by the push job, so it is not bounded by the push's
+     * own duration; a push with N parallel tasks can report up to N times its wall-clock time. One
+     * observation is recorded per terminal push per sink.
+     */
+    PUSH_JOB_DATA_WRITER_SINK_WRITE_TIME(
+        "push_job.data_writer.sink_write_time", MetricType.HISTOGRAM, MetricUnit.MILLISECOND,
+        "Summed data writer task duration spent writing to a push job sink, differentiated by push type and sink",
+        setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME, VENICE_PUSH_JOB_TYPE, VENICE_PUSH_JOB_DATA_WRITER_SINK)
+    ),
+
+    /**
+     * PushJobStatusStats: Pushes that gave up writing to external storage in a region. The push still succeeds,
+     * so this counter is the alertable signal that the region's version holds no external-storage copy. Counted
+     * once per region per accepted downgrade by the controller of the affected region.
+     */
+    PUSH_JOB_EXTERNAL_STORAGE_WRITE_FAILURE_COUNT(
+        "push_job.external_storage_write_failure.count", MetricType.COUNTER, MetricUnit.NUMBER,
+        "Pushes that exhausted external storage write retries and failed the region's version storage mode open to internal, differentiated by region",
+        setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME, VENICE_REGION_NAME)
     );
 
     private final MetricEntity metricEntity;

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestPushJobStatusStats.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestPushJobStatusStats.java
@@ -6,17 +6,27 @@ import static com.linkedin.venice.controller.VeniceHelixAdmin.emitPushJobStatusM
 import static com.linkedin.venice.controller.VeniceHelixAdmin.isPushJobFailedDueToUserError;
 import static com.linkedin.venice.status.PushJobDetailsStatus.isFailed;
 import static com.linkedin.venice.status.PushJobDetailsStatus.isSucceeded;
+import static com.linkedin.venice.status.protocol.PushJobDetailsAdditionalMetrics.EXTERNAL_STORAGE_WRITE_TIME_MS;
+import static com.linkedin.venice.status.protocol.PushJobDetailsAdditionalMetrics.VENICE_WRITE_TIME_MS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.linkedin.venice.PushJobCheckpoints;
 import com.linkedin.venice.controller.stats.LogCompactionStats;
 import com.linkedin.venice.controller.stats.PushJobStatusStats;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.stats.dimensions.VenicePushJobDataWriterSink;
 import com.linkedin.venice.status.PushJobDetailsStatus;
 import com.linkedin.venice.status.protocol.PushJobDetails;
 import com.linkedin.venice.status.protocol.PushJobDetailsStatusTuple;
@@ -30,10 +40,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.avro.util.Utf8;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 
 public class TestPushJobStatusStats {
+  private static final String STORE_NAME = "test-store";
+  private static final String CLUSTER_NAME = "cluster1";
   private static final Set<PushJobCheckpoints> CUSTOM_USER_ERROR_CHECKPOINTS =
       new HashSet<>(Collections.singletonList(DVC_INGESTION_ERROR_OTHER));
 
@@ -66,6 +79,8 @@ public class TestPushJobStatusStats {
     LogCompactionStats logCompactionStats = mock(LogCompactionStats.class);
     logCompactionStatsMap.put("cluster1", logCompactionStats);
 
+    Cache<String, Boolean> dataWriterSinkWriteTimeEmittedPushIds = Caffeine.newBuilder().build();
+
     int numberSuccess = 0;
     int numberUserErrors = 0;
     int numberNonUserErrors = 0;
@@ -85,7 +100,8 @@ public class TestPushJobStatusStats {
             logCompactionStatsMap,
             key,
             pushJobDetails,
-            userErrorCheckpoints);
+            userErrorCheckpoints,
+            dataWriterSinkWriteTimeEmittedPushIds);
         boolean isUserError = userErrorCheckpoints.contains(checkpoint);
 
         if (isUserError) {
@@ -140,6 +156,201 @@ public class TestPushJobStatusStats {
           }
         }
       }
+    }
+  }
+
+  /**
+   * The two data-writer durations are only meaningful once the push has reached a terminal, successful state:
+   * a push that failed partway through would otherwise contribute a partial duration to the same histogram as
+   * a completed push, with no status dimension to tell them apart. So nothing is observed for the intermediate
+   * statuses a push reports on its way to terminal, nor for a terminal but failed status.
+   */
+  @Test
+  public void testDataWriterSinkWriteTimeEmittedOnlyOnSucceededTerminalStatus() {
+    DataWriterSinkWriteTimeFixture fixture = new DataWriterSinkWriteTimeFixture(1200L, 300L);
+
+    for (PushJobDetailsStatus status: PushJobDetailsStatus.values()) {
+      fixture.reset();
+      fixture.setOverallStatus(status);
+      fixture.emit();
+
+      if (PushJobDetailsStatus.isTerminal(status.getValue()) && isSucceeded(status)) {
+        verify(fixture.pushJobStatusStats).recordDataWriterSinkWriteTime(
+            STORE_NAME,
+            Version.PushType.BATCH,
+            VenicePushJobDataWriterSink.EXTERNAL_STORAGE,
+            1200L);
+        verify(fixture.pushJobStatusStats).recordDataWriterSinkWriteTime(
+            STORE_NAME,
+            Version.PushType.BATCH,
+            VenicePushJobDataWriterSink.VENICE,
+            300L);
+      } else {
+        verify(fixture.pushJobStatusStats, never()).recordDataWriterSinkWriteTime(anyString(), any(), any(), anyLong());
+      }
+    }
+  }
+
+  @Test
+  public void testDataWriterSinkWriteTimeSkipsUnreportedDurations() {
+    // A null map is the schema default: the push reported no additional metrics, so there is nothing to observe.
+    DataWriterSinkWriteTimeFixture bothUnset = new DataWriterSinkWriteTimeFixture(null, null);
+    bothUnset.setOverallStatus(PushJobDetailsStatus.COMPLETED);
+    bothUnset.emit();
+    verify(bothUnset.pushJobStatusStats, never()).recordDataWriterSinkWriteTime(anyString(), any(), any(), anyLong());
+
+    // A push with no external storage configured omits that key but still reports its Venice leg.
+    DataWriterSinkWriteTimeFixture externalUnset = new DataWriterSinkWriteTimeFixture(null, 500L);
+    externalUnset.setOverallStatus(PushJobDetailsStatus.COMPLETED);
+    externalUnset.emit();
+    verify(externalUnset.pushJobStatusStats, never())
+        .recordDataWriterSinkWriteTime(anyString(), any(), eq(VenicePushJobDataWriterSink.EXTERNAL_STORAGE), anyLong());
+    verify(externalUnset.pushJobStatusStats)
+        .recordDataWriterSinkWriteTime(STORE_NAME, Version.PushType.BATCH, VenicePushJobDataWriterSink.VENICE, 500L);
+  }
+
+  @Test
+  public void testDataWriterSinkWriteTimeUsesIncrementalPushTypeDimension() {
+    DataWriterSinkWriteTimeFixture fixture = new DataWriterSinkWriteTimeFixture(10L, 20L);
+    fixture.setIncrementalPush(true);
+    fixture.setOverallStatus(PushJobDetailsStatus.END_OF_INCREMENTAL_PUSH_RECEIVED);
+    fixture.setOverallStatus(PushJobDetailsStatus.COMPLETED);
+    fixture.emit();
+
+    verify(fixture.pushJobStatusStats).recordDataWriterSinkWriteTime(
+        STORE_NAME,
+        Version.PushType.INCREMENTAL,
+        VenicePushJobDataWriterSink.EXTERNAL_STORAGE,
+        10L);
+    verify(fixture.pushJobStatusStats).recordDataWriterSinkWriteTime(
+        STORE_NAME,
+        Version.PushType.INCREMENTAL,
+        VenicePushJobDataWriterSink.VENICE,
+        20L);
+  }
+
+  /**
+   * The same terminal PushJobDetails record can be delivered more than once (retries, parent-to-child dual
+   * writes). Counters tolerate that, but a repeated duration would skew the distribution, so the durations
+   * are observed exactly once per push.
+   */
+  @Test
+  public void testDataWriterSinkWriteTimeIsDeduplicatedAcrossRepeatedTerminalReports() {
+    DataWriterSinkWriteTimeFixture fixture = new DataWriterSinkWriteTimeFixture(1200L, 300L);
+    fixture.setOverallStatus(PushJobDetailsStatus.COMPLETED);
+
+    fixture.emit();
+    fixture.emit();
+    fixture.emit();
+
+    verify(fixture.pushJobStatusStats, times(1)).recordDataWriterSinkWriteTime(
+        STORE_NAME,
+        Version.PushType.BATCH,
+        VenicePushJobDataWriterSink.EXTERNAL_STORAGE,
+        1200L);
+    verify(fixture.pushJobStatusStats, times(1))
+        .recordDataWriterSinkWriteTime(STORE_NAME, Version.PushType.BATCH, VenicePushJobDataWriterSink.VENICE, 300L);
+    // The push-status counters are intentionally left alone by the dedup.
+    verify(fixture.pushJobStatusStats, times(3)).recordBatchPushSuccessSensor(STORE_NAME);
+  }
+
+  @Test
+  public void testDataWriterSinkWriteTimeDedupIsPerPush() {
+    Cache<String, Boolean> sharedDedupCache = Caffeine.newBuilder().build();
+
+    DataWriterSinkWriteTimeFixture firstPush = new DataWriterSinkWriteTimeFixture(1200L, 300L, sharedDedupCache);
+    firstPush.setPushId("push-1");
+    firstPush.setOverallStatus(PushJobDetailsStatus.COMPLETED);
+    firstPush.emit();
+    firstPush.emit();
+
+    DataWriterSinkWriteTimeFixture secondPush = new DataWriterSinkWriteTimeFixture(999L, 111L, sharedDedupCache);
+    secondPush.setPushId("push-2");
+    secondPush.setOverallStatus(PushJobDetailsStatus.COMPLETED);
+    secondPush.emit();
+
+    verify(firstPush.pushJobStatusStats, times(1)).recordDataWriterSinkWriteTime(
+        STORE_NAME,
+        Version.PushType.BATCH,
+        VenicePushJobDataWriterSink.EXTERNAL_STORAGE,
+        1200L);
+    verify(secondPush.pushJobStatusStats, times(1)).recordDataWriterSinkWriteTime(
+        STORE_NAME,
+        Version.PushType.BATCH,
+        VenicePushJobDataWriterSink.EXTERNAL_STORAGE,
+        999L);
+  }
+
+  /** Wires up the mocks {@code emitPushJobStatusMetrics} needs to exercise the duration emission path. */
+  private static class DataWriterSinkWriteTimeFixture {
+    final PushJobStatusStats pushJobStatusStats = mock(PushJobStatusStats.class);
+    final PushJobStatusRecordKey key = new PushJobStatusRecordKey(STORE_NAME, 3);
+    final PushJobDetails pushJobDetails = mock(PushJobDetails.class);
+    final Map<String, PushJobStatusStats> pushJobStatusStatsMap = new HashMap<>();
+    final Map<String, LogCompactionStats> logCompactionStatsMap = new HashMap<>();
+    final Map<CharSequence, CharSequence> pushJobConfigs = new HashMap<>();
+    final List<PushJobDetailsStatusTuple> statusTuples = new ArrayList<>();
+    final Cache<String, Boolean> dedupCache;
+
+    DataWriterSinkWriteTimeFixture(Long externalStorageWriteTimeMs, Long veniceWriteTimeMs) {
+      this(externalStorageWriteTimeMs, veniceWriteTimeMs, Caffeine.newBuilder().build());
+    }
+
+    DataWriterSinkWriteTimeFixture(
+        Long externalStorageWriteTimeMs,
+        Long veniceWriteTimeMs,
+        Cache<String, Boolean> dedupCache) {
+      this.dedupCache = dedupCache;
+      pushJobStatusStatsMap.put(CLUSTER_NAME, pushJobStatusStats);
+      logCompactionStatsMap.put(CLUSTER_NAME, mock(LogCompactionStats.class));
+      pushJobConfigs.put(new Utf8("incremental.push"), "false");
+      when(pushJobDetails.getClusterName()).thenReturn(new Utf8(CLUSTER_NAME));
+      when(pushJobDetails.getPushJobConfigs()).thenReturn(pushJobConfigs);
+      when(pushJobDetails.getOverallStatus()).thenReturn(statusTuples);
+      when(pushJobDetails.getPushId()).thenReturn(new Utf8("test-push"));
+      when(pushJobDetails.getPushJobLatestCheckpoint())
+          .thenReturn(PushJobCheckpoints.JOB_STATUS_POLLING_COMPLETED.getValue());
+      // A null argument means the push never reported that leg. Both null leaves the whole map null, which is
+      // also what a v6 reader resolves an older v5 record to.
+      Map<CharSequence, Long> additionalPushMetrics = null;
+      if (externalStorageWriteTimeMs != null || veniceWriteTimeMs != null) {
+        additionalPushMetrics = new HashMap<>();
+        if (externalStorageWriteTimeMs != null) {
+          additionalPushMetrics.put(new Utf8(EXTERNAL_STORAGE_WRITE_TIME_MS), externalStorageWriteTimeMs);
+        }
+        if (veniceWriteTimeMs != null) {
+          additionalPushMetrics.put(new Utf8(VENICE_WRITE_TIME_MS), veniceWriteTimeMs);
+        }
+      }
+      when(pushJobDetails.getAdditionalPushMetrics()).thenReturn(additionalPushMetrics);
+    }
+
+    void setIncrementalPush(boolean isIncrementalPush) {
+      pushJobConfigs.put(new Utf8("incremental.push"), String.valueOf(isIncrementalPush));
+    }
+
+    void setPushId(String pushId) {
+      when(pushJobDetails.getPushId()).thenReturn(new Utf8(pushId));
+    }
+
+    void setOverallStatus(PushJobDetailsStatus status) {
+      statusTuples.add(new PushJobDetailsStatusTuple(status.getValue(), 0L));
+    }
+
+    void reset() {
+      statusTuples.clear();
+      Mockito.reset(pushJobStatusStats);
+      dedupCache.invalidateAll();
+    }
+
+    void emit() {
+      emitPushJobStatusMetrics(
+          pushJobStatusStatsMap,
+          logCompactionStatsMap,
+          key,
+          pushJobDetails,
+          DEFAULT_PUSH_JOB_USER_ERROR_CHECKPOINTS,
+          dedupCache);
     }
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -68,6 +68,7 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.Version.PushType;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.meta.VersionStorageModeUpdateReason;
 import com.linkedin.venice.meta.ViewConfig;
 import com.linkedin.venice.meta.ViewConfigImpl;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
@@ -242,25 +243,50 @@ public class TestVeniceHelixAdmin {
         () -> veniceHelixAdmin.getStorageModePerRegion(clusterName, missingStoreName));
   }
 
-  @Test
-  public void testUpdateStoreVersionStorageModeMutatesOnlyTheVersion() {
+  /**
+   * Wire a mocked admin so the real storage-mode update runs against {@code store} in region {@code regionName},
+   * with the metric hook left mocked so tests can assert on it.
+   */
+  private static VeniceHelixAdmin mockAdminForVersionStorageModeUpdate(
+      String clusterName,
+      Store store,
+      String regionName) {
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
-    String storeName = "store_version_storage_mode_update";
+    doReturn(regionName).when(veniceHelixAdmin).getRegionName();
+    doAnswer(invocation -> {
+      VeniceHelixAdmin.StoreMetadataOperation operation = invocation.getArgument(2);
+      operation.update(store, null);
+      return null;
+    }).when(veniceHelixAdmin).storeMetadataUpdate(eq(clusterName), eq(store.getName()), any());
+    doCallRealMethod().when(veniceHelixAdmin)
+        .updateStoreVersionStorageMode(anyString(), anyString(), anyInt(), any(), any(), any());
+    doCallRealMethod().when(veniceHelixAdmin)
+        .updateStoreVersionStorageMode(anyString(), anyString(), anyInt(), any(), any());
+    return veniceHelixAdmin;
+  }
+
+  private static Store dualWriteStoreWithVersion(String storeName) {
     Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
     store.setStorageMode(StorageMode.DUAL_WRITE);
     VersionImpl version = new VersionImpl(storeName, 1, "test-push");
     version.setStorageMode(StorageMode.DUAL_WRITE);
     store.addVersion(version);
-    doReturn("dc-0").when(veniceHelixAdmin).getRegionName();
-    doAnswer(invocation -> {
-      VeniceHelixAdmin.StoreMetadataOperation operation = invocation.getArgument(2);
-      operation.update(store, null);
-      return null;
-    }).when(veniceHelixAdmin).storeMetadataUpdate(eq(clusterName), eq(storeName), any());
-    doCallRealMethod().when(veniceHelixAdmin)
-        .updateStoreVersionStorageMode(clusterName, storeName, 1, StorageMode.INTERNAL, "dc-0");
+    return store;
+  }
 
-    veniceHelixAdmin.updateStoreVersionStorageMode(clusterName, storeName, 1, StorageMode.INTERNAL, "dc-0");
+  @Test
+  public void testUpdateStoreVersionStorageModeMutatesOnlyTheVersion() {
+    String storeName = "store_version_storage_mode_update";
+    Store store = dualWriteStoreWithVersion(storeName);
+    VeniceHelixAdmin veniceHelixAdmin = mockAdminForVersionStorageModeUpdate(clusterName, store, "dc-0");
+
+    veniceHelixAdmin.updateStoreVersionStorageMode(
+        clusterName,
+        storeName,
+        1,
+        StorageMode.INTERNAL,
+        "dc-0",
+        VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
 
     assertEquals(store.getStorageMode(), StorageMode.DUAL_WRITE);
     assertEquals(store.getVersion(1).getStorageMode(), StorageMode.INTERNAL);
@@ -271,11 +297,119 @@ public class TestVeniceHelixAdmin {
     VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
     doReturn("dc-0").when(veniceHelixAdmin).getRegionName();
     doCallRealMethod().when(veniceHelixAdmin)
-        .updateStoreVersionStorageMode(clusterName, "store", 1, StorageMode.INTERNAL, "dc-1");
+        .updateStoreVersionStorageMode(anyString(), anyString(), anyInt(), any(), any(), any());
 
-    veniceHelixAdmin.updateStoreVersionStorageMode(clusterName, "store", 1, StorageMode.INTERNAL, "dc-1");
+    veniceHelixAdmin.updateStoreVersionStorageMode(
+        clusterName,
+        "store",
+        1,
+        StorageMode.INTERNAL,
+        "dc-1",
+        VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
 
     verify(veniceHelixAdmin, never()).storeMetadataUpdate(anyString(), anyString(), any());
+    // A region the push never touched must not contribute to the fail-open alert.
+    verify(veniceHelixAdmin, never()).recordExternalStorageWriteFailure(anyString(), anyString(), anyString());
+  }
+
+  /**
+   * The affected region is the one whose controller applies the downgrade, so the metric must carry that
+   * controller's own region rather than anything derived from the original request.
+   */
+  @Test
+  public void testUpdateStoreVersionStorageModeRecordsExternalWriteFailureForMatchingRegion() {
+    String storeName = "store_version_storage_mode_external_write_failure";
+    Store store = dualWriteStoreWithVersion(storeName);
+    VeniceHelixAdmin veniceHelixAdmin = mockAdminForVersionStorageModeUpdate(clusterName, store, "dc-1");
+
+    veniceHelixAdmin.updateStoreVersionStorageMode(
+        clusterName,
+        storeName,
+        1,
+        StorageMode.INTERNAL,
+        "dc-0,dc-1",
+        VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
+
+    assertEquals(store.getVersion(1).getStorageMode(), StorageMode.INTERNAL);
+    verify(veniceHelixAdmin).recordExternalStorageWriteFailure(clusterName, storeName, "dc-1");
+  }
+
+  @Test
+  public void testUpdateStoreVersionStorageModeDoesNotRecordForUnrelatedReason() {
+    String storeName = "store_version_storage_mode_manual_downgrade";
+    Store store = dualWriteStoreWithVersion(storeName);
+    VeniceHelixAdmin veniceHelixAdmin = mockAdminForVersionStorageModeUpdate(clusterName, store, "dc-0");
+
+    veniceHelixAdmin.updateStoreVersionStorageMode(
+        clusterName,
+        storeName,
+        1,
+        StorageMode.INTERNAL,
+        "dc-0",
+        VersionStorageModeUpdateReason.UNSPECIFIED);
+
+    assertEquals(store.getVersion(1).getStorageMode(), StorageMode.INTERNAL);
+    // A manual or operational downgrade is not an external write failure and must not page anyone.
+    verify(veniceHelixAdmin, never()).recordExternalStorageWriteFailure(anyString(), anyString(), anyString());
+  }
+
+  /** Callers still on the overload without a reason must behave exactly as they did before. */
+  @Test
+  public void testUpdateStoreVersionStorageModeWithoutReasonDoesNotRecord() {
+    String storeName = "store_version_storage_mode_no_reason";
+    Store store = dualWriteStoreWithVersion(storeName);
+    VeniceHelixAdmin veniceHelixAdmin = mockAdminForVersionStorageModeUpdate(clusterName, store, "dc-0");
+
+    veniceHelixAdmin.updateStoreVersionStorageMode(clusterName, storeName, 1, StorageMode.INTERNAL, "dc-0");
+
+    assertEquals(store.getVersion(1).getStorageMode(), StorageMode.INTERNAL);
+    verify(veniceHelixAdmin, never()).recordExternalStorageWriteFailure(anyString(), anyString(), anyString());
+  }
+
+  /**
+   * The push job retries the fail-open request, so the same downgrade can arrive several times. Only the
+   * transition itself counts: a repeat finds the version already INTERNAL and must not inflate the alert.
+   */
+  @Test
+  public void testUpdateStoreVersionStorageModeDoesNotDoubleCountIdempotentRetry() {
+    String storeName = "store_version_storage_mode_idempotent_retry";
+    Store store = dualWriteStoreWithVersion(storeName);
+    VeniceHelixAdmin veniceHelixAdmin = mockAdminForVersionStorageModeUpdate(clusterName, store, "dc-0");
+
+    for (int attempt = 0; attempt < 3; attempt++) {
+      veniceHelixAdmin.updateStoreVersionStorageMode(
+          clusterName,
+          storeName,
+          1,
+          StorageMode.INTERNAL,
+          "dc-0",
+          VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
+    }
+
+    assertEquals(store.getVersion(1).getStorageMode(), StorageMode.INTERNAL);
+    verify(veniceHelixAdmin, times(1)).recordExternalStorageWriteFailure(clusterName, storeName, "dc-0");
+  }
+
+  /** Failing open is a downgrade to INTERNAL; re-enabling dual write is not a failure. */
+  @Test
+  public void testUpdateStoreVersionStorageModeDoesNotRecordOnUpgradeToDualWrite() {
+    String storeName = "store_version_storage_mode_upgrade";
+    Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
+    VersionImpl version = new VersionImpl(storeName, 1, "test-push");
+    version.setStorageMode(StorageMode.INTERNAL);
+    store.addVersion(version);
+    VeniceHelixAdmin veniceHelixAdmin = mockAdminForVersionStorageModeUpdate(clusterName, store, "dc-0");
+
+    veniceHelixAdmin.updateStoreVersionStorageMode(
+        clusterName,
+        storeName,
+        1,
+        StorageMode.DUAL_WRITE,
+        "dc-0",
+        VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
+
+    assertEquals(store.getVersion(1).getStorageMode(), StorageMode.DUAL_WRITE);
+    verify(veniceHelixAdmin, never()).recordExternalStorageWriteFailure(anyString(), anyString(), anyString());
   }
 
   /**

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -95,6 +95,7 @@ import com.linkedin.venice.meta.VeniceETLStrategy;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.meta.VersionStorageModeUpdateReason;
 import com.linkedin.venice.meta.ViewConfigImpl;
 import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.partitioner.InvalidKeySchemaPartitioner;
@@ -3035,6 +3036,10 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     assertThrows(VeniceException.class, () -> parentAdmin.getStorageModePerRegion(clusterName, storeName));
   }
 
+  /**
+   * The parent resolves the regions filter into one call per target region, so only the targeted region's child
+   * controller — the one that knows it is the affected region — is asked to downgrade and to count the failure.
+   */
   @Test
   public void testUpdateStoreVersionStorageModeTargetsOnlyRequestedRegions() {
     String storeName = "test_store_version_storage_mode_targeted";
@@ -3046,12 +3051,56 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(controllerClientMap).when(internalAdmin).getControllerClientMap(clusterName);
 
     ControllerResponse response = new ControllerResponse();
-    doReturn(response).when(dc1Client).updateStoreVersionStorageMode(storeName, 1, StorageMode.INTERNAL);
+    doReturn(response).when(dc1Client)
+        .updateStoreVersionStorageMode(
+            storeName,
+            1,
+            StorageMode.INTERNAL,
+            null,
+            VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
 
-    parentAdmin.updateStoreVersionStorageMode(clusterName, storeName, 1, StorageMode.INTERNAL, "dc-1");
+    parentAdmin.updateStoreVersionStorageMode(
+        clusterName,
+        storeName,
+        1,
+        StorageMode.INTERNAL,
+        "dc-1",
+        VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
 
-    verify(dc0Client, never()).updateStoreVersionStorageMode(anyString(), anyInt(), any());
-    verify(dc1Client).updateStoreVersionStorageMode(storeName, 1, StorageMode.INTERNAL);
+    verify(dc0Client, never()).updateStoreVersionStorageMode(anyString(), anyInt(), any(), any(), any());
+    verify(dc1Client).updateStoreVersionStorageMode(
+        storeName,
+        1,
+        StorageMode.INTERNAL,
+        null,
+        VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
+  }
+
+  /** A caller that supplies no reason must reach the children unchanged, as UNSPECIFIED. */
+  @Test
+  public void testUpdateStoreVersionStorageModeWithoutReasonForwardsUnspecified() {
+    String storeName = "test_store_version_storage_mode_no_reason";
+    Map<String, ControllerClient> controllerClientMap = new HashMap<>();
+    ControllerClient dc0Client = mock(ControllerClient.class);
+    controllerClientMap.put("dc-0", dc0Client);
+    doReturn(controllerClientMap).when(internalAdmin).getControllerClientMap(clusterName);
+
+    doReturn(new ControllerResponse()).when(dc0Client)
+        .updateStoreVersionStorageMode(
+            storeName,
+            1,
+            StorageMode.INTERNAL,
+            null,
+            VersionStorageModeUpdateReason.UNSPECIFIED);
+
+    parentAdmin.updateStoreVersionStorageMode(clusterName, storeName, 1, StorageMode.INTERNAL, "dc-0");
+
+    verify(dc0Client).updateStoreVersionStorageMode(
+        storeName,
+        1,
+        StorageMode.INTERNAL,
+        null,
+        VersionStorageModeUpdateReason.UNSPECIFIED);
   }
 
   @Test
@@ -3064,11 +3113,23 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
     ControllerResponse errorResponse = new ControllerResponse();
     errorResponse.setError("simulated child failure");
-    doReturn(errorResponse).when(dc0Client).updateStoreVersionStorageMode(storeName, 1, StorageMode.INTERNAL);
+    doReturn(errorResponse).when(dc0Client)
+        .updateStoreVersionStorageMode(
+            storeName,
+            1,
+            StorageMode.INTERNAL,
+            null,
+            VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
 
     assertThrows(
         VeniceException.class,
-        () -> parentAdmin.updateStoreVersionStorageMode(clusterName, storeName, 1, StorageMode.INTERNAL, "dc-0"));
+        () -> parentAdmin.updateStoreVersionStorageMode(
+            clusterName,
+            storeName,
+            1,
+            StorageMode.INTERNAL,
+            "dc-0",
+            VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE));
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoresRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoresRoutesTest.java
@@ -40,6 +40,7 @@ import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.meta.VersionStorageModeUpdateReason;
 import com.linkedin.venice.protocols.controller.ClusterStoreGrpcInfo;
 import com.linkedin.venice.protocols.controller.ListStoresGrpcRequest;
 import com.linkedin.venice.protocols.controller.ListStoresGrpcResponse;
@@ -127,6 +128,8 @@ public class StoresRoutesTest {
     doReturn("1").when(request).queryParams(eq(ControllerApiConstants.VERSION));
     doReturn(StorageMode.INTERNAL.name()).when(request).queryParams(eq(ControllerApiConstants.STORAGE_MODE));
     doReturn("dc-1").when(request).queryParamOrDefault(eq(ControllerApiConstants.REGIONS_FILTER), eq(""));
+    doReturn("").when(request)
+        .queryParamOrDefault(eq(ControllerApiConstants.VERSION_STORAGE_MODE_UPDATE_REASON), eq(""));
 
     Route route =
         new StoresRoutes(false, Optional.empty(), pubSubTopicRepository).updateStoreVersionStorageMode(mockAdmin);
@@ -136,7 +139,43 @@ public class StoresRoutesTest {
     Assert.assertFalse(response.isError());
     Assert.assertEquals(response.getCluster(), TEST_CLUSTER);
     Assert.assertEquals(response.getName(), TEST_STORE_NAME);
-    verify(mockAdmin).updateStoreVersionStorageMode(TEST_CLUSTER, TEST_STORE_NAME, 1, StorageMode.INTERNAL, "dc-1");
+    // A request that predates the reason parameter must still be accepted, and must not look like a fail-open.
+    verify(mockAdmin).updateStoreVersionStorageMode(
+        TEST_CLUSTER,
+        TEST_STORE_NAME,
+        1,
+        StorageMode.INTERNAL,
+        "dc-1",
+        VersionStorageModeUpdateReason.UNSPECIFIED);
+  }
+
+  @Test
+  public void testUpdateStoreVersionStorageModeForwardsExternalWriteFailureReason() throws Exception {
+    Admin mockAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(true).when(mockAdmin).isLeaderControllerFor(TEST_CLUSTER);
+
+    Request request = mock(Request.class);
+    doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
+    doReturn(TEST_STORE_NAME).when(request).queryParams(eq(ControllerApiConstants.NAME));
+    doReturn("1").when(request).queryParams(eq(ControllerApiConstants.VERSION));
+    doReturn(StorageMode.INTERNAL.name()).when(request).queryParams(eq(ControllerApiConstants.STORAGE_MODE));
+    doReturn("dc-1").when(request).queryParamOrDefault(eq(ControllerApiConstants.REGIONS_FILTER), eq(""));
+    doReturn(VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE.name()).when(request)
+        .queryParamOrDefault(eq(ControllerApiConstants.VERSION_STORAGE_MODE_UPDATE_REASON), eq(""));
+
+    Route route =
+        new StoresRoutes(false, Optional.empty(), pubSubTopicRepository).updateStoreVersionStorageMode(mockAdmin);
+    ControllerResponse response = ObjectMapperFactory.getInstance()
+        .readValue(route.handle(request, mock(Response.class)).toString(), ControllerResponse.class);
+
+    Assert.assertFalse(response.isError());
+    verify(mockAdmin).updateStoreVersionStorageMode(
+        TEST_CLUSTER,
+        TEST_STORE_NAME,
+        1,
+        StorageMode.INTERNAL,
+        "dc-1",
+        VersionStorageModeUpdateReason.EXTERNAL_WRITE_FAILURE);
   }
 
   @Test
@@ -150,6 +189,8 @@ public class StoresRoutesTest {
     doReturn("1").when(request).queryParams(eq(ControllerApiConstants.VERSION));
     doReturn(StorageMode.INTERNAL.name()).when(request).queryParams(eq(ControllerApiConstants.STORAGE_MODE));
     doReturn("dc-1").when(request).queryParamOrDefault(eq(ControllerApiConstants.REGIONS_FILTER), eq(""));
+    doReturn("").when(request)
+        .queryParamOrDefault(eq(ControllerApiConstants.VERSION_STORAGE_MODE_UPDATE_REASON), eq(""));
 
     StoresRoutes storesRoutes = new StoresRoutes(false, Optional.empty(), pubSubTopicRepository) {
       @Override
@@ -167,7 +208,13 @@ public class StoresRoutesTest {
         .readValue(route.handle(request, mock(Response.class)).toString(), ControllerResponse.class);
 
     Assert.assertFalse(response.isError());
-    verify(mockAdmin).updateStoreVersionStorageMode(TEST_CLUSTER, TEST_STORE_NAME, 1, StorageMode.INTERNAL, "dc-1");
+    verify(mockAdmin).updateStoreVersionStorageMode(
+        TEST_CLUSTER,
+        TEST_STORE_NAME,
+        1,
+        StorageMode.INTERNAL,
+        "dc-1",
+        VersionStorageModeUpdateReason.UNSPECIFIED);
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/stats/PushJobOtelMetricEntityTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/stats/PushJobOtelMetricEntityTest.java
@@ -1,8 +1,10 @@
 package com.linkedin.venice.controller.stats;
 
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_PUSH_JOB_DATA_WRITER_SINK;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_PUSH_JOB_STATUS;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_PUSH_JOB_TYPE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REGION_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
 import static com.linkedin.venice.utils.Utils.setOf;
 
@@ -27,6 +29,22 @@ public class PushJobOtelMetricEntityTest {
             MetricUnit.NUMBER,
             "Push job completions, differentiated by push type and status",
             setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME, VENICE_PUSH_JOB_TYPE, VENICE_PUSH_JOB_STATUS)));
+    map.put(
+        PushJobOtelMetricEntity.PUSH_JOB_DATA_WRITER_SINK_WRITE_TIME,
+        new MetricEntityExpectation(
+            "push_job.data_writer.sink_write_time",
+            MetricType.HISTOGRAM,
+            MetricUnit.MILLISECOND,
+            "Summed data writer task duration spent writing to a push job sink, differentiated by push type and sink",
+            setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME, VENICE_PUSH_JOB_TYPE, VENICE_PUSH_JOB_DATA_WRITER_SINK)));
+    map.put(
+        PushJobOtelMetricEntity.PUSH_JOB_EXTERNAL_STORAGE_WRITE_FAILURE_COUNT,
+        new MetricEntityExpectation(
+            "push_job.external_storage_write_failure.count",
+            MetricType.COUNTER,
+            MetricUnit.NUMBER,
+            "Pushes that exhausted external storage write retries and failed the region's version storage mode open to internal, differentiated by region",
+            setOf(VENICE_CLUSTER_NAME, VENICE_STORE_NAME, VENICE_REGION_NAME)));
     return map;
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/stats/PushJobStatusStatsOtelTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/stats/PushJobStatusStatsOtelTest.java
@@ -2,16 +2,23 @@ package com.linkedin.venice.controller.stats;
 
 import static com.linkedin.venice.controller.VeniceController.CONTROLLER_SERVICE_METRIC_ENTITIES;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_CLUSTER_NAME;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_PUSH_JOB_DATA_WRITER_SINK;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_PUSH_JOB_STATUS;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_PUSH_JOB_TYPE;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REGION_NAME;
 import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_STORE_NAME;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.meta.Version.PushType;
 import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
+import com.linkedin.venice.stats.dimensions.VenicePushJobDataWriterSink;
 import com.linkedin.venice.stats.dimensions.VenicePushJobStatus;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramPointData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -164,6 +171,109 @@ public class PushJobStatusStatsOtelTest {
   }
 
   @Test
+  public void testRecordDataWriterSinkWriteTimeDistinguishesSinks() {
+    stats.recordDataWriterSinkWriteTime(
+        TEST_STORE_NAME,
+        PushType.BATCH,
+        VenicePushJobDataWriterSink.EXTERNAL_STORAGE,
+        1500);
+    stats.recordDataWriterSinkWriteTime(TEST_STORE_NAME, PushType.BATCH, VenicePushJobDataWriterSink.VENICE, 400);
+
+    validateSinkWriteTime(1500, 1, sinkAttributes(PushType.BATCH, VenicePushJobDataWriterSink.EXTERNAL_STORAGE));
+    validateSinkWriteTime(400, 1, sinkAttributes(PushType.BATCH, VenicePushJobDataWriterSink.VENICE));
+  }
+
+  @Test
+  public void testRecordDataWriterSinkWriteTimeForIncrementalPush() {
+    stats.recordDataWriterSinkWriteTime(TEST_STORE_NAME, PushType.INCREMENTAL, VenicePushJobDataWriterSink.VENICE, 250);
+    validateSinkWriteTime(250, 1, sinkAttributes(PushType.INCREMENTAL, VenicePushJobDataWriterSink.VENICE));
+  }
+
+  @Test
+  public void testRecordDataWriterSinkWriteTimeSkipsNegativeValues() {
+    stats.recordDataWriterSinkWriteTime(
+        TEST_STORE_NAME,
+        PushType.BATCH,
+        VenicePushJobDataWriterSink.EXTERNAL_STORAGE,
+        -1);
+    stats.recordDataWriterSinkWriteTime(TEST_STORE_NAME, PushType.BATCH, VenicePushJobDataWriterSink.VENICE, -1);
+
+    // A push that never reported a leg must leave the distribution untouched rather than contribute a zero:
+    // with no observation at all the instrument never even materializes.
+    assertTrue(
+        inMemoryMetricReader.collectAllMetrics()
+            .stream()
+            .noneMatch(
+                metricData -> metricData.getName()
+                    .endsWith(
+                        PushJobStatusStats.PushJobOtelMetricEntity.PUSH_JOB_DATA_WRITER_SINK_WRITE_TIME
+                            .getMetricName())),
+        "No observation should be recorded for a negative duration");
+  }
+
+  @Test
+  public void testRecordDataWriterSinkWriteTimeAcceptsZero() {
+    stats.recordDataWriterSinkWriteTime(TEST_STORE_NAME, PushType.BATCH, VenicePushJobDataWriterSink.VENICE, 0);
+    ExponentialHistogramPointData pointData =
+        getSinkWriteTimeHistogram(sinkAttributes(PushType.BATCH, VenicePushJobDataWriterSink.VENICE));
+    assertNotNull(pointData, "Zero is a legitimate duration and must be recorded");
+    assertEquals(pointData.getCount(), 1);
+  }
+
+  @Test
+  public void testRecordExternalStorageWriteFailureCarriesRegion() {
+    stats.recordExternalStorageWriteFailure(TEST_STORE_NAME, "dc-1");
+
+    validateCounter(
+        PushJobStatusStats.PushJobOtelMetricEntity.PUSH_JOB_EXTERNAL_STORAGE_WRITE_FAILURE_COUNT.getMetricName(),
+        1,
+        externalStorageWriteFailureAttributes(TEST_STORE_NAME, "dc-1"));
+  }
+
+  /**
+   * Alerting is per fabric, so two regions failing for the same store must stay two separate time series rather
+   * than collapsing into one counter.
+   */
+  @Test
+  public void testRecordExternalStorageWriteFailureSeparatesRegions() {
+    stats.recordExternalStorageWriteFailure(TEST_STORE_NAME, "dc-0");
+    stats.recordExternalStorageWriteFailure(TEST_STORE_NAME, "dc-1");
+    stats.recordExternalStorageWriteFailure(TEST_STORE_NAME, "dc-1");
+
+    validateCounter(
+        PushJobStatusStats.PushJobOtelMetricEntity.PUSH_JOB_EXTERNAL_STORAGE_WRITE_FAILURE_COUNT.getMetricName(),
+        1,
+        externalStorageWriteFailureAttributes(TEST_STORE_NAME, "dc-0"));
+    validateCounter(
+        PushJobStatusStats.PushJobOtelMetricEntity.PUSH_JOB_EXTERNAL_STORAGE_WRITE_FAILURE_COUNT.getMetricName(),
+        2,
+        externalStorageWriteFailureAttributes(TEST_STORE_NAME, "dc-1"));
+  }
+
+  @Test
+  public void testExternalStorageWriteFailureNotRecordedWhenNothingFailed() {
+    stats.recordBatchPushSuccessSensor(TEST_STORE_NAME);
+
+    assertTrue(
+        inMemoryMetricReader.collectAllMetrics()
+            .stream()
+            .noneMatch(
+                metricData -> metricData.getName()
+                    .endsWith(
+                        PushJobStatusStats.PushJobOtelMetricEntity.PUSH_JOB_EXTERNAL_STORAGE_WRITE_FAILURE_COUNT
+                            .getMetricName())),
+        "A healthy push must not materialize the external storage write failure counter");
+  }
+
+  private static Attributes externalStorageWriteFailureAttributes(String storeName, String regionName) {
+    return Attributes.builder()
+        .put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME)
+        .put(VENICE_STORE_NAME.getDimensionNameInDefaultFormat(), storeName)
+        .put(VENICE_REGION_NAME.getDimensionNameInDefaultFormat(), regionName)
+        .build();
+  }
+
+  @Test
   public void testNoNpeWhenOtelDisabled() {
     VeniceMetricsRepository disabledRepo = new VeniceMetricsRepository(
         new VeniceMetricsConfig.Builder().setMetricPrefix(TEST_METRIC_PREFIX).setEmitOtelMetrics(false).build());
@@ -175,6 +285,7 @@ public class PushJobStatusStatsOtelTest {
     disabledStats.recordIncrementalPushSuccessSensor(TEST_STORE_NAME);
     disabledStats.recordIncrementalPushFailureDueToUserErrorSensor(TEST_STORE_NAME);
     disabledStats.recordIncrementalPushFailureNotDueToUserErrorSensor(TEST_STORE_NAME);
+    disabledStats.recordExternalStorageWriteFailure(TEST_STORE_NAME, "dc-0");
   }
 
   private void validateCounter(String metricName, long expectedValue, Attributes expectedAttributes) {
@@ -184,5 +295,34 @@ public class PushJobStatusStatsOtelTest {
         expectedAttributes,
         metricName,
         TEST_METRIC_PREFIX);
+  }
+
+  private static Attributes sinkAttributes(PushType pushType, VenicePushJobDataWriterSink sink) {
+    return Attributes.builder()
+        .put(VENICE_CLUSTER_NAME.getDimensionNameInDefaultFormat(), TEST_CLUSTER_NAME)
+        .put(VENICE_STORE_NAME.getDimensionNameInDefaultFormat(), TEST_STORE_NAME)
+        .put(VENICE_PUSH_JOB_TYPE.getDimensionNameInDefaultFormat(), pushType.getDimensionValue())
+        .put(VENICE_PUSH_JOB_DATA_WRITER_SINK.getDimensionNameInDefaultFormat(), sink.getDimensionValue())
+        .build();
+  }
+
+  private void validateSinkWriteTime(double expectedValue, long expectedCount, Attributes expectedAttributes) {
+    OpenTelemetryDataTestUtils.validateExponentialHistogramPointData(
+        inMemoryMetricReader,
+        expectedValue,
+        expectedValue,
+        expectedCount,
+        expectedValue * expectedCount,
+        expectedAttributes,
+        PushJobStatusStats.PushJobOtelMetricEntity.PUSH_JOB_DATA_WRITER_SINK_WRITE_TIME.getMetricName(),
+        TEST_METRIC_PREFIX);
+  }
+
+  private ExponentialHistogramPointData getSinkWriteTimeHistogram(Attributes expectedAttributes) {
+    return OpenTelemetryDataTestUtils.getExponentialHistogramPointData(
+        inMemoryMetricReader.collectAllMetrics(),
+        PushJobStatusStats.PushJobOtelMetricEntity.PUSH_JOB_DATA_WRITER_SINK_WRITE_TIME.getMetricName(),
+        TEST_METRIC_PREFIX,
+        expectedAttributes);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/stats/PushJobTehutiMetricNameEnumTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/stats/PushJobTehutiMetricNameEnumTest.java
@@ -20,6 +20,11 @@ public class PushJobTehutiMetricNameEnumTest {
     map.put(
         PushJobTehutiMetricNameEnum.INCREMENTAL_PUSH_JOB_FAILED_NON_USER_ERROR,
         "incremental_push_job_failed_non_user_error");
+    map.put(PushJobTehutiMetricNameEnum.PUSH_JOB_EXTERNAL_STORAGE_WRITE_TIME, "push_job_external_storage_write_time");
+    map.put(PushJobTehutiMetricNameEnum.PUSH_JOB_VENICE_WRITE_TIME, "push_job_venice_write_time");
+    map.put(
+        PushJobTehutiMetricNameEnum.PUSH_JOB_EXTERNAL_STORAGE_WRITE_FAILURE,
+        "push_job_external_storage_write_failure");
     return map;
   }
 


### PR DESCRIPTION
## Problem Statement

Two blind spots in the same push path:

1. When a push job is slow, there is no way to tell from the push job details whether the time went
   into the external storage write path or the Venice write path, short of re-running the push with
   debug logging. `jobDurationInMs` only gives the overall wall clock.
2. When a push exhausts its external-storage write retries, #2967 fails open: VPJ downgrades the
   affected regions' version storage mode back to `INTERNAL` and the push still **succeeds**. Nothing
   in the resulting telemetry says a region lost its external-storage copy, so the condition stays
   invisible until somebody reads that version.

## Solution

Activate `PushJobDetails` v6 and populate the two timing fields it added, emit controller metrics from
them, and add a separate alertable per-region counter for the fail-open case.

**Protocol activation**
- Removes the `PushJobDetails` v5 `versionOverrides` pin added by #2971.
- Bumps `AvroProtocolDefinition.PUSH_JOB_DETAILS` from 5 to 6.

v6 as staged by #2971 carries a single nullable `additionalPushMetrics` map (`map<string, long>`,
defaulting to `null`) rather than two fixed fields. Timings are reported under the
`externalStorageWriteTimeMs` and `veniceWriteTimeMs` keys; a missing key means that leg was not
reported, and a `null` map means the push reported no additional metrics at all. The region-level
failure signal below is deliberately **not** carried in this map — region names are unbounded and the
map has no per-region shape, so it is a controller metric instead.

After this change push jobs serialize v6. **A controller fleet that has not registered v6 rejects the
write**, which is why #2971 has to be deployed to the controllers first.

**VPJ side**
- `DualWriteVeniceWriter` measures the external storage write path: throttling wait, `batchPut` calls
  including retries and retry backoff, external flush, and external close. It separately measures the
  Venice write path: the Venice/Kafka put calls plus the Venice writer flush and close.
- Both durations are reported through `DataWriterTaskTracker` and carried by both transports:
  MapReduce through new counters in `MRJobCounterHelper`; Spark through **new task-output columns**
  declared in `SparkConstants` and written by `SparkPartitionWriter` / `SparkPartitionWriterFactory`,
  which `AbstractDataWriterSparkJob` sums from the completed task rows. Spark accumulators are
  deliberately **not** used: with speculative execution a partition can be attempted twice and both
  attempts' accumulator updates reach the driver, inflating the total.
- `VenicePushJob` sums the per-task values across successful data writer task outputs and publishes
  them under the two `additionalPushMetrics` keys, omitting a key when that leg was not reported.

**Controller side (timings)**
- `VeniceHelixAdmin` records the two durations from the reported `PushJobDetails`, skipping absent
  keys so an unreported push is not counted as a zero, and de-duplicating repeated reports for the
  same push so a retried report does not double count.
- `PushJobStatusStats` emits them per sink, with the new `VENICE_PUSH_JOB_DATA_WRITER_SINK` dimension
  (`external_storage` / `venice`).

## Alertable per-region external write failure counter

The fail-open is silent by design, so it needs its own explicit signal. Rather than a new endpoint, or
encoding region names into `PushJobDetails`, this reuses the existing
`update_store_version_storage_mode` API from #2967: it already carries a regions filter, the parent
resolves that filter into one call per child controller, and each child knows its own region. The
controller that applies the downgrade is therefore by construction the affected region.

**New optional request parameter.** `VersionStorageModeUpdateReason` (`UNSPECIFIED`,
`EXTERNAL_WRITE_FAILURE`) is a typed enum rather than a free-form string, sent as the optional
`version_storage_mode_update_reason` query parameter. It is telemetry intent only and never changes
the resulting storage mode. Absent, blank and unrecognized values resolve to `UNSPECIFIED`, so
existing callers keep compiling and working, and a newer client talking to an older controller — or
the reverse — never fails a request over it. All pre-existing `ControllerClient` and `Admin` overloads
are retained and delegate with `UNSPECIFIED`.

`VenicePushJob` sends `EXTERNAL_WRITE_FAILURE` alongside the existing regions filter from
`downgradeFailedExternalStorageRegionsToInternalBeforeEndOfPush`, and `VeniceParentHelixAdmin`
forwards the reason to each targeted child controller.

### Metric

| | |
|---|---|
| **Name** | `push_job.external_storage_write_failure.count` |
| **Type / unit** | `COUNTER` / `NUMBER` (not a duration histogram) |
| **Dimensions** | `venice.cluster.name`, `venice.store.name`, `venice.region.name` |
| **Tehuti sensor** | `push_job_external_storage_write_failure` (`Count`, `CountSinceLastMeasurement`) |

`venice.region.name` already existed and is reused; no new dimension enum was added.

### Emission and dedup semantics

- Emitted by `VeniceHelixAdmin` **in the affected region**, only when the reason is
  `EXTERNAL_WRITE_FAILURE` **and** this call is the one that actually transitions the version to
  `INTERNAL`.
- Regions excluded by the regions filter return early and emit nothing.
- **Dedup is the transition itself, not a cache.** The push job retries the fail-open request, so the
  same downgrade can arrive several times; a repeat finds the version already `INTERNAL`, changes
  nothing, and is not counted again. The counter therefore reads as *"regions that lost their
  external-storage copy"*, not *"requests received"*.
- A manual or otherwise unattributed storage-mode change carries `UNSPECIFIED` and is never counted.
  Re-enabling `DUAL_WRITE` is not a failure and is never counted.
- `PushJobStatusStats` is now registered for every cluster rather than only clusters with
  error-leader-replica fail over enabled, so the counter is reported fleet wide. This also removes a
  latent NPE at the existing `pushJobStatusStatsMap.get(cluster)` call site.

**Intended alert:** page on any non-zero rate of `push_job.external_storage_write_failure.count`,
grouped by region and store. A firing alert means that fabric's copy of that version exists only in
Venice, so reads routed to external storage for it will miss until the store is re-pushed.

Dimensions are deliberately bounded: push id and version number are never dimensions, and push type is
not one either because the controller applying the downgrade does not know it.

### Code changes

- [ ] Added new code behind **a config**. No new config. Timings are reported whenever the data writer
      reports them, and the failure counter whenever a fail-open downgrade is applied.
- [ ] Introduced new **log lines**. No new per-record logging. One warn per affected region when the
      fail-open downgrade is applied.

### **Concurrency-Specific Checks**

- [x] Code has **no race conditions** or **thread safety issues**. Timing accumulation is per data
      writer task, aggregated once in the driver from completed task outputs. The failure counter is
      decided inside the store write lock already held by `storeMetadataUpdate`.
- [x] Proper **synchronization mechanisms** are used where needed. The controller-side timing dedup
      uses a concurrent map keyed by push.
- [x] No **blocking calls** inside critical sections.
- [x] Verified **thread-safe collections** are used.
- [x] Validated proper exception handling in multi-threaded code.

## How was this PR tested?

- [x] New unit tests added.
- [x] Modified or extended existing tests, including the multi-region end-to-end fail-open test.
- [x] Verified backward compatibility (if applicable).

```
./gradlew :clients:venice-push-job:test --tests DualWriteVeniceWriterTest --tests VenicePushJobLifecycleTest \
    --tests MapReduceDataWriterTaskTrackerTest --tests SparkDataWriterTaskTrackerTest --tests AbstractDataWriterSparkJobTest
./gradlew :services:venice-controller:test --tests "com.linkedin.venice.controller.stats.PushJob*" \
    --tests TestPushJobStatusStats --tests TestVeniceHelixAdmin --tests TestVeniceParentHelixAdmin --tests StoresRoutesTest
    → 210 tests, 0 failures
./gradlew :internal:venice-common:test --tests TestPushJobDetailsSchemaCompatibility --tests ControllerClientTest \
    --tests ControllerRouteDimensionTest
./gradlew :internal:venice-client-common:test --tests VenicePushJobDataWriterSinkTest --tests VeniceMetricsDimensionsTest
./gradlew :internal:venice-test-common:integrationTest \
    --tests "...TestVPJDualWriteExternalStorageMultiRegion.dualWritePushSucceedsWhenOneRegionExhaustsExternalWriteRetries"
./gradlew spotlessCheck
```

**Unit coverage for the failure counter:** VPJ supplies `EXTERNAL_WRITE_FAILURE`; callers on the
overloads without a reason still compile and resolve to `UNSPECIFIED`; a region excluded by the filter
neither updates nor counts; the matching region counts once with its own region as the dimension; an
unrelated reason does not count; an upgrade to `DUAL_WRITE` does not count; three identical fail-open
requests count once; the parent forwards the reason to only the targeted child; two regions failing
for the same store stay two separate time series.

**End-to-end coverage.** `TestVPJDualWriteExternalStorageMultiRegion.dualWritePushSucceedsWhenOneRegionExhaustsExternalWriteRetries`
— the existing #2967 fail-open case, extended rather than duplicated — stands up two real regions and
runs a real VPJ push whose external writes always fail in one of them. On top of its existing
assertions that the push succeeds and that only the failed region's version moves to `INTERNAL`, it
now reads the child controllers' own `InMemoryMetricReader` and asserts that:

- the failed region's controller emits `push_job.external_storage_write_failure.count` **exactly
  once**, carrying that region as `venice.region.name`;
- the healthy region's controller emits **nothing**;
- the failed region's controller does **not** attribute the failure to the healthy region;
- replaying the same downgrade through the parent leaves the version `INTERNAL` and does **not** move
  the counter — which also exercises parent-to-child reason propagation on its own, outside the push.

That test is already parameterized over both data writer engines, so **Spark and MapReduce are both
covered**. Results:

```
dualWritePushSucceedsWhenOneRegionExhaustsExternalWriteRetries[0](DataWriterSparkJob)  PASSED (22.9 s)
dualWritePushSucceedsWhenOneRegionExhaustsExternalWriteRetries[2](DataWriterMRJob)     PASSED (16.5 s)
```

The count assertion was verified non-vacuous by temporarily expecting 2, which failed with
`expected [2] but found [1]` on both engines before being reverted.

Backward compatibility: a v6 reader resolves a v5 writer's record to a `null` `additionalPushMetrics`
map, so pushes from older VPJ versions keep reporting successfully during the rollout and simply do
not contribute timings. The storage-mode reason parameter is optional in both directions and needs no
deployment ordering.

### Metric shape (review follow-up)

The reported timing values are a **sum of per-task wall-clock durations**, not a push-level wall
clock, so with N parallel data writer tasks the sum can be up to N times the push duration. Tehuti
therefore gets **`Avg` and `Max` only**: a percentile needs a bounded, configured range, and a summed
task duration has no meaningful upper bound, so Tehuti percentiles would report infinity. The
distribution is available through the **OTel histogram** instead. The failure signal is a plain
counter for the same reason it is alertable: it counts events, not durations.

## Does this PR introduce any user-facing or breaking changes?

- [x] Yes, in the deployment-ordering sense only. Push jobs built from this commit serialize
      `PushJobDetails` v6, so **#2971 must be deployed to the controllers before this change ships**,
      otherwise the controller rejects the push job details write. No API, config or data-format
      change is visible to store owners; `additionalPushMetrics` defaults to `null` ("not reported")
      and the new storage-mode reason parameter is optional.
