### PR TITLE
[vpj] Preserve KIF input config precedence

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJob.java
@@ -194,23 +194,8 @@ public class DataWriterSparkJob extends AbstractDataWriterSparkJob {
     setInputConf(
         sparkSession,
         dataFrameReader,
-        VENICE_REPUSH_SOURCE_PUBSUB_BROKER,
-        pushJobSetting.repushSourcePubsubBroker);
-    dataFrameReader.option(PUBSUB_BROKER_ADDRESS, pushJobSetting.repushSourcePubsubBroker);
-    setInputConf(
-        sparkSession,
-        dataFrameReader,
-        KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP,
-        AvroCompatibilityHelper.toParsingForm(pushJobSetting.storeKeySchema));
-    setInputConf(
-        sparkSession,
-        dataFrameReader,
         KAFKA_INPUT_SOURCE_TOPIC_CHUNKING_ENABLED,
         String.valueOf(pushJobSetting.sourceKafkaInputVersionInfo.isChunkingEnabled()));
-
-    // Add KME (Kafka Message Envelope) schemas to support different message envelope versions
-    KafkaInputUtils.putSchemaMapIntoProperties(pushJobSetting.newKmeSchemasFromController)
-        .forEach((key, value) -> setInputConf(sparkSession, dataFrameReader, key, value));
 
     // SSL defaults: set SSL configurator class (with default) and security protocol.
     // These may not be in the job props, so set them explicitly before the bulk forwarding.
@@ -228,6 +213,22 @@ public class DataWriterSparkJob extends AbstractDataWriterSparkJob {
     for (String key: allJobProps.keySet()) {
       setInputConf(sparkSession, dataFrameReader, key, allJobProps.getString(key));
     }
+
+    setInputConf(
+        sparkSession,
+        dataFrameReader,
+        VENICE_REPUSH_SOURCE_PUBSUB_BROKER,
+        pushJobSetting.repushSourcePubsubBroker);
+    dataFrameReader.option(PUBSUB_BROKER_ADDRESS, pushJobSetting.repushSourcePubsubBroker);
+    setInputConf(
+        sparkSession,
+        dataFrameReader,
+        KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP,
+        AvroCompatibilityHelper.toParsingForm(pushJobSetting.storeKeySchema));
+
+    // Add KME (Kafka Message Envelope) schemas to support different message envelope versions
+    KafkaInputUtils.putSchemaMapIntoProperties(pushJobSetting.newKmeSchemasFromController)
+        .forEach((key, value) -> setInputConf(sparkSession, dataFrameReader, key, value));
 
     return dataFrameReader.load();
   }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJobTest.java
@@ -3,6 +3,8 @@ package com.linkedin.venice.spark.datawriter.jobs;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_SECURITY_PROTOCOL;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.NEWER_KME_SCHEMAS_PREFIX;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PARTITION_COUNT;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_PASSWORD_PROPERTY_NAME;
@@ -20,6 +22,7 @@ import com.linkedin.venice.pubsub.api.PubSubSecurityProtocol;
 import com.linkedin.venice.spark.SparkConstants;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import org.apache.avro.Schema;
@@ -30,6 +33,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -119,6 +123,49 @@ public class DataWriterSparkJobTest {
       // Expected - key should not exist
       assertTrue(true);
     }
+  }
+
+  @Test(dataProvider = "staleSourceKeySchemas")
+  public void testKafkaInputDataFrameUsesResolvedConfigsOverOriginals(String staleSourceKeySchema) {
+    ConfigTestSparkJob job = new ConfigTestSparkJob();
+    currentTestJob = job;
+
+    String kmeSchemaProperty = NEWER_KME_SCHEMAS_PREFIX + "14";
+    Properties props = createDefaultTestProperties();
+    props.setProperty(VENICE_REPUSH_SOURCE_PUBSUB_BROKER, "stale-broker:9092");
+    props.setProperty(KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, staleSourceKeySchema);
+    props.setProperty(kmeSchemaProperty, "\"int\"");
+    props.setProperty("custom.pubsub.adapter.property", "custom-value");
+
+    PushJobSetting setting = createKafkaInputSetting();
+    setting.repushSourcePubsubBroker = "resolved-broker:9092";
+    setting.newKmeSchemasFromController = Collections.singletonMap(14, "\"bytes\"");
+
+    job.configure(new VeniceProperties(props), setting);
+    job.getKafkaInputDataFrame();
+
+    SparkSession spark = job.getSparkSession();
+    assertEquals(
+        spark.conf().get(VENICE_REPUSH_SOURCE_PUBSUB_BROKER),
+        "resolved-broker:9092",
+        "The resolved source broker should override a stale original property");
+    assertEquals(
+        spark.conf().get(KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP),
+        "\"string\"",
+        "The controller-derived source key schema should override a stale original property");
+    assertEquals(
+        spark.conf().get(kmeSchemaProperty),
+        "\"bytes\"",
+        "The controller-derived KME schema should override a stale original property");
+    assertEquals(
+        spark.conf().get("custom.pubsub.adapter.property"),
+        "custom-value",
+        "Unrelated custom adapter properties should still be forwarded");
+  }
+
+  @DataProvider(name = "staleSourceKeySchemas")
+  public Object[][] staleSourceKeySchemas() {
+    return new Object[][] { { "\"int\"" }, { "" } };
   }
 
   private Properties createDefaultTestProperties() {


### PR DESCRIPTION
## Problem Statement

Spark Kafka-input repush forwarded all original job properties after applying normalized inputs. A stale source broker, source key schema, or Kafka Message Envelope schema could therefore replace the controller-derived value and make Spark diverge from MapReduce behavior.

## Solution

Forward general job properties first, then apply the resolved source broker and controller-derived key and Kafka Message Envelope schemas. This preserves custom adapter and other pass-through properties while keeping authoritative normalized values final.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] Local code review completed.
- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

Ran the focused `DataWriterSparkJobTest` suite, including stale and empty source key schemas, conflicting broker and KME schemas, and custom property forwarding. Ran the repository Spotless check.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
