### PR TITLE
[vpj] Fix Spark chunk assembly silently dropping records that MR would fail on

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/chunk/SparkChunkAssembler.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/chunk/SparkChunkAssembler.java
@@ -85,7 +85,14 @@ public class SparkChunkAssembler implements Serializable, AutoCloseable {
    *
    * @param keyBytes The key bytes
    * @param rows Iterator of rows for this key (MUST be sorted by offset DESC - highest offset first)
-   * @return Assembled row with DEFAULT_SCHEMA_WITH_SCHEMA_ID schema, or null if DELETE, incomplete chunks, or filtered by TTL
+   * @return Assembled row with DEFAULT_SCHEMA_WITH_SCHEMA_ID schema, or null if DELETE, orphan chunks
+   *         (chunks with no corresponding manifest), or filtered by TTL
+   * @throws RuntimeException (e.g. VeniceException, IllegalArgumentException, IllegalStateException) if the
+   *         assembled record is malformed - for example missing value/RMD chunks, a byte-count mismatch
+   *         against the manifest, an offset-ordering violation, or an unrecognized schema id/message type.
+   *         This intentionally mirrors {@code VeniceKafkaInputReducer#extractChunkedMessage}, which lets the
+   *         same exceptions from {@code ChunkAssembler#assembleAndGetValue} propagate and fail the MR task
+   *         rather than silently dropping the record.
    */
   public Row assembleChunks(byte[] keyBytes, Iterator<Row> rows) {
     // Handle empty iterator early
@@ -95,18 +102,14 @@ public class SparkChunkAssembler implements Serializable, AutoCloseable {
 
     Iterator<byte[]> valueIterator = new RowToSerializedValueIterator(rows);
 
-    ChunkAssembler.ValueBytesAndSchemaId assembled;
-    try {
-      assembled = getChunkAssembler().assembleAndGetValue(keyBytes, valueIterator);
-    } catch (IllegalStateException e) {
-      throw e;
-    } catch (Exception e) {
-      // If assembly fails (e.g., incomplete chunks, missing manifest, orphan chunks), return null
-      return null;
-    }
+    // Do not catch-and-swallow exceptions here: every exception ChunkAssembler#assembleAndGetValue throws
+    // (missing chunks, byte-count mismatch, ordering violation, unrecognized schema id) represents a genuinely
+    // corrupt/incomplete record, not a legitimate "no data" outcome. Legitimate null results (DELETE, orphan
+    // chunks with no manifest) are already returned as `null` by assembleAndGetValue below, without throwing.
+    ChunkAssembler.ValueBytesAndSchemaId assembled = getChunkAssembler().assembleAndGetValue(keyBytes, valueIterator);
 
     if (assembled == null) {
-      // Latest record is DELETE, or chunks are incomplete
+      // Latest record is DELETE with no RMD, or no manifest was ever found (orphan chunks)
       return null;
     }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -833,7 +833,7 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
       Row assembled = getOrCreateAssembler().assembleChunks(keyBytes, rowsList.iterator());
 
       if (assembled == null) {
-        // Latest record is DELETE, chunks incomplete, or filtered by TTL
+        // Latest record is DELETE, orphan chunks (no manifest), or filtered by TTL
         emptyRecordAcc.add(1);
         chunkMetrics.timeNs.add(System.nanoTime() - groupStartNs);
         return Collections.emptyIterator();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/chunk/SparkChunkAssemblerTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/spark/chunk/SparkChunkAssemblerTest.java
@@ -1,6 +1,9 @@
 package com.linkedin.venice.spark.chunk;
 
+import static com.linkedin.venice.spark.SparkConstants.CHUNKED_KEY_SUFFIX_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.KEY_COLUMN_NAME;
+import static com.linkedin.venice.spark.SparkConstants.MESSAGE_TYPE_COLUMN_NAME;
+import static com.linkedin.venice.spark.SparkConstants.OFFSET_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.RMD_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.RMD_VERSION_ID_COLUMN_NAME;
 import static com.linkedin.venice.spark.SparkConstants.SCHEMA_FOR_CHUNK_ASSEMBLY;
@@ -12,7 +15,12 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.venice.common.ChunkAssembler;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
+import com.linkedin.venice.hadoop.input.kafka.avro.MapperValueType;
 import com.linkedin.venice.kafka.protocol.GUID;
+import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -44,6 +52,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
@@ -587,6 +596,116 @@ public class SparkChunkAssemblerTest {
         (int) assembledChunked.getAs(SCHEMA_ID_COLUMN_NAME),
         REGULAR_SCHEMA_ID,
         "Assembled record should have original schema ID from manifest");
+  }
+
+  /**
+   * Regression test for the MR/Spark error-parity gap documented in
+   * docs/vpj-spark-migration-bugs/02-chunk-assembly-error-parity.md: when a manifest is present but one or
+   * more of its declared chunks is missing (e.g. KafkaInputFormat only read a partial set of a large
+   * message's chunks), {@link ChunkAssembler#assembleAndGetValue} throws a {@link VeniceException} ("Cannot
+   * assemble a large value. Missing N / M chunks."). MR's {@code VeniceKafkaInputReducer#extractChunkedMessage}
+   * calls that method with no try/catch, so this fails the reducer task. {@link SparkChunkAssembler#assembleChunks}
+   * catches every non-{@link IllegalStateException} thrown by the same call and returns {@code null}, which the
+   * caller treats identically to a DELETE, incomplete-chunk, or TTL-filtered record: the key is silently dropped
+   * instead of failing the job. This test proves both halves of that gap from the exact same serialized input.
+   */
+  @Test
+  public void testMissingChunksPropagateInSparkSameAsMR() {
+    byte[] key = "missing-chunk-key".getBytes();
+    int declaredChunkCount = 2; // manifest declares 2 chunks are needed to reassemble the value
+    int chunkSize = 10;
+    int segmentNumber = 1;
+    int sequenceNumber = 100;
+
+    KeyWithChunkingSuffixSerializer keySerializer = new KeyWithChunkingSuffixSerializer();
+    List<ByteBuffer> chunkKeysWithSuffix = new ArrayList<>();
+    for (int i = 0; i < declaredChunkCount; i++) {
+      ChunkedKeySuffix suffix = createChunkedKeySuffix(segmentNumber, sequenceNumber, i);
+      chunkKeysWithSuffix.add(keySerializer.serializeChunkedKey(key, suffix));
+    }
+
+    ChunkedValueManifest manifest = new ChunkedValueManifest();
+    manifest.keysWithChunkIdSuffix = chunkKeysWithSuffix;
+    manifest.schemaId = REGULAR_SCHEMA_ID;
+    manifest.size = declaredChunkCount * chunkSize;
+    ChunkedValueManifestSerializer manifestSerializer = new ChunkedValueManifestSerializer(true);
+    byte[] manifestBytes = ByteUtils.extractByteArray(manifestSerializer.serialize(manifest));
+
+    // Only supply chunk index 0; chunk index 1 (declared in the manifest) is missing.
+    ChunkedKeySuffix presentChunkSuffix = createChunkedKeySuffix(segmentNumber, sequenceNumber, 0);
+    byte[] presentChunkSuffixBytes = serializeChunkedKeySuffix(presentChunkSuffix);
+    byte[] presentChunkData = new byte[chunkSize];
+    Arrays.fill(presentChunkData, (byte) 7);
+
+    // Rows in DESCENDING order by offset: manifest (highest offset) first, then the single available chunk.
+    Row manifestRow = createRowWithSuffix(
+        key,
+        manifestBytes,
+        new byte[0],
+        AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion(),
+        -1,
+        201L,
+        0, // PUT
+        null);
+    Row chunkRow = createRowWithSuffix(
+        key,
+        presentChunkData,
+        new byte[0],
+        CHUNK_SCHEMA_ID,
+        -1,
+        200L,
+        0, // PUT
+        presentChunkSuffixBytes);
+    List<Row> rows = Arrays.asList(manifestRow, chunkRow);
+
+    // Spark: SparkChunkAssembler#assembleChunks now propagates the VeniceException from ChunkAssembler
+    // instead of swallowing it, matching MR's behavior of failing the task rather than silently dropping the key.
+    SparkChunkAssembler sparkAssembler = new SparkChunkAssembler(false);
+    try {
+      sparkAssembler.assembleChunks(key, new ArrayList<>(rows).iterator());
+      Assert.fail("Expected a VeniceException for missing chunks, matching MR's reducer-task failure");
+    } catch (VeniceException e) {
+      assertTrue(e.getMessage().contains("Missing 1 / 2 chunks"), "Unexpected exception message: " + e.getMessage());
+    }
+
+    // MR: VeniceKafkaInputReducer#extractChunkedMessage calls ChunkAssembler#assembleAndGetValue directly,
+    // with no try/catch, so the identical serialized input fails the reducer task with a VeniceException.
+    List<byte[]> serializedMapperValues = new ArrayList<>();
+    for (Row row: rows) {
+      serializedMapperValues.add(rowToSerializedMapperValue(row));
+    }
+    ChunkAssembler mrChunkAssembler = new ChunkAssembler(false);
+    try {
+      mrChunkAssembler.assembleAndGetValue(key, serializedMapperValues.iterator());
+      Assert.fail("Expected a VeniceException for missing chunks, matching MR's reducer-task failure");
+    } catch (VeniceException e) {
+      assertTrue(e.getMessage().contains("Missing 1 / 2 chunks"), "Unexpected exception message: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Converts a test {@link Row} (built with the {@code SCHEMA_FOR_CHUNK_ASSEMBLY} schema) into a serialized
+   * {@link KafkaInputMapperValue}, mirroring the conversion {@link SparkChunkAssembler}'s internal
+   * {@code RowToSerializedValueIterator} performs, so the same input bytes can be fed directly into
+   * {@link ChunkAssembler#assembleAndGetValue} to simulate the MR reducer path.
+   */
+  private byte[] rowToSerializedMapperValue(Row row) {
+    KafkaInputMapperValue mapperValue = new KafkaInputMapperValue();
+    mapperValue.schemaId = row.getAs(SCHEMA_ID_COLUMN_NAME);
+    mapperValue.offset = row.getAs(OFFSET_COLUMN_NAME);
+    int messageType = row.getAs(MESSAGE_TYPE_COLUMN_NAME);
+    mapperValue.valueType = messageType == MessageType.PUT.getValue() ? MapperValueType.PUT : MapperValueType.DELETE;
+    byte[] valueBytes = row.getAs(VALUE_COLUMN_NAME);
+    mapperValue.value = valueBytes != null ? ByteBuffer.wrap(valueBytes) : ByteBuffer.allocate(0);
+    mapperValue.replicationMetadataVersionId = row.getAs(RMD_VERSION_ID_COLUMN_NAME);
+    byte[] rmdBytes = row.getAs(RMD_COLUMN_NAME);
+    mapperValue.replicationMetadataPayload = rmdBytes != null ? ByteBuffer.wrap(rmdBytes) : ByteBuffer.allocate(0);
+    byte[] chunkedKeySuffixBytes = row.getAs(CHUNKED_KEY_SUFFIX_COLUMN_NAME);
+    mapperValue.chunkedKeySuffix =
+        chunkedKeySuffixBytes != null ? ByteBuffer.wrap(chunkedKeySuffixBytes) : ByteBuffer.allocate(0);
+    RecordSerializer<KafkaInputMapperValue> serializer =
+        FastSerializerDeserializerFactory.getFastAvroGenericSerializer(KafkaInputMapperValue.SCHEMA$);
+    return serializer.serialize(mapperValue);
   }
 
   private Row createRow(byte[] key, byte[] value, byte[] rmd, int schemaId, int rmdVersionId, long offset) {


### PR DESCRIPTION
## Problem Statement

`SparkChunkAssembler#assembleChunks` caught every exception from `ChunkAssembler#assembleAndGetValue` (except `IllegalStateException`) and returned `null`. The caller (`ChunkAssemblyFunction` in `AbstractDataWriterSparkJob`) treats a `null` result as a legitimate empty/deleted record, so keys with missing/incomplete chunks, byte-count mismatches, or offset-ordering violations were silently dropped instead of failing the task.

`VeniceKafkaInputReducer#extractChunkedMessage` (the MR reducer) calls the same `ChunkAssembler#assembleAndGetValue` with no try/catch, so identical malformed input fails the MR task loudly. This is a correctness gap between the two push-job engines introduced during the MR-to-Spark migration that could cause silent data loss in Spark-based pushes.

`ChunkAssembler#assembleAndGetValue` only returns `null` for two legitimate "no data" outcomes: DELETE with no RMD, or orphan chunks with no manifest ever found. Every exception it throws (missing chunks, byte-count mismatch, offset-ordering violation, unrecognized schema id) represents a genuinely corrupt/incomplete record.

## Solution

- Removed the blanket `catch (Exception e) { return null; }` in `SparkChunkAssembler#assembleChunks`. Exceptions from `ChunkAssembler#assembleAndGetValue` now propagate and fail the Spark task, matching MR's behavior.
- Updated the method's Javadoc and a stale comment in `AbstractDataWriterSparkJob` to reflect that "incomplete chunks" now throws rather than returning `null`.
- `null` is still returned only for the two legitimate no-data cases (DELETE with no RMD, orphan chunks with no manifest); every other failure now surfaces instead of being silently swallowed.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

Added a regression test, `testMissingChunksPropagateInSparkSameAsMR`, that feeds identical malformed input (a manifest declaring 2 chunks, but only 1 chunk present) into both paths:
- `SparkChunkAssembler#assembleChunks` now throws `VeniceException` ("Missing 1 / 2 chunks").
- `ChunkAssembler#assembleAndGetValue` called directly (simulating the MR reducer path) throws the same exception.

Ran `./gradlew :clients:venice-push-job:test --tests "com.linkedin.venice.spark.chunk.SparkChunkAssemblerTest"` (all 15 tests pass, including the new regression test) and the full `:clients:venice-push-job:test` module suite (all pass).

## Does this PR introduce any user-facing or breaking changes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.

Spark-based pushes that hit genuinely corrupt/incomplete chunked records (missing chunks, byte-count mismatch, offset-ordering violation, unrecognized schema id) will now **fail the push job** instead of silently dropping the affected record, matching MapReduce's existing behavior. This is intentional — it closes a silent-data-loss gap — but it means previously-"successful" Spark pushes with such malformed input will now surface as failures.
