### PR TITLE
[server] Allow future-version standby lag check to be enabled independently of thread pool strategy

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -1365,22 +1365,6 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getInt(SERVER_LAG_BASED_REPLICA_AUTO_RESUBSCRIBE_MAX_REPLICA_COUNT, 3);
     this.futureVersionStandbyLagCheckEnabled =
         serverProperties.getBoolean(SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED, false);
-    if (this.futureVersionStandbyLagCheckEnabled
-        && leaderFollowerThreadPoolStrategy != LeaderFollowerPartitionStateModelFactory.LeaderFollowerThreadPoolStrategy.DUAL_POOL_STRATEGY) {
-      String errorMessage = String.format(
-          "%s can only be enabled when %s is set to %s, since the lag-based wait synchronously occupies a "
-              + "state-transition worker thread and could otherwise delay current/backup-version transitions "
-              + "on a shared pool. Current strategy: %s. Please either set %s to %s or disable %s.",
-          SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED,
-          LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY,
-          LeaderFollowerPartitionStateModelFactory.LeaderFollowerThreadPoolStrategy.DUAL_POOL_STRATEGY,
-          leaderFollowerThreadPoolStrategy,
-          LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY,
-          LeaderFollowerPartitionStateModelFactory.LeaderFollowerThreadPoolStrategy.DUAL_POOL_STRATEGY,
-          SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED);
-      LOGGER.error(errorMessage);
-      throw new VeniceException(errorMessage);
-    }
     this.futureVersionStandbyLagThreshold =
         serverProperties.getLong(SERVER_FUTURE_VERSION_STANDBY_LAG_THRESHOLD, 1000L);
     this.futureVersionStandbyLagCheckTimeoutMinutes =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
@@ -6,7 +6,6 @@ import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.INGESTION_USE_DA_VINCI_CLIENT;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_FETCH_THROTTLER_FACTORS_PER_SECOND;
-import static com.linkedin.venice.ConfigKeys.LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.LOCAL_REGION_NAME;
 import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_AA_DCR_BUG_INJECTION_STORE_TO_REGION_MAP;
@@ -36,7 +35,6 @@ import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.davinci.blobtransfer.client.NettyFileTransferClient;
-import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModelFactory;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Arrays;
@@ -88,9 +86,6 @@ public class VeniceServerConfigTest {
   @Test
   public void testFutureVersionStandbyLagCheckOverrides() {
     Properties props = populatedBasicProperties();
-    props.setProperty(
-        LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY,
-        LeaderFollowerPartitionStateModelFactory.LeaderFollowerThreadPoolStrategy.DUAL_POOL_STRATEGY.name());
     props.setProperty(SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED, "true");
     props.setProperty(SERVER_FUTURE_VERSION_STANDBY_LAG_THRESHOLD, "2000");
     props.setProperty(SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_TIMEOUT_MINUTES, "60");
@@ -101,16 +96,6 @@ public class VeniceServerConfigTest {
     assertEquals(config.getFutureVersionStandbyLagThreshold(), 2000L);
     assertEquals(config.getFutureVersionStandbyLagCheckTimeoutMinutes(), 60);
     assertEquals(config.getFutureVersionStandbyLagCheckPollIntervalMinutes(), 5);
-  }
-
-  @Test
-  public void testFutureVersionStandbyLagCheckRequiresDualPoolStrategy() {
-    // Lag check enabled while the thread pool strategy defaults to SINGLE_POOL_STRATEGY must fail fast, since the
-    // wait synchronously occupies a shared state-transition worker thread.
-    Properties props = populatedBasicProperties();
-    props.setProperty(SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED, "true");
-
-    assertThrows(VeniceException.class, () -> new VeniceServerConfig(new VeniceProperties(props)));
   }
 
   @Test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helixrebalance/FutureVersionStandbyLagCheckTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helixrebalance/FutureVersionStandbyLagCheckTest.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.helixrebalance;
 
-import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModelFactory;
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
@@ -138,13 +137,6 @@ public class FutureVersionStandbyLagCheckTest {
     extraProperties.put(ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_THRESHOLD, 0);
     extraProperties.put(ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_TIMEOUT_MINUTES, timeoutMinutes);
     extraProperties.put(ConfigKeys.SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_POLL_INTERVAL_MINUTES, pollIntervalMinutes);
-    if (lagCheckEnabled) {
-      // The lag-based wait synchronously occupies a state-transition worker thread, so it is only allowed when
-      // future-version transitions run on their own dedicated pool.
-      extraProperties.put(
-          ConfigKeys.LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY,
-          LeaderFollowerPartitionStateModelFactory.LeaderFollowerThreadPoolStrategy.DUAL_POOL_STRATEGY.name());
-    }
 
     cluster.addVeniceServer(new Properties(), extraProperties);
     cluster.addVeniceServer(new Properties(), extraProperties);


### PR DESCRIPTION
## Summary

Follow-up to #2976. This decouples the future-version standby lag check feature from the `LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY` configuration, allowing it to be rolled out independently instead of requiring clusters to first switch to `DUAL_POOL_STRATEGY`.

## Why

#2976 originally added a fail-fast validation: the server would refuse to start if `SERVER_FUTURE_VERSION_STANDBY_LAG_CHECK_ENABLED=true` while the thread pool strategy was not `DUAL_POOL_STRATEGY`. The intent was to avoid the lag-based wait synchronously occupying a thread in the shared state-transition thread pool, which could delay current/backup-version transitions.

After further discussion with the team, the rollout plan for this feature no longer needs to be coupled to the dual-pool strategy rollout — the two will be evaluated and rolled out independently, so this validation is being removed.

## Changes

- `VeniceServerConfig.java`: Removed the startup-time validation requiring `futureVersionStandbyLagCheckEnabled` to be paired with `DUAL_POOL_STRATEGY` (including the associated error log and exception).
- `VeniceServerConfigTest.java`: Removed `testFutureVersionStandbyLagCheckRequiresDualPoolStrategy`; `testFutureVersionStandbyLagCheckOverrides` no longer sets `DUAL_POOL_STRATEGY`.
- `FutureVersionStandbyLagCheckTest.java` (integration test): Removed the automatic `DUAL_POOL_STRATEGY` setup; the test now runs under the default single-pool configuration.

## Tests

- `VeniceServerConfigTest`: all tests pass.
- `FutureVersionStandbyLagCheckTest`: all 3 integration tests pass under the default single-pool configuration.
