### PR TITLE
[vpj] Materialize executor-side SSL before Spark TTL filter and chunk assembly

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputUtils.java
@@ -120,6 +120,12 @@ public class KafkaInputUtils {
     if (strategy.equals(CompressionStrategy.ZSTD_WITH_DICT)) {
       Properties props = properties.toProperties();
       props.setProperty(KAFKA_BOOTSTRAP_SERVERS, kafkaUrl);
+      // Explicitly set PUBSUB_BROKER_ADDRESS so it takes precedence over any pass-through
+      // pubsub.broker.address already present in `properties` (see PubSubUtil#getPubSubBrokerAddress,
+      // which checks PUBSUB_BROKER_ADDRESS before falling back to KAFKA_BOOTSTRAP_SERVERS), mirroring
+      // getConsumerProperties(). Without this, the dictionary consumer created here could silently
+      // connect to the wrong (destination) broker instead of the intended source broker.
+      props.setProperty(PUBSUB_BROKER_ADDRESS, kafkaUrl);
       ByteBuffer dict = DictionaryUtils.readDictionaryFromKafka(topic, new VeniceProperties(props));
       return compressorFactory
           .createVersionSpecificCompressorIfNotExist(strategy, topic, ByteUtils.extractByteArray(dict));

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/VPJSSLUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/VPJSSLUtils.java
@@ -53,6 +53,28 @@ public class VPJSSLUtils {
     return newSslProperties;
   }
 
+  /**
+   * Sets up SSL on the executor side before creating a PubSub consumer, by materializing SSL properties
+   * from the Hadoop token file. This is a no-op when no SSL configurator class is configured.
+   */
+  public static VeniceProperties setupSSLForExecutor(VeniceProperties config) {
+    if (!config.containsKey(SSL_CONFIGURATOR_CLASS_CONFIG)) {
+      return config;
+    }
+    try {
+      Properties sslProps = getSslProperties(config);
+      Properties merged = config.toProperties();
+      merged.putAll(sslProps);
+      return new VeniceProperties(merged);
+    } catch (Exception e) {
+      String msg = "Failed to setup SSL for executor-side PubSub client creation. "
+          + "Ensure the Hadoop token file is accessible and SSL certificates are valid. " + "SSL configurator class: "
+          + config.getString(SSL_CONFIGURATOR_CLASS_CONFIG);
+      LOGGER.error(msg, e);
+      throw new VeniceException(msg, e);
+    }
+  }
+
   public static void validateSslProperties(VeniceProperties props) {
     String[] requiredSSLPropertiesNames = new String[] { SSL_KEY_PASSWORD_PROPERTY_NAME,
         SSL_KEY_STORE_PASSWORD_PROPERTY_NAME, SSL_KEY_STORE_PROPERTY_NAME, SSL_TRUST_STORE_PROPERTY_NAME };

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/VPJSSLUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/VPJSSLUtils.java
@@ -9,6 +9,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_STORE_PROPE
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_PREFIX;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_TRUST_STORE_PROPERTY_NAME;
 
+import com.linkedin.venice.annotation.VisibleForTesting;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.ssl.SSLConfigurator;
 import com.linkedin.venice.hadoop.ssl.TempFileSSLConfigurator;
@@ -54,24 +55,62 @@ public class VPJSSLUtils {
   }
 
   /**
+   * JVM-level cache of the materialized SSL properties (keystore/truststore temp file locations, etc).
+   * The Hadoop token file and SSL configurator class are fixed for the lifetime of an executor JVM, so
+   * the (potentially expensive) token-file read and temp-file materialization only need to happen once
+   * per executor, no matter how many times {@link #setupSSLForExecutor(VeniceProperties)} is called
+   * (e.g. once per Spark task, or once per key group). Failures are never cached so a transient issue
+   * (e.g. token file not yet mounted) can be retried on a subsequent call.
+   */
+  private static volatile Properties cachedExecutorSslProps = null;
+  private static final Object EXECUTOR_SSL_PROPS_LOCK = new Object();
+
+  /**
    * Sets up SSL on the executor side before creating a PubSub consumer, by materializing SSL properties
-   * from the Hadoop token file. This is a no-op when no SSL configurator class is configured.
+   * from the Hadoop token file. This is a no-op when no SSL configurator class is configured. The
+   * materialized SSL properties are cached per-JVM (see {@link #cachedExecutorSslProps}) so repeated
+   * calls on the same executor don't re-read the token file or re-write temp certificate files.
    */
   public static VeniceProperties setupSSLForExecutor(VeniceProperties config) {
     if (!config.containsKey(SSL_CONFIGURATOR_CLASS_CONFIG)) {
       return config;
     }
     try {
-      Properties sslProps = getSslProperties(config);
+      Properties sslProps = getCachedExecutorSslProperties(config);
       Properties merged = config.toProperties();
       merged.putAll(sslProps);
       return new VeniceProperties(merged);
     } catch (Exception e) {
       String msg = "Failed to setup SSL for executor-side PubSub client creation. "
-          + "Ensure the Hadoop token file is accessible and SSL certificates are valid. " + "SSL configurator class: "
+          + "Ensure the Hadoop token file is accessible and SSL certificates are valid. SSL configurator class: "
           + config.getString(SSL_CONFIGURATOR_CLASS_CONFIG);
       LOGGER.error(msg, e);
       throw new VeniceException(msg, e);
+    }
+  }
+
+  private static Properties getCachedExecutorSslProperties(VeniceProperties config) throws IOException {
+    Properties cached = cachedExecutorSslProps;
+    if (cached != null) {
+      return cached;
+    }
+    synchronized (EXECUTOR_SSL_PROPS_LOCK) {
+      cached = cachedExecutorSslProps;
+      if (cached == null) {
+        cached = getSslProperties(config);
+        cachedExecutorSslProps = cached;
+      }
+      return cached;
+    }
+  }
+
+  /**
+   * Test-only hook to reset the per-JVM SSL properties cache between test cases.
+   */
+  @VisibleForTesting
+  public static void resetExecutorSslPropsCacheForTests() {
+    synchronized (EXECUTOR_SSL_PROPS_LOCK) {
+      cachedExecutorSslProps = null;
     }
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/chunk/SparkChunkAssembler.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/chunk/SparkChunkAssembler.java
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
  * Converts Spark Rows to the format expected by ChunkAssembler, assembles chunks,
  * and returns the result as a Spark Row.
  */
-public class SparkChunkAssembler implements Serializable {
+public class SparkChunkAssembler implements Serializable, AutoCloseable {
   private static final long serialVersionUID = 1L;
 
   private static final RecordSerializer<KafkaInputMapperValue> SERIALIZER =
@@ -146,6 +146,17 @@ public class SparkChunkAssembler implements Serializable {
     }
 
     return assembledRow;
+  }
+
+  /**
+   * Releases resources (e.g. the post-assembly TTL filter's schema reader) held by this assembler.
+   * Safe to call even if the assembler was never used (transient fields still null).
+   */
+  @Override
+  public void close() {
+    if (ttlFilter != null) {
+      ttlFilter.close();
+    }
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -135,6 +135,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
+import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapGroupsFunction;
 import org.apache.spark.api.java.function.MapFunction;
@@ -155,6 +156,7 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.util.AccumulatorV2;
 import org.apache.spark.util.LongAccumulator;
+import org.apache.spark.util.TaskCompletionListener;
 
 
 /**
@@ -716,52 +718,135 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     dataFrame = dataFrame
         // Group by key
         .groupByKey((MapFunction<Row, byte[]>) row -> row.getAs(KEY_COLUMN_NAME), Encoders.BINARY())
-        // For each key group, sort by offset DESC and assemble
-        .flatMapGroups((FlatMapGroupsFunction<byte[], Row, Row>) (keyBytes, rowsIterator) -> {
-          long groupStartNs = System.nanoTime();
-          // Collect rows and sort by offset DESC (highest first)
-          List<Row> rowsList = new ArrayList<>();
-          rowsIterator.forEachRemaining(row -> {
-            chunkMetrics.recordsIn.add(1);
-            chunkMetrics.bytesIn.add(CountingIterator.computeByteSizeByIndices(row, inKeyIdx, inValIdx, inRmdIdx));
-            rowsList.add(row);
-          });
-
-          if (rowsList.isEmpty()) {
-            chunkMetrics.timeNs.add(System.nanoTime() - groupStartNs);
-            return Collections.emptyIterator();
-          }
-
-          // Sort by offset DESC
-          rowsList.sort((r1, r2) -> {
-            long offset1 = r1.getAs(OFFSET_COLUMN_NAME);
-            long offset2 = r2.getAs(OFFSET_COLUMN_NAME);
-            return Long.compare(offset2, offset1);
-          });
-
-          // Assemble chunks (and apply TTL filtering if enabled)
-          VeniceProperties executorFilterProps =
-              isTTLEnabled ? VPJSSLUtils.setupSSLForExecutor(broadcastFilterProps) : broadcastFilterProps;
-          SparkChunkAssembler assembler =
-              new SparkChunkAssembler(isRmdChunkingEnabled, isTTLEnabled, executorFilterProps);
-          Row assembled = assembler.assembleChunks(keyBytes, rowsList.iterator());
-
-          if (assembled == null) {
-            // Latest record is DELETE, chunks incomplete, or filtered by TTL
-            emptyRecordAcc.add(1);
-            chunkMetrics.timeNs.add(System.nanoTime() - groupStartNs);
-            return Collections.emptyIterator();
-          }
-
-          chunkMetrics.recordsOut.add(1);
-          chunkMetrics.bytesOut
-              .add(CountingIterator.computeByteSizeByIndices(assembled, outKeyIdx, outValIdx, outRmdIdx));
-          chunkMetrics.timeNs.add(System.nanoTime() - groupStartNs);
-          return Collections.singletonList(assembled).iterator();
-        }, encoder);
+        // For each key group, sort by offset DESC and assemble. ChunkAssemblyFunction caches the
+        // SparkChunkAssembler (and the SSL materialization it needs) once per Spark task and reuses it
+        // across all key groups processed by that task, instead of rebuilding it per key group.
+        .flatMapGroups(
+            new ChunkAssemblyFunction(
+                isRmdChunkingEnabled,
+                isTTLEnabled,
+                broadcastFilterProps,
+                inKeyIdx,
+                inValIdx,
+                inRmdIdx,
+                outKeyIdx,
+                outValIdx,
+                outRmdIdx,
+                emptyRecordAcc,
+                chunkMetrics),
+            encoder);
 
     LOGGER.info("Chunk assembly completed. Output schema: {}", dataFrame.schema());
     return dataFrame;
+  }
+
+  /**
+   * {@link FlatMapGroupsFunction} used by {@link #applyChunkAssembly(Dataset)}. Spark reuses the same
+   * deserialized function instance across every key group processed within a given task, so the
+   * {@link SparkChunkAssembler} (and, transitively, the executor-side SSL materialization and any
+   * dictionary/schema PubSub consumer it needs) is built lazily on the first key group and reused for
+   * the rest of the task, instead of being rebuilt per key group. The assembler is released via a
+   * {@link TaskContext} completion listener so its resources don't outlive the task.
+   */
+  private static class ChunkAssemblyFunction implements FlatMapGroupsFunction<byte[], Row, Row> {
+    private static final long serialVersionUID = 1L;
+
+    private final boolean isRmdChunkingEnabled;
+    private final boolean isTTLEnabled;
+    private final VeniceProperties broadcastFilterProps;
+    private final int inKeyIdx;
+    private final int inValIdx;
+    private final int inRmdIdx;
+    private final int outKeyIdx;
+    private final int outValIdx;
+    private final int outRmdIdx;
+    private final LongAccumulator emptyRecordAcc;
+    private final StageMetrics chunkMetrics;
+
+    private transient SparkChunkAssembler assembler;
+
+    ChunkAssemblyFunction(
+        boolean isRmdChunkingEnabled,
+        boolean isTTLEnabled,
+        VeniceProperties broadcastFilterProps,
+        int inKeyIdx,
+        int inValIdx,
+        int inRmdIdx,
+        int outKeyIdx,
+        int outValIdx,
+        int outRmdIdx,
+        LongAccumulator emptyRecordAcc,
+        StageMetrics chunkMetrics) {
+      this.isRmdChunkingEnabled = isRmdChunkingEnabled;
+      this.isTTLEnabled = isTTLEnabled;
+      this.broadcastFilterProps = broadcastFilterProps;
+      this.inKeyIdx = inKeyIdx;
+      this.inValIdx = inValIdx;
+      this.inRmdIdx = inRmdIdx;
+      this.outKeyIdx = outKeyIdx;
+      this.outValIdx = outValIdx;
+      this.outRmdIdx = outRmdIdx;
+      this.emptyRecordAcc = emptyRecordAcc;
+      this.chunkMetrics = chunkMetrics;
+    }
+
+    @Override
+    public Iterator<Row> call(byte[] keyBytes, Iterator<Row> rowsIterator) {
+      long groupStartNs = System.nanoTime();
+      // Collect rows and sort by offset DESC (highest first)
+      List<Row> rowsList = new ArrayList<>();
+      rowsIterator.forEachRemaining(row -> {
+        chunkMetrics.recordsIn.add(1);
+        chunkMetrics.bytesIn.add(CountingIterator.computeByteSizeByIndices(row, inKeyIdx, inValIdx, inRmdIdx));
+        rowsList.add(row);
+      });
+
+      if (rowsList.isEmpty()) {
+        chunkMetrics.timeNs.add(System.nanoTime() - groupStartNs);
+        return Collections.emptyIterator();
+      }
+
+      // Sort by offset DESC
+      rowsList.sort((r1, r2) -> {
+        long offset1 = r1.getAs(OFFSET_COLUMN_NAME);
+        long offset2 = r2.getAs(OFFSET_COLUMN_NAME);
+        return Long.compare(offset2, offset1);
+      });
+
+      Row assembled = getOrCreateAssembler().assembleChunks(keyBytes, rowsList.iterator());
+
+      if (assembled == null) {
+        // Latest record is DELETE, chunks incomplete, or filtered by TTL
+        emptyRecordAcc.add(1);
+        chunkMetrics.timeNs.add(System.nanoTime() - groupStartNs);
+        return Collections.emptyIterator();
+      }
+
+      chunkMetrics.recordsOut.add(1);
+      chunkMetrics.bytesOut.add(CountingIterator.computeByteSizeByIndices(assembled, outKeyIdx, outValIdx, outRmdIdx));
+      chunkMetrics.timeNs.add(System.nanoTime() - groupStartNs);
+      return Collections.singletonList(assembled).iterator();
+    }
+
+    /**
+     * Lazily builds the {@link SparkChunkAssembler} for this task (materializing executor-side SSL
+     * first, if TTL filtering is enabled) and registers a task-completion listener to release it once,
+     * so it isn't rebuilt for every key group processed by this task.
+     */
+    private SparkChunkAssembler getOrCreateAssembler() {
+      if (assembler == null) {
+        VeniceProperties executorFilterProps =
+            isTTLEnabled ? VPJSSLUtils.setupSSLForExecutor(broadcastFilterProps) : broadcastFilterProps;
+        SparkChunkAssembler newAssembler =
+            new SparkChunkAssembler(isRmdChunkingEnabled, isTTLEnabled, executorFilterProps);
+        TaskContext taskContext = TaskContext.get();
+        if (taskContext != null) {
+          taskContext.addTaskCompletionListener((TaskCompletionListener) context -> newAssembler.close());
+        }
+        assembler = newAssembler;
+      }
+      return assembler;
+    }
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -502,10 +502,16 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     }
 
     boolean isChunkingEnabled = pushJobSetting.sourceKafkaInputVersionInfo.isChunkingEnabled();
-    LOGGER.info(
-        "Applying TTL filtering with start timestamp: {} (chunking enabled: {})",
-        pushJobSetting.repushTTLStartTimeMs,
-        isChunkingEnabled);
+    if (isChunkingEnabled) {
+      // Every row is passed through unfiltered in this method when chunking is enabled (TTL filtering
+      // is instead applied post-assembly in applyChunkAssembly()), so skip building a
+      // SparkKafkaInputTTLFilter (and the HDFS schema fetch / dictionary consumer it may create) per
+      // partition entirely, rather than constructing one that's guaranteed to be a no-op.
+      LOGGER.info("TTL filtering deferred to post-assembly (chunking enabled); skipping raw TTL filter stage");
+      return dataFrame;
+    }
+
+    LOGGER.info("Applying TTL filtering with start timestamp: {}", pushJobSetting.repushTTLStartTimeMs);
 
     JavaSparkContext sparkContext = JavaSparkContext.fromSparkContext(sparkSession.sparkContext());
 
@@ -524,9 +530,17 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     final StageMetrics ttlMetrics = stageMetricsRegistry.register("ttl_filter");
 
     // Apply filter using mapPartitions for efficiency (one filter instance per partition)
+    boolean needsSslForDictionaryConsumer =
+        pushJobSetting.sourceVersionCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT;
     dataFrame = dataFrame.mapPartitions((MapPartitionsFunction<Row, Row>) iterator -> {
+      // SSL is only needed here when the source is ZSTD_WITH_DICT compressed, since that's the only
+      // case where SparkKafkaInputTTLFilter's VeniceRmdTTLFilter creates a PubSub consumer to read the
+      // compression dictionary (see KafkaInputUtils#getCompressor). Gating on this avoids turning an
+      // unrelated executor-side token-file problem into a hard failure for TTL repushes of
+      // NO_OP/GZIP-compressed stores, which never needed SSL on this path.
+      VeniceProperties partitionFilterProps = new VeniceProperties(broadcastFilterProps.value());
       VeniceProperties executorFilterProps =
-          VPJSSLUtils.setupSSLForExecutor(new VeniceProperties(broadcastFilterProps.value()));
+          needsSslForDictionaryConsumer ? VPJSSLUtils.setupSSLForExecutor(partitionFilterProps) : partitionFilterProps;
       SparkKafkaInputTTLFilter ttlFilter = new SparkKafkaInputTTLFilter(executorFilterProps);
       try {
         CountingIterator countedInput = new CountingIterator(
@@ -547,14 +561,6 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
           // handled separately in the reducer, not in the mapper's TTL filter chain).
           if (messageType == MessageType.DELETE.getValue()) {
             return true; // Keep DELETE records unchanged
-          }
-
-          // If chunking is enabled, skip ALL records in the raw TTL filter. TTL filtering
-          // will be handled post-assembly in applyChunkAssembly() instead. This avoids
-          // double-filtering where the raw filter's value/RMD modifications for
-          // PARTIALLY_UPDATED records are lost
-          if (isChunkingEnabled) {
-            return true;
           }
 
           // shouldFilter returns true if record should be removed
@@ -690,6 +696,13 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
   protected Dataset<Row> applyChunkAssembly(Dataset<Row> dataFrame) {
     boolean isRmdChunkingEnabled = pushJobSetting.sourceKafkaInputVersionInfo.isRmdChunkingEnabled();
     boolean isTTLEnabled = pushJobSetting.repushTTLEnabled;
+    // SSL is only needed ahead of TTL filtering when the source is ZSTD_WITH_DICT compressed, since
+    // that's the only case where VeniceRmdTTLFilter creates a PubSub consumer to read the compression
+    // dictionary (see KafkaInputUtils#getCompressor). Gating on this avoids turning an unrelated
+    // executor-side token-file problem into a hard failure for TTL repushes of NO_OP/GZIP-compressed
+    // stores, which never needed SSL on this path.
+    boolean needsSslForDictionaryConsumer =
+        isTTLEnabled && pushJobSetting.sourceVersionCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT;
 
     LOGGER.info("Chunk assembly starting (TTL filtering: {}). Input schema: {}", isTTLEnabled, dataFrame.schema());
 
@@ -725,6 +738,7 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
             new ChunkAssemblyFunction(
                 isRmdChunkingEnabled,
                 isTTLEnabled,
+                needsSslForDictionaryConsumer,
                 broadcastFilterProps,
                 inKeyIdx,
                 inValIdx,
@@ -753,6 +767,7 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
 
     private final boolean isRmdChunkingEnabled;
     private final boolean isTTLEnabled;
+    private final boolean needsSslForDictionaryConsumer;
     private final VeniceProperties broadcastFilterProps;
     private final int inKeyIdx;
     private final int inValIdx;
@@ -768,6 +783,7 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     ChunkAssemblyFunction(
         boolean isRmdChunkingEnabled,
         boolean isTTLEnabled,
+        boolean needsSslForDictionaryConsumer,
         VeniceProperties broadcastFilterProps,
         int inKeyIdx,
         int inValIdx,
@@ -779,6 +795,7 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
         StageMetrics chunkMetrics) {
       this.isRmdChunkingEnabled = isRmdChunkingEnabled;
       this.isTTLEnabled = isTTLEnabled;
+      this.needsSslForDictionaryConsumer = needsSslForDictionaryConsumer;
       this.broadcastFilterProps = broadcastFilterProps;
       this.inKeyIdx = inKeyIdx;
       this.inValIdx = inValIdx;
@@ -830,13 +847,15 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
 
     /**
      * Lazily builds the {@link SparkChunkAssembler} for this task (materializing executor-side SSL
-     * first, if TTL filtering is enabled) and registers a task-completion listener to release it once,
-     * so it isn't rebuilt for every key group processed by this task.
+     * first, only if the source is ZSTD_WITH_DICT compressed and TTL filtering will actually need a
+     * dictionary consumer) and registers a task-completion listener to release it once, so it isn't
+     * rebuilt for every key group processed by this task.
      */
     private SparkChunkAssembler getOrCreateAssembler() {
       if (assembler == null) {
-        VeniceProperties executorFilterProps =
-            isTTLEnabled ? VPJSSLUtils.setupSSLForExecutor(broadcastFilterProps) : broadcastFilterProps;
+        VeniceProperties executorFilterProps = needsSslForDictionaryConsumer
+            ? VPJSSLUtils.setupSSLForExecutor(broadcastFilterProps)
+            : broadcastFilterProps;
         SparkChunkAssembler newAssembler =
             new SparkChunkAssembler(isRmdChunkingEnabled, isTTLEnabled, executorFilterProps);
         TaskContext taskContext = TaskContext.get();

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -86,6 +86,7 @@ import com.linkedin.venice.hadoop.input.kafka.ttl.TTLResolutionPolicy;
 import com.linkedin.venice.hadoop.ssl.TempFileSSLConfigurator;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
 import com.linkedin.venice.hadoop.task.datawriter.IncrementalPushWriteQuotaUtils;
+import com.linkedin.venice.hadoop.utils.VPJSSLUtils;
 import com.linkedin.venice.jobs.DataWriterComputeJob;
 import com.linkedin.venice.jobs.StageMetricsSnapshot;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
@@ -522,8 +523,9 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
 
     // Apply filter using mapPartitions for efficiency (one filter instance per partition)
     dataFrame = dataFrame.mapPartitions((MapPartitionsFunction<Row, Row>) iterator -> {
-      SparkKafkaInputTTLFilter ttlFilter =
-          new SparkKafkaInputTTLFilter(new VeniceProperties(broadcastFilterProps.value()));
+      VeniceProperties executorFilterProps =
+          VPJSSLUtils.setupSSLForExecutor(new VeniceProperties(broadcastFilterProps.value()));
+      SparkKafkaInputTTLFilter ttlFilter = new SparkKafkaInputTTLFilter(executorFilterProps);
       try {
         CountingIterator countedInput = new CountingIterator(
             iterator,
@@ -738,8 +740,10 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
           });
 
           // Assemble chunks (and apply TTL filtering if enabled)
+          VeniceProperties executorFilterProps =
+              isTTLEnabled ? VPJSSLUtils.setupSSLForExecutor(broadcastFilterProps) : broadcastFilterProps;
           SparkChunkAssembler assembler =
-              new SparkChunkAssembler(isRmdChunkingEnabled, isTTLEnabled, broadcastFilterProps);
+              new SparkChunkAssembler(isRmdChunkingEnabled, isTTLEnabled, executorFilterProps);
           Row assembled = assembler.assembleChunks(keyBytes, rowsList.iterator());
 
           if (assembled == null) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/input/pubsub/SparkPubSubPartitionReaderFactory.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/input/pubsub/SparkPubSubPartitionReaderFactory.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.spark.input.pubsub;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.DEFAULT_PUBSUB_INPUT_SECONDARY_COMPARATOR_USE_LOCAL_LOGICAL_INDEX;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_FABRIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PUBSUB_INPUT_SECONDARY_COMPARATOR_USE_LOCAL_LOGICAL_INDEX;
-import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
 
 import com.linkedin.venice.chunking.ChunkKeyValueTransformer;
@@ -19,7 +18,6 @@ import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.vpj.VenicePushJobConstants;
 import com.linkedin.venice.vpj.pubsub.input.PubSubPartitionSplit;
-import java.util.Properties;
 import org.apache.avro.Schema;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -52,7 +50,7 @@ public class SparkPubSubPartitionReaderFactory implements PartitionReaderFactory
     }
 
     // Setup SSL on the executor side
-    VeniceProperties configWithSsl = setupSSLForExecutor(jobConfig);
+    VeniceProperties configWithSsl = VPJSSLUtils.setupSSLForExecutor(jobConfig);
 
     final SparkPubSubInputPartition inputPartition = (SparkPubSubInputPartition) genericInputPartition;
     final PubSubPartitionSplit partitionSplit = inputPartition.getPubSubPartitionSplit();
@@ -103,27 +101,6 @@ public class SparkPubSubPartitionReaderFactory implements PartitionReaderFactory
         regionName,
         isChunkingEnabled);
     return reader;
-  }
-
-  /**
-   * Sets up SSL on the executor side before creating the PubSub consumer.
-   */
-  private VeniceProperties setupSSLForExecutor(VeniceProperties config) {
-    if (!config.containsKey(SSL_CONFIGURATOR_CLASS_CONFIG)) {
-      return config;
-    }
-    try {
-      Properties sslProps = VPJSSLUtils.getSslProperties(config);
-      Properties merged = config.toProperties();
-      merged.putAll(sslProps);
-      return new VeniceProperties(merged);
-    } catch (Exception e) {
-      String msg = "Failed to setup SSL for executor-side consumer creation. "
-          + "Ensure the Hadoop token file is accessible and SSL certificates are valid. " + "SSL configurator class: "
-          + config.getString(SSL_CONFIGURATOR_CLASS_CONFIG);
-      LOGGER.error(msg, e);
-      throw new RuntimeException(msg, e);
-    }
   }
 
   // Make it explicit that this reader does not support columnar reads.

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputUtilsTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputUtilsTest.java
@@ -1,15 +1,44 @@
 package com.linkedin.venice.hadoop.input.kafka;
 
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_CONFIG_PREFIX;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KIF_RECORD_READER_KAFKA_CONFIG_PREFIX;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.compression.CompressorFactory;
+import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.hadoop.ssl.SSLConfigurator;
+import com.linkedin.venice.kafka.protocol.ControlMessage;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.StartOfPush;
+import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
+import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
+import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
+import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.VeniceProperties;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.security.Credentials;
 import org.apache.kafka.clients.CommonClientConfigs;
@@ -72,6 +101,49 @@ public class KafkaInputUtilsTest {
   }
 
   /**
+   * Regression test for a broker-precedence bug found in review of PR #2975: getCompressor() only set
+   * KAFKA_BOOTSTRAP_SERVERS on the properties handed to the dictionary consumer, so a stale/incorrect
+   * pubsub.broker.address already present in the input properties (e.g. pointing at the destination
+   * broker) would silently take precedence over the intended source broker (see
+   * PubSubUtil#getPubSubBrokerAddress, which checks PUBSUB_BROKER_ADDRESS before falling back to
+   * KAFKA_BOOTSTRAP_SERVERS). Verifies PUBSUB_BROKER_ADDRESS is explicitly overridden with the source
+   * kafkaUrl, mirroring KafkaInputUtils#getConsumerProperties.
+   */
+  @Test
+  public void testGetCompressorOverridesStalePubSubBrokerAddressForZstdWithDict() throws IOException {
+    RecordingPubSubConsumerAdapterFactory.reset();
+
+    Properties props = new Properties();
+    props.setProperty(PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS, RecordingPubSubConsumerAdapterFactory.class.getName());
+    // A stale/incorrect broker address already present on the input properties (e.g. left over from the
+    // destination cluster config) must not win over the source kafkaUrl passed to getCompressor().
+    props.setProperty(PUBSUB_BROKER_ADDRESS, "stale-destination-broker:9999");
+    VeniceProperties veniceProperties = new VeniceProperties(props);
+
+    CompressorFactory compressorFactory = new CompressorFactory();
+    try {
+      VeniceCompressor compressor = KafkaInputUtils.getCompressor(
+          compressorFactory,
+          CompressionStrategy.ZSTD_WITH_DICT,
+          "correct-source-broker:9092",
+          "test_store_v1",
+          veniceProperties);
+      assertNotNull(compressor);
+      assertEquals(
+          RecordingPubSubConsumerAdapterFactory.getObservedBrokerAddress(),
+          "correct-source-broker:9092",
+          "PUBSUB_BROKER_ADDRESS seen by the dictionary consumer factory should be the source kafkaUrl, "
+              + "not the stale value already present in the input properties");
+      assertEquals(
+          RecordingPubSubConsumerAdapterFactory.getObservedBootstrapServers(),
+          "correct-source-broker:9092",
+          "KAFKA_BOOTSTRAP_SERVERS seen by the dictionary consumer factory should also be the source kafkaUrl");
+    } finally {
+      compressorFactory.close();
+    }
+  }
+
+  /**
    * Dummy SSLConfigurator for simulating successful SSL config setup.
    */
   public static class DummySSLConfigurator implements SSLConfigurator {
@@ -80,6 +152,80 @@ public class KafkaInputUtilsTest {
       Properties sslProps = new Properties();
       sslProps.setProperty("ssl.test.property", "sslValue");
       return sslProps;
+    }
+  }
+
+  /**
+   * Test double for {@link PubSubConsumerAdapterFactory} that records the PUBSUB_BROKER_ADDRESS and
+   * KAFKA_BOOTSTRAP_SERVERS properties it's constructed with and returns a mock consumer that serves a
+   * minimal StartOfPush control message, so getCompressor()'s ZSTD_WITH_DICT dictionary read succeeds
+   * without needing a real Kafka broker.
+   */
+  public static class RecordingPubSubConsumerAdapterFactory
+      extends PubSubConsumerAdapterFactory<PubSubConsumerAdapter> {
+    private static final AtomicReference<String> OBSERVED_BROKER_ADDRESS = new AtomicReference<>();
+    private static final AtomicReference<String> OBSERVED_BOOTSTRAP_SERVERS = new AtomicReference<>();
+
+    static void reset() {
+      OBSERVED_BROKER_ADDRESS.set(null);
+      OBSERVED_BOOTSTRAP_SERVERS.set(null);
+    }
+
+    static String getObservedBrokerAddress() {
+      return OBSERVED_BROKER_ADDRESS.get();
+    }
+
+    static String getObservedBootstrapServers() {
+      return OBSERVED_BOOTSTRAP_SERVERS.get();
+    }
+
+    @Override
+    public PubSubConsumerAdapter create(PubSubConsumerAdapterContext context) {
+      VeniceProperties properties = context.getVeniceProperties();
+      OBSERVED_BROKER_ADDRESS.set(properties.getString(PUBSUB_BROKER_ADDRESS));
+      OBSERVED_BOOTSTRAP_SERVERS.set(properties.getString(KAFKA_BOOTSTRAP_SERVERS));
+
+      PubSubConsumerAdapter consumer = mock(PubSubConsumerAdapter.class);
+      when(consumer.getAssignment()).thenReturn(Collections.emptySet());
+      AtomicReference<PubSubTopicPartition> subscribedPartition = new AtomicReference<>();
+      doAnswer(invocation -> {
+        subscribedPartition.set(invocation.getArgument(0));
+        return null;
+      }).when(consumer).subscribe(any(PubSubTopicPartition.class), any(PubSubPosition.class));
+      doAnswer(invocation -> {
+        PubSubTopicPartition topicPartition = subscribedPartition.get();
+        return Collections
+            .singletonMap(topicPartition, Collections.singletonList(createStartOfPushMessage(topicPartition)));
+      }).when(consumer).poll(anyLong());
+      return consumer;
+    }
+
+    private static DefaultPubSubMessage createStartOfPushMessage(PubSubTopicPartition topicPartition) {
+      StartOfPush startOfPush = new StartOfPush();
+      startOfPush.compressionStrategy = CompressionStrategy.ZSTD_WITH_DICT.getValue();
+      startOfPush.compressionDictionary = ByteBuffer.wrap(new byte[] { 1, 2, 3, 4 });
+
+      ControlMessage controlMessage = new ControlMessage();
+      controlMessage.controlMessageType = ControlMessageType.START_OF_PUSH.getValue();
+      controlMessage.controlMessageUnion = startOfPush;
+      KafkaMessageEnvelope envelope =
+          new KafkaMessageEnvelope(MessageType.CONTROL_MESSAGE.getValue(), null, controlMessage, null);
+      return new ImmutablePubSubMessage(
+          new KafkaKey(MessageType.CONTROL_MESSAGE, new byte[0]),
+          envelope,
+          topicPartition,
+          ApacheKafkaOffsetPosition.of(0),
+          0L,
+          0);
+    }
+
+    @Override
+    public String getName() {
+      return RecordingPubSubConsumerAdapterFactory.class.getSimpleName();
+    }
+
+    @Override
+    public void close() throws IOException {
     }
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/TestVPJSSLUtils.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/TestVPJSSLUtils.java
@@ -13,10 +13,18 @@ import java.util.Properties;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.testng.Assert;
 import org.testng.SkipException;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
 public class TestVPJSSLUtils {
+  @BeforeMethod
+  public void resetExecutorSslPropsCache() {
+    // Ensure each test starts from a clean per-JVM SSL properties cache, since Gradle may reuse the
+    // same test worker JVM across test methods/classes.
+    VPJSSLUtils.resetExecutorSslPropsCacheForTests();
+  }
+
   @Test(expectedExceptions = VeniceException.class)
   public void testValidateInvalidSslProperties() {
     VPJSSLUtils.validateSslProperties(VeniceProperties.empty());

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/TestVPJSSLUtils.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/TestVPJSSLUtils.java
@@ -1,14 +1,18 @@
 package com.linkedin.venice.hadoop.utils;
 
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_PASSWORD_PROPERTY_NAME;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_STORE_PASSWORD_PROPERTY_NAME;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_STORE_PROPERTY_NAME;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_TRUST_STORE_PROPERTY_NAME;
 
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.hadoop.ssl.TempFileSSLConfigurator;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Properties;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 
@@ -29,6 +33,48 @@ public class TestVPJSSLUtils {
       VPJSSLUtils.validateSslProperties(new VeniceProperties(props));
     } catch (Exception e) {
       Assert.fail("Should not throw any exception");
+    }
+  }
+
+  @Test
+  public void testSetupSSLForExecutorIsNoOpWithoutSslConfigurator() {
+    VeniceProperties props = new VeniceProperties(new Properties());
+    VeniceProperties result = VPJSSLUtils.setupSSLForExecutor(props);
+    Assert.assertSame(
+        result,
+        props,
+        "setupSSLForExecutor should return the original properties unchanged when no SSL configurator is configured");
+  }
+
+  /**
+   * Edge/failure case: when an SSL configurator is configured but the Hadoop token file location cannot be
+   * resolved, executor-side SSL materialization must fail loudly with a VeniceException instead of silently
+   * falling back to a consumer/filter without SSL properties (which previously caused missing
+   * "ssl.keystore.type" failures deep inside PubSub consumer creation).
+   */
+  @Test
+  public void testSetupSSLForExecutorThrowsWhenTokenFileIsUnresolvable() {
+    if (System.getenv(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION) != null) {
+      throw new SkipException(
+          "Skipping because " + UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION
+              + " is set in the test environment and would make the failure scenario unreachable");
+    }
+
+    String previousTokenFileLocation = System.getProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
+    System.clearProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
+    try {
+      Properties props = new Properties();
+      props.setProperty(SSL_CONFIGURATOR_CLASS_CONFIG, TempFileSSLConfigurator.class.getName());
+      VPJSSLUtils.setupSSLForExecutor(new VeniceProperties(props));
+      Assert.fail("Expected a VeniceException when the Hadoop token file location cannot be resolved");
+    } catch (VeniceException e) {
+      Assert.assertTrue(
+          e.getMessage().contains("Failed to setup SSL for executor-side PubSub client creation"),
+          "Unexpected exception message: " + e.getMessage());
+    } finally {
+      if (previousTokenFileLocation != null) {
+        System.setProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION, previousTokenFileLocation);
+      }
     }
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/SparkExecutorTestUtils.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/SparkExecutorTestUtils.java
@@ -1,0 +1,190 @@
+package com.linkedin.venice.spark;
+
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_LOCATION;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_PASSWORD;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_TYPE;
+import static com.linkedin.venice.CommonConfigKeys.SSL_KEY_PASSWORD;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_LOCATION;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_PASSWORD;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_TYPE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.compression.ZstdWithDictCompressor;
+import com.linkedin.venice.hadoop.ssl.SSLConfigurator;
+import com.linkedin.venice.hadoop.ssl.UserCredentialsFactory;
+import com.linkedin.venice.kafka.protocol.ControlMessage;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.StartOfPush;
+import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
+import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
+import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
+import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+
+
+public final class SparkExecutorTestUtils {
+  public static final String TEST_KEYSTORE_TYPE = "PKCS12";
+  public static final String TEST_TRUSTSTORE_TYPE = "JKS";
+  private static final byte[] TEST_DICTIONARY = ZstdWithDictCompressor.buildDictionaryOnSyntheticAvroData();
+  private static final AtomicInteger SSL_CONFIGURATOR_INVOCATIONS = new AtomicInteger();
+  private static final AtomicInteger CONSUMER_FACTORY_INVOCATIONS = new AtomicInteger();
+  private static final AtomicInteger DICTIONARY_CONSUMER_INVOCATIONS = new AtomicInteger();
+
+  private SparkExecutorTestUtils() {
+  }
+
+  public static void resetInvocations() {
+    SSL_CONFIGURATOR_INVOCATIONS.set(0);
+    CONSUMER_FACTORY_INVOCATIONS.set(0);
+    DICTIONARY_CONSUMER_INVOCATIONS.set(0);
+  }
+
+  public static int getSslConfiguratorInvocations() {
+    return SSL_CONFIGURATOR_INVOCATIONS.get();
+  }
+
+  public static int getConsumerFactoryInvocations() {
+    return CONSUMER_FACTORY_INVOCATIONS.get();
+  }
+
+  public static int getDictionaryConsumerInvocations() {
+    return DICTIONARY_CONSUMER_INVOCATIONS.get();
+  }
+
+  public static byte[] getTestDictionary() {
+    return Arrays.copyOf(TEST_DICTIONARY, TEST_DICTIONARY.length);
+  }
+
+  public static void withTokenFile(ThrowingRunnable runnable) throws Exception {
+    synchronized (SparkExecutorTestUtils.class) {
+      File tokenFile = Files.createTempFile("spark-executor-ssl", ".tokens").toFile();
+      String tokenFileProperty = UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
+      String previousTokenFile = System.getProperty(tokenFileProperty);
+      try {
+        Credentials credentials = new Credentials();
+        for (int i = 0; i < UserCredentialsFactory.REQUIRED_SECRET_KEY_COUNT; i++) {
+          credentials.addSecretKey(new Text("secret-" + i), ("value-" + i).getBytes(StandardCharsets.UTF_8));
+        }
+        credentials.writeTokenStorageFile(new Path(tokenFile.toURI()), new Configuration());
+        System.setProperty(tokenFileProperty, tokenFile.getAbsolutePath());
+        runnable.run();
+      } finally {
+        if (previousTokenFile == null) {
+          System.clearProperty(tokenFileProperty);
+        } else {
+          System.setProperty(tokenFileProperty, previousTokenFile);
+        }
+        Files.deleteIfExists(tokenFile.toPath());
+      }
+    }
+  }
+
+  public static class RecordingSSLConfigurator implements SSLConfigurator {
+    @Override
+    public Properties setupSSLConfig(Properties properties, Credentials userCredentials) {
+      SSL_CONFIGURATOR_INVOCATIONS.incrementAndGet();
+      Properties sslProperties = new Properties();
+      sslProperties.setProperty(SSL_KEYSTORE_TYPE, TEST_KEYSTORE_TYPE);
+      sslProperties.setProperty(SSL_TRUSTSTORE_TYPE, TEST_TRUSTSTORE_TYPE);
+      sslProperties.setProperty(SSL_KEYSTORE_LOCATION, "/tmp/test-keystore");
+      sslProperties.setProperty(SSL_TRUSTSTORE_LOCATION, "/tmp/test-truststore");
+      sslProperties.setProperty(SSL_KEYSTORE_PASSWORD, "test-password");
+      sslProperties.setProperty(SSL_TRUSTSTORE_PASSWORD, "test-password");
+      sslProperties.setProperty(SSL_KEY_PASSWORD, "test-password");
+      return sslProperties;
+    }
+  }
+
+  public static class AssertingPubSubConsumerAdapterFactory
+      extends PubSubConsumerAdapterFactory<PubSubConsumerAdapter> {
+    @Override
+    public PubSubConsumerAdapter create(PubSubConsumerAdapterContext context) {
+      VeniceProperties properties = context.getVeniceProperties();
+      assertEquals(properties.getString(SSL_KEYSTORE_TYPE), TEST_KEYSTORE_TYPE);
+      assertEquals(properties.getString(SSL_TRUSTSTORE_TYPE), TEST_TRUSTSTORE_TYPE);
+      CONSUMER_FACTORY_INVOCATIONS.incrementAndGet();
+
+      PubSubConsumerAdapter consumer = mock(PubSubConsumerAdapter.class);
+      when(consumer.getAssignment()).thenReturn(Collections.emptySet());
+      if (context.getConsumerName().contains("DictionaryUtilsConsumer")) {
+        DICTIONARY_CONSUMER_INVOCATIONS.incrementAndGet();
+        configureDictionaryConsumer(consumer);
+      }
+      return consumer;
+    }
+
+    private static void configureDictionaryConsumer(PubSubConsumerAdapter consumer) {
+      AtomicReference<PubSubTopicPartition> subscribedPartition = new AtomicReference<>();
+      doAnswer(invocation -> {
+        subscribedPartition.set(invocation.getArgument(0));
+        return null;
+      }).when(consumer).subscribe(any(PubSubTopicPartition.class), any(PubSubPosition.class));
+      doAnswer(invocation -> {
+        PubSubTopicPartition topicPartition = subscribedPartition.get();
+        return Collections
+            .singletonMap(topicPartition, Collections.singletonList(createStartOfPushMessage(topicPartition)));
+      }).when(consumer).poll(anyLong());
+    }
+
+    private static DefaultPubSubMessage createStartOfPushMessage(PubSubTopicPartition topicPartition) {
+      StartOfPush startOfPush = new StartOfPush();
+      startOfPush.compressionStrategy = CompressionStrategy.ZSTD_WITH_DICT.getValue();
+      startOfPush.compressionDictionary = ByteBuffer.wrap(TEST_DICTIONARY);
+
+      ControlMessage controlMessage = new ControlMessage();
+      controlMessage.controlMessageType = ControlMessageType.START_OF_PUSH.getValue();
+      controlMessage.controlMessageUnion = startOfPush;
+      KafkaMessageEnvelope envelope =
+          new KafkaMessageEnvelope(MessageType.CONTROL_MESSAGE.getValue(), null, controlMessage, null);
+      return new ImmutablePubSubMessage(
+          new KafkaKey(MessageType.CONTROL_MESSAGE, new byte[0]),
+          envelope,
+          topicPartition,
+          ApacheKafkaOffsetPosition.of(0),
+          0L,
+          0);
+    }
+
+    @Override
+    public String getName() {
+      return AssertingPubSubConsumerAdapterFactory.class.getSimpleName();
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+  }
+
+  @FunctionalInterface
+  public interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJobRepushTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJobRepushTest.java
@@ -2,9 +2,25 @@ package com.linkedin.venice.spark.datawriter.jobs;
 
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
+import static com.linkedin.venice.spark.SparkConstants.CHUNKED_KEY_SUFFIX_COLUMN_NAME;
+import static com.linkedin.venice.spark.SparkConstants.KEY_COLUMN_NAME;
+import static com.linkedin.venice.spark.SparkConstants.MESSAGE_TYPE;
+import static com.linkedin.venice.spark.SparkConstants.MESSAGE_TYPE_COLUMN_NAME;
+import static com.linkedin.venice.spark.SparkConstants.OFFSET;
+import static com.linkedin.venice.spark.SparkConstants.OFFSET_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.RAW_PUBSUB_INPUT_TABLE_SCHEMA;
+import static com.linkedin.venice.spark.SparkConstants.REPLICATION_METADATA_PAYLOAD;
+import static com.linkedin.venice.spark.SparkConstants.RMD_COLUMN_NAME;
+import static com.linkedin.venice.spark.SparkConstants.RMD_VERSION_ID_COLUMN_NAME;
+import static com.linkedin.venice.spark.SparkConstants.SCHEMA_ID_COLUMN_NAME;
+import static com.linkedin.venice.spark.SparkConstants.VALUE_COLUMN_NAME;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_TOPIC_CHUNKING_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.PARTITION_COUNT;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_PASSWORD_PROPERTY_NAME;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_KEY_STORE_PROPERTY_NAME;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_TRUST_STORE_PROPERTY_NAME;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.TOPIC_PROP;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_PUSH_DESTINATION_PUBSUB_BROKER;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
@@ -14,6 +30,7 @@ import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.CompressorFactory;
 import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.hadoop.PushJobSetting;
+import com.linkedin.venice.hadoop.ssl.TempFileSSLConfigurator;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
@@ -29,12 +46,14 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.spark.api.java.function.MapPartitionsFunction;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
@@ -288,6 +307,191 @@ public class DataWriterSparkJobRepushTest {
       deleteDirectory(valueSchemaTempDir);
       deleteDirectory(rmdSchemaTempDir);
     }
+  }
+
+  /**
+   * Edge/failure case regression test: when TTL filtering is enabled and an SSL configurator is configured,
+   * executor-side SSL materialization must run before the raw TTL filter is constructed in the
+   * {@code mapPartitions} closure. Before this fix, {@code SparkKafkaInputTTLFilter} was constructed directly
+   * from broadcast job properties and never attempted SSL materialization, so this scenario would silently
+   * succeed instead of failing when the Hadoop token file cannot be resolved. This test forces Spark to
+   * actually execute the closure (via {@code collectAsList()}) so the fix is exercised end-to-end.
+   */
+  @Test
+  public void testApplyTTLFilterMaterializesExecutorSSL() throws Exception {
+    skipIfHadoopTokenFileEnvIsSet();
+    String testName = "testApplyTTLFilterMaterializesExecutorSSL";
+
+    File valueSchemaTempDir = Files.createTempDirectory("value-schemas").toFile();
+    File rmdSchemaTempDir = Files.createTempDirectory("rmd-schemas").toFile();
+    String previousTokenFileLocation = System.getProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
+    System.clearProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
+    try {
+      TestableDataWriterSparkJob job = new TestableDataWriterSparkJob(testName);
+      currentTestJob = job;
+
+      long ttlStartTime = System.currentTimeMillis();
+      Properties props = createDefaultTestProperties();
+      props.setProperty("repush.ttl.policy", "0"); // RT_WRITE_ONLY
+      props.setProperty("repush.ttl.start.timestamp", String.valueOf(ttlStartTime));
+      props.setProperty("value.schema.dir", valueSchemaTempDir.getAbsolutePath());
+      props.setProperty("rmd.schema.dir", rmdSchemaTempDir.getAbsolutePath());
+      props.setProperty("kafka.input.source.compression.strategy", "NO_OP");
+      props.setProperty(SSL_CONFIGURATOR_CLASS_CONFIG, TempFileSSLConfigurator.class.getName());
+      props.setProperty(SSL_KEY_STORE_PROPERTY_NAME, "identity.p12");
+      props.setProperty(SSL_TRUST_STORE_PROPERTY_NAME, "identity.jks");
+      props.setProperty(SSL_KEY_PASSWORD_PROPERTY_NAME, "test-password");
+
+      PushJobSetting setting = new PushJobSetting();
+      setting.isSourceKafka = true;
+      setting.kafkaInputTopic = "test_store_v1";
+      setting.repushSourcePubsubBroker = "localhost:9092";
+      setting.repushTTLEnabled = true;
+      setting.repushTTLStartTimeMs = ttlStartTime;
+      setting.valueSchemaDir = valueSchemaTempDir.getAbsolutePath();
+      setting.rmdSchemaDir = rmdSchemaTempDir.getAbsolutePath();
+      setting.topic = "test_store_v1";
+      setting.pushDestinationPubsubBroker = "localhost:9092";
+      setting.partitionerClass = DefaultVenicePartitioner.class.getName();
+      setting.partitionCount = 1;
+      setting.sourceKafkaInputVersionInfo = new VersionImpl("test_store", 1, "test-push-id");
+      // enableSSL must be true for setupCommonSparkConf() to propagate the SSL configurator class
+      // into the Spark session conf, which is how applyTTLFilter()/applyChunkAssembly() broadcast
+      // properties pick it up on the executor side.
+      setting.enableSSL = true;
+
+      job.configure(new VeniceProperties(props), setting);
+
+      List<Row> rows = Arrays.asList(createChunkedRow("key1", "chunk1", -1, 1L));
+      Dataset<Row> inputDF = job.getSparkSession().createDataFrame(rows, RAW_PUBSUB_INPUT_TABLE_SCHEMA);
+      Dataset<Row> outputDF = job.testableApplyTTLFilter(inputDF);
+
+      try {
+        outputDF.collectAsList();
+        fail("Expected executor-side SSL materialization to fail with an unresolved Hadoop token file");
+      } catch (Exception e) {
+        assertTrue(
+            containsCauseMessage(e, "Failed to setup SSL for executor-side PubSub client creation"),
+            "Unexpected failure while executing the TTL filter mapPartitions closure: " + e);
+      }
+    } finally {
+      if (previousTokenFileLocation != null) {
+        System.setProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION, previousTokenFileLocation);
+      }
+      deleteDirectory(valueSchemaTempDir);
+      deleteDirectory(rmdSchemaTempDir);
+    }
+  }
+
+  /**
+   * Edge/failure case regression test: the same SSL materialization gap existed in the chunk assembly
+   * {@code flatMapGroups} closure when TTL filtering is enabled. Before this fix, {@code SparkChunkAssembler}
+   * was constructed directly from broadcast job properties, so this scenario would silently succeed instead
+   * of failing when the Hadoop token file cannot be resolved.
+   */
+  @Test
+  public void testApplyChunkAssemblyMaterializesExecutorSSL() throws Exception {
+    skipIfHadoopTokenFileEnvIsSet();
+    String testName = "testApplyChunkAssemblyMaterializesExecutorSSL";
+
+    File valueSchemaTempDir = Files.createTempDirectory("value-schemas").toFile();
+    File rmdSchemaTempDir = Files.createTempDirectory("rmd-schemas").toFile();
+    String previousTokenFileLocation = System.getProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
+    System.clearProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
+    try {
+      TestableDataWriterSparkJob job = new TestableDataWriterSparkJob(testName);
+      currentTestJob = job;
+
+      long ttlStartTime = System.currentTimeMillis();
+      Properties props = createDefaultTestProperties();
+      props.setProperty("repush.ttl.policy", "0"); // RT_WRITE_ONLY
+      props.setProperty("repush.ttl.start.timestamp", String.valueOf(ttlStartTime));
+      props.setProperty("value.schema.dir", valueSchemaTempDir.getAbsolutePath());
+      props.setProperty("rmd.schema.dir", rmdSchemaTempDir.getAbsolutePath());
+      props.setProperty("kafka.input.source.compression.strategy", "NO_OP");
+      props.setProperty(KAFKA_INPUT_SOURCE_TOPIC_CHUNKING_ENABLED, "true");
+      props.setProperty(SSL_CONFIGURATOR_CLASS_CONFIG, TempFileSSLConfigurator.class.getName());
+      props.setProperty(SSL_KEY_STORE_PROPERTY_NAME, "identity.p12");
+      props.setProperty(SSL_TRUST_STORE_PROPERTY_NAME, "identity.jks");
+      props.setProperty(SSL_KEY_PASSWORD_PROPERTY_NAME, "test-password");
+
+      PushJobSetting setting = new PushJobSetting();
+      setting.isSourceKafka = true;
+      setting.kafkaInputTopic = "test_store_v1";
+      setting.repushSourcePubsubBroker = "localhost:9092";
+      setting.repushTTLEnabled = true;
+      setting.repushTTLStartTimeMs = ttlStartTime;
+      setting.valueSchemaDir = valueSchemaTempDir.getAbsolutePath();
+      setting.rmdSchemaDir = rmdSchemaTempDir.getAbsolutePath();
+      setting.topic = "test_store_v1";
+      setting.pushDestinationPubsubBroker = "localhost:9092";
+      setting.partitionerClass = DefaultVenicePartitioner.class.getName();
+      setting.partitionCount = 1;
+      VersionImpl sourceVersion = new VersionImpl("test_store", 1, "test-push-id");
+      sourceVersion.setChunkingEnabled(true);
+      setting.sourceKafkaInputVersionInfo = sourceVersion;
+      // enableSSL must be true for setupCommonSparkConf() to propagate the SSL configurator class
+      // into the Spark session conf, which is how applyTTLFilter()/applyChunkAssembly() broadcast
+      // properties pick it up on the executor side.
+      setting.enableSSL = true;
+
+      job.configure(new VeniceProperties(props), setting);
+
+      // A single non-chunked row is enough: the chunk assembler is constructed for any non-empty key group,
+      // regardless of whether the record turns out to be an actual chunk.
+      List<Row> rows = Arrays.asList(createPutRow("key1", "value1", 1L));
+      Dataset<Row> rawInputDF = job.getSparkSession().createDataFrame(rows, RAW_PUBSUB_INPUT_TABLE_SCHEMA);
+      // applyChunkAssembly() expects the same key/value/rmd/(+chunking metadata) shape that
+      // getInputDataFrame() produces for chunked input, not the raw pubsub schema.
+      Dataset<Row> chunkAssemblyInputDF = rawInputDF.selectExpr(
+          KEY_COLUMN_NAME,
+          VALUE_COLUMN_NAME,
+          "CAST(" + REPLICATION_METADATA_PAYLOAD + " AS BINARY) as " + RMD_COLUMN_NAME,
+          SCHEMA_ID_COLUMN_NAME + " as " + SCHEMA_ID_COLUMN_NAME,
+          RMD_VERSION_ID_COLUMN_NAME + " as " + RMD_VERSION_ID_COLUMN_NAME,
+          OFFSET + " as " + OFFSET_COLUMN_NAME,
+          MESSAGE_TYPE + " as " + MESSAGE_TYPE_COLUMN_NAME,
+          CHUNKED_KEY_SUFFIX_COLUMN_NAME + " as " + CHUNKED_KEY_SUFFIX_COLUMN_NAME);
+      Dataset<Row> outputDF = job.testableApplyChunkAssembly(chunkAssemblyInputDF);
+
+      try {
+        outputDF.collectAsList();
+        fail("Expected executor-side SSL materialization to fail with an unresolved Hadoop token file");
+      } catch (Exception e) {
+        assertTrue(
+            containsCauseMessage(e, "Failed to setup SSL for executor-side PubSub client creation"),
+            "Unexpected failure while executing the chunk assembly flatMapGroups closure: " + e);
+      }
+    } finally {
+      if (previousTokenFileLocation != null) {
+        System.setProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION, previousTokenFileLocation);
+      }
+      deleteDirectory(valueSchemaTempDir);
+      deleteDirectory(rmdSchemaTempDir);
+    }
+  }
+
+  /**
+   * Hadoop token file resolution prefers the environment variable over the system property. If the test
+   * environment already has it set, clearing the system property alone can't force the failure scenario.
+   */
+  private void skipIfHadoopTokenFileEnvIsSet() {
+    if (System.getenv(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION) != null) {
+      throw new SkipException(
+          "Skipping because " + UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION
+              + " is set in the test environment and would make the failure scenario unreachable");
+    }
+  }
+
+  private boolean containsCauseMessage(Throwable t, String expectedMessageFragment) {
+    Throwable current = t;
+    while (current != null) {
+      if (current.getMessage() != null && current.getMessage().contains(expectedMessageFragment)) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
   }
 
   private Row createChunkedRow(String key, String chunkData, int negativeSchemaId, long offset) {
@@ -737,7 +941,7 @@ public class DataWriterSparkJobRepushTest {
   }
 
   /**
-   * Testable subclass that exposes applyTTLFilter for direct testing.
+   * Testable subclass that exposes applyTTLFilter and applyChunkAssembly for direct testing.
    */
   private class TestableDataWriterSparkJob extends TestDataWriterSparkJob {
     TestableDataWriterSparkJob(String testName) {
@@ -746,6 +950,10 @@ public class DataWriterSparkJobRepushTest {
 
     public Dataset<Row> testableApplyTTLFilter(Dataset<Row> dataFrame) {
       return super.applyTTLFilter(dataFrame);
+    }
+
+    public Dataset<Row> testableApplyChunkAssembly(Dataset<Row> dataFrame) {
+      return super.applyChunkAssembly(dataFrame);
     }
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJobRepushTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJobRepushTest.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.spark.datawriter.jobs;
 
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
+import static com.linkedin.venice.ConfigKeys.PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.spark.SparkConstants.CHUNKED_KEY_SUFFIX_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.KEY_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.MESSAGE_TYPE;
@@ -12,6 +13,7 @@ import static com.linkedin.venice.spark.SparkConstants.RAW_PUBSUB_INPUT_TABLE_SC
 import static com.linkedin.venice.spark.SparkConstants.REPLICATION_METADATA_PAYLOAD;
 import static com.linkedin.venice.spark.SparkConstants.RMD_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.RMD_VERSION_ID_COLUMN_NAME;
+import static com.linkedin.venice.spark.SparkConstants.SCHEMA_FOR_CHUNK_ASSEMBLY;
 import static com.linkedin.venice.spark.SparkConstants.SCHEMA_ID_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.VALUE_COLUMN_NAME;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_TOPIC_CHUNKING_ENABLED;
@@ -31,21 +33,37 @@ import com.linkedin.venice.compression.CompressorFactory;
 import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.hadoop.PushJobSetting;
 import com.linkedin.venice.hadoop.ssl.TempFileSSLConfigurator;
+import com.linkedin.venice.kafka.protocol.GUID;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
+import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.ChunkedKeySuffixSerializer;
+import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.spark.SparkExecutorTestUtils;
 import com.linkedin.venice.spark.datawriter.task.DataWriterAccumulators;
 import com.linkedin.venice.spark.datawriter.writer.TestSparkPartitionWriter;
+import com.linkedin.venice.storage.protocol.ChunkId;
+import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
+import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.spark.api.java.function.MapPartitionsFunction;
 import org.apache.spark.broadcast.Broadcast;
@@ -472,6 +490,203 @@ public class DataWriterSparkJobRepushTest {
   }
 
   /**
+   * Ported from PR #2955's DataWriterSparkJobRepushTest.testApplyTTLFilterMaterializesSSLBeforeReadingZstdDictionary().
+   * Exercises the real bug scenario end-to-end: TTL filtering with ZSTD_WITH_DICT compression, which makes
+   * SparkKafkaInputTTLFilter create a second, internal "dictionary" PubSub consumer on the executor. Verifies
+   * the SSL configurator and PubSub consumer factory are actually invoked with correctly materialized SSL
+   * properties (not just that failure surfaces when SSL setup is skipped).
+   */
+  @Test
+  public void testApplyTTLFilterMaterializesSSLBeforeReadingZstdDictionary() throws Exception {
+    String testName = "testApplyTTLFilterMaterializesSSLBeforeReadingZstdDictionary";
+
+    File valueSchemaTempDir = Files.createTempDirectory("value-schemas").toFile();
+    File rmdSchemaTempDir = Files.createTempDirectory("rmd-schemas").toFile();
+
+    try {
+      TestableDataWriterSparkJob job = new TestableDataWriterSparkJob(testName);
+      currentTestJob = job;
+
+      String valueSchemaStr =
+          "{\"type\":\"record\",\"name\":\"TestValue\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"}]}";
+      String rmdSchemaStr =
+          "{\"type\":\"record\",\"name\":\"RmdRecord\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\"}]}";
+      Files.write(new File(valueSchemaTempDir, "1").toPath(), valueSchemaStr.getBytes());
+      Files.write(new File(rmdSchemaTempDir, "1_1").toPath(), rmdSchemaStr.getBytes());
+
+      long ttlStartTime = System.currentTimeMillis();
+      Properties props = createDefaultTestProperties();
+      props.setProperty("repush.ttl.policy", "0");
+      props.setProperty("repush.ttl.start.timestamp", String.valueOf(ttlStartTime));
+      props.setProperty("value.schema.dir", valueSchemaTempDir.getAbsolutePath());
+      props.setProperty("rmd.schema.dir", rmdSchemaTempDir.getAbsolutePath());
+      props.setProperty("kafka.input.source.compression.strategy", CompressionStrategy.ZSTD_WITH_DICT.name());
+      props.setProperty(SSL_CONFIGURATOR_CLASS_CONFIG, SparkExecutorTestUtils.RecordingSSLConfigurator.class.getName());
+      props.setProperty(
+          PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS,
+          SparkExecutorTestUtils.AssertingPubSubConsumerAdapterFactory.class.getName());
+      props.setProperty("pass.through.config.prefixes.list", "pubsub.");
+      props.setProperty(SSL_KEY_STORE_PROPERTY_NAME, "test-keystore-credential");
+      props.setProperty(SSL_TRUST_STORE_PROPERTY_NAME, "test-truststore-credential");
+      props.setProperty(SSL_KEY_PASSWORD_PROPERTY_NAME, "test-key-password-credential");
+
+      PushJobSetting setting = new PushJobSetting();
+      setting.isSourceKafka = true;
+      setting.enableSSL = true;
+      setting.sslToKafka = true;
+      setting.kafkaInputTopic = "test_store_v1";
+      setting.repushSourcePubsubBroker = "localhost:9092";
+      setting.repushTTLEnabled = true;
+      setting.repushTTLStartTimeMs = ttlStartTime;
+      setting.valueSchemaDir = valueSchemaTempDir.getAbsolutePath();
+      setting.rmdSchemaDir = rmdSchemaTempDir.getAbsolutePath();
+      setting.topic = "test_store_v1";
+      setting.pushDestinationPubsubBroker = "localhost:9092";
+      setting.partitionerClass = DefaultVenicePartitioner.class.getName();
+      setting.partitionCount = 1;
+      Version sourceVersion = new VersionImpl("test_store", 1, "test-push-id");
+      sourceVersion.setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT);
+      setting.sourceKafkaInputVersionInfo = sourceVersion;
+
+      job.configure(new VeniceProperties(props), setting);
+
+      List<Row> rows =
+          Arrays.asList(createChunkedRow("key1", "chunk1", -1, 1L), createChunkedRow("key2", "chunk2", -20, 2L));
+      Dataset<Row> inputDF = job.getSparkSession().createDataFrame(rows, RAW_PUBSUB_INPUT_TABLE_SCHEMA);
+
+      SparkExecutorTestUtils.resetInvocations();
+      SparkExecutorTestUtils.withTokenFile(() -> {
+        List<Row> outputRows = job.testableApplyTTLFilter(inputDF).collectAsList();
+        assertEquals(outputRows.size(), rows.size());
+        assertTrue(SparkExecutorTestUtils.getSslConfiguratorInvocations() > 0);
+        assertTrue(SparkExecutorTestUtils.getConsumerFactoryInvocations() > 0);
+        assertTrue(SparkExecutorTestUtils.getDictionaryConsumerInvocations() > 0);
+      });
+    } finally {
+      deleteDirectory(valueSchemaTempDir);
+      deleteDirectory(rmdSchemaTempDir);
+    }
+  }
+
+  /**
+   * Adapted from PR #2955's DataWriterSparkJobRepushTest.testApplyChunkAssemblyReusesExecutorSSLForPostAssemblyTTL().
+   * Exercises the real bug scenario end-to-end for the chunk-assembly path: TTL filtering with ZSTD_WITH_DICT
+   * compression after chunk reassembly, which makes SparkChunkAssembler create a second, internal "dictionary"
+   * PubSub consumer on the executor. Verifies the SSL configurator and PubSub consumer factory are invoked with
+   * correctly materialized SSL properties and that chunk reassembly still produces the correct output.
+   *
+   * Unlike the original PR #2955 test, this does NOT assert that the SSL configurator/consumer factory are
+   * invoked exactly once across both key groups in the task - that de-duplication comes from PR #2955's
+   * per-task assembler caching refactor, which is intentionally out of scope for this simplified fix (see PR
+   * description). This simplified fix constructs a new SparkChunkAssembler per key group, so SSL materialization
+   * and dictionary-consumer creation happen once per key group (twice here, for the two key groups below).
+   */
+  @Test
+  public void testApplyChunkAssemblyMaterializesSSLBeforePostAssemblyTTL() throws Exception {
+    String testName = "testApplyChunkAssemblyMaterializesSSLBeforePostAssemblyTTL";
+
+    File valueSchemaTempDir = Files.createTempDirectory("value-schemas").toFile();
+    File rmdSchemaTempDir = Files.createTempDirectory("rmd-schemas").toFile();
+
+    try {
+      Schema valueSchema = new Schema.Parser()
+          .parse("{\"type\":\"record\",\"name\":\"TestValue\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"}]}");
+      Schema rmdSchema = new Schema.Parser().parse(
+          "{\"type\":\"record\",\"name\":\"RmdRecord\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\"}]}");
+      Files.write(new File(valueSchemaTempDir, "1").toPath(), valueSchema.toString().getBytes());
+      Files.write(new File(rmdSchemaTempDir, "1_1").toPath(), rmdSchema.toString().getBytes());
+
+      long ttlStartTime = System.currentTimeMillis();
+      GenericRecord valueRecord = new GenericData.Record(valueSchema);
+      valueRecord.put("id", "fresh-value");
+      GenericRecord rmdRecord = new GenericData.Record(rmdSchema);
+      rmdRecord.put("timestamp", ttlStartTime + 1_000);
+
+      RecordSerializer<GenericRecord> valueSerializer =
+          FastSerializerDeserializerFactory.getFastAvroGenericSerializer(valueSchema);
+      RecordSerializer<GenericRecord> rmdSerializer =
+          FastSerializerDeserializerFactory.getFastAvroGenericSerializer(rmdSchema);
+      byte[] serializedValue = valueSerializer.serialize(valueRecord);
+      byte[] serializedRmd = rmdSerializer.serialize(rmdRecord);
+
+      CompressorFactory compressorFactory = new CompressorFactory();
+      VeniceCompressor zstdCompressor = compressorFactory.createVersionSpecificCompressorIfNotExist(
+          CompressionStrategy.ZSTD_WITH_DICT,
+          "spark-chunked-ttl-test",
+          SparkExecutorTestUtils.getTestDictionary());
+      byte[] compressedValue = ByteUtils.extractByteArray(zstdCompressor.compress(ByteBuffer.wrap(serializedValue), 0));
+
+      TestableDataWriterSparkJob job = new TestableDataWriterSparkJob(testName);
+      currentTestJob = job;
+
+      Properties props = createDefaultTestProperties();
+      props.setProperty("repush.ttl.policy", "0");
+      props.setProperty("repush.ttl.start.timestamp", String.valueOf(ttlStartTime));
+      props.setProperty("value.schema.dir", valueSchemaTempDir.getAbsolutePath());
+      props.setProperty("rmd.schema.dir", rmdSchemaTempDir.getAbsolutePath());
+      props.setProperty("kafka.input.source.compression.strategy", CompressionStrategy.ZSTD_WITH_DICT.name());
+      props.setProperty(SSL_CONFIGURATOR_CLASS_CONFIG, SparkExecutorTestUtils.RecordingSSLConfigurator.class.getName());
+      props.setProperty(
+          PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS,
+          SparkExecutorTestUtils.AssertingPubSubConsumerAdapterFactory.class.getName());
+      props.setProperty("pass.through.config.prefixes.list", "pubsub.");
+      props.setProperty(SSL_KEY_STORE_PROPERTY_NAME, "test-keystore-credential");
+      props.setProperty(SSL_TRUST_STORE_PROPERTY_NAME, "test-truststore-credential");
+      props.setProperty(SSL_KEY_PASSWORD_PROPERTY_NAME, "test-key-password-credential");
+
+      PushJobSetting setting = new PushJobSetting();
+      setting.isSourceKafka = true;
+      setting.enableSSL = true;
+      setting.sslToKafka = true;
+      setting.kafkaInputTopic = "test_store_v1";
+      setting.repushSourcePubsubBroker = "localhost:9092";
+      setting.repushTTLEnabled = true;
+      setting.repushTTLStartTimeMs = ttlStartTime;
+      setting.valueSchemaDir = valueSchemaTempDir.getAbsolutePath();
+      setting.rmdSchemaDir = rmdSchemaTempDir.getAbsolutePath();
+      setting.topic = "test_store_v1";
+      setting.pushDestinationPubsubBroker = "localhost:9092";
+      setting.partitionerClass = DefaultVenicePartitioner.class.getName();
+      setting.partitionCount = 1;
+      Version sourceVersion = new VersionImpl("test_store", 1, "test-push-id");
+      sourceVersion.setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT);
+      sourceVersion.setChunkingEnabled(true);
+      setting.sourceKafkaInputVersionInfo = sourceVersion;
+
+      job.configure(new VeniceProperties(props), setting);
+      job.getSparkSession().conf().set("spark.sql.shuffle.partitions", "1");
+
+      byte[] chunkedKey = "chunked-key".getBytes();
+      byte[] regularKey = "regular-key".getBytes();
+      List<Row> rows = new ArrayList<>();
+      rows.addAll(createSingleChunkRows(chunkedKey, compressedValue, serializedRmd));
+      rows.add(createAssemblyRow(regularKey, compressedValue, serializedRmd, 1, 1, 3L, null));
+      Dataset<Row> inputDF = job.getSparkSession().createDataFrame(rows, SCHEMA_FOR_CHUNK_ASSEMBLY);
+
+      SparkExecutorTestUtils.resetInvocations();
+      SparkExecutorTestUtils.withTokenFile(() -> {
+        List<Row> outputRows = job.testableApplyChunkAssembly(inputDF).collectAsList();
+
+        assertEquals(outputRows.size(), 2);
+        Row assembledChunk = outputRows.stream()
+            .filter(row -> Arrays.equals((byte[]) row.getAs("key"), chunkedKey))
+            .findFirst()
+            .orElse(null);
+        assertNotNull(assembledChunk, "Chunked value should survive post-assembly TTL filtering");
+        assertTrue(Arrays.equals((byte[]) assembledChunk.getAs("value"), compressedValue));
+        // No per-task assembler caching in this simplified fix: SSL is materialized and a dictionary
+        // consumer is created once per key group (2 key groups here), not once per task.
+        assertEquals(SparkExecutorTestUtils.getSslConfiguratorInvocations(), 2);
+        assertEquals(SparkExecutorTestUtils.getConsumerFactoryInvocations(), 2);
+        assertEquals(SparkExecutorTestUtils.getDictionaryConsumerInvocations(), 2);
+      });
+    } finally {
+      deleteDirectory(valueSchemaTempDir);
+      deleteDirectory(rmdSchemaTempDir);
+    }
+  }
+
+  /**
    * Hadoop token file resolution prefers the environment variable over the system property. If the test
    * environment already has it set, clearing the system property alone can't force the failure scenario.
    */
@@ -499,6 +714,59 @@ public class DataWriterSparkJobRepushTest {
         new Object[] { "region1", 0, offset, MessageType.PUT.getValue(), negativeSchemaId, key.getBytes(),
             chunkData.getBytes(), -1, new byte[0], null },
         RAW_PUBSUB_INPUT_TABLE_SCHEMA);
+  }
+
+  private List<Row> createSingleChunkRows(byte[] key, byte[] value, byte[] rmd) {
+    ChunkId chunkId = new ChunkId();
+    chunkId.segmentNumber = 1;
+    chunkId.messageSequenceNumber = 1;
+    chunkId.chunkIndex = 0;
+    chunkId.producerGUID = new GUID();
+
+    ChunkedKeySuffix suffix = new ChunkedKeySuffix();
+    suffix.chunkId = chunkId;
+    suffix.isChunk = true;
+
+    ChunkedKeySuffixSerializer suffixSerializer = new ChunkedKeySuffixSerializer();
+    byte[] suffixBytes = suffixSerializer.serialize("ignored", suffix);
+
+    ChunkedValueManifest manifest = new ChunkedValueManifest();
+    manifest.keysWithChunkIdSuffix =
+        Collections.singletonList(new KeyWithChunkingSuffixSerializer().serializeChunkedKey(key, suffix));
+    manifest.schemaId = 1;
+    manifest.size = value.length;
+    byte[] manifestBytes = ByteUtils.extractByteArray(new ChunkedValueManifestSerializer(true).serialize(manifest));
+
+    Row manifestRow = createAssemblyRow(
+        key,
+        manifestBytes,
+        rmd,
+        AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion(),
+        1,
+        2L,
+        null);
+    Row chunkRow = createAssemblyRow(
+        key,
+        value,
+        new byte[0],
+        AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion(),
+        -1,
+        1L,
+        suffixBytes);
+    return Arrays.asList(manifestRow, chunkRow);
+  }
+
+  private Row createAssemblyRow(
+      byte[] key,
+      byte[] value,
+      byte[] rmd,
+      int schemaId,
+      int rmdVersionId,
+      long offset,
+      byte[] chunkedKeySuffix) {
+    return new GenericRowWithSchema(
+        new Object[] { key, value, rmd, schemaId, rmdVersionId, offset, MessageType.PUT.getValue(), chunkedKeySuffix },
+        SCHEMA_FOR_CHUNK_ASSEMBLY);
   }
 
   /**

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJobRepushTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJobRepushTest.java
@@ -3,18 +3,8 @@ package com.linkedin.venice.spark.datawriter.jobs;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_BROKER_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS;
-import static com.linkedin.venice.spark.SparkConstants.CHUNKED_KEY_SUFFIX_COLUMN_NAME;
-import static com.linkedin.venice.spark.SparkConstants.KEY_COLUMN_NAME;
-import static com.linkedin.venice.spark.SparkConstants.MESSAGE_TYPE;
-import static com.linkedin.venice.spark.SparkConstants.MESSAGE_TYPE_COLUMN_NAME;
-import static com.linkedin.venice.spark.SparkConstants.OFFSET;
-import static com.linkedin.venice.spark.SparkConstants.OFFSET_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.RAW_PUBSUB_INPUT_TABLE_SCHEMA;
-import static com.linkedin.venice.spark.SparkConstants.REPLICATION_METADATA_PAYLOAD;
-import static com.linkedin.venice.spark.SparkConstants.RMD_COLUMN_NAME;
-import static com.linkedin.venice.spark.SparkConstants.RMD_VERSION_ID_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.SCHEMA_FOR_CHUNK_ASSEMBLY;
-import static com.linkedin.venice.spark.SparkConstants.SCHEMA_ID_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.VALUE_COLUMN_NAME;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_TOPIC_CHUNKING_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
@@ -338,17 +328,17 @@ public class DataWriterSparkJobRepushTest {
   }
 
   /**
-   * Edge/failure case regression test: when TTL filtering is enabled and an SSL configurator is configured,
-   * executor-side SSL materialization must run before the raw TTL filter is constructed in the
-   * {@code mapPartitions} closure. Before this fix, {@code SparkKafkaInputTTLFilter} was constructed directly
-   * from broadcast job properties and never attempted SSL materialization, so this scenario would silently
-   * succeed instead of failing when the Hadoop token file cannot be resolved. This test forces Spark to
-   * actually execute the closure (via {@code collectAsList()}) so the fix is exercised end-to-end.
+   * Regression test for the fail-open → fail-closed bug found in review of PR #2975: applyTTLFilter()
+   * must not attempt executor-side SSL materialization when the source compression strategy doesn't need
+   * a dictionary consumer. Only ZSTD_WITH_DICT does (see KafkaInputUtils#getCompressor). Verifies a
+   * TTL-only repush job with NO_OP compression completes successfully even when the Hadoop token file
+   * used by TempFileSSLConfigurator cannot be resolved — proving SSL setup was skipped rather than
+   * attempted and failing, instead of turning an unrelated token-file problem into a hard job failure.
    */
   @Test
-  public void testApplyTTLFilterMaterializesExecutorSSL() throws Exception {
+  public void testApplyTTLFilterSkipsSSLForNonDictCompressionStrategy() throws Exception {
     skipIfHadoopTokenFileEnvIsSet();
-    String testName = "testApplyTTLFilterMaterializesExecutorSSL";
+    String testName = "testApplyTTLFilterSkipsSSLForNonDictCompressionStrategy";
 
     File valueSchemaTempDir = Files.createTempDirectory("value-schemas").toFile();
     File rmdSchemaTempDir = Files.createTempDirectory("rmd-schemas").toFile();
@@ -383,6 +373,7 @@ public class DataWriterSparkJobRepushTest {
       setting.partitionerClass = DefaultVenicePartitioner.class.getName();
       setting.partitionCount = 1;
       setting.sourceKafkaInputVersionInfo = new VersionImpl("test_store", 1, "test-push-id");
+      setting.sourceVersionCompressionStrategy = CompressionStrategy.NO_OP;
       // enableSSL must be true for setupCommonSparkConf() to propagate the SSL configurator class
       // into the Spark session conf, which is how applyTTLFilter()/applyChunkAssembly() broadcast
       // properties pick it up on the executor side.
@@ -394,14 +385,10 @@ public class DataWriterSparkJobRepushTest {
       Dataset<Row> inputDF = job.getSparkSession().createDataFrame(rows, RAW_PUBSUB_INPUT_TABLE_SCHEMA);
       Dataset<Row> outputDF = job.testableApplyTTLFilter(inputDF);
 
-      try {
-        outputDF.collectAsList();
-        fail("Expected executor-side SSL materialization to fail with an unresolved Hadoop token file");
-      } catch (Exception e) {
-        assertTrue(
-            containsCauseMessage(e, "Failed to setup SSL for executor-side PubSub client creation"),
-            "Unexpected failure while executing the TTL filter mapPartitions closure: " + e);
-      }
+      // If SSL setup were attempted here (the pre-fix behavior), TempFileSSLConfigurator would throw
+      // because the Hadoop token file is unresolved. Successfully collecting proves SSL was skipped.
+      List<Row> outputRows = outputDF.collectAsList();
+      assertEquals(outputRows.size(), rows.size(), "Chunk manifest rows should pass through unfiltered");
     } finally {
       if (previousTokenFileLocation != null) {
         System.setProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION, previousTokenFileLocation);
@@ -412,31 +399,52 @@ public class DataWriterSparkJobRepushTest {
   }
 
   /**
-   * Edge/failure case regression test: the same SSL materialization gap existed in the chunk assembly
-   * {@code flatMapGroups} closure when TTL filtering is enabled. Before this fix, {@code SparkChunkAssembler}
-   * was constructed directly from broadcast job properties, so this scenario would silently succeed instead
-   * of failing when the Hadoop token file cannot be resolved.
+   * Regression test for the fail-open → fail-closed bug found in review of PR #2975: applyChunkAssembly()'s
+   * post-assembly TTL filter must not attempt executor-side SSL materialization when the source compression
+   * strategy doesn't need a dictionary consumer. Only ZSTD_WITH_DICT does (see KafkaInputUtils#getCompressor).
+   * Verifies a chunking + TTL repush job with NO_OP compression assembles and TTL-checks its record
+   * successfully even when the Hadoop token file used by TempFileSSLConfigurator cannot be resolved --
+   * proving SSL setup was skipped rather than attempted and failing.
    */
   @Test
-  public void testApplyChunkAssemblyMaterializesExecutorSSL() throws Exception {
+  public void testApplyChunkAssemblySkipsSSLForNonDictCompressionStrategy() throws Exception {
     skipIfHadoopTokenFileEnvIsSet();
-    String testName = "testApplyChunkAssemblyMaterializesExecutorSSL";
+    String testName = "testApplyChunkAssemblySkipsSSLForNonDictCompressionStrategy";
 
     File valueSchemaTempDir = Files.createTempDirectory("value-schemas").toFile();
     File rmdSchemaTempDir = Files.createTempDirectory("rmd-schemas").toFile();
     String previousTokenFileLocation = System.getProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
     System.clearProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
     try {
+      Schema valueSchema = new Schema.Parser()
+          .parse("{\"type\":\"record\",\"name\":\"TestValue\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"}]}");
+      Schema rmdSchema = new Schema.Parser().parse(
+          "{\"type\":\"record\",\"name\":\"RmdRecord\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\"}]}");
+      Files.write(new File(valueSchemaTempDir, "1").toPath(), valueSchema.toString().getBytes());
+      Files.write(new File(rmdSchemaTempDir, "1_1").toPath(), rmdSchema.toString().getBytes());
+
+      long ttlStartTime = System.currentTimeMillis();
+      GenericRecord valueRecord = new GenericData.Record(valueSchema);
+      valueRecord.put("id", "fresh-value");
+      GenericRecord rmdRecord = new GenericData.Record(rmdSchema);
+      rmdRecord.put("timestamp", ttlStartTime + 1_000);
+
+      RecordSerializer<GenericRecord> valueSerializer =
+          FastSerializerDeserializerFactory.getFastAvroGenericSerializer(valueSchema);
+      RecordSerializer<GenericRecord> rmdSerializer =
+          FastSerializerDeserializerFactory.getFastAvroGenericSerializer(rmdSchema);
+      byte[] serializedValue = valueSerializer.serialize(valueRecord);
+      byte[] serializedRmd = rmdSerializer.serialize(rmdRecord);
+
       TestableDataWriterSparkJob job = new TestableDataWriterSparkJob(testName);
       currentTestJob = job;
 
-      long ttlStartTime = System.currentTimeMillis();
       Properties props = createDefaultTestProperties();
       props.setProperty("repush.ttl.policy", "0"); // RT_WRITE_ONLY
       props.setProperty("repush.ttl.start.timestamp", String.valueOf(ttlStartTime));
       props.setProperty("value.schema.dir", valueSchemaTempDir.getAbsolutePath());
       props.setProperty("rmd.schema.dir", rmdSchemaTempDir.getAbsolutePath());
-      props.setProperty("kafka.input.source.compression.strategy", "NO_OP");
+      props.setProperty("kafka.input.source.compression.strategy", CompressionStrategy.NO_OP.name());
       props.setProperty(KAFKA_INPUT_SOURCE_TOPIC_CHUNKING_ENABLED, "true");
       props.setProperty(SSL_CONFIGURATOR_CLASS_CONFIG, TempFileSSLConfigurator.class.getName());
       props.setProperty(SSL_KEY_STORE_PROPERTY_NAME, "identity.p12");
@@ -457,7 +465,9 @@ public class DataWriterSparkJobRepushTest {
       setting.partitionCount = 1;
       VersionImpl sourceVersion = new VersionImpl("test_store", 1, "test-push-id");
       sourceVersion.setChunkingEnabled(true);
+      sourceVersion.setCompressionStrategy(CompressionStrategy.NO_OP);
       setting.sourceKafkaInputVersionInfo = sourceVersion;
+      setting.sourceVersionCompressionStrategy = CompressionStrategy.NO_OP;
       // enableSSL must be true for setupCommonSparkConf() to propagate the SSL configurator class
       // into the Spark session conf, which is how applyTTLFilter()/applyChunkAssembly() broadcast
       // properties pick it up on the executor side.
@@ -465,31 +475,17 @@ public class DataWriterSparkJobRepushTest {
 
       job.configure(new VeniceProperties(props), setting);
 
-      // A single non-chunked row is enough: the chunk assembler is constructed for any non-empty key group,
-      // regardless of whether the record turns out to be an actual chunk.
-      List<Row> rows = Arrays.asList(createPutRow("key1", "value1", 1L));
-      Dataset<Row> rawInputDF = job.getSparkSession().createDataFrame(rows, RAW_PUBSUB_INPUT_TABLE_SCHEMA);
-      // applyChunkAssembly() expects the same key/value/rmd/(+chunking metadata) shape that
-      // getInputDataFrame() produces for chunked input, not the raw pubsub schema.
-      Dataset<Row> chunkAssemblyInputDF = rawInputDF.selectExpr(
-          KEY_COLUMN_NAME,
-          VALUE_COLUMN_NAME,
-          "CAST(" + REPLICATION_METADATA_PAYLOAD + " AS BINARY) as " + RMD_COLUMN_NAME,
-          SCHEMA_ID_COLUMN_NAME + " as " + SCHEMA_ID_COLUMN_NAME,
-          RMD_VERSION_ID_COLUMN_NAME + " as " + RMD_VERSION_ID_COLUMN_NAME,
-          OFFSET + " as " + OFFSET_COLUMN_NAME,
-          MESSAGE_TYPE + " as " + MESSAGE_TYPE_COLUMN_NAME,
-          CHUNKED_KEY_SUFFIX_COLUMN_NAME + " as " + CHUNKED_KEY_SUFFIX_COLUMN_NAME);
-      Dataset<Row> outputDF = job.testableApplyChunkAssembly(chunkAssemblyInputDF);
+      byte[] regularKey = "regular-key".getBytes();
+      List<Row> rows =
+          Collections.singletonList(createAssemblyRow(regularKey, serializedValue, serializedRmd, 1, 1, 1L, null));
+      Dataset<Row> inputDF = job.getSparkSession().createDataFrame(rows, SCHEMA_FOR_CHUNK_ASSEMBLY);
 
-      try {
-        outputDF.collectAsList();
-        fail("Expected executor-side SSL materialization to fail with an unresolved Hadoop token file");
-      } catch (Exception e) {
-        assertTrue(
-            containsCauseMessage(e, "Failed to setup SSL for executor-side PubSub client creation"),
-            "Unexpected failure while executing the chunk assembly flatMapGroups closure: " + e);
-      }
+      // If SSL setup were attempted here (the pre-fix behavior), TempFileSSLConfigurator would throw
+      // because the Hadoop token file is unresolved. Successfully collecting the assembled, TTL-checked
+      // record proves SSL was skipped entirely.
+      List<Row> outputRows = job.testableApplyChunkAssembly(inputDF).collectAsList();
+      assertEquals(outputRows.size(), 1);
+      assertTrue(Arrays.equals((byte[]) outputRows.get(0).getAs(VALUE_COLUMN_NAME), serializedValue));
     } finally {
       if (previousTokenFileLocation != null) {
         System.setProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION, previousTokenFileLocation);
@@ -557,6 +553,7 @@ public class DataWriterSparkJobRepushTest {
       Version sourceVersion = new VersionImpl("test_store", 1, "test-push-id");
       sourceVersion.setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT);
       setting.sourceKafkaInputVersionInfo = sourceVersion;
+      setting.sourceVersionCompressionStrategy = CompressionStrategy.ZSTD_WITH_DICT;
 
       job.configure(new VeniceProperties(props), setting);
 
@@ -662,6 +659,7 @@ public class DataWriterSparkJobRepushTest {
       sourceVersion.setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT);
       sourceVersion.setChunkingEnabled(true);
       setting.sourceKafkaInputVersionInfo = sourceVersion;
+      setting.sourceVersionCompressionStrategy = CompressionStrategy.ZSTD_WITH_DICT;
 
       job.configure(new VeniceProperties(props), setting);
       job.getSparkSession().conf().set("spark.sql.shuffle.partitions", "1");
@@ -708,17 +706,6 @@ public class DataWriterSparkJobRepushTest {
           "Skipping because " + UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION
               + " is set in the test environment and would make the failure scenario unreachable");
     }
-  }
-
-  private boolean containsCauseMessage(Throwable t, String expectedMessageFragment) {
-    Throwable current = t;
-    while (current != null) {
-      if (current.getMessage() != null && current.getMessage().contains(expectedMessageFragment)) {
-        return true;
-      }
-      current = current.getCause();
-    }
-    return false;
   }
 
   private Row createChunkedRow(String key, String chunkData, int negativeSchemaId, long offset) {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJobRepushTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/datawriter/jobs/DataWriterSparkJobRepushTest.java
@@ -33,6 +33,7 @@ import com.linkedin.venice.compression.CompressorFactory;
 import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.hadoop.PushJobSetting;
 import com.linkedin.venice.hadoop.ssl.TempFileSSLConfigurator;
+import com.linkedin.venice.hadoop.utils.VPJSSLUtils;
 import com.linkedin.venice.kafka.protocol.GUID;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.meta.Version;
@@ -73,6 +74,7 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
@@ -84,6 +86,14 @@ import org.testng.annotations.Test;
  */
 public class DataWriterSparkJobRepushTest {
   private DataWriterSparkJob currentTestJob = null;
+
+  @BeforeMethod
+  public void resetExecutorSslPropsCache() {
+    // VPJSSLUtils caches materialized SSL properties per-JVM (see VPJSSLUtils#setupSSLForExecutor).
+    // Reset before every test so SSL-configurator invocation-count assertions aren't affected by
+    // caching from a previous test running in the same JVM/test worker.
+    VPJSSLUtils.resetExecutorSslPropsCacheForTests();
+  }
 
   @AfterMethod
   public void cleanupSparkSession() {
@@ -569,21 +579,21 @@ public class DataWriterSparkJobRepushTest {
   }
 
   /**
-   * Adapted from PR #2955's DataWriterSparkJobRepushTest.testApplyChunkAssemblyReusesExecutorSSLForPostAssemblyTTL().
+   * Ported from PR #2955's DataWriterSparkJobRepushTest.testApplyChunkAssemblyReusesExecutorSSLForPostAssemblyTTL().
    * Exercises the real bug scenario end-to-end for the chunk-assembly path: TTL filtering with ZSTD_WITH_DICT
    * compression after chunk reassembly, which makes SparkChunkAssembler create a second, internal "dictionary"
    * PubSub consumer on the executor. Verifies the SSL configurator and PubSub consumer factory are invoked with
    * correctly materialized SSL properties and that chunk reassembly still produces the correct output.
    *
-   * Unlike the original PR #2955 test, this does NOT assert that the SSL configurator/consumer factory are
-   * invoked exactly once across both key groups in the task - that de-duplication comes from PR #2955's
-   * per-task assembler caching refactor, which is intentionally out of scope for this simplified fix (see PR
-   * description). This simplified fix constructs a new SparkChunkAssembler per key group, so SSL materialization
-   * and dictionary-consumer creation happen once per key group (twice here, for the two key groups below).
+   * Also asserts that SSL materialization and dictionary-consumer creation happen exactly once across both key
+   * groups in the task, not once per key group, matching PR #2955's original assertion. That de-duplication
+   * comes from ChunkAssemblyFunction (see AbstractDataWriterSparkJob#applyChunkAssembly), which caches the
+   * SparkChunkAssembler once per Spark task and reuses it across key groups instead of PR #2955's per-task
+   * caching refactor.
    */
   @Test
-  public void testApplyChunkAssemblyMaterializesSSLBeforePostAssemblyTTL() throws Exception {
-    String testName = "testApplyChunkAssemblyMaterializesSSLBeforePostAssemblyTTL";
+  public void testApplyChunkAssemblyReusesExecutorSSLForPostAssemblyTTL() throws Exception {
+    String testName = "testApplyChunkAssemblyReusesExecutorSSLForPostAssemblyTTL";
 
     File valueSchemaTempDir = Files.createTempDirectory("value-schemas").toFile();
     File rmdSchemaTempDir = Files.createTempDirectory("rmd-schemas").toFile();
@@ -674,11 +684,13 @@ public class DataWriterSparkJobRepushTest {
             .orElse(null);
         assertNotNull(assembledChunk, "Chunked value should survive post-assembly TTL filtering");
         assertTrue(Arrays.equals((byte[]) assembledChunk.getAs("value"), compressedValue));
-        // No per-task assembler caching in this simplified fix: SSL is materialized and a dictionary
-        // consumer is created once per key group (2 key groups here), not once per task.
-        assertEquals(SparkExecutorTestUtils.getSslConfiguratorInvocations(), 2);
-        assertEquals(SparkExecutorTestUtils.getConsumerFactoryInvocations(), 2);
-        assertEquals(SparkExecutorTestUtils.getDictionaryConsumerInvocations(), 2);
+        // ChunkAssemblyFunction caches the SparkChunkAssembler (and the SSL/consumer setup behind it)
+        // once per Spark task and reuses it across all key groups in that task (2 key groups here,
+        // both landing in the single task from spark.sql.shuffle.partitions=1 above), so SSL
+        // materialization and dictionary-consumer creation happen exactly once, not once per key group.
+        assertEquals(SparkExecutorTestUtils.getSslConfiguratorInvocations(), 1);
+        assertEquals(SparkExecutorTestUtils.getConsumerFactoryInvocations(), 1);
+        assertEquals(SparkExecutorTestUtils.getDictionaryConsumerInvocations(), 1);
       });
     } finally {
       deleteDirectory(valueSchemaTempDir);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/input/pubsub/SparkPubSubPartitionReaderFactoryTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/input/pubsub/SparkPubSubPartitionReaderFactoryTest.java
@@ -1,12 +1,23 @@
 package com.linkedin.venice.spark.input.pubsub;
 
+import static com.linkedin.venice.ConfigKeys.PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_SOURCE_TOPIC_CHUNKING_ENABLED;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.KAFKA_INPUT_TOPIC;
+import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CLASS_CONFIG;
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
+import static org.testng.Assert.assertTrue;
 
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.spark.SparkExecutorTestUtils;
 import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.vpj.pubsub.input.PubSubPartitionSplit;
 import java.util.Properties;
 import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.connector.read.PartitionReader;
 import org.testng.annotations.Test;
 
 
@@ -24,5 +35,40 @@ public class SparkPubSubPartitionReaderFactoryTest {
     InputPartition invalidPartition = new InputPartition() {
     };
     factory.createReader(invalidPartition);
+  }
+
+  /**
+   * Ported from PR #2955's SparkPubSubPartitionReaderFactoryTest.testCreateReaderMaterializesExecutorSSL().
+   * Confirms this simplified fix does not regress the already-working reader path: the SSL configurator
+   * and PubSub consumer factory are still invoked with correctly materialized SSL properties.
+   */
+  @Test
+  public void testCreateReaderMaterializesExecutorSSL() throws Exception {
+    Properties properties = new Properties();
+    properties.setProperty(VENICE_REPUSH_SOURCE_PUBSUB_BROKER, "localhost:9092");
+    properties.setProperty(KAFKA_INPUT_TOPIC, "test-topic");
+    properties.setProperty(KAFKA_INPUT_SOURCE_TOPIC_CHUNKING_ENABLED, "false");
+    properties
+        .setProperty(SSL_CONFIGURATOR_CLASS_CONFIG, SparkExecutorTestUtils.RecordingSSLConfigurator.class.getName());
+    properties.setProperty(
+        PUBSUB_CONSUMER_ADAPTER_FACTORY_CLASS,
+        SparkExecutorTestUtils.AssertingPubSubConsumerAdapterFactory.class.getName());
+
+    PubSubTopicRepository topicRepository = new PubSubTopicRepository();
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(topicRepository.getTopic("test-topic"), 0);
+    PubSubPosition position = ApacheKafkaOffsetPosition.of(0);
+    SparkPubSubInputPartition inputPartition = new SparkPubSubInputPartition(
+        new PubSubPartitionSplit(topicRepository, topicPartition, position, position, 0, 0, 0));
+
+    SparkExecutorTestUtils.resetInvocations();
+    SparkExecutorTestUtils.withTokenFile(() -> {
+      SparkPubSubPartitionReaderFactory factory =
+          new SparkPubSubPartitionReaderFactory(new VeniceProperties(properties));
+      try (PartitionReader<?> reader = factory.createReader(inputPartition)) {
+        assertTrue(reader instanceof SparkPubSubInputPartitionReader);
+      }
+      assertTrue(SparkExecutorTestUtils.getSslConfiguratorInvocations() > 0);
+      assertTrue(SparkExecutorTestUtils.getConsumerFactoryInvocations() > 0);
+    });
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/input/pubsub/SparkPubSubPartitionReaderFactoryTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/input/pubsub/SparkPubSubPartitionReaderFactoryTest.java
@@ -7,6 +7,7 @@ import static com.linkedin.venice.vpj.VenicePushJobConstants.SSL_CONFIGURATOR_CL
 import static com.linkedin.venice.vpj.VenicePushJobConstants.VENICE_REPUSH_SOURCE_PUBSUB_BROKER;
 import static org.testng.Assert.assertTrue;
 
+import com.linkedin.venice.hadoop.utils.VPJSSLUtils;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.common.ApacheKafkaOffsetPosition;
@@ -18,10 +19,19 @@ import com.linkedin.venice.vpj.pubsub.input.PubSubPartitionSplit;
 import java.util.Properties;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReader;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
 public class SparkPubSubPartitionReaderFactoryTest {
+  @BeforeMethod
+  public void resetExecutorSslPropsCache() {
+    // VPJSSLUtils caches materialized SSL properties per-JVM; reset before every test so
+    // SSL-configurator invocation-count assertions aren't affected by caching from a previous test
+    // running in the same JVM/test worker.
+    VPJSSLUtils.resetExecutorSslPropsCacheForTests();
+  }
+
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testCreateReaderWithInvalidPartitionType() {
     Properties p = new Properties();


### PR DESCRIPTION
## Problem Statement

`SparkPubSubPartitionReaderFactory.createReader()` materializes SSL properties from the Hadoop token file before creating its PubSub consumer, but two other executor-side code paths that can also create a PubSub consumer do not:

- The TTL filter's `mapPartitions` closure in `AbstractDataWriterSparkJob.applyTTLFilter()` constructs `SparkKafkaInputTTLFilter` directly from broadcast job properties.
- The chunk assembly `flatMapGroups` closure in `AbstractDataWriterSparkJob.applyChunkAssembly()` constructs `SparkChunkAssembler` directly from broadcast job properties.

When TTL filtering is enabled together with dictionary compression (`ZSTD_WITH_DICT`), both of these components create a second, internal PubSub (dictionary) consumer on the executor. Since SSL was never materialized for these paths, consumer creation fails with errors like "Missing required property ssl.keystore.type".

This is a simplified, minimal fix for the same gap addressed more broadly in #2955. It intentionally does not include that PR's per-task caching refactor for `SparkChunkAssembler` (avoiding repeated SSL materialization / dictionary-consumer creation per key group) or the `UserCredentialsFactory` fail-fast hardening. Those are separate, deferrable follow-ups tracked independently.

## Solution

- Extracted the existing SSL materialization logic out of `SparkPubSubPartitionReaderFactory` into a shared, public `VPJSSLUtils.setupSSLForExecutor(VeniceProperties)` utility (no-op when no SSL configurator is configured; wraps failures in `VeniceException`).
- `SparkPubSubPartitionReaderFactory.createReader()` now calls the shared utility instead of its own private copy.
- `AbstractDataWriterSparkJob.applyTTLFilter()`'s `mapPartitions` closure now calls `VPJSSLUtils.setupSSLForExecutor(...)` before constructing `SparkKafkaInputTTLFilter`.
- `AbstractDataWriterSparkJob.applyChunkAssembly()`'s `flatMapGroups` closure now calls `VPJSSLUtils.setupSSLForExecutor(...)` (when TTL is enabled) before constructing `SparkChunkAssembler`, keeping the existing per-key-group instantiation unchanged.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

Added `TestVPJSSLUtils` coverage for the new shared utility (no-op without an SSL configurator, and failure when the Hadoop token file can't be resolved), plus two new regression tests in `DataWriterSparkJobRepushTest` that force actual Spark execution (`collectAsList()`) of the TTL filter and chunk assembly closures with an SSL configurator configured but no resolvable token file, asserting the SSL setup failure now surfaces from both paths (proving the pre-fix code would not have attempted SSL setup there at all).

Ran the affected test classes locally: `TestVPJSSLUtils`, `DataWriterSparkJobRepushTest`, `SparkPubSubPartitionReaderFactoryTest`, all passing. Also verified `spotlessCheck` passes.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
