### PR TITLE
[controller] Avoid NPE in job status when the version was deleted

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3776,7 +3776,7 @@ public class VeniceParentHelixAdmin implements Admin {
         // If the aggregate status is not terminal, but the parent version status is marked as KILLED, we should mark
         // the
         // push job status as terminal (ERROR) as job was killed
-        if (versionStatus.equals(KILLED)) {
+        if (versionStatus == KILLED) {
           LOGGER.info(
               "Marking execution status as ERROR for store {} because parent version status is KILLED",
               storeName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3721,6 +3721,10 @@ public class VeniceParentHelixAdmin implements Admin {
     ReadWriteStoreRepository repository = resources.getStoreMetadataRepository();
     Store parentStore = repository.getStore(storeName);
     Version version = parentStore.getVersion(versionNum);
+    // The version can be null when it was deleted while a client is still polling job status for it (e.g. a system
+    // push that was killed and had its stranded version removed). Derive the status null-safely so downstream checks
+    // never dereference a null version and the controller returns a valid status instead of HTTP 500.
+    VersionStatus versionStatus = version == null ? VersionStatus.NOT_CREATED : version.getStatus();
 
     // Check if push is in a terminal status in target regions for pushes using deferred swap and try
     // updating the parent status. Parent status should only be updated if it is currently in a STARTED state to avoid
@@ -3753,13 +3757,13 @@ public class VeniceParentHelixAdmin implements Admin {
         }
 
         if (isTargetRegionPushWithDeferredSwap) {
-          boolean isVersionTerminal = TERMINAL_VERSION_SWAP_STATUSES.contains(version.getStatus());
+          boolean isVersionTerminal = TERMINAL_VERSION_SWAP_STATUSES.contains(versionStatus);
           if (isVersionTerminal) {
             LOGGER.info(
                 "Truncating parent VT {} after push status {} and version status {}",
                 kafkaTopic,
                 currentReturnStatus.getRootStatus(),
-                version.getStatus());
+                versionStatus);
             truncateTopicsOptionally(
                 clusterName,
                 kafkaTopic,
@@ -3772,7 +3776,7 @@ public class VeniceParentHelixAdmin implements Admin {
         // If the aggregate status is not terminal, but the parent version status is marked as KILLED, we should mark
         // the
         // push job status as terminal (ERROR) as job was killed
-        if (version.getStatus().equals(KILLED)) {
+        if (versionStatus.equals(KILLED)) {
           LOGGER.info(
               "Marking execution status as ERROR for store {} because parent version status is KILLED",
               storeName);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2605,6 +2605,38 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   @Test
+  public void testDeletedVersionExecutionStatus() {
+    // A client can keep polling job status for a version after it was deleted (e.g. a killed system push whose
+    // stranded version was removed). In that case Store#getVersion returns null and Store#getVersionStatus returns
+    // NOT_CREATED. The job status path must not dereference the null version, otherwise the controller returns HTTP
+    // 500 for every poll instead of a valid execution status.
+    Map<ExecutionStatus, ControllerClient> clientMap = getMockJobStatusQueryClient();
+
+    Map<String, ControllerClient> errorMap = new HashMap<>();
+    errorMap.put("cluster", clientMap.get(ExecutionStatus.ERROR));
+    errorMap.put("cluster2", clientMap.get(ExecutionStatus.NOT_CREATED));
+    errorMap.put("cluster3", clientMap.get(ExecutionStatus.ERROR));
+
+    Store store = mock(Store.class);
+    doReturn(false).when(store).isIncrementalPushEnabled();
+    doReturn(store).when(internalAdmin).getStore(anyString(), anyString());
+    // Deleted version: getVersion is null and getVersionStatus falls back to NOT_CREATED (see AbstractStore).
+    doReturn(null).when(store).getVersion(anyInt());
+    doReturn(VersionStatus.NOT_CREATED).when(store).getVersionStatus(anyInt());
+
+    HelixVeniceClusterResources resources = mock(HelixVeniceClusterResources.class);
+    doReturn(mock(ClusterLockManager.class)).when(resources).getClusterLockManager();
+    doReturn(resources).when(internalAdmin).getHelixVeniceClusterResources(anyString());
+    ReadWriteStoreRepository repository = mock(ReadWriteStoreRepository.class);
+    doReturn(repository).when(resources).getStoreMetadataRepository();
+    doReturn(store).when(repository).getStore(anyString());
+
+    Admin.OfflinePushStatusInfo offlineJobStatus = parentAdmin.getOffLineJobStatus("IGNORED", "topic1_v1", errorMap);
+    // No NullPointerException; a valid aggregated child status is returned instead of an HTTP 500.
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.NOT_CREATED);
+  }
+
+  @Test
   public void testUpdateStore() {
     String storeName = Utils.getUniqueString("testUpdateStore");
     Store store = TestUtils.createTestStore(storeName, "test", System.currentTimeMillis());


### PR DESCRIPTION
## Problem Statement

The parent controller `job` endpoint (`queryJobStatus` → `JobRoutes.populateJobStatus` → `VeniceParentHelixAdmin.getOffLinePushStatus` → `getOffLineJobStatus`) throws a `NullPointerException` when a client polls job status for a version that has been **deleted**.

`getOffLineJobStatus` does:

```java
Version version = parentStore.getVersion(versionNum);   // null if the version was deleted
...
boolean isVersionTerminal = TERMINAL_VERSION_SWAP_STATUSES.contains(version.getStatus()); // NPE
...
if (version.getStatus().equals(KILLED)) { ... }         // NPE
```

`Store#getVersion` returns `null` when the version no longer exists. This happens in a normal race: a running system push (compliance/repush) is preempted by a user-initiated batch push, so the parent controller kills the in-flight version and **deletes the stranded version**, while the original push job (or another poller) keeps polling job status for that now-deleted version. Each poll then NPEs and the controller returns **HTTP 500**.

Observed in prod (prod-lva1, cluster `venice-4`, store `LssCrmUnifiedCsa`, deleted version `4154`): ~47k `NullPointerException`s from `AdminSparkServer` over ~23h, surfacing as a large spike of HTTP 5xx OTel errors on `Venice.Controller.Endpoint=job`. Captured stack trace:

```
java.lang.NullPointerException: Cannot invoke "com.linkedin.venice.meta.Version.getStatus()" because "version" is null
  at VeniceParentHelixAdmin.getOffLineJobStatus(VeniceParentHelixAdmin.java)
  at VeniceParentHelixAdmin.getOffLinePushStatus(VeniceParentHelixAdmin.java)
  at JobRoutes.populateJobStatus(JobRoutes.java:95)
  at JobRoutes.lambda$jobStatus$0(JobRoutes.java:65)
```

## Solution

Derive the version status null-safely once, mirroring `AbstractStore#getVersionStatus` semantics (which returns `NOT_CREATED` for an absent version), and use it for both the deferred-swap terminal check and the KILLED check:

```java
VersionStatus versionStatus = version == null ? VersionStatus.NOT_CREATED : version.getStatus();
```

When the version exists, behavior is identical to before (`versionStatus == version.getStatus()`). When the version was deleted, the endpoint now returns a valid aggregated execution status instead of throwing and returning HTTP 500. The adjacent terminal-path helpers (`clearPushRetryCooldownAttemptIfSucceeded`, `handleTerminalJobStatus`) already null-guard `version`, so no other changes are needed.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description. — No.
- [ ] Introduced new **log lines**. — No. An existing log line now prints `versionStatus`, which equals the prior value when the version exists.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging. — N/A.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**. The change is a local null-safe read; the surrounding store write lock is unchanged.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed. Unchanged.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation. Unchanged.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`). Unchanged.
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination. Unchanged.

## How was this PR tested?

- [ ] Local code review completed
- [x] New unit tests added. `TestVeniceParentHelixAdmin#testDeletedVersionExecutionStatus` reproduces the deleted-version path (`getVersion` → null, `getVersionStatus` → `NOT_CREATED`). Before the fix it threw NPE; now it returns a valid aggregated status.
- [ ] New integration tests added.
- [x] Modified or extended existing tests. Verified `testKilledVersionExecutionStatus` and `testGetExecutionStatus` still pass.
- [x] Verified backward compatibility (if applicable). Behavior is identical when the version exists.

```
TestVeniceParentHelixAdmin > testDeletedVersionExecutionStatus PASSED
TestVeniceParentHelixAdmin > testKilledVersionExecutionStatus PASSED
TestVeniceParentHelixAdmin > testGetExecutionStatus PASSED
```

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
