### PR TITLE
[da-vinci][changelog] Initialize store metadata before seeking

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -326,9 +326,14 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   }
 
   protected CompletableFuture<Void> internalSubscribe(Set<Integer> partitions, PubSubTopic topic) {
-    Store store = getStore();
-    throwIfReadsDisabled(store);
+    Store store = null;
+    if (!versionSwapByControlMessage) {
+      store = getStore();
+      throwIfReadsDisabled(store);
+    }
+    Store subscribedStore = store;
     return CompletableFuture.supplyAsync(() -> {
+      PubSubTopic topicToSubscribe = null;
       if (versionSwapByControlMessage) {
         boolean lockAcquiredAndNoOngoingVersionSwap = false;
         for (int i = 0; i <= MAX_SUBSCRIBE_RETRIES; i++) {
@@ -338,12 +343,16 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
           } catch (InterruptedException e) {
             throw new RuntimeException(e);
           }
+          Store latestStore = getStore();
+          throwIfReadsDisabled(latestStore);
+          PubSubTopic latestTopicToSubscribe = getTopicToSubscribe(topic, latestStore);
           subscriptionLock.writeLock().lock();
           if (versionSwapMessageState != null) {
             // A new version swap is in progress, wait for it to finish again
             subscriptionLock.writeLock().unlock();
           } else {
             // No version swap is in progress, proceed with subscription
+            topicToSubscribe = latestTopicToSubscribe;
             lockAcquiredAndNoOngoingVersionSwap = true;
             break;
           }
@@ -353,15 +362,13 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
           throw new VeniceException("Unable to subscribe to new partitions due to conflicting version swaps");
         }
       } else {
+        topicToSubscribe = getTopicToSubscribe(topic, subscribedStore);
         subscriptionLock.writeLock().lock();
       }
 
       try {
-        PubSubTopic topicToSubscribe;
-        if (topic == null) {
-          topicToSubscribe = getCurrentServingVersionTopic(store);
-        } else {
-          topicToSubscribe = topic;
+        if (topicToSubscribe == null) {
+          throw new VeniceException("Unable to resolve topic to subscribe for store: " + storeName);
         }
         Set<PubSubTopicPartition> topicPartitionSet = getTopicAssignment();
         for (PubSubTopicPartition topicPartition: topicPartitionSet) {
@@ -387,6 +394,13 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
       isSubscribed.set(true);
       return null;
     }, seekExecutorService);
+  }
+
+  private PubSubTopic getTopicToSubscribe(PubSubTopic topic, Store store) {
+    if (topic == null) {
+      return getCurrentServingVersionTopic(store);
+    }
+    return topic;
   }
 
   protected VeniceCompressor getVersionCompressor(PubSubTopic pubSubTopic) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -551,7 +551,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   }
 
   void checkLiveVersion(String topicName) {
-    Store store = storeRepository.getStore(storeName);
+    Store store = getStore();
     try {
       store.getVersionOrThrow(Version.parseVersionFromKafkaTopicName(topicName));
     } catch (StoreVersionNotFoundException ex) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -105,6 +105,7 @@ import org.apache.logging.log4j.Logger;
 public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsumer<K, V> {
   private static final Logger LOGGER = LogManager.getLogger(VeniceChangelogConsumerImpl.class);
   private static final int MAX_SUBSCRIBE_RETRIES = 5;
+  private static final long SUBSCRIBE_RETRY_BACKOFF_IN_MS = Time.MS_PER_SECOND;
   private static final String ROCKSDB_BUFFER_FOLDER = "rocksdb-chunk-buffer";
   protected long subscribeTime = Long.MAX_VALUE;
 
@@ -295,6 +296,10 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
 
   public void throwIfReadsDisabled() {
     Store store = getStore();
+    throwIfReadsDisabled(store);
+  }
+
+  private void throwIfReadsDisabled(Store store) {
     if (!store.isEnableReads()) {
       throw new StoreDisabledException(store.getName(), "read");
     }
@@ -321,10 +326,9 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   }
 
   protected CompletableFuture<Void> internalSubscribe(Set<Integer> partitions, PubSubTopic topic) {
-    throwIfReadsDisabled();
+    Store store = getStore();
+    throwIfReadsDisabled(store);
     return CompletableFuture.supplyAsync(() -> {
-      subscribeStoreRepository();
-
       if (versionSwapByControlMessage) {
         boolean lockAcquiredAndNoOngoingVersionSwap = false;
         for (int i = 0; i <= MAX_SUBSCRIBE_RETRIES; i++) {
@@ -355,7 +359,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
       try {
         PubSubTopic topicToSubscribe;
         if (topic == null) {
-          topicToSubscribe = getCurrentServingVersionTopic();
+          topicToSubscribe = getCurrentServingVersionTopic(store);
         } else {
           topicToSubscribe = topic;
         }
@@ -504,6 +508,10 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
 
   protected PubSubTopic getCurrentServingVersionTopic() {
     Store store = getStore();
+    return getCurrentServingVersionTopic(store);
+  }
+
+  private PubSubTopic getCurrentServingVersionTopic(Store store) {
     int currentVersion = store.getCurrentVersion();
     if (currentVersion == Store.NON_EXISTING_VERSION) {
       throw new VeniceException("Store: " + storeName + " does not have a current serving version");
@@ -749,11 +757,21 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
       } catch (Exception ex) {
         if (i < MAX_SUBSCRIBE_RETRIES) {
           LOGGER.warn("Store Repository subscription failed for store: {}! Will retry...", storeName, ex);
+          sleepBeforeSubscribeRetry();
         } else {
           LOGGER.error("Store Repository subscription failed for store: {}! Aborting!!", storeName, ex);
           throw new VeniceException("Failed to subscribe to store metadata for store: " + storeName, ex);
         }
       }
+    }
+  }
+
+  private void sleepBeforeSubscribeRetry() {
+    try {
+      TimeUnit.MILLISECONDS.sleep(SUBSCRIBE_RETRY_BACKOFF_IN_MS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new VeniceException("Interrupted while retrying store metadata subscription for store: " + storeName, e);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -748,7 +748,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
         throw new VeniceException("Interrupted while subscribing to store metadata for store: " + storeName, e);
       } catch (Exception ex) {
         if (i < MAX_SUBSCRIBE_RETRIES) {
-          LOGGER.error("Store Repository subscription failed for store: {}! Will retry...", storeName, ex);
+          LOGGER.warn("Store Repository subscription failed for store: {}! Will retry...", storeName, ex);
         } else {
           LOGGER.error("Store Repository subscription failed for store: {}! Aborting!!", storeName, ex);
           throw new VeniceException("Failed to subscribe to store metadata for store: " + storeName, ex);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -323,23 +323,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   protected CompletableFuture<Void> internalSubscribe(Set<Integer> partitions, PubSubTopic topic) {
     throwIfReadsDisabled();
     return CompletableFuture.supplyAsync(() -> {
-      try {
-        for (int i = 0; i <= MAX_SUBSCRIBE_RETRIES; i++) {
-          try {
-            storeRepository.subscribe(storeName);
-            break;
-          } catch (Exception ex) {
-            if (i < MAX_SUBSCRIBE_RETRIES) {
-              LOGGER.error("Store Repository subscription failed!  Will Retry...", ex);
-            } else {
-              LOGGER.error("Store Repository subscription failed! Aborting!!", ex);
-              throw ex;
-            }
-          }
-        }
-      } catch (InterruptedException e) {
-        throw new RuntimeException(e);
-      }
+      subscribeStoreRepository();
 
       if (versionSwapByControlMessage) {
         boolean lockAcquiredAndNoOngoingVersionSwap = false;
@@ -519,13 +503,21 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   }
 
   protected PubSubTopic getCurrentServingVersionTopic() {
-    Store store = storeRepository.getStore(storeName);
+    Store store = getStore();
     int currentVersion = store.getCurrentVersion();
+    if (currentVersion == Store.NON_EXISTING_VERSION) {
+      throw new VeniceException("Store: " + storeName + " does not have a current serving version");
+    }
     if (changelogClientConfig.getViewName() == null || changelogClientConfig.getViewName().isEmpty()) {
       return pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName, currentVersion));
     }
 
-    return pubSubTopicRepository.getTopic(store.getVersion(currentVersion).kafkaTopicName());
+    Version version = store.getVersion(currentVersion);
+    if (version == null) {
+      throw new VeniceException(
+          "Current serving version: " + currentVersion + " does not exist in metadata for store: " + storeName);
+    }
+    return pubSubTopicRepository.getTopic(version.kafkaTopicName());
   }
 
   @Override
@@ -738,12 +730,31 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   }
 
   private Store getStore() {
-    try {
-      storeRepository.subscribe(storeName);
-    } catch (InterruptedException e) {
-      throw new VeniceException("Failed to get store info with exception:", e);
+    subscribeStoreRepository();
+    Store store = storeRepository.getStore(storeName);
+    if (store == null) {
+      throw new VeniceException("Store metadata is unavailable for store: " + storeName);
     }
-    return storeRepository.getStore(storeName);
+    return store;
+  }
+
+  private void subscribeStoreRepository() {
+    for (int i = 0; i <= MAX_SUBSCRIBE_RETRIES; i++) {
+      try {
+        storeRepository.subscribe(storeName);
+        return;
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new VeniceException("Interrupted while subscribing to store metadata for store: " + storeName, e);
+      } catch (Exception ex) {
+        if (i < MAX_SUBSCRIBE_RETRIES) {
+          LOGGER.error("Store Repository subscription failed for store: {}! Will retry...", storeName, ex);
+        } else {
+          LOGGER.error("Store Repository subscription failed for store: {}! Aborting!!", storeName, ex);
+          throw new VeniceException("Failed to subscribe to store metadata for store: " + storeName, ex);
+        }
+      }
+    }
   }
 
   @Override

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -266,6 +266,46 @@ public class VeniceChangelogConsumerImplTest {
   }
 
   @Test
+  public void testSeekToCheckpointSubscribesBeforeCheckingLiveVersion()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceChangelogConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer(),
+        veniceChangelogConsumerClientFactory);
+    veniceChangelogConsumer.setStoreRepository(mockRepository);
+    VeniceChangeCoordinate checkpoint = new VeniceChangeCoordinate(oldVersionTopic.getName(), mockPubSubPosition, 0);
+
+    veniceChangelogConsumer.seekToCheckpoint(Collections.singleton(checkpoint)).get(10, TimeUnit.SECONDS);
+
+    org.mockito.InOrder inOrder = Mockito.inOrder(mockRepository, mockPubSubConsumer);
+    inOrder.verify(mockRepository).subscribe(storeName);
+    inOrder.verify(mockRepository).getStore(storeName);
+    inOrder.verify(mockPubSubConsumer)
+        .subscribe(new PubSubTopicPartitionImpl(oldVersionTopic, 0), mockPubSubPosition, true);
+  }
+
+  @Test
+  public void testSeekToCheckpointFailsWhenStoreMetadataIsUnavailable() {
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceChangelogConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer(),
+        veniceChangelogConsumerClientFactory);
+    NativeMetadataRepositoryViewAdapter coldRepository = mock(NativeMetadataRepositoryViewAdapter.class);
+    when(coldRepository.getStore(storeName)).thenReturn(null);
+    veniceChangelogConsumer.setStoreRepository(coldRepository);
+    VeniceChangeCoordinate checkpoint = new VeniceChangeCoordinate(oldVersionTopic.getName(), mockPubSubPosition, 0);
+
+    ExecutionException exception = Assert.expectThrows(
+        ExecutionException.class,
+        () -> veniceChangelogConsumer.seekToCheckpoint(Collections.singleton(checkpoint)).get(10, TimeUnit.SECONDS));
+    assertTrue(exception.getCause() instanceof VeniceException);
+    assertTrue(exception.getCause().getMessage().contains("Store metadata is unavailable for store: " + storeName));
+    verify(mockPubSubConsumer, never()).subscribe(any(), any(PubSubPosition.class), anyBoolean());
+  }
+
+  @Test
   public void testAfterImageConsumerSeek() throws ExecutionException, InterruptedException {
     MultiSchemaResponse multiRMDSchemaResponse = mock(MultiSchemaResponse.class);
     MultiSchemaResponse.Schema rmdSchemaFromMultiSchemaResponse = mock(MultiSchemaResponse.Schema.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -215,6 +215,57 @@ public class VeniceChangelogConsumerImplTest {
   }
 
   @Test
+  public void testGetCurrentServingVersionTopicSubscribesBeforeReadingStoreMetadata() throws InterruptedException {
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceChangelogConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer(),
+        veniceChangelogConsumerClientFactory);
+    veniceChangelogConsumer.setStoreRepository(mockRepository);
+
+    assertEquals(veniceChangelogConsumer.getCurrentServingVersionTopic(), oldVersionTopic);
+
+    org.mockito.InOrder inOrder = Mockito.inOrder(mockRepository);
+    inOrder.verify(mockRepository).subscribe(storeName);
+    inOrder.verify(mockRepository).getStore(storeName);
+  }
+
+  @Test
+  public void testGetCurrentServingVersionTopicFailsWhenStoreMetadataIsUnavailable() throws InterruptedException {
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceChangelogConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer(),
+        veniceChangelogConsumerClientFactory);
+    NativeMetadataRepositoryViewAdapter coldRepository = mock(NativeMetadataRepositoryViewAdapter.class);
+    when(coldRepository.getStore(storeName)).thenReturn(null);
+    veniceChangelogConsumer.setStoreRepository(coldRepository);
+
+    VeniceException exception =
+        Assert.expectThrows(VeniceException.class, veniceChangelogConsumer::getCurrentServingVersionTopic);
+    assertTrue(exception.getMessage().contains("Store metadata is unavailable for store: " + storeName));
+    verify(coldRepository).subscribe(storeName);
+  }
+
+  @Test
+  public void testGetCurrentServingVersionTopicFailsWhenCurrentVersionIsMissing() {
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceChangelogConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer(),
+        veniceChangelogConsumerClientFactory);
+    NativeMetadataRepositoryViewAdapter repository = mock(NativeMetadataRepositoryViewAdapter.class);
+    Store store = mock(Store.class);
+    when(store.getCurrentVersion()).thenReturn(Store.NON_EXISTING_VERSION);
+    when(repository.getStore(storeName)).thenReturn(store);
+    veniceChangelogConsumer.setStoreRepository(repository);
+
+    VeniceException exception =
+        Assert.expectThrows(VeniceException.class, veniceChangelogConsumer::getCurrentServingVersionTopic);
+    assertTrue(exception.getMessage().contains("does not have a current serving version"));
+  }
+
+  @Test
   public void testAfterImageConsumerSeek() throws ExecutionException, InterruptedException {
     MultiSchemaResponse multiRMDSchemaResponse = mock(MultiSchemaResponse.class);
     MultiSchemaResponse.Schema rmdSchemaFromMultiSchemaResponse = mock(MultiSchemaResponse.Schema.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -266,6 +266,23 @@ public class VeniceChangelogConsumerImplTest {
   }
 
   @Test
+  public void testSubscribeUsesSingleStoreMetadataSubscription() throws ExecutionException, InterruptedException {
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceChangelogConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer(),
+        veniceChangelogConsumerClientFactory);
+    veniceChangelogConsumer.setStoreRepository(mockRepository);
+
+    veniceChangelogConsumer.subscribe(Collections.singleton(0)).get();
+
+    verify(mockRepository).subscribe(storeName);
+    verify(mockRepository).getStore(storeName);
+    verify(mockPubSubConsumer)
+        .subscribe(new PubSubTopicPartitionImpl(oldVersionTopic, 0), PubSubSymbolicPosition.EARLIEST);
+  }
+
+  @Test
   public void testSeekToCheckpointSubscribesBeforeCheckingLiveVersion()
       throws ExecutionException, InterruptedException, TimeoutException {
     VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceChangelogConsumerImpl<>(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -283,6 +283,48 @@ public class VeniceChangelogConsumerImplTest {
   }
 
   @Test
+  public void testSubscribeUsesStoreMetadataAfterVersionSwapWait()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    ChangelogClientConfig versionSwapConfig = getChangelogClientConfig().setVersionSwapByControlMessageEnabled(true);
+    versionSwapConfig.setClientRegionName("region1").setTotalRegionCount(1);
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceChangelogConsumerImpl<>(
+        versionSwapConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer(),
+        veniceChangelogConsumerClientFactory);
+    NativeMetadataRepositoryViewAdapter repository = mock(NativeMetadataRepositoryViewAdapter.class);
+    Store oldStore = mock(Store.class);
+    Store newStore = mock(Store.class);
+    Version oldVersion = new VersionImpl(storeName, 1, "foo");
+    Version newVersion = new VersionImpl(storeName, 2, "foo");
+    PubSubTopic newVersionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName, 2));
+    oldVersion.setPartitionCount(partitionCount);
+    newVersion.setPartitionCount(partitionCount);
+    when(oldStore.getName()).thenReturn(storeName);
+    when(newStore.getName()).thenReturn(storeName);
+    when(oldStore.isEnableReads()).thenReturn(true);
+    when(newStore.isEnableReads()).thenReturn(true);
+    when(oldStore.getCurrentVersion()).thenReturn(1);
+    when(newStore.getCurrentVersion()).thenReturn(2);
+    when(oldStore.getVersion(1)).thenReturn(oldVersion);
+    when(newStore.getVersion(2)).thenReturn(newVersion);
+    CountDownLatch versionSwapCompleted = new CountDownLatch(1);
+    when(repository.getStore(storeName))
+        .thenAnswer(invocation -> versionSwapCompleted.getCount() == 0 ? newStore : oldStore);
+    veniceChangelogConsumer.setStoreRepository(repository);
+    veniceChangelogConsumer.onGoingVersionSwapSignal.set(versionSwapCompleted);
+
+    CompletableFuture<Void> subscribeFuture = veniceChangelogConsumer.subscribe(Collections.singleton(0));
+    versionSwapCompleted.countDown();
+    subscribeFuture.get(10, TimeUnit.SECONDS);
+
+    verify(mockPubSubConsumer, never())
+        .subscribe(new PubSubTopicPartitionImpl(oldVersionTopic, 0), PubSubSymbolicPosition.EARLIEST);
+    verify(mockPubSubConsumer)
+        .subscribe(new PubSubTopicPartitionImpl(newVersionTopic, 0), PubSubSymbolicPosition.EARLIEST);
+  }
+
+  @Test
   public void testSeekToCheckpointSubscribesBeforeCheckingLiveVersion()
       throws ExecutionException, InterruptedException, TimeoutException {
     VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceChangelogConsumerImpl<>(


### PR DESCRIPTION
## Problem Statement

Flink Venice CDC readers can start before the TaskManager-local store metadata cache has been initialized. Startup seek paths need store-level metadata even when the connector already knows the partitions:

- END/TIMESTAMP startup seeks need the current serving version topic.
- Restored checkpoints carry explicit version-topic offsets, but `seekToCheckpoint()` still validates that the checkpointed version is live.

Both paths previously read `storeRepository.getStore(storeName)` directly and could dereference missing metadata, surfacing as NPEs during deployment startup.

## Solution

Route all startup seek metadata reads through the same store metadata subscription path used by other store reads before accessing store/version state. The change validates unavailable store metadata, missing current serving versions, and missing version metadata with typed `VeniceException`s so startup failures identify the metadata issue instead of crashing with an NPE.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.

No new config is introduced. Retryable store metadata subscription failures log at WARN; the final failure after retries are exhausted logs at ERROR.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

The metadata subscription happens before seek lock usage and preserves the existing seek/subscription locking behavior.

## How was this PR tested?

- [x] Local code review completed
- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

Ran:

```bash
./gradlew :clients:da-vinci-client:test --tests com.linkedin.davinci.consumer.VeniceChangelogConsumerImplTest --quiet
```

Also ran local branch review with no final findings.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

This changes internal startup failure modes from NPEs to typed `VeniceException`s for missing store metadata/current version state.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
