### PR TITLE
[controller] Preserve lifecycle hooks when update carries empty hooks list

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreLifecycleHooksPolicy.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreLifecycleHooksPolicy.java
@@ -20,14 +20,24 @@ public final class StoreLifecycleHooksPolicy {
    * Resolve the effective lifecycle-hooks list for a store update: when the caller did not
    * supply a new list, keep the current one; when they did, reject any entry without a class
    * name and otherwise return the new list as-is.
+   *
+   * <p>A present-but-empty list is treated the same as an absent value (no change). The
+   * {@code UpdateStore} Avro field is a non-nullable list that defaults to {@code []}, so an
+   * empty list on the wire is indistinguishable from "the caller never touched this field".
+   * Applying it as a clear let an unrelated update_store (e.g. one that only flips
+   * {@code storage_mode}) silently wipe a store's configured hooks. Preserving the current
+   * hooks in that case makes every apply path (parent, Kafka child, and direct REST child)
+   * robust against callers that serialize the default. There is intentionally no supported way
+   * to clear hooks via an empty list; a genuine clear would require a distinct sentinel.
    */
   public static List<LifecycleHooksRecord> validateLifecycleHooks(
       Store oldStore,
       Optional<List<LifecycleHooksRecord>> newLifecycleHooks) {
     List<LifecycleHooksRecord> currLifecycleHooks = oldStore.getStoreLifecycleHooks();
 
-    // No change to existing store lifecycle hooks
-    if (!newLifecycleHooks.isPresent()) {
+    // No change to existing store lifecycle hooks: either the field was absent, or it was the
+    // serialized empty-list default (which cannot be distinguished from "unset" on the wire).
+    if (!newLifecycleHooks.isPresent() || newLifecycleHooks.get().isEmpty()) {
       return currLifecycleHooks.isEmpty() ? Collections.emptyList() : currLifecycleHooks;
     }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
@@ -807,6 +807,36 @@ public class StoreConfigUpdaterTest extends AbstractTestVeniceParentHelixAdmin {
   }
 
   /**
+   * Regression guard for the incident where an unrelated child-side update_store (here, one that
+   * also flips {@code storageMode}) carried the serialized empty-list default for lifecycle hooks
+   * and wiped a store's configured hooks. The child apply path must preserve the store's existing
+   * hooks rather than clear them.
+   */
+  @Test
+  public void testApplyOnChild_EmptyLifecycleHooks_DoesNotWipeExistingHooks() {
+    String storeName = Utils.getUniqueString("child-lifecycle-hooks-preserve");
+    VeniceHelixAdmin admin = newChildAdminMock(storeName);
+    Store store = admin.getStore(clusterName, storeName);
+    LifecycleHooksRecord existingHook = new LifecycleHooksRecordImpl("com.example.SomeHooks", Collections.emptyMap());
+    store.setStoreLifecycleHooks(Collections.singletonList(existingHook));
+
+    // Mirrors the incident: storage_mode change + serialized empty-list default for hooks.
+    UpdateStoreQueryParams params = new UpdateStoreQueryParams().setStorageMode(StorageMode.DUAL_WRITE)
+        .setStoreLifecycleHooks(Collections.emptyList());
+
+    StoreConfigUpdater.applyOnChild(admin, clusterName, storeName, params);
+
+    ArgumentCaptor<List<LifecycleHooksRecord>> captor = ArgumentCaptor.forClass(List.class);
+    verify(admin, times(1)).setStoreLifecycleHooks(eq(clusterName), eq(storeName), captor.capture());
+    List<LifecycleHooksRecord> applied = captor.getValue();
+    assertEquals(applied.size(), 1, "The existing hook must be preserved, not cleared");
+    assertEquals(
+        applied.get(0).getStoreLifecycleHooksClassName(),
+        "com.example.SomeHooks",
+        "An empty lifecycle-hooks list must preserve the store's existing hook, not clear it");
+  }
+
+  /**
    * Covers the child-side ingestion-pause branch: when {@code ingestionPauseMode} is set with a
    * regions list, the non-parent path computes {@code appliesToThisRegion} and writes through
    * {@code storeMetadataUpdate}. We don't assert the resolved persisted state here because the

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/storeconfig/StoreLifecycleHooksPolicyTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/storeconfig/StoreLifecycleHooksPolicyTest.java
@@ -45,4 +45,53 @@ public class StoreLifecycleHooksPolicyTest {
     Assert.assertSame(result, hooks);
     verify(lifecycleHooksRecord).setStoreLifecycleHooksClassName("com.linkedin.venice.Hook");
   }
+
+  /**
+   * Regression guard for the incident where an unrelated update_store (only changing
+   * storage_mode) carried the serialized empty-list default for lifecycle hooks and wiped a
+   * store's configured hooks. A present-but-empty list must be treated as "no change" and
+   * preserve the current hooks, exactly like an absent value.
+   */
+  @Test
+  public void testValidateLifecycleHooksPresentEmptyPreservesExistingHooks() {
+    Store oldStore = mock(Store.class);
+    LifecycleHooksRecord existingHook = mock(LifecycleHooksRecord.class);
+    List<LifecycleHooksRecord> existingHooks = Collections.singletonList(existingHook);
+    when(oldStore.getStoreLifecycleHooks()).thenReturn(existingHooks);
+
+    List<LifecycleHooksRecord> result =
+        StoreLifecycleHooksPolicy.validateLifecycleHooks(oldStore, Optional.of(Collections.emptyList()));
+
+    Assert.assertEquals(result, existingHooks, "A present-but-empty list must preserve existing hooks");
+  }
+
+  /**
+   * When the caller does not supply the field at all, the current hooks must be preserved.
+   */
+  @Test
+  public void testValidateLifecycleHooksAbsentPreservesExistingHooks() {
+    Store oldStore = mock(Store.class);
+    LifecycleHooksRecord existingHook = mock(LifecycleHooksRecord.class);
+    List<LifecycleHooksRecord> existingHooks = Collections.singletonList(existingHook);
+    when(oldStore.getStoreLifecycleHooks()).thenReturn(existingHooks);
+
+    List<LifecycleHooksRecord> result = StoreLifecycleHooksPolicy.validateLifecycleHooks(oldStore, Optional.empty());
+
+    Assert.assertEquals(result, existingHooks, "An absent value must preserve existing hooks");
+  }
+
+  /**
+   * A present-but-empty list when the store has no hooks yet must stay empty (not error, not
+   * fabricate hooks).
+   */
+  @Test
+  public void testValidateLifecycleHooksPresentEmptyWithNoExistingHooksStaysEmpty() {
+    Store oldStore = mock(Store.class);
+    when(oldStore.getStoreLifecycleHooks()).thenReturn(Collections.emptyList());
+
+    List<LifecycleHooksRecord> result =
+        StoreLifecycleHooksPolicy.validateLifecycleHooks(oldStore, Optional.of(Collections.emptyList()));
+
+    Assert.assertTrue(result.isEmpty(), "Empty in, no existing hooks, must remain empty");
+  }
 }


### PR DESCRIPTION
## Problem

An `update_store` that did not intend to change lifecycle hooks could silently wipe a store's configured hooks.

`store_lifecycle_hooks_list` has no "unset" representation on the wire: the `UpdateStore` Avro field is a non-nullable array defaulting to `[]`, so a **present-but-empty** list is indistinguishable from "the caller never touched this field". `StoreLifecycleHooksPolicy.validateLifecycleHooks` only preserved the current hooks when the value was **absent**; a present-but-empty list was returned as-is and applied as a **clear**.

This bit the direct child-controller REST path (`StoreConfigUpdater.applyOnChild`), which has no `updatedConfigsList` gate — an update that only flipped `storage_mode` also carried the empty-default hooks list and cleared the hooks. The parent → Kafka → child path was protected only because empty hooks are never added to `updatedConfigsList` and get filtered out by `AdminExecutionTask`, a fragile, path-dependent safety net (and `replicateAllConfigs=true` bypasses it entirely).

## Fix

Treat a present-but-empty list the same as an absent value (no change) in the shared `validateLifecycleHooks`, which is called by both `applyOnChild` and `applyOnParent`. Every apply path now preserves the current hooks, matching how every other field falls back to its current value when unspecified. Clearing hooks via an empty list is intentionally unsupported; a genuine clear would require a distinct sentinel.

## Testing Done

- `StoreLifecycleHooksPolicyTest`: present-empty preserves existing hooks; absent preserves; present-empty with no existing hooks stays empty (plus existing blank-class-name/trim cases).
- `StoreConfigUpdaterTest.testApplyOnChild_EmptyLifecycleHooks_DoesNotWipeExistingHooks`: reproduces the failure (a `storage_mode` change carrying an empty hooks list on a store that already has a hook) and asserts the existing hook is preserved, not cleared.

`./gradlew :services:venice-controller:test --tests "com.linkedin.venice.controller.storeconfig.StoreLifecycleHooksPolicyTest" --tests "com.linkedin.venice.controller.StoreConfigUpdaterTest"` — BUILD SUCCESSFUL.
