### PR TITLE
[da-vinci] Invalidate stale demotions before going offline

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -170,6 +170,9 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
 
   @Transition(to = HelixState.OFFLINE_STATE, from = HelixState.STANDBY_STATE)
   public void onBecomeOfflineFromStandby(Message message, NotificationContext context) {
+    // Invalidate any queued LEADER_TO_STANDBY action before stopping consumption. Otherwise, a delayed demotion
+    // could run after this transition and restore follower-only state, such as the follower heartbeat monitor.
+    leaderSessionId.incrementAndGet();
     heartbeatMonitoringService.updateLagMonitor(
         message.getResourceName(),
         getPartition(),

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
@@ -164,16 +164,28 @@ public class LeaderFollowerPartitionStateModelTest {
     NotificationContext context = mock(NotificationContext.class);
     when(message.getResourceName()).thenReturn(resourceName);
     LeaderSessionIdChecker[] demotionChecker = new LeaderSessionIdChecker[1];
+    Runnable[] delayedDemotion = new Runnable[1];
     doAnswer(invocation -> {
       demotionChecker[0] = invocation.getArgument(2);
+      delayedDemotion[0] = () -> {
+        if (demotionChecker[0].isSessionIdValid()) {
+          heartbeatMonitoringService.updateLagMonitor(
+              resourceName,
+              partition,
+              HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR,
+              Utils.getReplicaId(resourceName, partition));
+        }
+      };
       return null;
     }).when(storeIngestionService).demoteToStandby(eq(storeAndServerConfigs), eq(partition), any());
 
     leaderFollowerPartitionStateModel.onBecomeStandbyFromLeader(message, context);
     assertNotNull(demotionChecker[0]);
+    assertNotNull(delayedDemotion[0]);
     assertTrue(demotionChecker[0].isSessionIdValid());
 
     leaderFollowerPartitionStateModel.onBecomeOfflineFromStandby(message, context);
+    delayedDemotion[0].run();
 
     assertFalse(demotionChecker[0].isSessionIdValid());
     verify(heartbeatMonitoringService, never()).updateLagMonitor(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -25,6 +26,7 @@ import static org.testng.Assert.fail;
 
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
+import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel.LeaderSessionIdChecker;
 import com.linkedin.davinci.ingestion.DefaultIngestionBackend;
 import com.linkedin.davinci.ingestion.IngestionBackend;
 import com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService;
@@ -154,6 +156,31 @@ public class LeaderFollowerPartitionStateModelTest {
     leaderFollowerPartitionStateModelSpy.onBecomeOfflineFromStandby(message, context);
     verify(heartbeatMonitoringService)
         .updateLagMonitor(eq(resourceName), eq(partition), eq(HeartbeatLagMonitorAction.REMOVE_MONITOR), anyString());
+  }
+
+  @Test
+  public void testOfflineTransitionInvalidatesDelayedLeaderToStandbyAction() {
+    Message message = mock(Message.class);
+    NotificationContext context = mock(NotificationContext.class);
+    when(message.getResourceName()).thenReturn(resourceName);
+    LeaderSessionIdChecker[] demotionChecker = new LeaderSessionIdChecker[1];
+    doAnswer(invocation -> {
+      demotionChecker[0] = invocation.getArgument(2);
+      return null;
+    }).when(storeIngestionService).demoteToStandby(eq(storeAndServerConfigs), eq(partition), any());
+
+    leaderFollowerPartitionStateModel.onBecomeStandbyFromLeader(message, context);
+    assertNotNull(demotionChecker[0]);
+    assertTrue(demotionChecker[0].isSessionIdValid());
+
+    leaderFollowerPartitionStateModel.onBecomeOfflineFromStandby(message, context);
+
+    assertFalse(demotionChecker[0].isSessionIdValid());
+    verify(heartbeatMonitoringService, never()).updateLagMonitor(
+        eq(resourceName),
+        eq(partition),
+        eq(HeartbeatLagMonitorAction.SET_FOLLOWER_MONITOR),
+        anyString());
   }
 
   @Test


### PR DESCRIPTION
## Problem Statement

Asynchronous replica cleanup can advance a replica to `OFFLINE` while an earlier `LEADER_TO_STANDBY` action remains queued. If that delayed demotion runs afterward, it can modify ingestion state and restore follower heartbeat monitoring for an offline replica.

## Solution

Invalidate the leader-session token when the `STANDBY` to `OFFLINE` transition begins. The existing consumer-action validation then rejects any queued stale demotion before it modifies ingestion state or heartbeat monitoring.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

No configuration or logging changes are introduced.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

The existing atomic leader-session generation provides the cross-thread validity check. This change introduces no collections, blocking calls, or exception-handling changes.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

```text
./gradlew --no-daemon :clients:da-vinci-client:test --tests 'com.linkedin.davinci.helix.LeaderFollowerPartitionStateModelTest.testOfflineTransitionInvalidatesDelayedLeaderToStandbyAction'
```

The focused regression test verifies that the delayed demotion token becomes invalid and no later `SET_FOLLOWER_MONITOR` update occurs.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

This contribution is original work and is licensed to the project under its open source license.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
