### PR TITLE
[controller][common] Parallelize version swap broadcasts

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -95,6 +95,7 @@ import org.apache.logging.log4j.Logger;
 public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   private static final ChunkedPayloadAndManifest EMPTY_CHUNKED_PAYLOAD_AND_MANIFEST =
       new ChunkedPayloadAndManifest(null, null);
+  private static final int ASYNC_BROADCAST_THREAD_COUNT = 8;
 
   // use for running async close and to fetch number of partitions with timeout from producer
   private final ThreadPoolExecutor threadPoolExecutor;
@@ -423,11 +424,11 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     this.defaultLeaderMetadata = new DefaultLeaderMetadata(this.writerId);
     this.producerGUID = GuidUtils.getGUID(props);
     this.logger = LogManager.getLogger("VeniceWriter [" + GuidUtils.getHexFromGuid(producerGUID) + "]");
-    // Create a thread pool which can have max 2 threads.
+    // Keep broadcast concurrency bounded because each task can synchronously wait for START_OF_SEGMENT.
     // Except during VW start and close we expect it to have zero threads to avoid unnecessary resource usage.
     this.threadPoolExecutor = new ThreadPoolExecutor(
-        2,
-        2,
+        ASYNC_BROADCAST_THREAD_COUNT,
+        ASYNC_BROADCAST_THREAD_COUNT,
         5,
         TimeUnit.SECONDS,
         new LinkedBlockingQueue<>(),
@@ -1664,14 +1665,34 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     Validate.notEmpty(newServingVersionTopic);
     Validate.notEmpty(sourceRegion);
     Validate.notEmpty(destinationRegion);
-    ControlMessage controlMessage = getEmptyControlMessage(ControlMessageType.VERSION_SWAP);
-    controlMessage.controlMessageUnion = generateVersionSwapMessage(
-        oldServingVersionTopic,
-        newServingVersionTopic,
-        sourceRegion,
-        destinationRegion,
-        generationId);
-    return broadcastControlMessage(controlMessage, debugInfo);
+    List<CompletableFuture<PubSubProduceResult>> partitionWriteFutures = new ArrayList<>(numberOfPartitions);
+    for (int partition = 0; partition < numberOfPartitions; partition++) {
+      int destinationPartition = partition;
+      CompletableFuture<PubSubProduceResult> partitionWriteFuture = new CompletableFuture<>();
+      partitionWriteFutures.add(partitionWriteFuture);
+      threadPoolExecutor.execute(() -> {
+        try {
+          ControlMessage controlMessage = getEmptyControlMessage(ControlMessageType.VERSION_SWAP);
+          controlMessage.controlMessageUnion = generateVersionSwapMessage(
+              oldServingVersionTopic,
+              newServingVersionTopic,
+              sourceRegion,
+              destinationRegion,
+              generationId);
+          sendControlMessage(controlMessage, destinationPartition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER)
+              .whenComplete((result, throwable) -> {
+                if (throwable == null) {
+                  partitionWriteFuture.complete(result);
+                } else {
+                  partitionWriteFuture.completeExceptionally(throwable);
+                }
+              });
+        } catch (Exception e) {
+          partitionWriteFuture.completeExceptionally(e);
+        }
+      });
+    }
+    return partitionWriteFutures;
   }
 
   private VersionSwap generateVersionSwapMessage(

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -57,6 +57,7 @@ import com.linkedin.venice.pubsub.api.EmptyPubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
+import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
@@ -87,7 +88,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.kafka.common.errors.TimeoutException;
@@ -102,6 +106,47 @@ public class VeniceWriterUnitTest {
   private static final int CHUNK_MANIFEST_SCHEMA_ID =
       AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion();
   private static final int CHUNK_VALUE_SCHEMA_ID = AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion();
+
+  @Test(timeOut = TIMEOUT)
+  public void testVersionSwapBroadcastsPartitionsConcurrentlyAndInOrder() throws Exception {
+    int partitionCount = 4;
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    CountDownLatch allPartitionsStarted = new CountDownLatch(partitionCount);
+    Map<Integer, List<ControlMessageType>> controlMessageTypesByPartition = new ConcurrentHashMap<>();
+    when(mockedProducer.sendMessage(anyString(), anyInt(), any(), any(), any(), any())).thenAnswer(invocation -> {
+      int partition = invocation.getArgument(1);
+      KafkaMessageEnvelope envelope = invocation.getArgument(3);
+      ControlMessage controlMessage = (ControlMessage) envelope.payloadUnion;
+      ControlMessageType controlMessageType = ControlMessageType.valueOf(controlMessage);
+      controlMessageTypesByPartition.computeIfAbsent(partition, ignored -> new ArrayList<>()).add(controlMessageType);
+      if (controlMessageType == ControlMessageType.START_OF_SEGMENT) {
+        allPartitionsStarted.countDown();
+        assertTrue(
+            allPartitionsStarted.await(2, TimeUnit.SECONDS),
+            "START_OF_SEGMENT sends should run concurrently across partitions");
+      }
+      return CompletableFuture.completedFuture(mock(PubSubProduceResult.class));
+    });
+    VeniceWriterOptions options = new VeniceWriterOptions.Builder("test_rt").setPartitionCount(partitionCount).build();
+    VeniceWriter<Object, Object, Object> writer = new VeniceWriter<>(options, VeniceProperties.empty(), mockedProducer);
+
+    List<CompletableFuture<PubSubProduceResult>> futures = writer.nonBlockingBroadcastVersionSwapWithRegionInfo(
+        "test_v1",
+        "test_v2",
+        "source-region",
+        "destination-region",
+        1L,
+        Collections.emptyMap());
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+
+    assertEquals(controlMessageTypesByPartition.size(), partitionCount);
+    for (int partition = 0; partition < partitionCount; partition++) {
+      assertEquals(
+          controlMessageTypesByPartition.get(partition),
+          Arrays.asList(ControlMessageType.START_OF_SEGMENT, ControlMessageType.VERSION_SWAP));
+    }
+    writer.close(false);
+  }
 
   @Test(dataProvider = "Chunking-And-Partition-Counts", dataProviderClass = DataProviderUtils.class)
   public void testTargetPartitionIsSameForAllOperationsWithTheSameKey(boolean isChunkingEnabled, int partitionCount) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/DeferredVersionSwapService.java
@@ -845,7 +845,8 @@ public class DeferredVersionSwapService extends AbstractVeniceService {
             + regionsToRollback;
         logMessageIfNotRedundant(message);
 
-        veniceParentHelixAdmin.rollbackToBackupVersion(clusterName, parentStore.getName(), regionsToRollback);
+        veniceParentHelixAdmin
+            .rollbackToBackupVersionForDeferredVersionSwap(clusterName, parentStore.getName(), regionsToRollback);
         updateStore(clusterName, parentStore.getName(), VersionStatus.ROLLED_BACK, targetVersionNum);
         LOGGER.info(
             "Updated store status to ROLLED_BACK for store: {} on version: {}",

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -240,6 +240,8 @@ public class VeniceParentHelixAdmin implements Admin {
   public static final List<Class<? extends Throwable>> RETRY_FAILURE_TYPES = Collections.singletonList(Exception.class);
   private static final int ROLL_FORWARD_REQUEST_TIMEOUT = 60 * Time.MS_PER_SECOND;
   private static final int CONTROLLER_STORE_POLL_TIMEOUT = 5 * Time.MS_PER_SECOND;
+  private static final int ROLLBACK_STATUS_POLL_MAX_ATTEMPTS = 15;
+  private static final Duration ROLLBACK_STATUS_POLL_MAX_DURATION = Duration.ofMinutes(2);
 
   final Map<String, Boolean> asyncSetupEnabledMap;
   private final VeniceHelixAdmin veniceHelixAdmin;
@@ -2787,7 +2789,7 @@ public class VeniceParentHelixAdmin implements Admin {
     // a positive signal — treat those regions as not-confirmed so we don't inflate the count.
     Set<String> assumeRolledBackIfUnreachable = filterProvided ? targetedRegions : Collections.emptySet();
 
-    // Poll child regions with exponential backoff to allow for ZK propagation lag after admin message consumption.
+    // Poll beyond the multi-region Version Swap broadcast deadline so child metadata has time to become visible.
     int rolledBackRegionCount = 0;
     try {
       rolledBackRegionCount = RetryUtils.executeWithMaxAttemptAndExponentialBackoff(() -> {
@@ -2808,10 +2810,10 @@ public class VeniceParentHelixAdmin implements Admin {
         }
         return count;
       },
-          5,
+          ROLLBACK_STATUS_POLL_MAX_ATTEMPTS,
           Duration.ofSeconds(1),
           Duration.ofSeconds(10),
-          Duration.ofSeconds(30),
+          ROLLBACK_STATUS_POLL_MAX_DURATION,
           Collections.singletonList(VeniceException.class));
     } catch (Exception e) {
       // Retries exhausted — do a final poll to get the latest count

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2630,6 +2630,23 @@ public class VeniceParentHelixAdmin implements Admin {
    */
   @Override
   public void rollbackToBackupVersion(String clusterName, String storeName, String regionFilter) {
+    rollbackToBackupVersion(clusterName, storeName, regionFilter, true);
+  }
+
+  /**
+   * Deferred swaps leave the parent's current version on the backup while rolling back promoted child regions.
+   * {@link DeferredVersionSwapService} finalizes the target version status, so parent rollback aggregation is both
+   * redundant and harmful here because its two-minute poll would block the service's single worker.
+   */
+  void rollbackToBackupVersionForDeferredVersionSwap(String clusterName, String storeName, String regionFilter) {
+    rollbackToBackupVersion(clusterName, storeName, regionFilter, false);
+  }
+
+  private void rollbackToBackupVersion(
+      String clusterName,
+      String storeName,
+      String regionFilter,
+      boolean updateParentStatus) {
     int rolledBackVersionNum;
     acquireAdminMessageLock(clusterName, storeName);
     try {
@@ -2654,7 +2671,7 @@ public class VeniceParentHelixAdmin implements Admin {
 
     // Update parent version status outside of admin message lock to avoid blocking concurrent
     // admin operations during the exponential-backoff polling of child regions.
-    if (rolledBackVersionNum != NON_EXISTING_VERSION) {
+    if (updateParentStatus && rolledBackVersionNum != NON_EXISTING_VERSION) {
       updateParentVersionStatusAfterRollback(clusterName, storeName, rolledBackVersionNum, regionFilter);
     }
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcher.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcher.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.utils.VeniceResourceCloseResult;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterFactory;
 import com.linkedin.venice.writer.VeniceWriterOptions;
@@ -15,11 +16,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -65,7 +68,10 @@ public class MultiRegionRealTimeTopicSwitcher extends RealTimeTopicSwitcher {
         Math.max(1, allAASourceDataCenterBrokerAddressMap.size()),
         new DaemonThreadFactory("Version-Swap-" + storeName));
     Map<String, CompletableFuture<Void>> dataCenterBroadcastFutureMap = new HashMap<>();
+    Map<String, VeniceWriter> dataCenterWriterMap = new ConcurrentHashMap<>();
     long deadlineNs = System.nanoTime() + TimeUnit.SECONDS.toNanos(DEFAULT_BROADCAST_TIMEOUT_IN_SECONDS);
+    AtomicBoolean broadcastAborted = new AtomicBoolean(false);
+    boolean broadcastCompleted = false;
     try {
       for (Map.Entry<String, String> entry: allAASourceDataCenterBrokerAddressMap.entrySet()) {
         String dataCenterName = entry.getKey();
@@ -81,12 +87,16 @@ public class MultiRegionRealTimeTopicSwitcher extends RealTimeTopicSwitcher {
                     generationId,
                     dataCenterName,
                     brokerAddress,
-                    deadlineNs),
+                    deadlineNs,
+                    dataCenterWriterMap,
+                    broadcastAborted),
                 regionExecutor));
       }
 
       CompletableFuture.allOf(dataCenterBroadcastFutureMap.values().toArray(new CompletableFuture[0]))
           .get(getRemainingTimeInMs(deadlineNs), TimeUnit.MILLISECONDS);
+      broadcastCompleted = true;
+      closeWritersGracefully(dataCenterWriterMap, deadlineNs);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new VeniceException(
@@ -109,6 +119,10 @@ public class MultiRegionRealTimeTopicSwitcher extends RealTimeTopicSwitcher {
               dataCenterBroadcastFutureMap),
           e);
     } finally {
+      if (!broadcastCompleted) {
+        broadcastAborted.set(true);
+        closeWritersUngracefully(dataCenterWriterMap);
+      }
       regionExecutor.shutdownNow();
     }
   }
@@ -121,9 +135,11 @@ public class MultiRegionRealTimeTopicSwitcher extends RealTimeTopicSwitcher {
       long generationId,
       String dataCenterName,
       String brokerAddress,
-      long deadlineNs) {
+      long deadlineNs,
+      Map<String, VeniceWriter> dataCenterWriterMap,
+      AtomicBoolean broadcastAborted) {
     VeniceWriter veniceWriter = null;
-    boolean gracefulCloseCompleted = false;
+    boolean partitionBroadcastCompleted = false;
     try {
       VeniceWriterOptions.Builder writerOptionsBuilder =
           new VeniceWriterOptions.Builder(topicName).setTime(getTimer()).setPartitionCount(partitionCount);
@@ -131,6 +147,7 @@ public class MultiRegionRealTimeTopicSwitcher extends RealTimeTopicSwitcher {
         writerOptionsBuilder.setBrokerAddress(brokerAddress);
       }
       veniceWriter = veniceWriterFactory.createVeniceWriter(writerOptionsBuilder.build());
+      dataCenterWriterMap.put(dataCenterName, veniceWriter);
       List<CompletableFuture<PubSubProduceResult>> partitionFutures =
           veniceWriter.nonBlockingBroadcastVersionSwapWithRegionInfo(
               previousStoreVersion.kafkaTopicName(),
@@ -141,8 +158,7 @@ public class MultiRegionRealTimeTopicSwitcher extends RealTimeTopicSwitcher {
               Collections.emptyMap());
       CompletableFuture.allOf(partitionFutures.toArray(new CompletableFuture[0]))
           .get(getRemainingTimeInMs(deadlineNs), TimeUnit.MILLISECONDS);
-      veniceWriter.closeAsync(true).get(getRemainingTimeInMs(deadlineNs), TimeUnit.MILLISECONDS);
-      gracefulCloseCompleted = true;
+      partitionBroadcastCompleted = true;
       LOGGER.info(
           "Successfully sent Version Swap message with generation id: {}, source data center: {} for store: {} from version: {} to version: {} to topic: {} in data center: {}",
           generationId,
@@ -158,9 +174,64 @@ public class MultiRegionRealTimeTopicSwitcher extends RealTimeTopicSwitcher {
     } catch (ExecutionException | TimeoutException e) {
       throw new VeniceException("Failed to broadcast Version Swap message to " + dataCenterName, e);
     } finally {
-      if (veniceWriter != null && !gracefulCloseCompleted) {
-        veniceWriter.closeAsync(false);
+      if (veniceWriter != null && (!partitionBroadcastCompleted || broadcastAborted.get())
+          && dataCenterWriterMap.remove(dataCenterName, veniceWriter)) {
+        closeWriterUngracefully(dataCenterName, veniceWriter);
       }
+    }
+  }
+
+  private void closeWritersGracefully(Map<String, VeniceWriter> dataCenterWriterMap, long deadlineNs) {
+    if (dataCenterWriterMap.isEmpty()) {
+      return;
+    }
+    Map<String, CompletableFuture<VeniceResourceCloseResult>> closeFutureMap = new HashMap<>();
+    for (Map.Entry<String, VeniceWriter> entry: dataCenterWriterMap.entrySet()) {
+      try {
+        closeFutureMap.put(entry.getKey(), entry.getValue().closeAsync(true));
+      } catch (RuntimeException e) {
+        LOGGER.warn(
+            "Failed to start graceful close for Version Swap writer in data center: {}; falling back to ungraceful close",
+            entry.getKey(),
+            e);
+        closeWriterUngracefully(entry.getKey(), entry.getValue());
+      }
+    }
+
+    try {
+      CompletableFuture.allOf(closeFutureMap.values().toArray(new CompletableFuture[0]))
+          .get(getRemainingTimeInMs(deadlineNs), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOGGER.warn("Interrupted while gracefully closing Version Swap writers; falling back to ungraceful close", e);
+    } catch (ExecutionException | TimeoutException e) {
+      LOGGER.warn("Failed to gracefully close all Version Swap writers; falling back to ungraceful close", e);
+    }
+
+    for (Map.Entry<String, CompletableFuture<VeniceResourceCloseResult>> entry: closeFutureMap.entrySet()) {
+      CompletableFuture<VeniceResourceCloseResult> closeFuture = entry.getValue();
+      if (!closeFuture.isDone() || closeFuture.isCancelled() || closeFuture.isCompletedExceptionally()) {
+        LOGGER.warn(
+            "Graceful close did not complete successfully for Version Swap writer in data center: {}; falling back to ungraceful close",
+            entry.getKey());
+        closeWriterUngracefully(entry.getKey(), dataCenterWriterMap.get(entry.getKey()));
+      }
+    }
+  }
+
+  private void closeWritersUngracefully(Map<String, VeniceWriter> dataCenterWriterMap) {
+    for (Map.Entry<String, VeniceWriter> entry: dataCenterWriterMap.entrySet()) {
+      if (dataCenterWriterMap.remove(entry.getKey(), entry.getValue())) {
+        closeWriterUngracefully(entry.getKey(), entry.getValue());
+      }
+    }
+  }
+
+  private void closeWriterUngracefully(String dataCenterName, VeniceWriter veniceWriter) {
+    try {
+      veniceWriter.closeAsync(false);
+    } catch (RuntimeException e) {
+      LOGGER.warn("Failed to start ungraceful close for Version Swap writer in data center: {}", dataCenterName, e);
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcher.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcher.java
@@ -5,6 +5,7 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.manager.TopicManager;
+import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterFactory;
@@ -14,14 +15,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
 public class MultiRegionRealTimeTopicSwitcher extends RealTimeTopicSwitcher {
   private static final Logger LOGGER = LogManager.getLogger(MultiRegionRealTimeTopicSwitcher.class);
-  private static final int DEFAULT_PER_DATA_CENTER_BROADCAST_TIMEOUT_IN_SECONDS = 60;
+  private static final int DEFAULT_BROADCAST_TIMEOUT_IN_SECONDS = 60;
   private final Map<String, String> allAASourceDataCenterBrokerAddressMap;
   private final String localDataCenterName;
 
@@ -56,55 +61,144 @@ public class MultiRegionRealTimeTopicSwitcher extends RealTimeTopicSwitcher {
         storeName,
         partitionCount,
         allAASourceDataCenterBrokerAddressMap.size());
+    ExecutorService regionExecutor = Executors.newFixedThreadPool(
+        Math.max(1, allAASourceDataCenterBrokerAddressMap.size()),
+        new DaemonThreadFactory("Version-Swap-" + storeName));
     Map<String, CompletableFuture<Void>> dataCenterBroadcastFutureMap = new HashMap<>();
-    for (Map.Entry<String, String> entry: allAASourceDataCenterBrokerAddressMap.entrySet()) {
-      String dataCenterName = entry.getKey();
+    long deadlineNs = System.nanoTime() + TimeUnit.SECONDS.toNanos(DEFAULT_BROADCAST_TIMEOUT_IN_SECONDS);
+    try {
+      for (Map.Entry<String, String> entry: allAASourceDataCenterBrokerAddressMap.entrySet()) {
+        String dataCenterName = entry.getKey();
+        String brokerAddress = entry.getValue();
+        dataCenterBroadcastFutureMap.put(
+            dataCenterName,
+            CompletableFuture.runAsync(
+                () -> broadcastVersionSwapToDataCenter(
+                    previousStoreVersion,
+                    nextStoreVersion,
+                    topicName,
+                    partitionCount,
+                    generationId,
+                    dataCenterName,
+                    brokerAddress,
+                    deadlineNs),
+                regionExecutor));
+      }
+
+      CompletableFuture.allOf(dataCenterBroadcastFutureMap.values().toArray(new CompletableFuture[0]))
+          .get(getRemainingTimeInMs(deadlineNs), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new VeniceException(
+          getBroadcastFailureMessage(
+              generationId,
+              storeName,
+              previousStoreVersion,
+              nextStoreVersion,
+              topicName,
+              dataCenterBroadcastFutureMap),
+          e);
+    } catch (ExecutionException | TimeoutException e) {
+      throw new VeniceException(
+          getBroadcastFailureMessage(
+              generationId,
+              storeName,
+              previousStoreVersion,
+              nextStoreVersion,
+              topicName,
+              dataCenterBroadcastFutureMap),
+          e);
+    } finally {
+      regionExecutor.shutdownNow();
+    }
+  }
+
+  private void broadcastVersionSwapToDataCenter(
+      Version previousStoreVersion,
+      Version nextStoreVersion,
+      String topicName,
+      int partitionCount,
+      long generationId,
+      String dataCenterName,
+      String brokerAddress,
+      long deadlineNs) {
+    VeniceWriter veniceWriter = null;
+    boolean gracefulCloseCompleted = false;
+    try {
       VeniceWriterOptions.Builder writerOptionsBuilder =
           new VeniceWriterOptions.Builder(topicName).setTime(getTimer()).setPartitionCount(partitionCount);
       if (!dataCenterName.equals(localDataCenterName)) {
-        writerOptionsBuilder.setBrokerAddress(entry.getValue());
+        writerOptionsBuilder.setBrokerAddress(brokerAddress);
       }
-      try (VeniceWriter veniceWriter = veniceWriterFactory.createVeniceWriter(writerOptionsBuilder.build())) {
-        List<CompletableFuture<PubSubProduceResult>> futures =
-            veniceWriter.nonBlockingBroadcastVersionSwapWithRegionInfo(
-                previousStoreVersion.kafkaTopicName(),
-                nextStoreVersion.kafkaTopicName(),
-                localDataCenterName,
-                dataCenterName,
-                generationId,
-                Collections.emptyMap());
-        dataCenterBroadcastFutureMap
-            .put(dataCenterName, CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])));
+      veniceWriter = veniceWriterFactory.createVeniceWriter(writerOptionsBuilder.build());
+      List<CompletableFuture<PubSubProduceResult>> partitionFutures =
+          veniceWriter.nonBlockingBroadcastVersionSwapWithRegionInfo(
+              previousStoreVersion.kafkaTopicName(),
+              nextStoreVersion.kafkaTopicName(),
+              localDataCenterName,
+              dataCenterName,
+              generationId,
+              Collections.emptyMap());
+      CompletableFuture.allOf(partitionFutures.toArray(new CompletableFuture[0]))
+          .get(getRemainingTimeInMs(deadlineNs), TimeUnit.MILLISECONDS);
+      veniceWriter.closeAsync(true).get(getRemainingTimeInMs(deadlineNs), TimeUnit.MILLISECONDS);
+      gracefulCloseCompleted = true;
+      LOGGER.info(
+          "Successfully sent Version Swap message with generation id: {}, source data center: {} for store: {} from version: {} to version: {} to topic: {} in data center: {}",
+          generationId,
+          localDataCenterName,
+          previousStoreVersion.getStoreName(),
+          previousStoreVersion.getNumber(),
+          nextStoreVersion.getNumber(),
+          topicName,
+          dataCenterName);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new VeniceException("Interrupted while broadcasting Version Swap message to " + dataCenterName, e);
+    } catch (ExecutionException | TimeoutException e) {
+      throw new VeniceException("Failed to broadcast Version Swap message to " + dataCenterName, e);
+    } finally {
+      if (veniceWriter != null && !gracefulCloseCompleted) {
+        veniceWriter.closeAsync(false);
       }
     }
+  }
 
-    // Check the result of each data center broadcast
+  private long getRemainingTimeInMs(long deadlineNs) throws TimeoutException {
+    long remainingTimeInMs = TimeUnit.NANOSECONDS.toMillis(deadlineNs - System.nanoTime());
+    if (remainingTimeInMs <= 0) {
+      throw new TimeoutException("Version Swap broadcast exceeded its deadline");
+    }
+    return remainingTimeInMs;
+  }
+
+  private String getBroadcastFailureMessage(
+      long generationId,
+      String storeName,
+      Version previousStoreVersion,
+      Version nextStoreVersion,
+      String topicName,
+      Map<String, CompletableFuture<Void>> dataCenterBroadcastFutureMap) {
+    StringBuilder incompleteDataCenters = new StringBuilder();
     for (Map.Entry<String, CompletableFuture<Void>> entry: dataCenterBroadcastFutureMap.entrySet()) {
-      try {
-        entry.getValue().get(DEFAULT_PER_DATA_CENTER_BROADCAST_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
-        LOGGER.info(
-            "Successfully sent Version Swap message with generation id: {}, source data center: {} for store: {} from version: {} to version: {} to topic: {} in data center: {}",
-            generationId,
-            localDataCenterName,
-            storeName,
-            previousStoreVersion.getNumber(),
-            nextStoreVersion.getNumber(),
-            topicName,
-            entry.getValue());
-      } catch (Exception e) {
-        String message = String.format(
-            "Failed to broadcast Version Swap message with generation id: %s, source data center: %s for store: %s from version: %s to version: %s to topic: %s in data center: %s",
-            generationId,
-            localDataCenterName,
-            storeName,
-            previousStoreVersion.getNumber(),
-            nextStoreVersion.getNumber(),
-            topicName,
-            entry.getKey());
-        LOGGER.error(message, e);
-        throw new VeniceException(message);
+      if (!entry.getValue().isDone() || entry.getValue().isCompletedExceptionally()) {
+        if (incompleteDataCenters.length() > 0) {
+          incompleteDataCenters.append(',');
+        }
+        incompleteDataCenters.append(entry.getKey());
       }
     }
+    String message = String.format(
+        "Failed to broadcast Version Swap message with generation id: %s, source data center: %s for store: %s from version: %s to version: %s to topic: %s in data center(s): %s",
+        generationId,
+        localDataCenterName,
+        storeName,
+        previousStoreVersion.getNumber(),
+        nextStoreVersion.getNumber(),
+        topicName,
+        incompleteDataCenters);
+    LOGGER.error(message);
+    return message;
   }
 
   long getVersionSwapGenerationId() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcher.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcher.java
@@ -164,7 +164,7 @@ public class MultiRegionRealTimeTopicSwitcher extends RealTimeTopicSwitcher {
     }
   }
 
-  private long getRemainingTimeInMs(long deadlineNs) throws TimeoutException {
+  long getRemainingTimeInMs(long deadlineNs) throws TimeoutException {
     long remainingTimeInMs = TimeUnit.NANOSECONDS.toMillis(deadlineNs - System.nanoTime());
     if (remainingTimeInMs <= 0) {
       throw new TimeoutException("Version Swap broadcast exceeded its deadline");

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -3314,6 +3314,26 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   @Test
+  public void testDeferredRollbackSkipsParentStatusPolling() {
+    String rollbackStoreName = "test-deferred-rollback-status";
+    doReturn(2).when(store).getCurrentVersion();
+    VeniceParentHelixAdmin adminSpy = spy(parentAdmin);
+    doReturn(store).when(adminSpy).getStore(clusterName, rollbackStoreName);
+    doNothing().when(adminSpy)
+        .sendAdminMessageAndWaitForConsumed(eq(clusterName), eq(rollbackStoreName), any(AdminOperation.class));
+
+    ControllerClient childControllerClient = mock(ControllerClient.class);
+    doReturn(Collections.singletonMap(regionName, childControllerClient)).when(internalAdmin)
+        .getControllerClientMap(clusterName);
+
+    adminSpy.rollbackToBackupVersionForDeferredVersionSwap(clusterName, rollbackStoreName, regionName);
+
+    verify(adminSpy)
+        .sendAdminMessageAndWaitForConsumed(eq(clusterName), eq(rollbackStoreName), any(AdminOperation.class));
+    verify(childControllerClient, never()).getStore(eq(rollbackStoreName), anyInt());
+  }
+
+  @Test
   public void checkNewPushCapacityFromChildrenBlocksWhenChildRolledBackWithinRetention() {
     String store = "npc_from_children_rollback_block";
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcherTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcherTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -32,6 +34,7 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
@@ -201,6 +204,140 @@ public class MultiRegionRealTimeTopicSwitcherTest {
     verify(remoteWriterB, never()).close(false);
   }
 
+  @Test(timeOut = 5000)
+  public void testFailedPartitionBroadcastReportsAllRegionsAndCleansUpWriters() {
+    String localDc = "dc_local";
+    String remoteDcA = "dc_a";
+    String remoteDcB = "dc_b";
+    VeniceWriterFactory writerFactory = mock(VeniceWriterFactory.class);
+    VeniceWriter remoteWriterA = mock(VeniceWriter.class);
+    VeniceWriter remoteWriterB = mock(VeniceWriter.class);
+    CountDownLatch allRegionsStartedBroadcasting = new CountDownLatch(2);
+    when(writerFactory.createVeniceWriter(any(VeniceWriterOptions.class))).thenAnswer(invocation -> {
+      String broker = ((VeniceWriterOptions) invocation.getArgument(0)).getBrokerAddress();
+      return "broker-a".equals(broker) ? remoteWriterA : remoteWriterB;
+    });
+    when(remoteWriterA.nonBlockingBroadcastVersionSwapWithRegionInfo(any(), any(), any(), any(), anyLong(), any()))
+        .thenAnswer(invocation -> awaitAllRegionsAndReturnFailedFuture(allRegionsStartedBroadcasting));
+    when(remoteWriterB.nonBlockingBroadcastVersionSwapWithRegionInfo(any(), any(), any(), any(), anyLong(), any()))
+        .thenAnswer(invocation -> awaitAllRegionsAndReturnFailedFuture(allRegionsStartedBroadcasting));
+    when(remoteWriterA.closeAsync(false))
+        .thenReturn(CompletableFuture.completedFuture(VeniceResourceCloseResult.SUCCESS));
+    when(remoteWriterB.closeAsync(false))
+        .thenReturn(CompletableFuture.completedFuture(VeniceResourceCloseResult.SUCCESS));
+
+    Map<String, String> brokerMap = new HashMap<>();
+    brokerMap.put(remoteDcA, "broker-a");
+    brokerMap.put(remoteDcB, "broker-b");
+    MultiRegionRealTimeTopicSwitcher switcher =
+        newSwitcher(mock(TopicManager.class), writerFactory, brokerMap, localDc);
+    Version previousVersion = version("TestStore", 1, 8);
+    Version nextVersion = version("TestStore", 2, 12);
+
+    VeniceException exception = Assert.expectThrows(
+        VeniceException.class,
+        () -> switcher.broadcastVersionSwap(previousVersion, nextVersion, "TestStore_rt"));
+
+    Assert.assertTrue(exception.getMessage().contains(remoteDcA));
+    Assert.assertTrue(exception.getMessage().contains(remoteDcB));
+    verify(remoteWriterA).closeAsync(false);
+    verify(remoteWriterB).closeAsync(false);
+    verify(remoteWriterA, never()).closeAsync(true);
+    verify(remoteWriterB, never()).closeAsync(true);
+  }
+
+  @Test
+  public void testGracefulCloseFailureTriggersUngracefulCleanup() {
+    String localDc = "dc_local";
+    VeniceWriterFactory writerFactory = mock(VeniceWriterFactory.class);
+    VeniceWriter writer = mock(VeniceWriter.class);
+    when(writerFactory.createVeniceWriter(any(VeniceWriterOptions.class))).thenReturn(writer);
+    when(writer.nonBlockingBroadcastVersionSwapWithRegionInfo(any(), any(), any(), any(), anyLong(), any()))
+        .thenReturn(Collections.singletonList(CompletableFuture.completedFuture(mock(PubSubProduceResult.class))));
+    CompletableFuture<VeniceResourceCloseResult> failedClose = new CompletableFuture<>();
+    failedClose.completeExceptionally(new VeniceException("close failed"));
+    when(writer.closeAsync(true)).thenReturn(failedClose);
+    when(writer.closeAsync(false)).thenReturn(CompletableFuture.completedFuture(VeniceResourceCloseResult.SUCCESS));
+
+    MultiRegionRealTimeTopicSwitcher switcher = newSwitcher(
+        mock(TopicManager.class),
+        writerFactory,
+        Collections.singletonMap(localDc, "broker-local"),
+        localDc);
+
+    Assert.expectThrows(
+        VeniceException.class,
+        () -> switcher.broadcastVersionSwap(version("TestStore", 1, 8), version("TestStore", 2, 12), "TestStore_rt"));
+
+    verify(writer).closeAsync(true);
+    verify(writer).closeAsync(false);
+  }
+
+  @Test
+  public void testWriterCreationFailureDoesNotAttemptCleanup() {
+    String localDc = "dc_local";
+    VeniceWriterFactory writerFactory = mock(VeniceWriterFactory.class);
+    doThrow(new VeniceException("writer creation failed")).when(writerFactory)
+        .createVeniceWriter(any(VeniceWriterOptions.class));
+    MultiRegionRealTimeTopicSwitcher switcher = newSwitcher(
+        mock(TopicManager.class),
+        writerFactory,
+        Collections.singletonMap(localDc, "broker-local"),
+        localDc);
+
+    VeniceException exception = Assert.expectThrows(
+        VeniceException.class,
+        () -> switcher.broadcastVersionSwap(version("TestStore", 1, 8), version("TestStore", 2, 12), "TestStore_rt"));
+
+    Assert.assertTrue(exception.getMessage().contains(localDc));
+  }
+
+  @Test
+  public void testEmptyDataCenterMapAndPreviousVersionPartitionCount() {
+    VeniceWriterFactory writerFactory = mock(VeniceWriterFactory.class);
+    Version previousVersion = version("TestStore", 1, 8);
+    MultiRegionRealTimeTopicSwitcher switcher =
+        newSwitcher(mock(TopicManager.class), writerFactory, Collections.emptyMap(), "dc_local");
+
+    switcher.broadcastVersionSwap(previousVersion, version("TestStore", 2, 12), previousVersion.kafkaTopicName());
+
+    verify(writerFactory, never()).createVeniceWriter(any(VeniceWriterOptions.class));
+  }
+
+  @Test
+  public void testRemainingBroadcastDeadline() throws Exception {
+    MultiRegionRealTimeTopicSwitcher switcher =
+        newSwitcher(mock(TopicManager.class), mock(VeniceWriterFactory.class), Collections.emptyMap(), "dc_local");
+
+    Assert.assertTrue(switcher.getRemainingTimeInMs(System.nanoTime() + TimeUnit.SECONDS.toNanos(1)) > 0);
+    Assert.expectThrows(TimeoutException.class, () -> switcher.getRemainingTimeInMs(System.nanoTime() - 1));
+  }
+
+  private MultiRegionRealTimeTopicSwitcher newSwitcher(
+      TopicManager topicManager,
+      VeniceWriterFactory writerFactory,
+      Map<String, String> brokerMap,
+      String localDc) {
+    Properties props = new Properties();
+    props.put(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, "dummy");
+    return new MultiRegionRealTimeTopicSwitcher(
+        topicManager,
+        writerFactory,
+        new VeniceProperties(props),
+        pubSubTopicRepository,
+        brokerMap,
+        localDc);
+  }
+
+  private static Version version(String storeName, int number, int partitionCount) {
+    Version version = mock(Version.class);
+    when(version.getStoreName()).thenReturn(storeName);
+    when(version.getNumber()).thenReturn(number);
+    when(version.getPartitionCount()).thenReturn(partitionCount);
+    when(version.kafkaTopicName()).thenReturn(Version.composeKafkaTopic(storeName, number));
+    return version;
+  }
+
   private static void completeCloseFuturesAfterAllWritersStartClosing(
       AtomicInteger initiatedCloseCount,
       CompletableFuture<VeniceResourceCloseResult>... closeFutures) {
@@ -216,5 +353,16 @@ public class MultiRegionRealTimeTopicSwitcherTest {
         allRegionsStartedBroadcasting.await(2, TimeUnit.SECONDS),
         "All regional broadcasts should start concurrently");
     return Collections.singletonList(CompletableFuture.completedFuture(mock(PubSubProduceResult.class)));
+  }
+
+  private static java.util.List<CompletableFuture<PubSubProduceResult>> awaitAllRegionsAndReturnFailedFuture(
+      CountDownLatch allRegionsStartedBroadcasting) throws InterruptedException {
+    allRegionsStartedBroadcasting.countDown();
+    Assert.assertTrue(
+        allRegionsStartedBroadcasting.await(2, TimeUnit.SECONDS),
+        "All regional broadcasts should start concurrently");
+    CompletableFuture<PubSubProduceResult> failedFuture = new CompletableFuture<>();
+    failedFuture.completeExceptionally(new VeniceException("partition write failed"));
+    return Collections.singletonList(failedFuture);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcherTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcherTest.java
@@ -199,9 +199,9 @@ public class MultiRegionRealTimeTopicSwitcherTest {
     verify(localWriter).closeAsync(true);
     verify(remoteWriterA).closeAsync(true);
     verify(remoteWriterB).closeAsync(true);
-    verify(localWriter, never()).close(false);
-    verify(remoteWriterA, never()).close(false);
-    verify(remoteWriterB, never()).close(false);
+    verify(localWriter, never()).closeAsync(false);
+    verify(remoteWriterA, never()).closeAsync(false);
+    verify(remoteWriterB, never()).closeAsync(false);
   }
 
   @Test(timeOut = 5000)
@@ -247,7 +247,7 @@ public class MultiRegionRealTimeTopicSwitcherTest {
   }
 
   @Test
-  public void testGracefulCloseFailureTriggersUngracefulCleanup() {
+  public void testGracefulCloseFailureDoesNotFailCompletedBroadcast() {
     String localDc = "dc_local";
     VeniceWriterFactory writerFactory = mock(VeniceWriterFactory.class);
     VeniceWriter writer = mock(VeniceWriter.class);
@@ -265,10 +265,35 @@ public class MultiRegionRealTimeTopicSwitcherTest {
         Collections.singletonMap(localDc, "broker-local"),
         localDc);
 
-    Assert.expectThrows(
-        VeniceException.class,
-        () -> switcher.broadcastVersionSwap(version("TestStore", 1, 8), version("TestStore", 2, 12), "TestStore_rt"));
+    switcher.broadcastVersionSwap(version("TestStore", 1, 8), version("TestStore", 2, 12), "TestStore_rt");
 
+    verify(writer).closeAsync(true);
+    verify(writer).closeAsync(false);
+  }
+
+  @Test(timeOut = 5000)
+  public void testGracefulCloseTimeoutDoesNotFailCompletedBroadcast() throws Exception {
+    String localDc = "dc_local";
+    VeniceWriterFactory writerFactory = mock(VeniceWriterFactory.class);
+    VeniceWriter writer = mock(VeniceWriter.class);
+    when(writerFactory.createVeniceWriter(any(VeniceWriterOptions.class))).thenReturn(writer);
+    when(writer.nonBlockingBroadcastVersionSwapWithRegionInfo(any(), any(), any(), any(), anyLong(), any()))
+        .thenReturn(Collections.singletonList(CompletableFuture.completedFuture(mock(PubSubProduceResult.class))));
+    CompletableFuture<VeniceResourceCloseResult> neverCompletingClose = new CompletableFuture<>();
+    when(writer.closeAsync(true)).thenReturn(neverCompletingClose);
+    when(writer.closeAsync(false)).thenReturn(CompletableFuture.completedFuture(VeniceResourceCloseResult.SUCCESS));
+
+    MultiRegionRealTimeTopicSwitcher switcher = spy(
+        newSwitcher(
+            mock(TopicManager.class),
+            writerFactory,
+            Collections.singletonMap(localDc, "broker-local"),
+            localDc));
+    doReturn(100L).when(switcher).getRemainingTimeInMs(anyLong());
+
+    switcher.broadcastVersionSwap(version("TestStore", 1, 8), version("TestStore", 2, 12), "TestStore_rt");
+
+    Assert.assertFalse(neverCompletingClose.isDone());
     verify(writer).closeAsync(true);
     verify(writer).closeAsync(false);
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcherTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcherTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -19,14 +20,19 @@ import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.utils.VeniceResourceCloseResult;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterFactory;
 import com.linkedin.venice.writer.VeniceWriterOptions;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -35,7 +41,7 @@ import org.testng.annotations.Test;
 public class MultiRegionRealTimeTopicSwitcherTest {
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
-  @Test
+  @Test(timeOut = 5000)
   public void testBroadcastVersionSwapWithRegionInfoToAllDataCenters() {
     // Arrange inputs
     String storeName = "TestStore";
@@ -50,6 +56,7 @@ public class MultiRegionRealTimeTopicSwitcherTest {
     VeniceWriter localWriter = mock(VeniceWriter.class);
     VeniceWriter remoteWriterA = mock(VeniceWriter.class);
     VeniceWriter remoteWriterB = mock(VeniceWriter.class);
+    CountDownLatch allRegionsStartedBroadcasting = new CountDownLatch(3);
     when(writerFactory.createVeniceWriter(any(VeniceWriterOptions.class))).thenAnswer(invocation -> {
       VeniceWriterOptions opts = invocation.getArgument(0);
       String broker = opts.getBrokerAddress();
@@ -67,11 +74,39 @@ public class MultiRegionRealTimeTopicSwitcherTest {
     });
     // Ensure nonBlockingBroadcast returns completed futures so switcher does not block
     when(localWriter.nonBlockingBroadcastVersionSwapWithRegionInfo(any(), any(), any(), any(), anyLong(), any()))
-        .thenReturn(Collections.singletonList(CompletableFuture.completedFuture(mock(PubSubProduceResult.class))));
+        .thenAnswer(invocation -> awaitAllRegionsAndReturnCompletedFuture(allRegionsStartedBroadcasting));
     when(remoteWriterA.nonBlockingBroadcastVersionSwapWithRegionInfo(any(), any(), any(), any(), anyLong(), any()))
-        .thenReturn(Collections.singletonList(CompletableFuture.completedFuture(mock(PubSubProduceResult.class))));
+        .thenAnswer(invocation -> awaitAllRegionsAndReturnCompletedFuture(allRegionsStartedBroadcasting));
     when(remoteWriterB.nonBlockingBroadcastVersionSwapWithRegionInfo(any(), any(), any(), any(), anyLong(), any()))
-        .thenReturn(Collections.singletonList(CompletableFuture.completedFuture(mock(PubSubProduceResult.class))));
+        .thenAnswer(invocation -> awaitAllRegionsAndReturnCompletedFuture(allRegionsStartedBroadcasting));
+    CompletableFuture<VeniceResourceCloseResult> localCloseFuture = new CompletableFuture<>();
+    CompletableFuture<VeniceResourceCloseResult> remoteCloseFutureA = new CompletableFuture<>();
+    CompletableFuture<VeniceResourceCloseResult> remoteCloseFutureB = new CompletableFuture<>();
+    AtomicInteger initiatedCloseCount = new AtomicInteger();
+    when(localWriter.closeAsync(true)).thenAnswer(invocation -> {
+      completeCloseFuturesAfterAllWritersStartClosing(
+          initiatedCloseCount,
+          localCloseFuture,
+          remoteCloseFutureA,
+          remoteCloseFutureB);
+      return localCloseFuture;
+    });
+    when(remoteWriterA.closeAsync(true)).thenAnswer(invocation -> {
+      completeCloseFuturesAfterAllWritersStartClosing(
+          initiatedCloseCount,
+          localCloseFuture,
+          remoteCloseFutureA,
+          remoteCloseFutureB);
+      return remoteCloseFutureA;
+    });
+    when(remoteWriterB.closeAsync(true)).thenAnswer(invocation -> {
+      completeCloseFuturesAfterAllWritersStartClosing(
+          initiatedCloseCount,
+          localCloseFuture,
+          remoteCloseFutureA,
+          remoteCloseFutureB);
+      return remoteCloseFutureB;
+    });
 
     Properties props = new Properties();
     props.put(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, "dummy");
@@ -157,5 +192,29 @@ public class MultiRegionRealTimeTopicSwitcherTest {
         remoteDcB,
         deterministicGenerationId,
         Collections.EMPTY_MAP);
+
+    verify(localWriter).closeAsync(true);
+    verify(remoteWriterA).closeAsync(true);
+    verify(remoteWriterB).closeAsync(true);
+    verify(localWriter, never()).close(false);
+    verify(remoteWriterA, never()).close(false);
+    verify(remoteWriterB, never()).close(false);
+  }
+
+  private static void completeCloseFuturesAfterAllWritersStartClosing(
+      AtomicInteger initiatedCloseCount,
+      CompletableFuture<VeniceResourceCloseResult>... closeFutures) {
+    if (initiatedCloseCount.incrementAndGet() == closeFutures.length) {
+      Arrays.stream(closeFutures).forEach(future -> future.complete(VeniceResourceCloseResult.SUCCESS));
+    }
+  }
+
+  private static java.util.List<CompletableFuture<PubSubProduceResult>> awaitAllRegionsAndReturnCompletedFuture(
+      CountDownLatch allRegionsStartedBroadcasting) throws InterruptedException {
+    allRegionsStartedBroadcasting.countDown();
+    Assert.assertTrue(
+        allRegionsStartedBroadcasting.await(2, TimeUnit.SECONDS),
+        "All regional broadcasts should start concurrently");
+    return Collections.singletonList(CompletableFuture.completedFuture(mock(PubSubProduceResult.class)));
   }
 }


### PR DESCRIPTION
## Problem Statement
Rollback VSM can timeout during parent status polling due to slow/sequential VSM broadcasting at two levels. Partition level and region level.

## Solution
Reduce rollback completion latency by running multi-region version swap workflows concurrently and processing partitions with a bounded eight-thread VeniceWriter executor.

Preserve per-partition START_OF_SEGMENT-to-VERSION_SWAP ordering, await every partition acknowledgement, and gracefully close each regional writer within a shared 60-second deadline. Failed workflows schedule ungraceful cleanup without extending the admin operation.

Extend parent rollback status polling to two minutes so parent metadata can observe child rollback completion after version swap delivery.

Add unit coverage that requires concurrent regional dispatch and concurrent partition initialization while verifying per-partition control-message ordering and graceful writer closure.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
