### PR TITLE
[controller] Introduce VeniceMetadataZkClient wrapper (ZK client re-architecture, PR 3)

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -372,12 +372,17 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   private final HelixAdminClient helixAdminClient;
   private TopicManagerRepository topicManagerRepository;
-  private final ZkClient zkClient;
+  /**
+   * Owns the single ZK client used for Venice metadata (System #2): Stores, Schemas, StoreConfig,
+   * OfflinePushStatus, AdminTopicMetadata, StoreGraveyard, Personas, etc. See {@link VeniceMetadataZkClient}.
+   */
+  private final VeniceMetadataZkClient veniceMetadataZkClient;
   /**
    * A dedicated Zk client for reading Helix cluster metadata (System #1 — LIVEINSTANCES, EXTERNALVIEW) directly from
-   * ZK. This is intentionally kept separate from {@link #zkClient}, which owns Venice metadata (System #2). Helix reads
-   * must not ride on {@link #zkClient}: a later HA change repoints {@link #zkClient} at a separate/backup ensemble for
-   * Venice-metadata availability, and these Helix reads must stay on the Helix ZK rather than follow it.
+   * ZK. This is intentionally kept separate from {@link #veniceMetadataZkClient}, which owns Venice metadata (System
+   * #2). Helix reads must not ride on {@link #veniceMetadataZkClient}: a later HA change repoints it at a
+   * separate/backup ensemble for Venice-metadata availability, and these Helix reads must stay on the Helix ZK
+   * rather than follow it.
    */
   private final ZkClient helixZkClient;
   private final HelixAdapterSerializer adapterSerializer;
@@ -566,10 +571,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     // holds a separate ZKHelixAdmin of its own.
     this.helixAdminClient = new ZkHelixAdminClient(multiClusterConfigs, metricsRepository);
     // There is no way to get the internal zkClient from HelixManager or HelixAdmin. So create a new one here.
-    this.zkClient = ZkClientFactory.newZkClient(multiClusterConfigs.getZkAddress());
-    this.zkClient.subscribeStateChanges(new ZkClientStatusStats(metricsRepository, "controller-zk-client"));
+    this.veniceMetadataZkClient =
+        new VeniceMetadataZkClient(multiClusterConfigs.getZkAddress(), metricsRepository, "controller-zk-client");
     // System #1 (Helix cluster metadata) reads get their own Zk client on the Helix ZK address, kept off the
-    // Venice-metadata zkClient above. See {@link #helixZkClient}.
+    // Venice-metadata veniceMetadataZkClient above. See {@link #helixZkClient}.
     this.helixZkClient = ZkClientFactory.newZkClient(multiClusterConfigs.getZkAddress());
     this.helixZkClient.subscribeStateChanges(new ZkClientStatusStats(metricsRepository, "controller-helix-zk-client"));
     this.adapterSerializer = new HelixAdapterSerializer();
@@ -592,11 +597,15 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     this.topicManagerRepository =
         new TopicManagerRepository(topicManagerContext, getKafkaBootstrapServers(isSslToKafka()));
 
-    this.allowlistAccessor = new ZkAllowlistAccessor(zkClient, adapterSerializer);
-    this.executionIdAccessor = new ZkExecutionIdAccessor(zkClient, adapterSerializer);
-    this.storeConfigRepo = new HelixReadOnlyStoreConfigRepository(zkClient, adapterSerializer);
+    this.allowlistAccessor = new ZkAllowlistAccessor(veniceMetadataZkClient.getZkClient(), adapterSerializer);
+    this.executionIdAccessor = new ZkExecutionIdAccessor(veniceMetadataZkClient.getZkClient(), adapterSerializer);
+    this.storeConfigRepo =
+        new HelixReadOnlyStoreConfigRepository(veniceMetadataZkClient.getZkClient(), adapterSerializer);
     storeConfigRepo.refresh();
-    this.storeGraveyard = new HelixStoreGraveyard(zkClient, adapterSerializer, multiClusterConfigs.getClusters());
+    this.storeGraveyard = new HelixStoreGraveyard(
+        veniceMetadataZkClient.getZkClient(),
+        adapterSerializer,
+        multiClusterConfigs.getClusters());
     this.veniceWriterFactory = new VeniceWriterFactory(
         commonConfig.getProps().toProperties(),
         pubSubClientsFactory.getProducerAdapterFactory(),
@@ -632,12 +641,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     pushJobStatusStoreClusterName = commonConfig.getPushJobStatusStoreClusterName();
 
     zkSharedSystemStoreRepository = new SharedHelixReadOnlyZKSharedSystemStoreRepository(
-        zkClient,
+        veniceMetadataZkClient.getZkClient(),
         adapterSerializer,
         commonConfig.getSystemSchemaClusterName());
     zkSharedSchemaRepository = new SharedHelixReadOnlyZKSharedSchemaRepository(
         zkSharedSystemStoreRepository,
-        zkClient,
+        veniceMetadataZkClient.getZkClient(),
         adapterSerializer,
         commonConfig.getSystemSchemaClusterName(),
         commonConfig.getRefreshAttemptsForZkReconnect(),
@@ -778,7 +787,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
 
     controllerStateModelFactory = new VeniceDistClusterControllerStateModelFactory(
-        zkClient,
+        veniceMetadataZkClient.getZkClient(),
         adapterSerializer,
         this,
         multiClusterConfigs,
@@ -1046,7 +1055,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   public ZkClient getZkClient() {
-    return zkClient;
+    return veniceMetadataZkClient.getZkClient();
   }
 
   public ExecutionIdAccessor getExecutionIdAccessor() {
@@ -6830,7 +6839,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       controllerStateModelFactory.close();
       helixManager.disconnect();
       topicManagerRepository.close();
-      zkClient.close();
+      veniceMetadataZkClient.close();
       helixZkClient.close();
       helixAdminClient.close();
     } catch (Exception e) {
@@ -8203,9 +8212,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       Utils.closeQuietlyWithErrorLogged(this.zkSharedSystemStoreRepository);
       Utils.closeQuietlyWithErrorLogged(this.zkSharedSchemaRepository);
       try {
-        zkClient.close();
+        veniceMetadataZkClient.close();
       } catch (Exception e) {
-        LOGGER.error("Failed to close zkClient. Swallowing and moving on.", e);
+        LOGGER.error("Failed to close veniceMetadataZkClient. Swallowing and moving on.", e);
       }
       try {
         helixZkClient.close();
@@ -8268,8 +8277,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   private HelixReadWriteLiveClusterConfigRepository getReadWriteLiveClusterConfigRepository(String cluster) {
     return clusterToLiveClusterConfigRepo.computeIfAbsent(cluster, clusterName -> {
-      HelixReadWriteLiveClusterConfigRepository clusterConfigRepository =
-          new HelixReadWriteLiveClusterConfigRepository(zkClient, adapterSerializer, clusterName);
+      HelixReadWriteLiveClusterConfigRepository clusterConfigRepository = new HelixReadWriteLiveClusterConfigRepository(
+          veniceMetadataZkClient.getZkClient(),
+          adapterSerializer,
+          clusterName);
       clusterConfigRepository.refresh();
       return clusterConfigRepository;
     });
@@ -8277,8 +8288,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   private HelixReadWriteDarkClusterConfigRepository getReadWriteDarkClusterConfigRepository(String cluster) {
     return clusterToDarkClusterConfigRepo.computeIfAbsent(cluster, clusterName -> {
-      HelixReadWriteDarkClusterConfigRepository clusterConfigRepository =
-          new HelixReadWriteDarkClusterConfigRepository(zkClient, adapterSerializer, clusterName);
+      HelixReadWriteDarkClusterConfigRepository clusterConfigRepository = new HelixReadWriteDarkClusterConfigRepository(
+          veniceMetadataZkClient.getZkClient(),
+          adapterSerializer,
+          clusterName);
       clusterConfigRepository.refresh();
       return clusterConfigRepository;
     });
@@ -8701,11 +8714,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     if (checkOfflinePush) {
       VeniceOfflinePushMonitorAccessor accessor = new VeniceOfflinePushMonitorAccessor(
           clusterName,
-          zkClient,
+          veniceMetadataZkClient.getZkClient(),
           adapterSerializer,
           multiClusterConfigs.getLogContext(),
           multiClusterConfigs.getCommonConfig().getRefreshAttemptsForZkReconnect());
-      List<String> offlinePushes = zkClient.getChildren(accessor.getOfflinePushStatuesParentPath());
+      List<String> offlinePushes =
+          veniceMetadataZkClient.getZkClient().getChildren(accessor.getOfflinePushStatuesParentPath());
       offlinePushes.forEach(resource -> {
         if (Version.isVersionTopic(resource)) {
           String storeNameForResource = Version.parseStoreFromVersionTopic(resource);
@@ -9233,7 +9247,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     ReadWriteStoreRepository repository = getHelixVeniceClusterResources(clusterName).getStoreMetadataRepository();
     List<String> deletedZNodes = new ArrayList<>();
     Set<String> irrelevantStoreVersions = new HashSet<>();
-    ZkBaseDataAccessor<ZNRecord> znRecordAccessor = new ZkBaseDataAccessor<>(zkClient);
+    ZkBaseDataAccessor<ZNRecord> znRecordAccessor = new ZkBaseDataAccessor<>(veniceMetadataZkClient.getZkClient());
     String instancesZkPath = HelixUtils.getHelixClusterZkPath(clusterName) + "/" + ZK_INSTANCES_SUB_PATH;
     List<String> instances = znRecordAccessor.getChildNames(instancesZkPath, AccessOption.PERSISTENT);
     for (String instance: instances) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceMetadataZkClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceMetadataZkClient.java
@@ -1,0 +1,48 @@
+package com.linkedin.venice.controller;
+
+import com.linkedin.venice.helix.ZkClientFactory;
+import com.linkedin.venice.stats.ZkClientStatusStats;
+import io.tehuti.metrics.MetricsRepository;
+import java.io.Closeable;
+import org.apache.helix.zookeeper.impl.client.ZkClient;
+
+
+/**
+ * Owns the single {@link ZkClient} used for Venice metadata (System #2): Stores, Schemas, StoreConfig,
+ * OfflinePushStatus, AdminTopicMetadata, StoreGraveyard, Personas, etc.
+ *
+ * <p>ZooKeeper is used by the controller for two distinct systems:
+ * <ol>
+ *   <li>Helix cluster coordination (owned by Helix APIs) — see {@link ZkHelixAdminClient} and
+ *   {@link VeniceHelixAdmin}'s dedicated {@code helixZkClient}.</li>
+ *   <li>Venice metadata (owned by Venice code) — owned by this class.</li>
+ * </ol>
+ *
+ * <p>Giving the Venice-metadata ZK connection a single, explicit owner keeps its lifecycle (construction,
+ * connection-status stats, close) in one place, and creates the seam a later HA change needs: repointing
+ * Venice metadata at a separate/backup ZK ensemble will only require changing the address passed to this
+ * class's constructor, rather than touching any of the Venice-metadata accessor classes (e.g.
+ * {@code ZkAllowlistAccessor}, {@code ZkExecutionIdAccessor}, {@code HelixReadOnlyStoreConfigRepository},
+ * {@code HelixStoreGraveyard}) that all consume the {@link ZkClient} returned by {@link #getZkClient()}.
+ */
+public class VeniceMetadataZkClient implements Closeable {
+  private final ZkClient zkClient;
+
+  public VeniceMetadataZkClient(String zkAddress, MetricsRepository metricsRepository, String statsNamePrefix) {
+    this.zkClient = ZkClientFactory.newZkClient(zkAddress);
+    this.zkClient.subscribeStateChanges(new ZkClientStatusStats(metricsRepository, statsNamePrefix));
+  }
+
+  /**
+   * @return the underlying {@link ZkClient} connected to the Venice-metadata ZK ensemble, for the
+   * Venice-metadata accessor classes to consume directly.
+   */
+  public ZkClient getZkClient() {
+    return zkClient;
+  }
+
+  @Override
+  public void close() {
+    zkClient.close();
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #2872 / #2891 (ZK client re-architecture series). Introduces a new `VeniceMetadataZkClient` class that owns the lifecycle (construction, connection-status stats, close) of the single ZK client used for Venice metadata (System #2: Stores, Schemas, StoreConfig, OfflinePushStatus, AdminTopicMetadata, StoreGraveyard, Personas).

`VeniceHelixAdmin`'s raw `ZkClient` field is replaced with this wrapper. All existing Venice-metadata accessor classes (`ZkAllowlistAccessor`, `ZkExecutionIdAccessor`, `HelixReadOnlyStoreConfigRepository`, `HelixStoreGraveyard`, `SharedHelixReadOnlyZKSharedSystemStoreRepository`, `SharedHelixReadOnlyZKSharedSchemaRepository`, `VeniceDistClusterControllerStateModelFactory`, `VeniceOfflinePushMonitorAccessor`, `HelixReadWriteLiveClusterConfigRepository`, `HelixReadWriteDarkClusterConfigRepository`, `ZkBaseDataAccessor`) continue to consume the raw `ZkClient` unchanged via `veniceMetadataZkClient.getZkClient()`, so this is purely a lifecycle/ownership change with **no behaviour difference**.

This creates the seam called out in #2891's follow-ups: a later HA change can repoint Venice metadata at a separate/backup ZK ensemble by changing only the address passed into `VeniceMetadataZkClient`'s constructor, without touching any Venice-metadata accessor call sites.

## Why no behaviour change

- Same ZK address, same `ZkClientFactory.newZkClient(...)` call, same `ZkClientStatusStats` subscription as before.
- Every consumer receives the exact same underlying `ZkClient` instance — just one level of indirection away via `getZkClient()`.
- Construction ordering and shutdown (`stopVeniceController()`, `close()`) are unchanged, just routed through the wrapper.

## Testing

| Test | Coverage | Status |
|---|---|---|
| `:services:venice-controller:compileJava` / `compileTestJava` | Build | Pass |
| `spotlessCheck` | Format | Pass |
| `TestVeniceHelixAdmin` (33 tests) | Existing admin behaviour unaffected | Pass |
