### PR TITLE
[compat][test] Normalize byte buffer schema defaults

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
@@ -8,7 +8,9 @@ import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.schema.SchemaData;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +18,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.IndexedRecord;
 import org.apache.commons.lang.StringUtils;
 
 
@@ -241,9 +245,43 @@ public class AvroSupersetSchemaUtils {
         .setOrder(field.order());
     // set default as AvroCompatibilityHelper builder might drop defaults if there is type mismatch
     if (field.hasDefaultValue()) {
-      fieldBuilder.setDefault(getFieldDefault(field));
+      fieldBuilder.setDefault(normalizeFieldDefault(getFieldDefault(field)));
     }
     return fieldBuilder;
+  }
+
+  /**
+   * FieldBuilder does not make ByteBuffer defaults Avro-friendly. Normalize them recursively without mutating the
+   * source buffers or exposing their backing arrays.
+   */
+  private static Object normalizeFieldDefault(Object defaultValue) {
+    if (defaultValue instanceof ByteBuffer) {
+      ByteBuffer buffer = ((ByteBuffer) defaultValue).duplicate();
+      byte[] bytes = new byte[buffer.remaining()];
+      buffer.get(bytes);
+      return bytes;
+    }
+    if (defaultValue instanceof List) {
+      List<?> defaultList = (List<?>) defaultValue;
+      List<Object> normalizedList = new ArrayList<>(defaultList.size());
+      defaultList.forEach(value -> normalizedList.add(normalizeFieldDefault(value)));
+      return normalizedList;
+    }
+    if (defaultValue instanceof Map) {
+      Map<?, ?> defaultMap = (Map<?, ?>) defaultValue;
+      Map<Object, Object> normalizedMap = new LinkedHashMap<>(defaultMap.size());
+      defaultMap.forEach((key, value) -> normalizedMap.put(key, normalizeFieldDefault(value)));
+      return normalizedMap;
+    }
+    if (defaultValue instanceof IndexedRecord) {
+      IndexedRecord defaultRecord = (IndexedRecord) defaultValue;
+      GenericData.Record normalizedRecord = new GenericData.Record(defaultRecord.getSchema());
+      for (Schema.Field field: defaultRecord.getSchema().getFields()) {
+        normalizedRecord.put(field.pos(), normalizeFieldDefault(defaultRecord.get(field.pos())));
+      }
+      return normalizedRecord;
+    }
+    return defaultValue;
   }
 
   private static FieldBuilder deepCopySchemaField(Schema.Field field) {
@@ -272,7 +310,7 @@ public class AvroSupersetSchemaUtils {
         fieldBuilder.setSchema(generateSupersetSchema(fieldInExistingSchema.schema(), fieldInNewSchema.schema()))
             .setDoc(fieldInNewSchema.doc() != null ? fieldInNewSchema.doc() : fieldInExistingSchema.doc());
         if (!fieldInNewSchema.hasDefaultValue() && fieldInExistingSchema.hasDefaultValue()) {
-          fieldBuilder.setDefault(getFieldDefault(fieldInExistingSchema));
+          fieldBuilder.setDefault(normalizeFieldDefault(getFieldDefault(fieldInExistingSchema)));
         }
       }
       Schema.Field generatedField = fieldBuilder.build();

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -20,6 +20,7 @@ import com.linkedin.venice.serializer.AvroGenericDeserializer;
 import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.utils.AvroSchemaUtils;
 import com.linkedin.venice.utils.AvroSupersetSchemaUtils;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -672,6 +673,45 @@ public class TestAvroSupersetSchemaUtils {
             .generateSupersetSchema(USER_WITH_NESTED_RECORD_SCHEMA, USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA)
             .toString(),
         USER_WITH_NESTED_RECORD_AND_DEFAULT_SCHEMA.toString());
+  }
+
+  @Test
+  public void testGenerateSupersetSchemaPreservesEmptyBytesDefault() {
+    String existingSchemaStr = "{\"type\":\"record\",\"name\":\"RecordWithBitmap\",\"fields\":["
+        + "{\"name\":\"memberBitmap\",\"type\":\"bytes\",\"default\":\"\"}]}";
+    String newSchemaStr = "{\"type\":\"record\",\"name\":\"RecordWithBitmap\",\"fields\":["
+        + "{\"name\":\"memberBitmap\",\"type\":\"bytes\",\"default\":\"\"},"
+        + "{\"name\":\"newField\",\"type\":\"string\",\"default\":\"\"}]}";
+
+    Schema existingSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(existingSchemaStr);
+    Schema newSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(newSchemaStr);
+
+    Schema supersetSchema = AvroSupersetSchemaUtils.generateSupersetSchema(existingSchema, newSchema);
+
+    Assert.assertNotNull(supersetSchema.getField("newField"));
+    Object memberBitmapDefault = AvroSchemaUtils.getFieldDefault(supersetSchema.getField("memberBitmap"));
+    Assert.assertTrue(memberBitmapDefault instanceof ByteBuffer);
+    Assert.assertEquals(((ByteBuffer) memberBitmapDefault).remaining(), 0);
+  }
+
+  @Test
+  public void testGenerateSupersetSchemaPreservesNestedBytesDefault() {
+    String existingSchemaStr = "{\"type\":\"record\",\"name\":\"RecordWithSettings\",\"fields\":["
+        + "{\"name\":\"settings\",\"type\":{\"type\":\"record\",\"name\":\"Settings\",\"fields\":["
+        + "{\"name\":\"memberBitmap\",\"type\":\"bytes\"}]}," + "\"default\":{\"memberBitmap\":\"\\u0001\\u0002\"}}]}";
+    String newSchemaStr = "{\"type\":\"record\",\"name\":\"RecordWithSettings\",\"fields\":["
+        + "{\"name\":\"settings\",\"type\":{\"type\":\"record\",\"name\":\"Settings\",\"fields\":["
+        + "{\"name\":\"memberBitmap\",\"type\":\"bytes\"}]}," + "\"default\":{\"memberBitmap\":\"\\u0001\\u0002\"}},"
+        + "{\"name\":\"newField\",\"type\":\"string\",\"default\":\"\"}]}";
+
+    Schema existingSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(existingSchemaStr);
+    Schema newSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(newSchemaStr);
+
+    Schema supersetSchema = AvroSupersetSchemaUtils.generateSupersetSchema(existingSchema, newSchema);
+
+    GenericRecord settingsDefault =
+        (GenericRecord) AvroSchemaUtils.getFieldDefault(supersetSchema.getField("settings"));
+    Assert.assertEquals(settingsDefault.get("memberBitmap"), ByteBuffer.wrap(new byte[] { 1, 2 }));
   }
 
   @Test


### PR DESCRIPTION
## Problem Statement

Superset schema generation fails when an Avro field has a `bytes` default. Avro materializes the default as a `ByteBuffer`, but the field builder passes that object to schema-default JSON conversion, which accepts `byte[]` instead. This prevents otherwise compatible schemas from being registered.

## Solution

Normalize `ByteBuffer` defaults to copied `byte[]` values before rebuilding superset schema fields. The normalization also handles defaults nested in lists, maps, and records. Buffer position and limit are preserved, and backing arrays are not exposed.

###  Code changes
- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

###  **Concurrency-Specific Checks**
Both reviewer and PR author to verify
- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

The normalization uses method-local objects and introduces no shared mutable state, synchronization, or blocking calls.

## How was this PR tested?

- [x] Local code review completed.
- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

```bash
./gradlew :internal:venice-client-common:test \
  --tests com.linkedin.venice.schema.TestAvroSupersetSchemaUtils
```

Added coverage for empty top-level `bytes` defaults and non-empty `bytes` defaults nested inside record defaults.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
