### PR TITLE
[compat] Make maxNearlineRecordSizeBytes a per-version config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -328,13 +328,7 @@ subprojects {
       // Protocol changes should pin the current version via this override and remove the override in a follow-up PR
       // when actually using the new protocol. Example to pin KME to v12 when introducing v13:
       // project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
-      def versionOverrides = [
-          // StoreMetaValue v48 stages the version-level maxNearlineRecordSizeBytes field on StoreVersion. Pinned to
-          // the current active version so the generated classes stay on v47 and no code path can serialize v48 yet.
-          // The override is removed and METADATA_SYSTEM_SCHEMA_STORE is bumped to v48 in the follow-up PR that reads
-          // and snapshots the per-version limit, which is also what makes the controllers register v48.
-          project(':internal:venice-common').file('src/main/resources/avro/StoreMetaValue/v47', PathValidation.DIRECTORY),
-      ]
+      def versionOverrides = []
 
       def schemaDirs = [sourceDir]
       sourceDir.eachDir { typeDir ->

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2980,8 +2980,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   /**
-   * maxRecordSizeBytes (and the nearline variant) is a store-level config that defaults to -1.
-   * The default value will be set fleet-wide using the default.max.record.size.bytes on config the server and controller.
+   * {@code maxRecordSizeBytes} is read live from the store; {@code maxNearlineRecordSizeBytes} is snapshotted onto
+   * the {@link com.linkedin.venice.meta.Version} at creation time. A backfilled value of <= 0 resolves to the
+   * fleet-wide default.max.record.size.bytes server config.
    */
   private int backfillRecordSizeLimit(int recordSizeLimit) {
     return (recordSizeLimit > 0) ? recordSizeLimit : serverConfig.getDefaultMaxRecordSizeBytes();
@@ -2992,7 +2993,15 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   protected int getMaxNearlineRecordSizeBytes() {
-    return backfillRecordSizeLimit(storeRepository.getStore(storeName).getMaxNearlineRecordSizeBytes());
+    Integer versionLevelLimit = getVersion().getMaxNearlineRecordSizeBytes();
+    // A null snapshot means the version was created before this field existed (StoreMetaValue < v48); fall back to
+    // the live store-level value so a previously configured nearline limit survives the upgrade instead of reverting
+    // to the fleet default. A non-null snapshot (including -1) is used as-is, so a later store-level change never
+    // retroactively alters enforcement for an already-created version.
+    int recordSizeLimit = (versionLevelLimit != null)
+        ? versionLevelLimit
+        : storeRepository.getStore(storeName).getMaxNearlineRecordSizeBytes();
+    return backfillRecordSizeLimit(recordSizeLimit);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -828,6 +828,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return versionNumber;
   }
 
+  /** The {@link Version} snapshot this task was constructed with; source of version-level configs frozen at creation. */
+  protected Version getVersion() {
+    return version;
+  }
+
   protected void throwIfNotRunning() {
     if (!isRunning()) {
       throw new VeniceException(" Topic " + kafkaVersionTopic + " is shutting down, no more messages accepted");

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTaskTest.java
@@ -2910,6 +2910,45 @@ public class LeaderFollowerStoreIngestionTaskTest {
   }
 
   @Test
+  public void testGetMaxNearlineRecordSizeBytesFallback() throws Exception {
+    MockTaskContext ctx = createMockTaskForGatingTests();
+    doCallRealMethod().when(ctx.task).getMaxNearlineRecordSizeBytes();
+
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(100).when(serverConfig).getDefaultMaxRecordSizeBytes();
+    setField(ctx.task, "serverConfig", serverConfig);
+
+    ReadOnlyStoreRepository storeRepository = mock(ReadOnlyStoreRepository.class);
+    setField(ctx.task, "storeRepository", storeRepository);
+    Store store = mock(Store.class);
+    doReturn(store).when(storeRepository).getStore("testStore");
+
+    Version version = mock(Version.class);
+    doReturn(version).when(ctx.task).getVersion();
+
+    // 1. Non-null per-version snapshot (1024): used directly, no fallback to the store.
+    doReturn(1024).when(version).getMaxNearlineRecordSizeBytes();
+    assertEquals(ctx.task.getMaxNearlineRecordSizeBytes(), 1024);
+    verify(store, never()).getMaxNearlineRecordSizeBytes();
+
+    // 2. Non-null snapshot of a store that was unset at creation (-1): used as-is, so it resolves to the fleet
+    // default and a LATER store-level change (10MB) is ignored -- no retroactive change for an existing version.
+    doReturn(-1).when(version).getMaxNearlineRecordSizeBytes();
+    doReturn(10_000_000).when(store).getMaxNearlineRecordSizeBytes();
+    assertEquals(ctx.task.getMaxNearlineRecordSizeBytes(), 100);
+    verify(store, never()).getMaxNearlineRecordSizeBytes();
+
+    // 3. Null snapshot (version created before v48): fall back to the live store-level value (2048).
+    doReturn(null).when(version).getMaxNearlineRecordSizeBytes();
+    doReturn(2048).when(store).getMaxNearlineRecordSizeBytes();
+    assertEquals(ctx.task.getMaxNearlineRecordSizeBytes(), 2048);
+
+    // 4. Null snapshot with an unset store: backfill the fleet-wide default.max.record.size.bytes server config (100).
+    doReturn(-1).when(store).getMaxNearlineRecordSizeBytes();
+    assertEquals(ctx.task.getMaxNearlineRecordSizeBytes(), 100);
+  }
+
+  @Test
   public void testRecordAssembledRmdSizeGating() throws Exception {
     MockTaskContext ctx = createMockTaskForGatingTests();
     setField(ctx.task, "isRmdChunked", false);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
@@ -147,6 +147,8 @@ public abstract class AbstractStore implements Store {
       version.setChunkingEnabled(isChunkingEnabled());
       version.setRmdChunkingEnabled(isRmdChunkingEnabled());
 
+      version.setMaxNearlineRecordSizeBytes(getMaxNearlineRecordSizeBytes());
+
       PartitionerConfig partitionerConfig = getPartitionerConfig();
       if (partitionerConfig != null) {
         version.setPartitionerConfig(partitionerConfig.clone());

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -425,6 +425,16 @@ public class ReadOnlyStore implements Store {
     }
 
     @Override
+    public Integer getMaxNearlineRecordSizeBytes() {
+      return this.delegate.getMaxNearlineRecordSizeBytes();
+    }
+
+    @Override
+    public void setMaxNearlineRecordSizeBytes(Integer maxNearlineRecordSizeBytes) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String getStoreName() {
       return this.delegate.getStoreName();
     }
@@ -2077,6 +2087,7 @@ public class ReadOnlyStore implements Store {
     // storeVersion.setBufferReplayEnabledForHybrid();
     storeVersion.setChunkingEnabled(version.isChunkingEnabled());
     storeVersion.setRmdChunkingEnabled(version.isRmdChunkingEnabled());
+    storeVersion.setMaxNearlineRecordSizeBytes(version.getMaxNearlineRecordSizeBytes());
     storeVersion.setPushType(version.getPushType().getValue());
     storeVersion.setPartitionCount(version.getPartitionCount());
     storeVersion.setPartitionerConfig(convertPartitionerConfig(version.getPartitionerConfig()));

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Version.java
@@ -185,6 +185,16 @@ public interface Version extends Comparable<Version>, DataModelBackedStructure<S
 
   void setRmdChunkingEnabled(boolean rmdChunkingEnabled);
 
+  /**
+   * The version-level nearline max record size, snapshotted from the store-level config at version-creation time.
+   * Returns {@code null} for versions created before this field existed (their metadata has no snapshot); callers
+   * should fall back to the live store-level value in that case. A non-null value (including -1) is an immutable
+   * per-version snapshot.
+   */
+  Integer getMaxNearlineRecordSizeBytes();
+
+  void setMaxNearlineRecordSizeBytes(Integer maxNearlineRecordSizeBytes);
+
   String getStoreName();
 
   String getPushJobId();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
@@ -176,6 +176,16 @@ public class VersionImpl implements Version {
   }
 
   @Override
+  public Integer getMaxNearlineRecordSizeBytes() {
+    return this.storeVersion.maxNearlineRecordSizeBytes;
+  }
+
+  @Override
+  public void setMaxNearlineRecordSizeBytes(Integer maxNearlineRecordSizeBytes) {
+    this.storeVersion.maxNearlineRecordSizeBytes = maxNearlineRecordSizeBytes;
+  }
+
+  @Override
   public final String getStoreName() {
     return this.storeVersion.storeName.toString();
   }
@@ -594,6 +604,7 @@ public class VersionImpl implements Version {
     clonedVersion.setCompressionStrategy(getCompressionStrategy());
     clonedVersion.setChunkingEnabled(isChunkingEnabled());
     clonedVersion.setRmdChunkingEnabled(isRmdChunkingEnabled());
+    clonedVersion.setMaxNearlineRecordSizeBytes(getMaxNearlineRecordSizeBytes());
     clonedVersion.setPushType(getPushType());
     clonedVersion.setNativeReplicationEnabled(isNativeReplicationEnabled());
     clonedVersion.setPushStreamSourceAddress(getPushStreamSourceAddress());

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -119,7 +119,7 @@ public enum AvroProtocolDefinition {
   /**
    * Value schema for metadata system store.
    */
-  METADATA_SYSTEM_SCHEMA_STORE(47, StoreMetaValue.class),
+  METADATA_SYSTEM_SCHEMA_STORE(48, StoreMetaValue.class),
 
   /*
     Value Schema for Parent Controller Metadata system store

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestZKStore.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestZKStore.java
@@ -10,6 +10,8 @@ import static org.testng.Assert.assertTrue;
 import com.linkedin.venice.exceptions.StoreDisabledException;
 import com.linkedin.venice.exceptions.StoreVersionNotFoundException;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.systemstore.schemas.StoreProperties;
+import com.linkedin.venice.systemstore.schemas.StoreVersion;
 import com.linkedin.venice.utils.ConfigCommonUtils.ActivationState;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
@@ -581,6 +583,52 @@ public class TestZKStore {
     // A later store-level change does NOT mutate the already-added version.
     store.setStorageMode(StorageMode.EXTERNAL);
     Assert.assertEquals(store.getVersion(1).getStorageMode(), StorageMode.DUAL_WRITE);
+  }
+
+  @Test
+  public void testAddVersionCopiesStoreLevelMaxNearlineRecordSizeBytes() {
+    Store store = TestUtils.createTestStore("testStore", "owner", System.currentTimeMillis());
+    store.setMaxNearlineRecordSizeBytes(1024);
+    store.addVersion(new VersionImpl(store.getName(), 1, "pushJobId"));
+    // addVersion snapshots the current store-level value onto the new version.
+    Assert.assertEquals(store.getVersion(1).getMaxNearlineRecordSizeBytes(), Integer.valueOf(1024));
+    // A later store-level change does NOT mutate the already-added version.
+    store.setMaxNearlineRecordSizeBytes(2048);
+    Assert.assertEquals(store.getVersion(1).getMaxNearlineRecordSizeBytes(), Integer.valueOf(1024));
+  }
+
+  @Test
+  public void testAddVersionSnapshotsUnsetStoreAsNonNull() {
+    Store store = TestUtils.createTestStore("testStore", "owner", System.currentTimeMillis());
+    // An unset store value (-1) is still snapshotted as a concrete non-null value, so the version is distinguishable
+    // from a pre-v48 version that has no snapshot at all (null) and must never track later store-level changes.
+    store.setMaxNearlineRecordSizeBytes(-1);
+    store.addVersion(new VersionImpl(store.getName(), 1, "pushJobId"));
+    Assert.assertEquals(store.getVersion(1).getMaxNearlineRecordSizeBytes(), Integer.valueOf(-1));
+    store.setMaxNearlineRecordSizeBytes(2048);
+    Assert.assertEquals(store.getVersion(1).getMaxNearlineRecordSizeBytes(), Integer.valueOf(-1));
+  }
+
+  @Test
+  public void testVersionLevelMaxNearlineRecordSizeBytes() {
+    Version version = new VersionImpl("testStore", 1, "pushJobId");
+    Assert.assertNull(version.getMaxNearlineRecordSizeBytes()); // no snapshot exists by default
+    version.setMaxNearlineRecordSizeBytes(8192);
+    Assert.assertEquals(version.getMaxNearlineRecordSizeBytes(), Integer.valueOf(8192));
+    Assert.assertEquals(version.cloneVersion().getMaxNearlineRecordSizeBytes(), Integer.valueOf(8192));
+  }
+
+  @Test
+  public void testCloneStorePropertiesPreservesVersionMaxNearlineRecordSizeBytes() {
+    Store store = TestUtils.createTestStore("testStore", "owner", System.currentTimeMillis());
+    store.setMaxNearlineRecordSizeBytes(4096);
+    store.addVersion(new VersionImpl(store.getName(), 1, "pushJobId"));
+    // Round-trip through the ReadOnlyStore -> StoreProperties serialization path (cloneStoreProperties ->
+    // convertVersion) that publishes version metadata; the per-version snapshot must survive it, otherwise the
+    // server would silently fall back to the live store setting.
+    StoreProperties storeProperties = new ReadOnlyStore(store).cloneStoreProperties();
+    StoreVersion storeVersion = storeProperties.getVersions().get(0);
+    Assert.assertEquals(storeVersion.getMaxNearlineRecordSizeBytes(), Integer.valueOf(4096));
   }
 
 }


### PR DESCRIPTION
> **Stacked on #2991** (`[protocol][build] Stage StoreMetaValue v48`). This PR activates the staged schema: it removes the `compileAvro` `versionOverrides` pin and bumps `AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE` 47→48, then adds the read/snapshot logic. It is self-contained and green on its own; #2991 is the isolated schema-only precursor for reviewers who want to look at the wire change in isolation. Merge #2991 first, then this rebases to a pin-removal + logic diff.

## Why
Nearline (realtime-topic partial-update) ingestion is continuous. Reading the oversized-record limit live from the store would retroactively change enforcement for already in-flight versions. This makes `maxNearlineRecordSizeBytes` a **per-version** config, snapshotted onto the `Version` at version-creation time (mirroring `chunkingEnabled` / `storageMode`), so a later store-config change only affects future versions.

Batch `maxRecordSizeBytes` is intentionally left as a live store-level read — a batch push writes a version exactly once, so its value is already de-facto frozen per version.

## Wire contract
`StoreVersion.maxNearlineRecordSizeBytes` is a nullable union `["null","int"]`, default `null`:
- **`null`** = pre-v48 version, no snapshot → the server falls back to the live store-level value at runtime (preserves behavior for metadata written before v48).
- **non-null, including `-1`** = an immutable per-version snapshot; later store-level changes never affect it (`-1` = store was unset at creation, backfilled to the server default at runtime).

## Changes
- **Schema/protocol** — remove the v47 pin in `build.gradle`, bump `METADATA_SYSTEM_SCHEMA_STORE` 47→48 (schema itself introduced in #2991).
- **Version / VersionImpl** — `Integer get/setMaxNearlineRecordSizeBytes` backed by the nullable `StoreVersion` field; carried through `cloneVersion()`.
- **ReadOnlyStore** — delegating getter (setter throws) + `convertVersion` reverse mapping.
- **AbstractStore.addVersion** — snapshot the store-level value onto the new version.
- **Server read path** — `LeaderFollowerStoreIngestionTask.getMaxNearlineRecordSizeBytes()` reads the per-version snapshot via a new `StoreIngestionTask.getVersion()` accessor, with the null→live-store fallback above.
- **Tests** — `TestZKStore`: snapshot + immutability, null default, `cloneVersion` preservation, and a `cloneStoreProperties().getVersions()` round-trip. `LeaderFollowerStoreIngestionTaskTest`: version→store→fleet-default fallback and no-retroactive-change.

## VALIDATION_OVERRIDE
The `enforce-lines-added` check rejects a PR that touches both a `src/main` `.avsc` and a `src/main` `.java` file. This PR does, because it activates schema v48 (present in the diff via the stacked #2991 commit) in the same change that adds the consuming Java — they must be atomic so the generated `StoreVersion` version matches the registered `METADATA_SYSTEM_SCHEMA_STORE`. Totals are well under the line caps; only the schema-plus-Java coupling rule is triggered, so `VALIDATION_OVERRIDE` is the sanctioned path.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
