### PR TITLE
[vpj] Avoid empty assignment during dictionary sampling handoff

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
@@ -242,8 +242,6 @@ public class KafkaInputDictTrainer {
       for (InputSplit split: splits) {
         long currentFilledSize = 0;
         long sampledRecordCnt = 0;
-        // Reset Kafka consumer before using it
-        reusedConsumer.batchUnsubscribe(reusedConsumer.getAssignment());
         RecordReader<KafkaInputMapperKey, KafkaInputMapperValue> recordReader =
             kafkaInputFormat.getRecordReader(split, jobConf, Reporter.NULL, reusedConsumer);
         try {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputFormat.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputFormat.java
@@ -70,6 +70,7 @@ public class KafkaInputFormat implements InputFormat<KafkaInputMapperKey, KafkaI
       Reporter reporter,
       PubSubConsumerAdapter consumer) {
     DataWriterTaskTracker taskTracker = new ReporterBackedMapReduceDataWriterTaskTracker(reporter);
-    return new KafkaInputRecordReader(split, job, taskTracker, consumer);
+    // This overload reuses one consumer across dictionary-training splits.
+    return new KafkaInputRecordReader(split, job, taskTracker, consumer, true);
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputRecordReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputRecordReader.java
@@ -85,6 +85,15 @@ public class KafkaInputRecordReader implements RecordReader<KafkaInputMapperKey,
       JobConf job,
       DataWriterTaskTracker taskTracker,
       PubSubConsumerAdapter consumer) {
+    this(split, job, taskTracker, consumer, false);
+  }
+
+  KafkaInputRecordReader(
+      InputSplit split,
+      JobConf job,
+      DataWriterTaskTracker taskTracker,
+      PubSubConsumerAdapter consumer,
+      boolean useNonEmptyAssignmentHandoff) {
 
     if (!(split instanceof KafkaInputSplit)) {
       throw new VeniceException("InputSplit for RecordReader is not valid split type.");
@@ -108,7 +117,8 @@ public class KafkaInputRecordReader implements RecordReader<KafkaInputMapperKey,
         DEFAULT_PUBSUB_INPUT_SECONDARY_COMPARATOR_USE_LOCAL_LOGICAL_INDEX);
 
     // Build iterator directly from the split
-    this.pubSubSplitIterator = new PubSubSplitIterator(consumer, pubSubSplit, useLogicalIndexOffset);
+    this.pubSubSplitIterator =
+        new PubSubSplitIterator(consumer, pubSubSplit, useLogicalIndexOffset, useNonEmptyAssignmentHandoff);
 
     LOGGER.info(
         "KafkaInputRecordReader started for split index: {} topicPartition: {} start: {} end(exclusive): {} "

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/pubsub/input/PubSubSplitIterator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/vpj/pubsub/input/PubSubSplitIterator.java
@@ -10,9 +10,11 @@ import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.Utils;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -51,8 +53,11 @@ public class PubSubSplitIterator implements AutoCloseable {
   private final long targetCount;
   private final long splitStartIndex;
   private final OffsetMode mode;
+  private final boolean useNonEmptyAssignmentHandoff;
   private Iterator<DefaultPubSubMessage> consumedRecordsIterator;
   private PubSubPosition currentPosition;
+  private Set<PubSubTopicPartition> previousAssignments = Collections.emptySet();
+  private boolean handoffPending;
   private boolean closed;
 
   // Total messages consumed from the broker, including control messages.
@@ -76,6 +81,18 @@ public class PubSubSplitIterator implements AutoCloseable {
       long pollTimeoutMs,
       int emptyRetryTimes,
       long emptySleepMs) {
+    this(pubSubConsumer, split, useLogicalIndexOffset, false, pollTimeoutMs, emptyRetryTimes, emptySleepMs);
+  }
+
+  @VisibleForTesting
+  PubSubSplitIterator(
+      PubSubConsumerAdapter pubSubConsumer,
+      PubSubPartitionSplit split,
+      boolean useLogicalIndexOffset,
+      boolean useNonEmptyAssignmentHandoff,
+      long pollTimeoutMs,
+      int emptyRetryTimes,
+      long emptySleepMs) {
     this.pubSubConsumer = pubSubConsumer;
     this.topicPartition = split.getPubSubTopicPartition();
     this.startPosition = split.getStartPubSubPosition();
@@ -83,6 +100,7 @@ public class PubSubSplitIterator implements AutoCloseable {
     this.targetCount = split.getNumberOfRecords();
     this.splitStartIndex = split.getStartIndex();
     this.mode = useLogicalIndexOffset ? OffsetMode.LOGICAL_INDEX : OffsetMode.NUMERIC;
+    this.useNonEmptyAssignmentHandoff = useNonEmptyAssignmentHandoff;
     this.pollTimeoutMs = pollTimeoutMs;
     this.emptyRetryTimes = emptyRetryTimes;
     this.emptySleepMs = emptySleepMs;
@@ -102,11 +120,47 @@ public class PubSubSplitIterator implements AutoCloseable {
         DEFAULT_EMPTY_SLEEP_MS);
   }
 
+  public PubSubSplitIterator(
+      PubSubConsumerAdapter pubSubConsumer,
+      PubSubPartitionSplit split,
+      boolean useLogicalIndexOffset,
+      boolean useNonEmptyAssignmentHandoff) {
+    this(
+        pubSubConsumer,
+        split,
+        useLogicalIndexOffset,
+        useNonEmptyAssignmentHandoff,
+        DEFAULT_POLL_TIMEOUT_MS,
+        DEFAULT_EMPTY_RESULT_RETRIES,
+        DEFAULT_EMPTY_SLEEP_MS);
+  }
+
   @VisibleForTesting
   final void start() {
+    if (useNonEmptyAssignmentHandoff) {
+      // Keep the previous assignment until polling proves that the target subscription and seek are active.
+      previousAssignments = new HashSet<>(pubSubConsumer.getAssignment());
+      if (previousAssignments.contains(topicPartition)) {
+        throw new VeniceException("Target topic-partition is already assigned: " + topicPartition);
+      }
+      pubSubConsumer.subscribe(topicPartition, startPosition, true);
+      handoffPending = !previousAssignments.isEmpty();
+      pausePreviousAssignments();
+      return;
+    }
+
     // defensive if caller reuses consumer
     pubSubConsumer.batchUnsubscribe(pubSubConsumer.getAssignment());
     pubSubConsumer.subscribe(topicPartition, startPosition, true);
+  }
+
+  private void pausePreviousAssignments() {
+    if (!handoffPending) {
+      return;
+    }
+    for (PubSubTopicPartition previousAssignment: previousAssignments) {
+      pubSubConsumer.pause(previousAssignment);
+    }
   }
 
   public boolean hasNext() {
@@ -126,19 +180,43 @@ public class PubSubSplitIterator implements AutoCloseable {
       return;
     }
     Map<PubSubTopicPartition, List<DefaultPubSubMessage>> polled = Collections.emptyMap();
+    List<DefaultPubSubMessage> targetPartitionRecords = Collections.emptyList();
     for (int i = 0; i < emptyRetryTimes; i++) {
+      if (useNonEmptyAssignmentHandoff && handoffPending && i > 0) {
+        // Re-apply the pause in case a deferred subscription reset the consumer's paused state.
+        pausePreviousAssignments();
+      }
       polled = pubSubConsumer.poll(pollTimeoutMs);
-      if (!polled.isEmpty()) {
+      if (useNonEmptyAssignmentHandoff) {
+        List<DefaultPubSubMessage> records = polled.get(topicPartition);
+        if (records != null && !records.isEmpty()) {
+          targetPartitionRecords = records;
+          break;
+        }
+      } else if (!polled.isEmpty()) {
         break;
       }
-      Thread.sleep(emptySleepMs);
+      if (polled.isEmpty()) {
+        Thread.sleep(emptySleepMs);
+      }
     }
-    if (polled.isEmpty()) {
+    if ((useNonEmptyAssignmentHandoff && targetPartitionRecords.isEmpty())
+        || (!useNonEmptyAssignmentHandoff && polled.isEmpty())) {
       throw new VeniceException(
           "Empty poll after " + emptyRetryTimes + " retries, tp=" + topicPartition + " pos=" + currentPosition + " end="
               + endPositionExclusive + ". This may indicate no data available in the topic or partition.");
     }
-    consumedRecordsIterator = Utils.iterateOnMapOfLists(polled);
+    if (useNonEmptyAssignmentHandoff) {
+      if (handoffPending) {
+        // A target record proves that removing the previous assignments cannot leave the consumer unassigned.
+        pubSubConsumer.batchUnsubscribe(previousAssignments);
+        previousAssignments = Collections.emptySet();
+        handoffPending = false;
+      }
+      consumedRecordsIterator = targetPartitionRecords.iterator();
+    } else {
+      consumedRecordsIterator = Utils.iterateOnMapOfLists(polled);
+    }
   }
 
   public PubSubInputRecord next() throws IOException {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
@@ -253,7 +253,8 @@ public class TestKafkaInputDictTrainer {
         Optional.of(mockTrainer1),
         getParam(1000),
         getCompressorBuilder(new NoopCompressor()));
-    trainer1.trainDict(Optional.of(mock(PubSubConsumerAdapter.class)));
+    PubSubConsumerAdapter reusedConsumer = mock(PubSubConsumerAdapter.class);
+    trainer1.trainDict(Optional.of(reusedConsumer));
 
     verify(mockTrainer1).addSample(eq("p0_value0".getBytes()));
     verify(mockTrainer1).addSample(eq("p0_value1".getBytes()));
@@ -261,6 +262,7 @@ public class TestKafkaInputDictTrainer {
     verify(mockTrainer1).addSample(eq("p1_value0".getBytes()));
     verify(mockTrainer1).addSample(eq("p1_value1".getBytes()));
     verify(mockTrainer1).addSample(eq("p1_value2".getBytes()));
+    verify(reusedConsumer, never()).batchUnsubscribe(any());
 
     // Small sampling will collect the first several records
     readerForP0.reset();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/vpj/pubsub/input/PubSubSplitIteratorTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/vpj/pubsub/input/PubSubSplitIteratorTest.java
@@ -5,7 +5,9 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -34,6 +36,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.mockito.InOrder;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -80,6 +83,52 @@ public class PubSubSplitIteratorTest {
     PubSubSplitIterator iterator3 = new PubSubSplitIterator(mockConsumer3, customSplit, false);
     assertEquals(iterator3.getTopicPartition(), testTopicPartition);
     iterator3.close();
+  }
+
+  @Test
+  public void testNonEmptyAssignmentHandoffWaitsForTargetPartition() throws IOException {
+    PubSubTopicPartition previousTopicPartition = new PubSubTopicPartitionImpl(testTopic, TEST_PARTITION + 1);
+    when(mockConsumer.getAssignment()).thenReturn(Collections.singleton(previousTopicPartition));
+    when(mockConsumer.positionDifference(any(), any(), any())).thenReturn(10L, 9L);
+
+    Map<PubSubTopicPartition, List<DefaultPubSubMessage>> previousPartitionOnly = new HashMap<>();
+    previousPartitionOnly.put(previousTopicPartition, Collections.singletonList(createMockDataMessage(100L)));
+    Map<PubSubTopicPartition, List<DefaultPubSubMessage>> overlappingPoll = new HashMap<>();
+    overlappingPoll.put(previousTopicPartition, Collections.singletonList(createMockDataMessage(101L)));
+    overlappingPoll.put(testTopicPartition, Collections.singletonList(createMockDataMessage(5L)));
+    when(mockConsumer.poll(anyLong())).thenReturn(previousPartitionOnly, overlappingPoll);
+
+    PubSubSplitIterator iterator = new PubSubSplitIterator(mockConsumer, testSplit, false, true, 1, 3, 0);
+    PubSubInputRecord record = iterator.next();
+
+    assertNotNull(record);
+    assertEquals(record.getOffset(), 5L);
+    InOrder inOrder = inOrder(mockConsumer);
+    inOrder.verify(mockConsumer).getAssignment();
+    inOrder.verify(mockConsumer).subscribe(eq(testTopicPartition), any(PubSubPosition.class), eq(true));
+    inOrder.verify(mockConsumer).pause(previousTopicPartition);
+    inOrder.verify(mockConsumer).poll(1L);
+    inOrder.verify(mockConsumer).pause(previousTopicPartition);
+    inOrder.verify(mockConsumer).poll(1L);
+    inOrder.verify(mockConsumer).batchUnsubscribe(Collections.singleton(previousTopicPartition));
+    iterator.close();
+  }
+
+  @Test
+  public void testNonEmptyAssignmentHandoffKeepsPreviousAssignmentAfterOldOnlyPolls() {
+    PubSubTopicPartition previousTopicPartition = new PubSubTopicPartitionImpl(testTopic, TEST_PARTITION + 1);
+    when(mockConsumer.getAssignment()).thenReturn(Collections.singleton(previousTopicPartition));
+    Map<PubSubTopicPartition, List<DefaultPubSubMessage>> previousPartitionOnly = new HashMap<>();
+    previousPartitionOnly.put(previousTopicPartition, Collections.singletonList(createMockDataMessage(100L)));
+    when(mockConsumer.poll(anyLong())).thenReturn(previousPartitionOnly);
+
+    PubSubSplitIterator iterator = new PubSubSplitIterator(mockConsumer, testSplit, false, true, 1, 2, 0);
+    VeniceException exception = expectThrows(VeniceException.class, iterator::next);
+
+    assertTrue(exception.getMessage().contains("Empty poll after"));
+    verify(mockConsumer, times(2)).pause(previousTopicPartition);
+    verify(mockConsumer, never()).batchUnsubscribe(any());
+    iterator.close();
   }
 
   @Test


### PR DESCRIPTION
## Problem Statement

`KafkaInputDictTrainer` reuses one pub-sub consumer while sampling current-version partitions sequentially. The trainer and `PubSubSplitIterator` both cleared the current assignment before subscribing to the next partition.

For adapters that release their underlying resources when the assignment becomes empty, every partition transition recreated the consumer resources. Dictionary training therefore scaled poorly with partition count and could time out before sampling completed.

## Solution

The reused-consumer path now performs a non-empty handoff:

1. Retain the previous assignment and subscribe to the target partition from the existing inclusive split position.
2. Pause the previous assignment while both partitions overlap.
3. Filter poll results to the target partition.
4. Wait for a target record, which confirms that the target assignment and seek are active.
5. Unsubscribe the previous assignment only after that confirmation.

The current consumer API does not expose an atomic assignment-and-seek replacement operation, so the target record is used as the readiness barrier. The implementation keeps at most the previous and target assignments during a transition. It does not assign all partitions at once.

This behavior is enabled only by the `KafkaInputFormat` overload used for dictionary training with a shared consumer. Existing standalone `PubSubSplitIterator` behavior remains unchanged.

### Code changes

- [ ] Added new code behind **a config**. No new config is introduced because this is a narrowly scoped internal handoff fix.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**. The iterator remains single-threaded.
- [x] Proper **synchronization mechanisms** are used where needed. Consumer adapter synchronization remains unchanged.
- [x] No **blocking calls** were added inside adapter critical sections.
- [x] No new shared or cross-thread collections were introduced.
- [x] Poll failures leave the previous assignment in place rather than transitioning through an empty assignment.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility. Default iterator construction retains the existing reset behavior.

```shell
./gradlew spotlessCheck :clients:venice-push-job:spotbugsMain \
  :clients:venice-push-job:test \
  --tests "com.linkedin.venice.vpj.pubsub.input.PubSubSplitIteratorTest" \
  --tests "com.linkedin.venice.hadoop.input.kafka.TestKafkaInputDictTrainer" \
  --tests "com.linkedin.venice.hadoop.input.kafka.KafkaInputRecordReaderTest"
```

The tests cover a normal overlapping handoff, filtering old-partition records, waiting through old-only polls, and preserving the previous assignment when the target never produces a record.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. There are no config, logging, API contract, or user-facing behavior changes.
- [ ] Yes. Clearly explain the behavior change and its impact.