### PR TITLE
[dvc][changelog] Reject terminal versions after restart

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -642,6 +642,12 @@ public class DaVinciBackend implements Closeable {
     return currentVersion == null ? -1 : currentVersion.getNumber();
   }
 
+  @VisibleForTesting
+  public Set<Integer> getSubscribedVersionNumbers(String storeName) {
+    StoreBackend storeBackend = storeByNameMap.get(storeName);
+    return storeBackend == null ? Collections.emptySet() : storeBackend.getSubscribedVersionNumbers();
+  }
+
   private Version getVeniceLatestNonFaultyVersion(Store store, Set<Integer> faultyVersions) {
     Version latestNonFaultyVersion = null;
     for (Version version: store.getVersions()) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -659,13 +659,7 @@ public class DaVinciBackend implements Closeable {
     return store.getVersion(store.getCurrentVersion());
   }
 
-  /**
-   * A candidate version must not be selected, retained, ingested, or promoted by a regular Da Vinci client
-   * (including Stateful CDC) when it is either locally faulty or its authoritative {@link VersionStatus} is
-   * terminal: {@link VersionStatus#ROLLED_BACK}, {@link VersionStatus#ERROR}, or {@link VersionStatus#KILLED}.
-   * The rollback target itself is not filtered here because its status is not terminal once it becomes the
-   * current version; the ineligible version is the rolled-back-from version.
-   */
+  /** Terminal versions and versions with process-local ingestion failures are not Da Vinci candidates. */
   static boolean isDaVinciVersionIneligible(Version version, Set<Integer> faultyVersions) {
     if (version == null) {
       return true;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -53,6 +53,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
 import com.linkedin.venice.meta.SubscriptionBasedReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreWriter;
@@ -644,7 +645,7 @@ public class DaVinciBackend implements Closeable {
   private Version getVeniceLatestNonFaultyVersion(Store store, Set<Integer> faultyVersions) {
     Version latestNonFaultyVersion = null;
     for (Version version: store.getVersions()) {
-      if (faultyVersions.contains(version.getNumber())) {
+      if (isDaVinciVersionIneligible(version, faultyVersions)) {
         continue;
       }
       if (latestNonFaultyVersion == null || latestNonFaultyVersion.getNumber() < version.getNumber()) {
@@ -656,6 +657,23 @@ public class DaVinciBackend implements Closeable {
 
   private Version getVeniceCurrentVersion(Store store) {
     return store.getVersion(store.getCurrentVersion());
+  }
+
+  /**
+   * A candidate version must not be selected, retained, ingested, or promoted by a regular Da Vinci client
+   * (including Stateful CDC) when it is either locally faulty or its authoritative {@link VersionStatus} is
+   * terminal: {@link VersionStatus#ROLLED_BACK}, {@link VersionStatus#ERROR}, or {@link VersionStatus#KILLED}.
+   * The rollback target itself is not filtered here because its status is not terminal once it becomes the
+   * current version; the ineligible version is the rolled-back-from version.
+   */
+  static boolean isDaVinciVersionIneligible(Version version, Set<Integer> faultyVersions) {
+    if (version == null) {
+      return true;
+    }
+    VersionStatus status = version.getStatus();
+    boolean terminalStatus = VersionStatus.isVersionRolledBack(status) || VersionStatus.isVersionErrored(status)
+        || VersionStatus.isVersionKilled(status);
+    return terminalStatus || faultyVersions.contains(version.getNumber());
   }
 
   private final StoreDataChangedListener storeChangeListener = new StoreDataChangedListener() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
@@ -472,8 +472,7 @@ public class StoreBackend {
       }
       int veniceCurrentVersionNumber = veniceCurrentVersion.getNumber();
       int daVinciFutureVersionNumber = daVinciFutureVersion.getVersion().getNumber();
-      // Re-read the future version's authoritative metadata so an ingestion-completion callback cannot race
-      // a rollback/kill and promote a terminal (or removed) version. A null here means it no longer exists.
+      // Re-read authoritative metadata before promotion to catch a concurrent terminal transition.
       Version futureVersion =
           backend.getStoreRepository().getStoreOrThrow(storeName).getVersion(daVinciFutureVersionNumber);
       boolean isDaVinciFutureVersionInvalid =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci;
 import com.linkedin.davinci.client.DaVinciSeekCheckpointInfo;
 import com.linkedin.davinci.config.StoreBackendConfig;
 import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.venice.annotation.VisibleForTesting;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
@@ -119,6 +120,18 @@ public class StoreBackend {
 
   public ReferenceCounted<VersionBackend> getDaVinciCurrentVersion() {
     return daVinciCurrentVersionRef.get();
+  }
+
+  @VisibleForTesting
+  synchronized Set<Integer> getSubscribedVersionNumbers() {
+    Set<Integer> versionNumbers = new HashSet<>(2);
+    if (daVinciCurrentVersion != null) {
+      versionNumbers.add(daVinciCurrentVersion.getVersion().getNumber());
+    }
+    if (daVinciFutureVersion != null) {
+      versionNumbers.add(daVinciFutureVersion.getVersion().getNumber());
+    }
+    return versionNumbers;
   }
 
   private synchronized void setDaVinciCurrentVersion(VersionBackend version) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
@@ -441,14 +441,17 @@ public class StoreBackend {
     if (daVinciFutureVersion != null) {
       Store store = backend.getStoreRepository().getStoreOrThrow(storeName);
       int versionNumber = daVinciFutureVersion.getVersion().getNumber();
-      if (store.getVersion(versionNumber) == null) {
+      Version futureVersion = store.getVersion(versionNumber);
+      if (futureVersion == null) {
         LOGGER.info(
             "Deleting obsolete future version " + daVinciFutureVersion + ", currentVersion=" + daVinciCurrentVersion);
         deleteFutureVersion();
+        return;
       }
-      if (faultyVersionSet.contains(versionNumber)) {
+      if (DaVinciBackend.isDaVinciVersionIneligible(futureVersion, faultyVersionSet)) {
         LOGGER.info(
-            "Deleting faulty future version " + daVinciFutureVersion + ", currentVersion=" + daVinciCurrentVersion);
+            "Deleting ineligible future version " + daVinciFutureVersion + " (status=" + futureVersion.getStatus()
+                + "), currentVersion=" + daVinciCurrentVersion);
         deleteFutureVersion();
       }
     }
@@ -469,12 +472,12 @@ public class StoreBackend {
       }
       int veniceCurrentVersionNumber = veniceCurrentVersion.getNumber();
       int daVinciFutureVersionNumber = daVinciFutureVersion.getVersion().getNumber();
+      // Re-read the future version's authoritative metadata so an ingestion-completion callback cannot race
+      // a rollback/kill and promote a terminal (or removed) version. A null here means it no longer exists.
+      Version futureVersion =
+          backend.getStoreRepository().getStoreOrThrow(storeName).getVersion(daVinciFutureVersionNumber);
       boolean isDaVinciFutureVersionInvalid =
-          faultyVersionSet.contains(daVinciFutureVersionNumber) || backend.getStoreRepository()
-              .getStoreOrThrow(storeName)
-              .getVersions()
-              .stream()
-              .noneMatch(v -> (v.getNumber() == daVinciFutureVersionNumber));
+          DaVinciBackend.isDaVinciVersionIneligible(futureVersion, faultyVersionSet);
       /**
        * We will only swap it to current version slot when it is fully pushed and the version number is (or was) the
        * current version in store config.

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
@@ -928,18 +928,12 @@ public class StoreBackendTest {
     return new Object[][] { { VersionStatus.STARTED }, { VersionStatus.PUSHED } };
   }
 
-  /**
-   * Incident-15857: a regular Da Vinci client restarting with a current v1 and a retained higher v2 whose
-   * authoritative status is terminal (ROLLED_BACK/ERROR/KILLED) must not select v2 as its future version,
-   * even when v2 carries the local target-swap region. A fresh {@link StoreBackend} models process memory
-   * after restart (empty {@code faultyVersionSet}), so the terminal status is the only signal available.
-   */
   @Test(dataProvider = "terminalVersionStatuses")
   public void testRestartDoesNotSubscribeRetainedTerminalTargetVersion(VersionStatus terminalStatus) throws Exception {
     int partition = 0;
     version1.setStatus(VersionStatus.ONLINE);
     version2.setStatus(terminalStatus);
-    version2.setTargetSwapRegion("dc-0"); // local region — exercises the target-region active path
+    version2.setTargetSwapRegion("dc-0");
     store.setCurrentVersion(version1.getNumber());
 
     CompletableFuture<?> subscribeResult = storeBackend.subscribe(ComplementSet.of(partition));
@@ -954,17 +948,12 @@ public class StoreBackendTest {
         "A restarted DVC must not subscribe a retained " + terminalStatus + " version as its future version");
   }
 
-  /**
-   * Positive control for the terminal-status filter: a retained higher target-region version whose status is
-   * still in flight (STARTED/PUSHED) must remain subscribable as the future version. This guards against the
-   * fix over-rejecting legal deferred-swap candidates.
-   */
   @Test(dataProvider = "nonTerminalSubscribableStatuses")
   public void testRestartSubscribesRetainedNonTerminalTargetVersion(VersionStatus subscribableStatus) throws Exception {
     int partition = 0;
     version1.setStatus(VersionStatus.ONLINE);
     version2.setStatus(subscribableStatus);
-    version2.setTargetSwapRegion("dc-0"); // local region — active target-region push
+    version2.setTargetSwapRegion("dc-0");
     store.setCurrentVersion(version1.getNumber());
 
     CompletableFuture<?> subscribeResult = storeBackend.subscribe(ComplementSet.of(partition));
@@ -977,10 +966,6 @@ public class StoreBackendTest {
             + " target-region version as its future version");
   }
 
-  /**
-   * The numeric-highest selector used for future-version selection and startup storage-engine retention must
-   * skip a terminal higher version and fall back to the highest non-terminal version.
-   */
   @Test(dataProvider = "terminalVersionStatuses")
   public void testLatestNonFaultyVersionSkipsTerminalStatus(VersionStatus terminalStatus) {
     version1.setStatus(VersionStatus.ONLINE);
@@ -992,10 +977,6 @@ public class StoreBackendTest {
         "Latest non-faulty selection must skip the terminal higher version " + terminalStatus);
   }
 
-  /**
-   * A version already occupying the DVC future slot must be deleted once its authoritative status becomes
-   * terminal, and must not be re-subscribed on the same store change.
-   */
   @Test(dataProvider = "terminalVersionStatuses")
   public void testExistingFutureVersionDeletedWhenStatusBecomesTerminal(VersionStatus terminalStatus) throws Exception {
     int partition = 0;
@@ -1016,11 +997,6 @@ public class StoreBackendTest {
     }
   }
 
-  /**
-   * Promotion-race guard: an ingestion-completion callback must not promote a future version to current when
-   * metadata has marked that version terminal, even though its number would otherwise satisfy the promotion
-   * bound ({@code futureNumber <= veniceCurrentNumber}).
-   */
   @Test(dataProvider = "terminalVersionStatuses")
   public void testTerminalFutureVersionNotPromotedByIngestionCompletion(VersionStatus terminalStatus) throws Exception {
     int partition = 0;
@@ -1029,13 +1005,11 @@ public class StoreBackendTest {
     subscribeResult.get(3, TimeUnit.SECONDS);
     assertTrue(versionMap.containsKey(version2.kafkaTopicName()), "version2 must first be subscribed as future");
 
-    // Future v2 finished ingesting and its number satisfies the promotion bound, but metadata invalidation
-    // has marked it terminal. Drive the ingestion-completion swap path directly to avoid depending on the
-    // asynchronous bootstrapping-aware callback timing.
     versionMap.get(version2.kafkaTopicName()).completePartition(partition);
     store.setCurrentVersion(version2.getNumber());
     store.updateVersionStatus(version2.getNumber(), terminalStatus);
 
+    // Isolate the promotion race from asynchronous bootstrapping callback timing.
     storeBackend.trySwapDaVinciCurrentVersion(null);
 
     try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
@@ -63,6 +63,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -914,6 +915,134 @@ public class StoreBackendTest {
     // Sanity: DVC is now serving version2.
     try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {
       assertEquals(versionRef.get().getVersion().getNumber(), version2.getNumber());
+    }
+  }
+
+  @DataProvider(name = "terminalVersionStatuses")
+  public static Object[][] terminalVersionStatuses() {
+    return new Object[][] { { VersionStatus.ROLLED_BACK }, { VersionStatus.ERROR }, { VersionStatus.KILLED } };
+  }
+
+  @DataProvider(name = "nonTerminalSubscribableStatuses")
+  public static Object[][] nonTerminalSubscribableStatuses() {
+    return new Object[][] { { VersionStatus.STARTED }, { VersionStatus.PUSHED } };
+  }
+
+  /**
+   * Incident-15857: a regular Da Vinci client restarting with a current v1 and a retained higher v2 whose
+   * authoritative status is terminal (ROLLED_BACK/ERROR/KILLED) must not select v2 as its future version,
+   * even when v2 carries the local target-swap region. A fresh {@link StoreBackend} models process memory
+   * after restart (empty {@code faultyVersionSet}), so the terminal status is the only signal available.
+   */
+  @Test(dataProvider = "terminalVersionStatuses")
+  public void testRestartDoesNotSubscribeRetainedTerminalTargetVersion(VersionStatus terminalStatus) throws Exception {
+    int partition = 0;
+    version1.setStatus(VersionStatus.ONLINE);
+    version2.setStatus(terminalStatus);
+    version2.setTargetSwapRegion("dc-0"); // local region — exercises the target-region active path
+    store.setCurrentVersion(version1.getNumber());
+
+    CompletableFuture<?> subscribeResult = storeBackend.subscribe(ComplementSet.of(partition));
+    versionMap.get(version1.kafkaTopicName()).completePartition(partition);
+    subscribeResult.get(3, TimeUnit.SECONDS);
+
+    try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {
+      assertEquals(versionRef.get().getVersion().getNumber(), version1.getNumber());
+    }
+    assertFalse(
+        versionMap.containsKey(version2.kafkaTopicName()),
+        "A restarted DVC must not subscribe a retained " + terminalStatus + " version as its future version");
+  }
+
+  /**
+   * Positive control for the terminal-status filter: a retained higher target-region version whose status is
+   * still in flight (STARTED/PUSHED) must remain subscribable as the future version. This guards against the
+   * fix over-rejecting legal deferred-swap candidates.
+   */
+  @Test(dataProvider = "nonTerminalSubscribableStatuses")
+  public void testRestartSubscribesRetainedNonTerminalTargetVersion(VersionStatus subscribableStatus) throws Exception {
+    int partition = 0;
+    version1.setStatus(VersionStatus.ONLINE);
+    version2.setStatus(subscribableStatus);
+    version2.setTargetSwapRegion("dc-0"); // local region — active target-region push
+    store.setCurrentVersion(version1.getNumber());
+
+    CompletableFuture<?> subscribeResult = storeBackend.subscribe(ComplementSet.of(partition));
+    versionMap.get(version1.kafkaTopicName()).completePartition(partition);
+    subscribeResult.get(3, TimeUnit.SECONDS);
+
+    assertTrue(
+        versionMap.containsKey(version2.kafkaTopicName()),
+        "A restarted DVC must still subscribe a retained " + subscribableStatus
+            + " target-region version as its future version");
+  }
+
+  /**
+   * The numeric-highest selector used for future-version selection and startup storage-engine retention must
+   * skip a terminal higher version and fall back to the highest non-terminal version.
+   */
+  @Test(dataProvider = "terminalVersionStatuses")
+  public void testLatestNonFaultyVersionSkipsTerminalStatus(VersionStatus terminalStatus) {
+    version1.setStatus(VersionStatus.ONLINE);
+    version2.setStatus(terminalStatus);
+    Version selected = backend.getVeniceLatestNonFaultyVersion(store.getName(), Collections.emptySet());
+    assertEquals(
+        selected.getNumber(),
+        version1.getNumber(),
+        "Latest non-faulty selection must skip the terminal higher version " + terminalStatus);
+  }
+
+  /**
+   * A version already occupying the DVC future slot must be deleted once its authoritative status becomes
+   * terminal, and must not be re-subscribed on the same store change.
+   */
+  @Test(dataProvider = "terminalVersionStatuses")
+  public void testExistingFutureVersionDeletedWhenStatusBecomesTerminal(VersionStatus terminalStatus) throws Exception {
+    int partition = 0;
+    CompletableFuture<?> subscribeResult = storeBackend.subscribe(ComplementSet.of(partition));
+    versionMap.get(version1.kafkaTopicName()).completePartition(partition);
+    subscribeResult.get(3, TimeUnit.SECONDS);
+    assertTrue(versionMap.containsKey(version2.kafkaTopicName()), "version2 must first be subscribed as future");
+
+    store.updateVersionStatus(version2.getNumber(), terminalStatus);
+    backend.handleStoreChanged(storeBackend);
+
+    assertFalse(
+        versionMap.containsKey(version2.kafkaTopicName()),
+        "Future version must be deleted once its status becomes " + terminalStatus);
+    verify(ingestionBackend, times(1)).removeStorageEngine(eq(version2.kafkaTopicName()));
+    try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {
+      assertEquals(versionRef.get().getVersion().getNumber(), version1.getNumber());
+    }
+  }
+
+  /**
+   * Promotion-race guard: an ingestion-completion callback must not promote a future version to current when
+   * metadata has marked that version terminal, even though its number would otherwise satisfy the promotion
+   * bound ({@code futureNumber <= veniceCurrentNumber}).
+   */
+  @Test(dataProvider = "terminalVersionStatuses")
+  public void testTerminalFutureVersionNotPromotedByIngestionCompletion(VersionStatus terminalStatus) throws Exception {
+    int partition = 0;
+    CompletableFuture<?> subscribeResult = storeBackend.subscribe(ComplementSet.of(partition));
+    versionMap.get(version1.kafkaTopicName()).completePartition(partition);
+    subscribeResult.get(3, TimeUnit.SECONDS);
+    assertTrue(versionMap.containsKey(version2.kafkaTopicName()), "version2 must first be subscribed as future");
+
+    // Future v2 finished ingesting and its number satisfies the promotion bound, but metadata invalidation
+    // has marked it terminal. Drive the ingestion-completion swap path directly to avoid depending on the
+    // asynchronous bootstrapping-aware callback timing.
+    versionMap.get(version2.kafkaTopicName()).completePartition(partition);
+    store.setCurrentVersion(version2.getNumber());
+    store.updateVersionStatus(version2.getNumber(), terminalStatus);
+
+    storeBackend.trySwapDaVinciCurrentVersion(null);
+
+    try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {
+      assertEquals(
+          versionRef.get().getVersion().getNumber(),
+          version1.getNumber(),
+          "A terminal future version must not be promoted to current by the ingestion-completion swap path");
     }
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/StoreBackendTest.java
@@ -53,8 +53,10 @@ import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
 import java.io.File;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -940,9 +942,7 @@ public class StoreBackendTest {
     versionMap.get(version1.kafkaTopicName()).completePartition(partition);
     subscribeResult.get(3, TimeUnit.SECONDS);
 
-    try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {
-      assertEquals(versionRef.get().getVersion().getNumber(), version1.getNumber());
-    }
+    assertEquals(storeBackend.getSubscribedVersionNumbers(), Collections.singleton(version1.getNumber()));
     assertFalse(
         versionMap.containsKey(version2.kafkaTopicName()),
         "A restarted DVC must not subscribe a retained " + terminalStatus + " version as its future version");
@@ -960,6 +960,9 @@ public class StoreBackendTest {
     versionMap.get(version1.kafkaTopicName()).completePartition(partition);
     subscribeResult.get(3, TimeUnit.SECONDS);
 
+    assertEquals(
+        storeBackend.getSubscribedVersionNumbers(),
+        new HashSet<>(Arrays.asList(version1.getNumber(), version2.getNumber())));
     assertTrue(
         versionMap.containsKey(version2.kafkaTopicName()),
         "A restarted DVC must still subscribe a retained " + subscribableStatus
@@ -992,9 +995,7 @@ public class StoreBackendTest {
         versionMap.containsKey(version2.kafkaTopicName()),
         "Future version must be deleted once its status becomes " + terminalStatus);
     verify(ingestionBackend, times(1)).removeStorageEngine(eq(version2.kafkaTopicName()));
-    try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {
-      assertEquals(versionRef.get().getVersion().getNumber(), version1.getNumber());
-    }
+    assertEquals(storeBackend.getSubscribedVersionNumbers(), Collections.singleton(version1.getNumber()));
   }
 
   @Test(dataProvider = "terminalVersionStatuses")

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/StatefulVeniceChangelogConsumerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/StatefulVeniceChangelogConsumerTest.java
@@ -45,6 +45,7 @@ import static org.testng.Assert.assertTrue;
 
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.d2.balancer.D2ClientBuilder;
+import com.linkedin.davinci.client.AvroGenericDaVinciClient;
 import com.linkedin.davinci.consumer.ChangeEvent;
 import com.linkedin.davinci.consumer.ChangelogClientConfig;
 import com.linkedin.davinci.consumer.StatefulVeniceChangelogConsumer;
@@ -55,7 +56,9 @@ import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.MultiStoreTopicsResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.endToEnd.TestChangelogKey;
 import com.linkedin.venice.endToEnd.TestChangelogValue;
@@ -64,7 +67,9 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.samza.VeniceSystemProducer;
 import com.linkedin.venice.store.rocksdb.RocksDBUtils;
@@ -76,6 +81,7 @@ import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.view.TestView;
+import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.File;
 import java.nio.file.Files;
@@ -359,6 +365,116 @@ public class StatefulVeniceChangelogConsumerTest {
     } finally {
       cleanUpStoreAndVerify(storeName);
     }
+  }
+
+  /**
+   * Incident-15857 regression: after a rollback, a restarted Stateful CDC consumer — a fresh
+   * {@link com.linkedin.davinci.DaVinciBackend} with an empty in-memory faulty-version set, bootstrapping from the
+   * same on-disk data directory — must not resurrect the rolled-back version. It must serve the rollback-target
+   * current version (v1), retain no future version, and emit only v1 change events, never events from the
+   * ROLLED_BACK v2.
+   */
+  @Test(timeOut = TEST_TIMEOUT * 2)
+  public void testStatefulCdcDoesNotResurrectRolledBackVersionAfterRestart() throws Exception {
+    String storeName = Utils.getUniqueString("store");
+    String inputDirPath = setUpStore(storeName); // batch push -> v1 becomes current
+
+    Properties testConsumerProperties =
+        ChangelogConsumerTestUtils.buildConsumerProperties(clusterWrapper, inputDirPath);
+    testConsumerProperties.put(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, true);
+    ChangelogClientConfig globalChangelogClientConfig =
+        new ChangelogClientConfig().setConsumerProperties(testConsumerProperties)
+            .setControllerD2ServiceName(D2_SERVICE_NAME)
+            .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
+            .setLocalD2ZkHosts(zkAddress)
+            .setControllerRequestRetryCount(3)
+            .setD2Client(d2Client);
+
+    try {
+      // Phase 1: start on v1, push v2, and let DVC promote v2 to current so v2 is fully ingested on disk.
+      VeniceChangelogConsumerClientFactory factory =
+          new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
+      try (StatefulVeniceChangelogConsumer<GenericRecord, GenericRecord> consumer =
+          factory.getStatefulChangelogConsumer(storeName)) {
+        consumer.start().get();
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+          assertEquals(getDaVinciVersionGauge(storeName, "current_version_number"), 1.0);
+        });
+
+        Properties props = defaultVPJProps(clusterWrapper, inputDirPath, storeName);
+        IntegrationTestPushUtils.runVPJ(props);
+        clusterWrapper.useControllerClient(controllerClient -> {
+          TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+            assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 2);
+          });
+        });
+        // DVC promotes v2 to current once it finishes ingesting; this guarantees the v2 engine is on disk.
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
+          assertEquals(getDaVinciVersionGauge(storeName, "current_version_number"), 2.0);
+        });
+      }
+      // Fully drain the shared backend reference count so the restart starts with an empty in-memory
+      // faulty-version set, modelling a real process restart.
+      AvroGenericDaVinciClient.resetDaVinciBackendForTests();
+
+      // Phase 2: roll back to v1; wait until v2 is authoritatively ROLLED_BACK and still retained.
+      clusterWrapper.useControllerClient(controllerClient -> {
+        ControllerResponse rollbackResponse = controllerClient.rollbackToBackupVersion(storeName);
+        assertFalse(rollbackResponse.isError(), "rollback failed: " + rollbackResponse.getError());
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+          StoreResponse storeResponse = controllerClient.getStore(storeName);
+          assertFalse(storeResponse.isError(), "getStore error: " + storeResponse.getError());
+          assertEquals(storeResponse.getStore().getCurrentVersion(), 1);
+          assertTrue(
+              storeResponse.getStore().getVersion(2).isPresent()
+                  && storeResponse.getStore().getVersion(2).get().getStatus() == VersionStatus.ROLLED_BACK,
+              "Expected v2 to be ROLLED_BACK after rollback, got: " + storeResponse.getStore().getVersion(2));
+        });
+      });
+
+      // Phase 3: restart on the SAME data directory with a fresh factory/backend.
+      VeniceChangelogConsumerClientFactory restartedFactory =
+          new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
+      Map<String, PubSubMessage<GenericRecord, ChangeEvent<GenericRecord>, VeniceChangeCoordinate>> restartEventsMap =
+          new HashMap<>();
+      List<PubSubMessage<GenericRecord, ChangeEvent<GenericRecord>, VeniceChangeCoordinate>> restartEventsList =
+          new ArrayList<>();
+      try (StatefulVeniceChangelogConsumer<GenericRecord, GenericRecord> restartedConsumer =
+          restartedFactory.getStatefulChangelogConsumer(storeName)) {
+        restartedConsumer.start().get();
+
+        // The rollback-target v1 must be current, and the ROLLED_BACK v2 must NOT be retained as a future version.
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
+          assertEquals(getDaVinciVersionGauge(storeName, "current_version_number"), 1.0);
+          assertEquals(getDaVinciVersionGauge(storeName, "future_version_number"), (double) Store.NON_EXISTING_VERSION);
+        });
+
+        // Produce fresh nearline records against v1 and confirm every emitted event originates from v1, never v2.
+        try (VeniceSystemProducer veniceProducer =
+            IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeName, Version.PushType.STREAM)) {
+          runSamzaStreamJob(veniceProducer, storeName, 1, null, 10, 0, 200, false);
+        }
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, false, () -> {
+          pollChangeEventsFromChangeCaptureConsumer(restartEventsMap, restartEventsList, restartedConsumer);
+          assertTrue(restartEventsMap.size() >= 10, "Expected at least the 10 fresh v1 nearline puts after restart");
+        });
+        for (PubSubMessage<GenericRecord, ChangeEvent<GenericRecord>, VeniceChangeCoordinate> message: restartEventsList) {
+          int versionFromMessage = Version.parseVersionFromVersionTopicName(message.getTopicPartition().getTopicName());
+          assertEquals(versionFromMessage, 1, "No change event may originate from the rolled-back v2");
+        }
+
+        // The future slot must stay empty: v2 is never resurrected.
+        assertEquals(getDaVinciVersionGauge(storeName, "future_version_number"), (double) Store.NON_EXISTING_VERSION);
+      }
+    } finally {
+      cleanUpStoreAndVerify(storeName);
+    }
+  }
+
+  private double getDaVinciVersionGauge(String storeName, String gaugeName) {
+    Metric metric = metricsRepository.getMetric("." + storeName + "--" + gaugeName + ".Gauge");
+    assertNotNull(metric, "Expected DVC gauge " + gaugeName + " for store " + storeName + " to be registered");
+    return metric.value();
   }
 
   /**

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/StatefulVeniceChangelogConsumerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/StatefulVeniceChangelogConsumerTest.java
@@ -367,17 +367,10 @@ public class StatefulVeniceChangelogConsumerTest {
     }
   }
 
-  /**
-   * Incident-15857 regression: after a rollback, a restarted Stateful CDC consumer — a fresh
-   * {@link com.linkedin.davinci.DaVinciBackend} with an empty in-memory faulty-version set, bootstrapping from the
-   * same on-disk data directory — must not resurrect the rolled-back version. It must serve the rollback-target
-   * current version (v1), retain no future version, and emit only v1 change events, never events from the
-   * ROLLED_BACK v2.
-   */
   @Test(timeOut = TEST_TIMEOUT * 2)
   public void testStatefulCdcDoesNotResurrectRolledBackVersionAfterRestart() throws Exception {
     String storeName = Utils.getUniqueString("store");
-    String inputDirPath = setUpStore(storeName); // batch push -> v1 becomes current
+    String inputDirPath = setUpStore(storeName);
 
     Properties testConsumerProperties =
         ChangelogConsumerTestUtils.buildConsumerProperties(clusterWrapper, inputDirPath);
@@ -391,7 +384,6 @@ public class StatefulVeniceChangelogConsumerTest {
             .setD2Client(d2Client);
 
     try {
-      // Phase 1: start on v1, push v2, and let DVC promote v2 to current so v2 is fully ingested on disk.
       VeniceChangelogConsumerClientFactory factory =
           new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
       try (StatefulVeniceChangelogConsumer<GenericRecord, GenericRecord> consumer =
@@ -408,16 +400,13 @@ public class StatefulVeniceChangelogConsumerTest {
             assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 2);
           });
         });
-        // DVC promotes v2 to current once it finishes ingesting; this guarantees the v2 engine is on disk.
         TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
           assertEquals(getDaVinciVersionGauge(storeName, "current_version_number"), 2.0);
         });
       }
-      // Fully drain the shared backend reference count so the restart starts with an empty in-memory
-      // faulty-version set, modelling a real process restart.
+      // Reset process-local state while preserving the on-disk engines used by the restarted client.
       AvroGenericDaVinciClient.resetDaVinciBackendForTests();
 
-      // Phase 2: roll back to v1; wait until v2 is authoritatively ROLLED_BACK and still retained.
       clusterWrapper.useControllerClient(controllerClient -> {
         ControllerResponse rollbackResponse = controllerClient.rollbackToBackupVersion(storeName);
         assertFalse(rollbackResponse.isError(), "rollback failed: " + rollbackResponse.getError());
@@ -432,7 +421,6 @@ public class StatefulVeniceChangelogConsumerTest {
         });
       });
 
-      // Phase 3: restart on the SAME data directory with a fresh factory/backend.
       VeniceChangelogConsumerClientFactory restartedFactory =
           new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
       Map<String, PubSubMessage<GenericRecord, ChangeEvent<GenericRecord>, VeniceChangeCoordinate>> restartEventsMap =
@@ -443,13 +431,11 @@ public class StatefulVeniceChangelogConsumerTest {
           restartedFactory.getStatefulChangelogConsumer(storeName)) {
         restartedConsumer.start().get();
 
-        // The rollback-target v1 must be current, and the ROLLED_BACK v2 must NOT be retained as a future version.
         TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
           assertEquals(getDaVinciVersionGauge(storeName, "current_version_number"), 1.0);
           assertEquals(getDaVinciVersionGauge(storeName, "future_version_number"), (double) Store.NON_EXISTING_VERSION);
         });
 
-        // Produce fresh nearline records against v1 and confirm every emitted event originates from v1, never v2.
         try (VeniceSystemProducer veniceProducer =
             IntegrationTestPushUtils.getSamzaProducer(clusterWrapper, storeName, Version.PushType.STREAM)) {
           runSamzaStreamJob(veniceProducer, storeName, 1, null, 10, 0, 200, false);
@@ -463,7 +449,6 @@ public class StatefulVeniceChangelogConsumerTest {
           assertEquals(versionFromMessage, 1, "No change event may originate from the rolled-back v2");
         }
 
-        // The future slot must stay empty: v2 is never resurrected.
         assertEquals(getDaVinciVersionGauge(storeName, "future_version_number"), (double) Store.NON_EXISTING_VERSION);
       }
     } finally {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/StatefulVeniceChangelogConsumerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/StatefulVeniceChangelogConsumerTest.java
@@ -67,7 +67,6 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
-import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
@@ -81,17 +80,18 @@ import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.view.TestView;
-import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -390,7 +390,7 @@ public class StatefulVeniceChangelogConsumerTest {
           factory.getStatefulChangelogConsumer(storeName)) {
         consumer.start().get();
         TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
-          assertEquals(getDaVinciVersionGauge(storeName, "current_version_number"), 1.0);
+          assertEquals(getSubscribedVersionNumbers(storeName), Collections.singleton(1));
         });
 
         Properties props = defaultVPJProps(clusterWrapper, inputDirPath, storeName);
@@ -401,7 +401,7 @@ public class StatefulVeniceChangelogConsumerTest {
           });
         });
         TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
-          assertEquals(getDaVinciVersionGauge(storeName, "current_version_number"), 2.0);
+          assertEquals(getSubscribedVersionNumbers(storeName), Collections.singleton(2));
         });
       }
       // Reset process-local state while preserving the on-disk engines used by the restarted client.
@@ -432,8 +432,7 @@ public class StatefulVeniceChangelogConsumerTest {
         restartedConsumer.start().get();
 
         TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
-          assertEquals(getDaVinciVersionGauge(storeName, "current_version_number"), 1.0);
-          assertEquals(getDaVinciVersionGauge(storeName, "future_version_number"), (double) Store.NON_EXISTING_VERSION);
+          assertEquals(getSubscribedVersionNumbers(storeName), Collections.singleton(1));
         });
 
         try (VeniceSystemProducer veniceProducer =
@@ -449,17 +448,15 @@ public class StatefulVeniceChangelogConsumerTest {
           assertEquals(versionFromMessage, 1, "No change event may originate from the rolled-back v2");
         }
 
-        assertEquals(getDaVinciVersionGauge(storeName, "future_version_number"), (double) Store.NON_EXISTING_VERSION);
+        assertEquals(getSubscribedVersionNumbers(storeName), Collections.singleton(1));
       }
     } finally {
       cleanUpStoreAndVerify(storeName);
     }
   }
 
-  private double getDaVinciVersionGauge(String storeName, String gaugeName) {
-    Metric metric = metricsRepository.getMetric("." + storeName + "--" + gaugeName + ".Gauge");
-    assertNotNull(metric, "Expected DVC gauge " + gaugeName + " for store " + storeName + " to be registered");
-    return metric.value();
+  private Set<Integer> getSubscribedVersionNumbers(String storeName) {
+    return AvroGenericDaVinciClient.getBackend().getSubscribedVersionNumbers(storeName);
   }
 
   /**


### PR DESCRIPTION
## Problem Statement

Da Vinci selects the highest version outside its process-local faulty-version set when deciding which future version to subscribe. That set is empty after a restart, so a retained higher version marked `ROLLED_BACK`, `ERROR`, or `KILLED` could be selected, retained, and promoted even though authoritative store metadata marks it terminal. Stateful CDC could then reopen the terminal version after a rollback.

## Solution

Add one Da Vinci eligibility check that combines process-local ingestion failures with authoritative terminal version status. Apply it to candidate selection, startup storage-engine retention, future-version cleanup, and future-to-current promotion. Current-version priority and existing `STARTED`, `PUSHED`, and `ONLINE` flows remain unchanged.

Add regression coverage for:

- Fresh-client selection across `ROLLED_BACK`, `ERROR`, and `KILLED`.
- Legal target-region `STARTED` and `PUSHED` candidates.
- Cleanup of an existing future version after a terminal transition.
- The ingestion-completion promotion race.
- Stateful CDC restart after rollback using the same on-disk data directory.

### Code changes

- [ ] Added new code behind **a config**. No config was added; this is an unconditional correctness fix.
- [x] Introduced new **log lines**.
  - [x] Confirmed logs need no **rate limiting** because they run only when an ineligible future version is removed.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed. No new synchronization is required.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`). No new shared collections were introduced.
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination. No new worker threads were introduced.

## How was this PR tested?

- [x] Local code review completed.
- [x] New unit tests added.
- [x] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
