### PR TITLE
Add lag-based wait for future-version OFFLINE->STANDBY transition

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -1365,6 +1365,22 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getInt(SERVER_LAG_BASED_REPLICA_AUTO_RESUBSCRIBE_MAX_REPLICA_COUNT, 3);
     this.futureVersionStandbyLagCheckEnabled =
         serverProperties.getBoolean(SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED, false);
+    if (this.futureVersionStandbyLagCheckEnabled
+        && leaderFollowerThreadPoolStrategy != LeaderFollowerPartitionStateModelFactory.LeaderFollowerThreadPoolStrategy.DUAL_POOL_STRATEGY) {
+      String errorMessage = String.format(
+          "%s can only be enabled when %s is set to %s, since the lag-based wait synchronously occupies a "
+              + "state-transition worker thread and could otherwise delay current/backup-version transitions "
+              + "on a shared pool. Current strategy: %s. Please either set %s to %s or disable %s.",
+          SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED,
+          LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY,
+          LeaderFollowerPartitionStateModelFactory.LeaderFollowerThreadPoolStrategy.DUAL_POOL_STRATEGY,
+          leaderFollowerThreadPoolStrategy,
+          LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY,
+          LeaderFollowerPartitionStateModelFactory.LeaderFollowerThreadPoolStrategy.DUAL_POOL_STRATEGY,
+          SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED);
+      LOGGER.error(errorMessage);
+      throw new VeniceException(errorMessage);
+    }
     this.futureVersionStandbyLagThreshold =
         serverProperties.getLong(SERVER_FUTURE_VERSION_STANDBY_LAG_THRESHOLD, 1000L);
     this.futureVersionStandbyLagCheckTimeoutMinutes =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -128,6 +128,10 @@ import static com.linkedin.venice.ConfigKeys.SERVER_DRAIN_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_ENABLE_LIVE_CONFIG_BASED_KAFKA_THROTTLING;
 import static com.linkedin.venice.ConfigKeys.SERVER_ENABLE_PARALLEL_BATCH_GET;
 import static com.linkedin.venice.ConfigKeys.SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST;
+import static com.linkedin.venice.ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_POLL_INTERVAL_MINUTES;
+import static com.linkedin.venice.ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_TIMEOUT_MINUTES;
+import static com.linkedin.venice.ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_THRESHOLD;
 import static com.linkedin.venice.ConfigKeys.SERVER_GLOBAL_RT_DIV_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_HEARTBEAT_REPORTER_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_HELIX_JOIN_AS_UNKNOWN;
@@ -768,6 +772,11 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final int lagBasedReplicaAutoResubscribeThresholdInSeconds;
   private final int lagBasedReplicaAutoResubscribeMaxReplicaCount;
 
+  private final boolean futureVersionStandbyLagCheckEnabled;
+  private final long futureVersionStandbyLagThreshold;
+  private final int futureVersionStandbyLagCheckTimeoutMinutes;
+  private final int futureVersionStandbyLagCheckPollIntervalMinutes;
+
   private final int serverIngestionInfoLogLineLimit;
 
   private final boolean parallelResourceShutdownEnabled;
@@ -1354,6 +1363,14 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getInt(SERVER_LAG_BASED_REPLICA_AUTO_RESUBSCRIBE_THRESHOLD_IN_SECONDS, 600);
     this.lagBasedReplicaAutoResubscribeMaxReplicaCount =
         serverProperties.getInt(SERVER_LAG_BASED_REPLICA_AUTO_RESUBSCRIBE_MAX_REPLICA_COUNT, 3);
+    this.futureVersionStandbyLagCheckEnabled =
+        serverProperties.getBoolean(SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED, false);
+    this.futureVersionStandbyLagThreshold =
+        serverProperties.getLong(SERVER_FUTURE_VERSION_STANDBY_LAG_THRESHOLD, 1000L);
+    this.futureVersionStandbyLagCheckTimeoutMinutes =
+        serverProperties.getInt(SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_TIMEOUT_MINUTES, 2 * 60);
+    this.futureVersionStandbyLagCheckPollIntervalMinutes =
+        serverProperties.getInt(SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_POLL_INTERVAL_MINUTES, 15);
     this.useMetricsBasedPositionInLagComputation =
         serverProperties.getBoolean(SERVER_USE_METRICS_BASED_POSITION_IN_LAG_COMPUTATION, false);
     this.useUpstreamPubSubPositionWithFallback =
@@ -2433,6 +2450,22 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getLagBasedReplicaAutoResubscribeMaxReplicaCount() {
     return lagBasedReplicaAutoResubscribeMaxReplicaCount;
+  }
+
+  public boolean isFutureVersionStandbyLagCheckEnabled() {
+    return futureVersionStandbyLagCheckEnabled;
+  }
+
+  public long getFutureVersionStandbyLagThreshold() {
+    return futureVersionStandbyLagThreshold;
+  }
+
+  public int getFutureVersionStandbyLagCheckTimeoutMinutes() {
+    return futureVersionStandbyLagCheckTimeoutMinutes;
+  }
+
+  public int getFutureVersionStandbyLagCheckPollIntervalMinutes() {
+    return futureVersionStandbyLagCheckPollIntervalMinutes;
   }
 
   public boolean isUseMetricsBasedPositionInLagComputationEnabled() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
@@ -1,9 +1,11 @@
 package com.linkedin.davinci.helix;
 
+import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.ingestion.IngestionBackend;
 import com.linkedin.davinci.kafka.consumer.PartitionReplicaIngestionContext;
 import com.linkedin.davinci.kafka.consumer.StoreIngestionService;
+import com.linkedin.davinci.kafka.consumer.StoreIngestionTask;
 import com.linkedin.davinci.stats.ParticipantStateTransitionStats;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
@@ -405,6 +407,64 @@ public abstract class AbstractPartitionStateModel extends StateModel {
       logger.error(errorMsg, e);
       // Please note, after throwing this exception, this node will become ERROR for this resource.
       throw new VeniceException(errorMsg, e);
+    }
+  }
+
+  /**
+   * Best-effort wait, applicable to a future-version replica whose push is still in progress (i.e. neither the
+   * current version, nor a future version which has already finished ingesting), for the replica's local version
+   * topic lag to drop to or below an acceptable threshold before completing the OFFLINE -> STANDBY transition.
+   *
+   * Callers are expected to only invoke this method when
+   * {@link VeniceServerConfig#isFutureVersionStandbyLagCheckEnabled()} is true.
+   *
+   * Unlike {@link #waitConsumptionCompleted}, this does not wait for ingestion to fully complete: it only waits
+   * until the measured lag is within {@link VeniceServerConfig#getFutureVersionStandbyLagThreshold()}, or until
+   * {@link VeniceServerConfig#getFutureVersionStandbyLagCheckTimeoutMinutes()} elapses, whichever happens first.
+   * If lag cannot be measured, or the ingestion task is not found, this method returns immediately, preserving
+   * the pre-existing (no-wait) behavior for this case.
+   */
+  protected void waitUntilFutureVersionLagAcceptable(String resourceName) {
+    VeniceServerConfig serverConfig = storeAndServerConfigs;
+    String replicaId = Utils.getReplicaId(resourceName, partition);
+    StoreIngestionTask ingestionTask = getStoreIngestionService().getStoreIngestionTask(resourceName);
+    if (ingestionTask == null) {
+      logger.warn(
+          "No ingestion task found for replica {} when checking future version standby lag, proceeding to STANDBY without waiting.",
+          replicaId);
+      return;
+    }
+    long lagThreshold = serverConfig.getFutureVersionStandbyLagThreshold();
+    long timeoutMs = TimeUnit.MINUTES.toMillis(serverConfig.getFutureVersionStandbyLagCheckTimeoutMinutes());
+    long pollIntervalMs = TimeUnit.MINUTES.toMillis(serverConfig.getFutureVersionStandbyLagCheckPollIntervalMinutes());
+    long deadlineMs = System.currentTimeMillis() + timeoutMs;
+    while (true) {
+      long lag = ingestionTask.getLocalVersionTopicLag(partition);
+      if (lag == Long.MAX_VALUE) {
+        logger.warn(
+            "Could not measure local version topic lag for replica {}, proceeding to STANDBY without waiting.",
+            replicaId);
+        return;
+      }
+      if (lag <= lagThreshold) {
+        logger.info(
+            "Future version replica {} local version topic lag {} is within threshold {}, proceeding to STANDBY.",
+            replicaId,
+            lag,
+            lagThreshold);
+        return;
+      }
+      long remainingMs = deadlineMs - System.currentTimeMillis();
+      if (remainingMs <= 0) {
+        logger.warn(
+            "Future version replica {} local version topic lag {} still above threshold {} after {}min timeout, proceeding to STANDBY.",
+            replicaId,
+            lag,
+            lagThreshold,
+            serverConfig.getFutureVersionStandbyLagCheckTimeoutMinutes());
+        return;
+      }
+      Utils.sleep(Math.min(pollIntervalMs, remainingMs));
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.VeniceStoreType;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushmonitor.HybridStoreQuotaStatus;
 import com.linkedin.venice.utils.LogContext;
@@ -411,9 +412,9 @@ public abstract class AbstractPartitionStateModel extends StateModel {
   }
 
   /**
-   * Best-effort wait, applicable to a future-version replica whose push is still in progress (i.e. neither the
-   * current version, nor a future version which has already finished ingesting), for the replica's local version
-   * topic lag to drop to or below an acceptable threshold before completing the OFFLINE -> STANDBY transition.
+   * Best-effort wait, applicable to a future-version replica whose push is still in progress (i.e. the version's
+   * status is {@link VersionStatus#STARTED}), for the replica's local version topic lag to drop to or below an
+   * acceptable threshold before completing the OFFLINE -> STANDBY transition.
    *
    * Callers are expected to only invoke this method when
    * {@link VeniceServerConfig#isFutureVersionStandbyLagCheckEnabled()} is true.
@@ -423,6 +424,11 @@ public abstract class AbstractPartitionStateModel extends StateModel {
    * {@link VeniceServerConfig#getFutureVersionStandbyLagCheckTimeoutMinutes()} elapses, whichever happens first.
    * If lag cannot be measured, or the ingestion task is not found, this method returns immediately, preserving
    * the pre-existing (no-wait) behavior for this case.
+   *
+   * The version's status is re-checked on every poll so that a version which transitions away from
+   * {@link VersionStatus#STARTED} while waiting (e.g. to {@link VersionStatus#KILLED} or
+   * {@link VersionStatus#ERROR} due to an asynchronous kill/cleanup racing with this transition) does not
+   * needlessly occupy the state-transition worker thread until the full timeout elapses.
    */
   protected void waitUntilFutureVersionLagAcceptable(String resourceName) {
     VeniceServerConfig serverConfig = storeAndServerConfigs;
@@ -439,6 +445,12 @@ public abstract class AbstractPartitionStateModel extends StateModel {
     long pollIntervalMs = TimeUnit.MINUTES.toMillis(serverConfig.getFutureVersionStandbyLagCheckPollIntervalMinutes());
     long deadlineMs = System.currentTimeMillis() + timeoutMs;
     while (true) {
+      if (!isVersionStarted(resourceName)) {
+        logger.info(
+            "Future version replica {} is no longer in STARTED status, proceeding to STANDBY without further waiting.",
+            replicaId);
+        return;
+      }
       long lag = ingestionTask.getLocalVersionTopicLag(partition);
       if (lag == Long.MAX_VALUE) {
         logger.warn(
@@ -465,6 +477,24 @@ public abstract class AbstractPartitionStateModel extends StateModel {
         return;
       }
       Utils.sleep(Math.min(pollIntervalMs, remainingMs));
+    }
+  }
+
+  /**
+   * @return true if the version corresponding to {@code resourceName} currently has status
+   * {@link VersionStatus#STARTED}, false otherwise (including if the store/version can no longer be found).
+   */
+  private boolean isVersionStarted(String resourceName) {
+    try {
+      Store store = getStoreRepo().getStoreOrThrow(getStoreName());
+      Version version = store.getVersion(getVersionNumber());
+      return version != null && version.getStatus() == VersionStatus.STARTED;
+    } catch (VeniceException e) {
+      logger.warn(
+          "Could not determine version status for resource {} while checking future version lag.",
+          resourceName,
+          e);
+      return false;
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -105,6 +105,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       // A future version is ready to serve if it's status is either PUSHED or ONLINE
       // PUSHED is set for future versions of a target region push with deferred swap
       // ONLINE is set for future versions of a push with deferred swap
+      boolean isFutureVersion = Utils.isFutureVersion(resourceName, getStoreRepo());
       boolean isFutureVersionReady = Utils.isFutureVersionReady(resourceName, getStoreRepo());
       /**
        * For current version and already completed future versions, firstly create a latch, then start ingestion and wait
@@ -136,6 +137,10 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
           Utils.getReplicaId(message.getResourceName(), getPartition()));
       if (isCurrentVersion || isFutureVersionReady) {
         waitConsumptionCompleted(resourceName, notifier);
+      } else if (isFutureVersion && getStoreAndServerConfigs().isFutureVersionStandbyLagCheckEnabled()) {
+        // Future version whose push is still in progress: best-effort wait for lag to become acceptable before
+        // this replica becomes eligible for leader election (no-op unless explicitly enabled).
+        waitUntilFutureVersionLagAcceptable(resourceName);
       }
     });
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -13,6 +13,8 @@ import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
 import com.linkedin.venice.helix.HelixState;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Utils;
 import java.util.concurrent.CompletableFuture;
@@ -107,6 +109,13 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       // ONLINE is set for future versions of a push with deferred swap
       boolean isFutureVersion = Utils.isFutureVersion(resourceName, getStoreRepo());
       boolean isFutureVersionReady = Utils.isFutureVersionReady(resourceName, getStoreRepo());
+      // An explicitly active future-version push: the version is a future version and its push is still in
+      // progress (status is STARTED). Using the explicit status, rather than "future and not ready", avoids
+      // racing with terminal states (KILLED/ERROR/ROLLED_BACK) that can overlap with an in-flight
+      // OFFLINE -> STANDBY transition when a version is killed and cleaned up asynchronously.
+      Version version = store.getVersion(getVersionNumber());
+      boolean isFutureVersionInProgress =
+          isFutureVersion && version != null && version.getStatus() == VersionStatus.STARTED;
       /**
        * For current version and already completed future versions, firstly create a latch, then start ingestion and wait
        * for ingestion completion to make sure that the state transition waits until this new replica finished consuming
@@ -137,7 +146,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
           Utils.getReplicaId(message.getResourceName(), getPartition()));
       if (isCurrentVersion || isFutureVersionReady) {
         waitConsumptionCompleted(resourceName, notifier);
-      } else if (isFutureVersion && getStoreAndServerConfigs().isFutureVersionStandbyLagCheckEnabled()) {
+      } else if (isFutureVersionInProgress && getStoreAndServerConfigs().isFutureVersionStandbyLagCheckEnabled()) {
         // Future version whose push is still in progress: best-effort wait for lag to become acceptable before
         // this replica becomes eligible for leader election (no-op unless explicitly enabled).
         waitUntilFutureVersionLagAcceptable(resourceName);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3869,6 +3869,24 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return diff - 1;
   }
 
+  /**
+   * Best-effort measurement of how far behind {@code partition}'s local version topic consumption is, relative to
+   * the end of the local version topic partition. Unlike {@link #isReadyToServe(PartitionConsumptionState)}, this
+   * does not require END_OF_PUSH to have been received, so it can be used to gate in-progress (future version)
+   * pushes.
+   *
+   * @return the lag in number of records, or {@link Long#MAX_VALUE} if it could not be measured (e.g. no
+   * {@link PartitionConsumptionState} yet for the partition, or a PubSub error occurred).
+   */
+  public long getLocalVersionTopicLag(int partition) {
+    PartitionConsumptionState pcs = getPartitionConsumptionStateMap().get(partition);
+    if (pcs == null) {
+      return Long.MAX_VALUE;
+    }
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(versionTopic, partition);
+    return measureLagWithCallToPubSub(localKafkaServer, topicPartition, pcs.getLatestProcessedVtPosition());
+  }
+
   public abstract int getWriteComputeErrorCode();
 
   public abstract void updateLeaderTopicOnFollower(PartitionConsumptionState partitionConsumptionState);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
@@ -14,6 +14,10 @@ import static com.linkedin.venice.ConfigKeys.SERVER_CROSS_TP_PARALLEL_PROCESSING
 import static com.linkedin.venice.ConfigKeys.SERVER_CROSS_TP_PARALLEL_PROCESSING_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_DEAD_LEADER_READY_TO_SERVE_FALLBACK_THRESHOLD_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST;
+import static com.linkedin.venice.ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_POLL_INTERVAL_MINUTES;
+import static com.linkedin.venice.ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_TIMEOUT_MINUTES;
+import static com.linkedin.venice.ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_THRESHOLD;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_OTEL_STATS_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_VALID_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_LEADER_HANDOVER_USE_DOL_MECHANISM_FOR_SYSTEM_STORES;
@@ -66,6 +70,32 @@ public class VeniceServerConfigTest {
     assertEquals(jvmArgs.size(), 2);
     assertEquals(jvmArgs.get(0), "-Xms256M");
     assertEquals(jvmArgs.get(1), "-Xmx256G");
+  }
+
+  @Test
+  public void testFutureVersionStandbyLagCheckDefaults() {
+    Properties props = populatedBasicProperties();
+    VeniceServerConfig config = new VeniceServerConfig(new VeniceProperties(props));
+
+    assertFalse(config.isFutureVersionStandbyLagCheckEnabled());
+    assertEquals(config.getFutureVersionStandbyLagThreshold(), 1000L);
+    assertEquals(config.getFutureVersionStandbyLagCheckTimeoutMinutes(), 2 * 60);
+    assertEquals(config.getFutureVersionStandbyLagCheckPollIntervalMinutes(), 15);
+  }
+
+  @Test
+  public void testFutureVersionStandbyLagCheckOverrides() {
+    Properties props = populatedBasicProperties();
+    props.setProperty(SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED, "true");
+    props.setProperty(SERVER_FUTURE_VERSION_STANDBY_LAG_THRESHOLD, "2000");
+    props.setProperty(SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_TIMEOUT_MINUTES, "60");
+    props.setProperty(SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_POLL_INTERVAL_MINUTES, "5");
+    VeniceServerConfig config = new VeniceServerConfig(new VeniceProperties(props));
+
+    assertTrue(config.isFutureVersionStandbyLagCheckEnabled());
+    assertEquals(config.getFutureVersionStandbyLagThreshold(), 2000L);
+    assertEquals(config.getFutureVersionStandbyLagCheckTimeoutMinutes(), 60);
+    assertEquals(config.getFutureVersionStandbyLagCheckPollIntervalMinutes(), 5);
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.INGESTION_USE_DA_VINCI_CLIENT;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_FETCH_THROTTLER_FACTORS_PER_SECOND;
+import static com.linkedin.venice.ConfigKeys.LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.LOCAL_REGION_NAME;
 import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_AA_DCR_BUG_INJECTION_STORE_TO_REGION_MAP;
@@ -35,6 +36,7 @@ import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.davinci.blobtransfer.client.NettyFileTransferClient;
+import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModelFactory;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Arrays;
@@ -86,6 +88,9 @@ public class VeniceServerConfigTest {
   @Test
   public void testFutureVersionStandbyLagCheckOverrides() {
     Properties props = populatedBasicProperties();
+    props.setProperty(
+        LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY,
+        LeaderFollowerPartitionStateModelFactory.LeaderFollowerThreadPoolStrategy.DUAL_POOL_STRATEGY.name());
     props.setProperty(SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED, "true");
     props.setProperty(SERVER_FUTURE_VERSION_STANDBY_LAG_THRESHOLD, "2000");
     props.setProperty(SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_TIMEOUT_MINUTES, "60");
@@ -96,6 +101,16 @@ public class VeniceServerConfigTest {
     assertEquals(config.getFutureVersionStandbyLagThreshold(), 2000L);
     assertEquals(config.getFutureVersionStandbyLagCheckTimeoutMinutes(), 60);
     assertEquals(config.getFutureVersionStandbyLagCheckPollIntervalMinutes(), 5);
+  }
+
+  @Test
+  public void testFutureVersionStandbyLagCheckRequiresDualPoolStrategy() {
+    // Lag check enabled while the thread pool strategy defaults to SINGLE_POOL_STRATEGY must fail fast, since the
+    // wait synchronously occupies a shared state-transition worker thread.
+    Properties props = populatedBasicProperties();
+    props.setProperty(SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED, "true");
+
+    assertThrows(VeniceException.class, () -> new VeniceServerConfig(new VeniceProperties(props)));
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
@@ -114,6 +114,18 @@ public class LeaderFollowerPartitionStateModelTest {
         resourceName);
   }
 
+  /**
+   * Stubs {@code metadataRepo} so the version under test resolves to {@link VersionStatus#STARTED}, satisfying
+   * the per-poll status re-check inside {@code waitUntilFutureVersionLagAcceptable}.
+   */
+  private void stubVersionStarted() {
+    Store store = mock(Store.class);
+    Version mockVersion = mock(Version.class);
+    when(mockVersion.getStatus()).thenReturn(VersionStatus.STARTED);
+    when(store.getVersion(storeVersion)).thenReturn(mockVersion);
+    doReturn(store).when(metadataRepo).getStoreOrThrow(anyString());
+  }
+
   @Test
   public void testUpdateLagMonitor() {
     Message message = mock(Message.class);
@@ -654,6 +666,7 @@ public class LeaderFollowerPartitionStateModelTest {
     when(storeAndServerConfigs.getFutureVersionStandbyLagThreshold()).thenReturn(100L);
     when(storeAndServerConfigs.getFutureVersionStandbyLagCheckTimeoutMinutes()).thenReturn(5);
     when(storeAndServerConfigs.getFutureVersionStandbyLagCheckPollIntervalMinutes()).thenReturn(1);
+    stubVersionStarted();
 
     StoreIngestionTask ingestionTask = mock(StoreIngestionTask.class);
     doReturn(ingestionTask).when(storeIngestionService).getStoreIngestionTask(resourceName);
@@ -674,6 +687,7 @@ public class LeaderFollowerPartitionStateModelTest {
     when(storeAndServerConfigs.getFutureVersionStandbyLagThreshold()).thenReturn(100L);
     when(storeAndServerConfigs.getFutureVersionStandbyLagCheckTimeoutMinutes()).thenReturn(5);
     when(storeAndServerConfigs.getFutureVersionStandbyLagCheckPollIntervalMinutes()).thenReturn(0);
+    stubVersionStarted();
 
     StoreIngestionTask ingestionTask = mock(StoreIngestionTask.class);
     doReturn(ingestionTask).when(storeIngestionService).getStoreIngestionTask(resourceName);
@@ -682,6 +696,36 @@ public class LeaderFollowerPartitionStateModelTest {
     leaderFollowerPartitionStateModel.waitUntilFutureVersionLagAcceptable(resourceName);
 
     verify(ingestionTask, times(3)).getLocalVersionTopicLag(partition);
+  }
+
+  /**
+   * If the version transitions away from {@link VersionStatus#STARTED} (e.g. to {@link VersionStatus#KILLED})
+   * while polling, the wait must stop re-checking lag and return immediately on the next poll, rather than
+   * continuing to occupy the state-transition worker thread until the timeout elapses.
+   */
+  @Test
+  public void testWaitUntilFutureVersionLagAcceptableStopsWhenVersionNoLongerStarted() {
+    when(storeAndServerConfigs.isFutureVersionStandbyLagCheckEnabled()).thenReturn(true);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagThreshold()).thenReturn(100L);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagCheckTimeoutMinutes()).thenReturn(5);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagCheckPollIntervalMinutes()).thenReturn(0);
+
+    Store store = mock(Store.class);
+    Version mockVersion = mock(Version.class);
+    // First poll: still STARTED (so lag is measured once); subsequent polls: version has been killed.
+    when(mockVersion.getStatus()).thenReturn(VersionStatus.STARTED, VersionStatus.KILLED);
+    when(store.getVersion(storeVersion)).thenReturn(mockVersion);
+    doReturn(store).when(metadataRepo).getStoreOrThrow(anyString());
+
+    StoreIngestionTask ingestionTask = mock(StoreIngestionTask.class);
+    doReturn(ingestionTask).when(storeIngestionService).getStoreIngestionTask(resourceName);
+    // Lag never catches up, so the only way the loop can exit before the timeout is via the status re-check.
+    doReturn(200L).when(ingestionTask).getLocalVersionTopicLag(partition);
+
+    leaderFollowerPartitionStateModel.waitUntilFutureVersionLagAcceptable(resourceName);
+
+    // Lag should only have been measured once, before the version's status flipped away from STARTED.
+    verify(ingestionTask, times(1)).getLocalVersionTopicLag(partition);
   }
 
   /**
@@ -694,6 +738,7 @@ public class LeaderFollowerPartitionStateModelTest {
     when(storeAndServerConfigs.getFutureVersionStandbyLagThreshold()).thenReturn(100L);
     when(storeAndServerConfigs.getFutureVersionStandbyLagCheckTimeoutMinutes()).thenReturn(0);
     when(storeAndServerConfigs.getFutureVersionStandbyLagCheckPollIntervalMinutes()).thenReturn(0);
+    stubVersionStarted();
 
     StoreIngestionTask ingestionTask = mock(StoreIngestionTask.class);
     doReturn(ingestionTask).when(storeIngestionService).getStoreIngestionTask(resourceName);
@@ -715,6 +760,7 @@ public class LeaderFollowerPartitionStateModelTest {
     when(storeAndServerConfigs.getFutureVersionStandbyLagThreshold()).thenReturn(0L);
     when(storeAndServerConfigs.getFutureVersionStandbyLagCheckTimeoutMinutes()).thenReturn(5);
     when(storeAndServerConfigs.getFutureVersionStandbyLagCheckPollIntervalMinutes()).thenReturn(1);
+    stubVersionStarted();
 
     StoreIngestionTask ingestionTask = mock(StoreIngestionTask.class);
     doReturn(ingestionTask).when(storeIngestionService).getStoreIngestionTask(resourceName);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -28,6 +29,7 @@ import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.ingestion.DefaultIngestionBackend;
 import com.linkedin.davinci.ingestion.IngestionBackend;
 import com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService;
+import com.linkedin.davinci.kafka.consumer.StoreIngestionTask;
 import com.linkedin.davinci.stats.ParticipantStateTransitionStats;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatLagMonitorAction;
 import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
@@ -616,6 +618,199 @@ public class LeaderFollowerPartitionStateModelTest {
         System.err.println("Failed to cleanup test directory: " + testDataPath + ", error: " + e.getMessage());
       }
     }
+  }
+
+  /**
+   * When {@link com.linkedin.venice.ConfigKeys#SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED} is not enabled
+   * (the default), {@code onBecomeStandbyFromOffline} must not invoke {@code waitUntilFutureVersionLagAcceptable}
+   * at all for an in-progress future-version push, preserving the pre-existing (no-wait) behavior.
+   */
+  @Test
+  public void testWaitUntilFutureVersionLagAcceptableDisabledByDefault() throws InterruptedException {
+    Message message = mock(Message.class);
+    NotificationContext context = mock(NotificationContext.class);
+    when(message.getResourceName()).thenReturn(resourceName);
+
+    Store store = mock(Store.class);
+    Version mockVersion = mock(Version.class);
+    when(mockVersion.getStatus()).thenReturn(VersionStatus.STARTED); // push still in progress, not ready
+    when(store.getVersion(storeVersion)).thenReturn(mockVersion);
+    doReturn(store).when(metadataRepo).getStoreOrThrow(anyString());
+    doReturn(store).when(metadataRepo).getStore(anyString());
+
+    LeaderFollowerPartitionStateModel spyModel = spy(leaderFollowerPartitionStateModel);
+    spyModel.onBecomeStandbyFromOffline(message, context);
+
+    verify(spyModel, never()).waitUntilFutureVersionLagAcceptable(anyString());
+  }
+
+  /**
+   * When lag is already within the configured threshold, the wait must return immediately after a single
+   * measurement, without sleeping/polling further.
+   */
+  @Test
+  public void testWaitUntilFutureVersionLagAcceptableProceedsWhenLagWithinThreshold() {
+    when(storeAndServerConfigs.isFutureVersionStandbyLagCheckEnabled()).thenReturn(true);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagThreshold()).thenReturn(100L);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagCheckTimeoutMinutes()).thenReturn(5);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagCheckPollIntervalMinutes()).thenReturn(1);
+
+    StoreIngestionTask ingestionTask = mock(StoreIngestionTask.class);
+    doReturn(ingestionTask).when(storeIngestionService).getStoreIngestionTask(resourceName);
+    doReturn(50L).when(ingestionTask).getLocalVersionTopicLag(partition);
+
+    leaderFollowerPartitionStateModel.waitUntilFutureVersionLagAcceptable(resourceName);
+
+    verify(ingestionTask, times(1)).getLocalVersionTopicLag(partition);
+  }
+
+  /**
+   * When lag starts above the threshold but catches up within the timeout window, the wait must keep polling
+   * (re-measuring lag) until it becomes acceptable, then return.
+   */
+  @Test
+  public void testWaitUntilFutureVersionLagAcceptablePollsUntilLagCatchesUp() {
+    when(storeAndServerConfigs.isFutureVersionStandbyLagCheckEnabled()).thenReturn(true);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagThreshold()).thenReturn(100L);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagCheckTimeoutMinutes()).thenReturn(5);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagCheckPollIntervalMinutes()).thenReturn(0);
+
+    StoreIngestionTask ingestionTask = mock(StoreIngestionTask.class);
+    doReturn(ingestionTask).when(storeIngestionService).getStoreIngestionTask(resourceName);
+    doReturn(200L, 200L, 50L).when(ingestionTask).getLocalVersionTopicLag(partition);
+
+    leaderFollowerPartitionStateModel.waitUntilFutureVersionLagAcceptable(resourceName);
+
+    verify(ingestionTask, times(3)).getLocalVersionTopicLag(partition);
+  }
+
+  /**
+   * When lag never catches up, the wait must give up after the configured timeout and proceed anyway
+   * (best-effort semantics), rather than blocking indefinitely.
+   */
+  @Test
+  public void testWaitUntilFutureVersionLagAcceptableTimesOutAndProceeds() {
+    when(storeAndServerConfigs.isFutureVersionStandbyLagCheckEnabled()).thenReturn(true);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagThreshold()).thenReturn(100L);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagCheckTimeoutMinutes()).thenReturn(0);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagCheckPollIntervalMinutes()).thenReturn(0);
+
+    StoreIngestionTask ingestionTask = mock(StoreIngestionTask.class);
+    doReturn(ingestionTask).when(storeIngestionService).getStoreIngestionTask(resourceName);
+    doReturn(200L).when(ingestionTask).getLocalVersionTopicLag(partition);
+
+    // Must return promptly (best-effort timeout) instead of looping forever.
+    leaderFollowerPartitionStateModel.waitUntilFutureVersionLagAcceptable(resourceName);
+
+    verify(ingestionTask, atLeastOnce()).getLocalVersionTopicLag(partition);
+  }
+
+  /**
+   * When lag cannot be measured (e.g. PubSub error surfaced as {@code Long.MAX_VALUE}), the wait must fail open
+   * and proceed immediately, matching the pre-existing (no-wait) behavior.
+   */
+  @Test
+  public void testWaitUntilFutureVersionLagAcceptableFailsOpenWhenLagCannotBeMeasured() {
+    when(storeAndServerConfigs.isFutureVersionStandbyLagCheckEnabled()).thenReturn(true);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagThreshold()).thenReturn(0L);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagCheckTimeoutMinutes()).thenReturn(5);
+    when(storeAndServerConfigs.getFutureVersionStandbyLagCheckPollIntervalMinutes()).thenReturn(1);
+
+    StoreIngestionTask ingestionTask = mock(StoreIngestionTask.class);
+    doReturn(ingestionTask).when(storeIngestionService).getStoreIngestionTask(resourceName);
+    doReturn(Long.MAX_VALUE).when(ingestionTask).getLocalVersionTopicLag(partition);
+
+    leaderFollowerPartitionStateModel.waitUntilFutureVersionLagAcceptable(resourceName);
+
+    verify(ingestionTask, times(1)).getLocalVersionTopicLag(partition);
+  }
+
+  /**
+   * When no ingestion task is found for the resource (e.g. torn down concurrently), the wait must fail open and
+   * return without throwing.
+   */
+  @Test
+  public void testWaitUntilFutureVersionLagAcceptableFailsOpenWhenNoIngestionTask() {
+    when(storeAndServerConfigs.isFutureVersionStandbyLagCheckEnabled()).thenReturn(true);
+    doReturn(null).when(storeIngestionService).getStoreIngestionTask(resourceName);
+
+    // Should not throw NPE and should return immediately.
+    leaderFollowerPartitionStateModel.waitUntilFutureVersionLagAcceptable(resourceName);
+  }
+
+  /**
+   * OFFLINE-&gt;STANDBY for a future version whose push is still in progress (neither current version nor an
+   * already-ready future version) must route through {@link LeaderFollowerPartitionStateModel#waitUntilFutureVersionLagAcceptable}
+   * instead of the full-completion {@code waitConsumptionCompleted} path.
+   */
+  @Test
+  public void testOnBecomeStandbyFromOfflineUsesLagWaitForInProgressFutureVersion() throws InterruptedException {
+    Message message = mock(Message.class);
+    NotificationContext context = mock(NotificationContext.class);
+    when(message.getResourceName()).thenReturn(resourceName);
+
+    Store store = mock(Store.class);
+    // getCurrentVersion() defaults to 0 (Mockito primitive default), which is not equal to storeVersion (3),
+    // so this replica is not the current version.
+    Version mockVersion = mock(Version.class);
+    when(mockVersion.getStatus()).thenReturn(VersionStatus.STARTED); // push still in progress, not ready
+    when(store.getVersion(storeVersion)).thenReturn(mockVersion);
+    doReturn(store).when(metadataRepo).getStoreOrThrow(anyString());
+    // Utils.isFutureVersion() uses getStore() (not getStoreOrThrow()) to resolve the store.
+    doReturn(store).when(metadataRepo).getStore(anyString());
+    when(storeAndServerConfigs.isFutureVersionStandbyLagCheckEnabled()).thenReturn(true);
+
+    LeaderFollowerPartitionStateModel spyModel = spy(leaderFollowerPartitionStateModel);
+    spyModel.onBecomeStandbyFromOffline(message, context);
+
+    verify(spyModel, times(1)).waitUntilFutureVersionLagAcceptable(resourceName);
+    verify(notifier, never()).waitConsumptionCompleted(anyString(), anyInt(), anyInt(), any());
+  }
+
+  /**
+   * OFFLINE-&gt;STANDBY for the current version must continue to use the full-completion
+   * {@code waitConsumptionCompleted} path, and must not invoke the new lag-based wait.
+   */
+  @Test
+  public void testOnBecomeStandbyFromOfflineUsesFullWaitForCurrentVersion() throws InterruptedException {
+    Message message = mock(Message.class);
+    NotificationContext context = mock(NotificationContext.class);
+    when(message.getResourceName()).thenReturn(resourceName);
+
+    Store store = mock(Store.class);
+    when(store.getCurrentVersion()).thenReturn(storeVersion);
+    when(store.getVersion(storeVersion)).thenReturn(mock(Version.class));
+    doReturn(store).when(metadataRepo).getStoreOrThrow(anyString());
+
+    LeaderFollowerPartitionStateModel spyModel = spy(leaderFollowerPartitionStateModel);
+    spyModel.onBecomeStandbyFromOffline(message, context);
+
+    verify(spyModel, never()).waitUntilFutureVersionLagAcceptable(anyString());
+    verify(notifier, times(1)).waitConsumptionCompleted(eq(resourceName), eq(partition), anyInt(), any());
+  }
+
+  /**
+   * OFFLINE-&gt;STANDBY for a backup version (older than the current serving version) must not use either wait
+   * path: it's neither the current version nor a future version, so it should proceed immediately.
+   */
+  @Test
+  public void testOnBecomeStandbyFromOfflineSkipsBothWaitsForBackupVersion() throws InterruptedException {
+    Message message = mock(Message.class);
+    NotificationContext context = mock(NotificationContext.class);
+    when(message.getResourceName()).thenReturn(resourceName);
+
+    Store store = mock(Store.class);
+    // Current version is newer than this replica's version, so this replica is a backup version.
+    when(store.getCurrentVersion()).thenReturn(storeVersion + 1);
+    when(store.getVersion(storeVersion)).thenReturn(mock(Version.class));
+    doReturn(store).when(metadataRepo).getStoreOrThrow(anyString());
+    doReturn(store).when(metadataRepo).getStore(anyString());
+
+    LeaderFollowerPartitionStateModel spyModel = spy(leaderFollowerPartitionStateModel);
+    spyModel.onBecomeStandbyFromOffline(message, context);
+
+    verify(spyModel, never()).waitUntilFutureVersionLagAcceptable(anyString());
+    verify(notifier, never()).waitConsumptionCompleted(anyString(), anyInt(), anyInt(), any());
   }
 
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -6261,6 +6261,47 @@ public abstract class StoreIngestionTaskTest {
   }
 
   @Test
+  public void testGetLocalVersionTopicLag() throws Exception {
+    StoreIngestionTask storeIngestionTask = mock(StoreIngestionTask.class);
+    doCallRealMethod().when(storeIngestionTask).getLocalVersionTopicLag(anyInt());
+
+    Map<Integer, PartitionConsumptionState> pcsMap = new VeniceConcurrentHashMap<>();
+    doReturn(pcsMap).when(storeIngestionTask).getPartitionConsumptionStateMap();
+
+    // No PartitionConsumptionState yet for this partition -> lag cannot be measured
+    assertEquals(
+        storeIngestionTask.getLocalVersionTopicLag(PARTITION_FOO),
+        Long.MAX_VALUE,
+        "When no PCS exists for the partition, lag should be reported as infinite.");
+
+    // Set the private final fields normally populated by the constructor, which is bypassed by mock()
+    PubSubTopicRepository topicRepository = new PubSubTopicRepository();
+    PubSubTopic versionTopic = topicRepository.getTopic(Version.composeKafkaTopic("test_store", 1));
+    Field versionTopicField = storeIngestionTask.getClass().getSuperclass().getDeclaredField("versionTopic");
+    versionTopicField.setAccessible(true);
+    versionTopicField.set(storeIngestionTask, versionTopic);
+    Field localKafkaServerField = storeIngestionTask.getClass().getSuperclass().getDeclaredField("localKafkaServer");
+    localKafkaServerField.setAccessible(true);
+    localKafkaServerField.set(storeIngestionTask, "localhost:1234");
+
+    PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
+    PubSubPosition currentPosition = InMemoryPubSubPosition.of(5L);
+    doReturn(currentPosition).when(pcs).getLatestProcessedVtPosition();
+    pcsMap.put(PARTITION_FOO, pcs);
+
+    doReturn(123L).when(storeIngestionTask)
+        .measureLagWithCallToPubSub(
+            eq("localhost:1234"),
+            eq(new PubSubTopicPartitionImpl(versionTopic, PARTITION_FOO)),
+            eq(currentPosition));
+
+    assertEquals(
+        storeIngestionTask.getLocalVersionTopicLag(PARTITION_FOO),
+        123L,
+        "When a PCS exists, lag should be delegated to measureLagWithCallToPubSub against the local VT.");
+  }
+
+  @Test
   public void testMeasureLagWithCallToPubSubWhenTopicDoesNotExist() {
     final PubSubTopicPartition partition = new PubSubTopicPartitionImpl(pubSubTopic, 0);
     final InMemoryPubSubPosition endPosition = InMemoryPubSubPosition.of(10L);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -3271,6 +3271,42 @@ public class ConfigKeys {
       "server.lag.based.replica.auto.resubscribe.max.replica.count";
 
   /**
+   * Config to enable/disable blocking the OFFLINE-&gt;STANDBY transition for future-version replicas whose push
+   * is still in progress (i.e. not yet PUSHED/ONLINE), until the replica's local version topic consumption lag
+   * drops to or below {@link #SERVER_FUTURE_VERSION_STANDBY_LAG_THRESHOLD}. This prevents Helix from electing a
+   * brand-new/lagging replica as leader immediately after it reaches STANDBY. Default is false.
+   */
+  public static final String SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED =
+      "server.future.version.standby.lag.check.enabled";
+
+  /**
+   * Config to control the acceptable local version topic lag (number of records behind the end of the topic)
+   * for a future-version, in-progress-push replica to be allowed to complete the OFFLINE-&gt;STANDBY transition.
+   * Only used when {@link #SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED} is true. Default is 1000 records,
+   * a small buffer to absorb normal producer/consumer jitter rather than requiring an exact catch-up.
+   */
+  public static final String SERVER_FUTURE_VERSION_STANDBY_LAG_THRESHOLD =
+      "server.future.version.standby.lag.threshold";
+
+  /**
+   * Config to control the maximum duration, in minutes, to block the OFFLINE-&gt;STANDBY transition while waiting
+   * for a future-version, in-progress-push replica's lag to become acceptable. This is a best-effort wait: once
+   * the timeout elapses, the transition proceeds regardless of the measured lag, to avoid liveness issues.
+   * Only used when {@link #SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED} is true. Default is 120 min = 2 hours,
+   * to accommodate replicas that are still bootstrapping.
+   */
+  public static final String SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_TIMEOUT_MINUTES =
+      "server.future.version.standby.lag.check.timeout.minutes";
+
+  /**
+   * Config to control the interval, in minutes, between successive lag re-measurements while waiting for a
+   * future-version, in-progress-push replica's lag to become acceptable. Only used when
+   * {@link #SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED} is true. Default is 15 min.
+   */
+  public static final String SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_POLL_INTERVAL_MINUTES =
+      "server.future.version.standby.lag.check.poll.interval.minutes";
+
+  /**
    * Whether to enable producer throughput optimization for realtime workload or not.
    * Two strategies:
    * 1. Disable compression.

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helixrebalance/FutureVersionStandbyLagCheckTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helixrebalance/FutureVersionStandbyLagCheckTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.helixrebalance;
 
+import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModelFactory;
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
@@ -137,6 +138,13 @@ public class FutureVersionStandbyLagCheckTest {
     extraProperties.put(ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_THRESHOLD, 0);
     extraProperties.put(ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_TIMEOUT_MINUTES, timeoutMinutes);
     extraProperties.put(ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_POLL_INTERVAL_MINUTES, pollIntervalMinutes);
+    if (lagCheckEnabled) {
+      // The lag-based wait synchronously occupies a state-transition worker thread, so it is only allowed when
+      // future-version transitions run on their own dedicated pool.
+      extraProperties.put(
+          ConfigKeys.LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY,
+          LeaderFollowerPartitionStateModelFactory.LeaderFollowerThreadPoolStrategy.DUAL_POOL_STRATEGY.name());
+    }
 
     cluster.addVeniceServer(new Properties(), extraProperties);
     cluster.addVeniceServer(new Properties(), extraProperties);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helixrebalance/FutureVersionStandbyLagCheckTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helixrebalance/FutureVersionStandbyLagCheckTest.java
@@ -1,0 +1,144 @@
+package com.linkedin.venice.helixrebalance;
+
+import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.meta.OfflinePushStrategy;
+import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.writer.VeniceWriter;
+import java.util.HashMap;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+/**
+ * Integration tests covering the future-version standby lag check feature (best-effort progress-based leader
+ * election): when a replica transitions OFFLINE -> STANDBY for a future version whose push is still in progress,
+ * the state transition can optionally poll the local version-topic lag and wait for it to drop below a threshold
+ * (instead of waiting for full ingestion completion), bounded by a timeout so the push job is never blocked
+ * indefinitely.
+ */
+public class FutureVersionStandbyLagCheckTest {
+  private VeniceClusterWrapper cluster;
+  private final int replicaFactor = 2;
+  private final int partitionSize = 1000;
+  private final int partitionNum = 1;
+
+  @BeforeMethod
+  public void setUp() {
+    Properties extraProperties = new Properties();
+    extraProperties.put(ConfigKeys.DEFAULT_OFFLINE_PUSH_STRATEGY, OfflinePushStrategy.WAIT_ALL_REPLICAS.name());
+    extraProperties.put(ConfigKeys.OFFLINE_JOB_START_TIMEOUT_MS, 30_000);
+    VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
+        .numberOfServers(0)
+        .numberOfRouters(1)
+        .replicationFactor(replicaFactor)
+        .partitionSize(partitionSize)
+        .sslToStorageNodes(false)
+        .sslToKafka(false)
+        .extraProperties(extraProperties)
+        .build();
+    cluster = ServiceFactory.getVeniceCluster(options);
+  }
+
+  @AfterMethod
+  public void cleanUp() {
+    cluster.close();
+  }
+
+  /**
+   * With the lag check enabled and a threshold/timeout that are easily satisfiable, a future version push should
+   * still complete successfully: the OFFLINE -> STANDBY transition polls the local lag, observes it catch up
+   * quickly (since the push is tiny), and proceeds to STANDBY without waiting for the whole timeout budget.
+   */
+  @Test(timeOut = 120 * Time.MS_PER_SECOND)
+  public void testFutureVersionPushCompletesWhenLagCheckEnabledAndLagCatchesUp() throws Exception {
+    setUpServers(true, 60, 1);
+    String storeName = Utils.getUniqueString("testFutureVersionLagCheckEnabled");
+    runPushAndVerifyCompletion(storeName);
+    // Push a future version on top; it should also complete even with the lag check enabled.
+    runPushAndVerifyCompletion(storeName);
+  }
+
+  /**
+   * With the lag check enabled but a timeout of 0 seconds (i.e. the wait budget is immediately exhausted), the
+   * OFFLINE -> STANDBY transition must fail open and proceed exactly like the feature being disabled, so the push
+   * job still completes instead of hanging or failing.
+   */
+  @Test(timeOut = 120 * Time.MS_PER_SECOND)
+  public void testFutureVersionPushCompletesWhenLagCheckTimesOutImmediately() throws Exception {
+    setUpServers(true, 0, 1);
+    String storeName = Utils.getUniqueString("testFutureVersionLagCheckTimeout");
+    runPushAndVerifyCompletion(storeName);
+    runPushAndVerifyCompletion(storeName);
+  }
+
+  /**
+   * With the lag check disabled (default behavior), future version pushes complete as before. This acts as the
+   * baseline/regression guard for the new feature.
+   */
+  @Test(timeOut = 120 * Time.MS_PER_SECOND)
+  public void testFutureVersionPushCompletesWhenLagCheckDisabled() throws Exception {
+    setUpServers(false, 0, 0);
+    String storeName = Utils.getUniqueString("testFutureVersionLagCheckDisabled");
+    runPushAndVerifyCompletion(storeName);
+    runPushAndVerifyCompletion(storeName);
+  }
+
+  private void runPushAndVerifyCompletion(String storeName) {
+    if (cluster.getLeaderVeniceController().getVeniceAdmin().getStore(cluster.getClusterName(), storeName) == null) {
+      cluster.getNewStore(storeName);
+      long storageQuota = (long) partitionNum * partitionSize;
+      cluster.updateStore(storeName, new UpdateStoreQueryParams().setStorageQuotaInByte(storageQuota));
+    }
+
+    String topicName = createVersionAndPushData(storeName);
+
+    TestUtils.waitForNonDeterministicAssertion(
+        60,
+        TimeUnit.SECONDS,
+        true,
+        () -> Assert.assertEquals(
+            cluster.getLeaderVeniceController()
+                .getVeniceAdmin()
+                .getOffLinePushStatus(cluster.getClusterName(), topicName)
+                .getExecutionStatus(),
+            ExecutionStatus.COMPLETED));
+  }
+
+  private String createVersionAndPushData(String storeName) {
+    VersionCreationResponse response = cluster.getNewVersion(storeName);
+
+    String topicName = response.getKafkaTopic();
+    Assert.assertEquals(response.getReplicas(), replicaFactor);
+    Assert.assertEquals(response.getPartitions(), partitionNum);
+
+    try (VeniceWriter<String, String, byte[]> veniceWriter = cluster.getVeniceWriter(topicName)) {
+      veniceWriter.broadcastStartOfPush(new HashMap<>());
+      veniceWriter.put("test", "test", 1);
+      veniceWriter.broadcastEndOfPush(new HashMap<>());
+    }
+    return topicName;
+  }
+
+  private void setUpServers(boolean lagCheckEnabled, int timeoutMinutes, int pollIntervalMinutes) {
+    Properties extraProperties = new Properties();
+    extraProperties.put(ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED, lagCheckEnabled);
+    extraProperties.put(ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_THRESHOLD, 0);
+    extraProperties.put(ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_TIMEOUT_MINUTES, timeoutMinutes);
+    extraProperties.put(ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_POLL_INTERVAL_MINUTES, pollIntervalMinutes);
+
+    cluster.addVeniceServer(new Properties(), extraProperties);
+    cluster.addVeniceServer(new Properties(), extraProperties);
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helixrebalance/FutureVersionStandbyLagCheckTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helixrebalance/FutureVersionStandbyLagCheckTest.java
@@ -30,9 +30,9 @@ import org.testng.annotations.Test;
  */
 public class FutureVersionStandbyLagCheckTest {
   private VeniceClusterWrapper cluster;
-  private final int replicaFactor = 2;
-  private final int partitionSize = 1000;
-  private final int partitionNum = 1;
+  private static final int replicaFactor = 2;
+  private static final int partitionSize = 1000;
+  private static final int partitionNum = 1;
 
   @BeforeMethod
   public void setUp() {


### PR DESCRIPTION
## Summary

Implements a best-effort, progress-based leader election safeguard: when a replica transitions OFFLINE->STANDBY for a future version whose push is still in progress (version status is `STARTED`; not the current version, not an already-ready future version), the transition now polls local version-topic lag and waits for it to drop below a configurable threshold before proceeding, instead of immediately becoming STANDBY. This reduces the chance that a lagging replica gets elected LEADER shortly after.

The wait is bounded by a timeout and fails open (proceeds as before) if the feature is disabled, the ingestion task/lag can't be resolved, the version is no longer `STARTED` (e.g. killed/errored/rolled back mid-wait), or the timeout elapses, so push jobs are never blocked indefinitely.

Since the wait synchronously occupies a Helix state-transition worker thread, the feature can only be enabled when the server's thread pool strategy is `DUAL_POOL_STRATEGY` (dedicated pool for future-version transitions); enabling it under `SINGLE_POOL_STRATEGY` (the current production default) fails server startup with an actionable error.

## New configs (VeniceServerConfig / ConfigKeys)

- `server.future.version.standby.lag.check.enabled` (default `false`)
- `server.future.version.standby.lag.threshold` (default `1000` records)
- `server.future.version.standby.lag.check.timeout.minutes` (default `120` = 2 hours)
- `server.future.version.standby.lag.check.poll.interval.minutes` (default `15`)

Enabling `server.future.version.standby.lag.check.enabled` requires `server.leader.follower.state.transition.thread.pool.strategy=DUAL_POOL_STRATEGY`; otherwise `VeniceServerConfig` throws at startup.

## Changes

- `StoreIngestionTask#getLocalVersionTopicLag`: exposes per-partition local VT lag via the existing `measureLagWithCallToPubSub` primitive.
- `AbstractPartitionStateModel#waitUntilFutureVersionLagAcceptable`: new polling-wait loop; re-checks the version's status (`STARTED`) on every poll so a version killed/errored mid-wait exits promptly instead of occupying the worker thread until the next lag measurement or timeout.
- `LeaderFollowerPartitionStateModel#onBecomeStandbyFromOffline`: hooks the new wait into the in-progress future-version branch, using an explicit `VersionStatus.STARTED` check (rather than "future and not ready") to correctly exclude backup versions and terminal states (`KILLED`/`ERROR`/`ROLLED_BACK`).
- `VeniceServerConfig`: fails fast at startup if the lag check is enabled without `DUAL_POOL_STRATEGY`, since production currently defaults to `SINGLE_POOL_STRATEGY`.

## Tests

- Unit tests for `VeniceServerConfig` getters/defaults, the dual-pool-strategy startup validation, `getLocalVersionTopicLag`, and the new wait method's enabled/disabled/polling/timeout/fail-open/version-status-recheck paths in `LeaderFollowerPartitionStateModelTest`.
- New integration test `FutureVersionStandbyLagCheckTest` covering enabled (lag catches up), enabled with immediate timeout (fail-open), and disabled (baseline) scenarios against a real cluster.

🤖 Generated with [GitHub Copilot CLI](https://github.com/github/copilot-cli)
