### PR TITLE
[da-vinci][test] Handle compacted migration replay deficits

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4259,14 +4259,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * Whether an end-of-push record-count deficit is the expected, nonfatal kind produced by a store
    * migration replaying a pre-existing source version topic that log compaction may have shrunk
    * below the original end-of-push count.
-   *
-   * <p>{@link Store#isMigrationDuplicateStore()} alone is too broad — it covers the whole
-   * destination store while migration is active, including brand-new pushes — so it is paired with a
-   * per-version check: the destination store's {@code createdTime} marks the migration boundary,
-   * cloned source versions keep their older source {@code createdTime}, and a push created on the
-   * destination gets a fresh one. For a source push cloned shortly after migration starts, that
-   * comparison relies on normal bounded controller clock skew. Fails closed: missing or non-positive
-   * metadata on either side keeps the strict (fatal) behavior.
    */
   boolean isPreExistingMigrationCloneReplay(Store store) {
     if (store == null || !store.isMigrationDuplicateStore()) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4146,12 +4146,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * </ol>
    *
    * <p>If either leg fails: increments {@code batch_push_record_count_mismatch} (informational —
-   * fires regardless of strict-mode state). A deficit is treated as nonfatal (warn-and-continue)
-   * ONLY for a pre-existing version that was cloned onto a store-migration destination and is
-   * replaying a source version topic that log compaction may have shrunk below the original
-   * end-of-push count (see {@link #isPreExistingMigrationCloneReplay(Store)}). Every other case —
-   * including a brand-new push started while migration is still active — logs a tagged error string
-   * and, on a non-DaVinci replica, if the server-level config
+   * fires regardless of strict-mode state) and logs a tagged error string. A deficit is nonfatal
+   * (warn-and-continue) only for a migration-clone replay (see
+   * {@link #isPreExistingMigrationCloneReplay(Store)}). Otherwise, on a non-DaVinci replica, if the
+   * server-level config
    * {@code server.batch.push.record.count.verification.fail.on.mismatch.enabled} is {@code true}
    * (default), also increments {@code record_count_mismatch_failure} and throws
    * {@link VeniceException} (failing ingestion). DaVinci replicas skip both the failure sensor
@@ -4258,37 +4256,17 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   /**
-   * Decide whether an end-of-push record-count deficit is the <em>expected</em>, nonfatal kind that
-   * only a store-migration replay of a pre-existing version can produce.
+   * Whether an end-of-push record-count deficit is the expected, nonfatal kind produced by a store
+   * migration replaying a pre-existing source version topic that log compaction may have shrunk
+   * below the original end-of-push count.
    *
-   * <p>During store migration the destination replays each source version topic. Kafka log
-   * compaction can remove superseded records from that topic before the destination finishes
-   * replaying it, so the replica legitimately consumes fewer records than the original push's
-   * end-of-push count carried on the "prc" header. That deficit must NOT fail ingestion. A push that
-   * is started fresh while migration is still active, however, is an ordinary push and must keep the
-   * strict (fail-on-deficit) behavior.
-   *
-   * <p>The store-level {@link Store#isMigrationDuplicateStore()} flag alone cannot separate the two:
-   * it is set for the whole destination store while migration is active, including for new pushes.
-   * We therefore combine it with a per-version lifecycle invariant:
-   * <ul>
-   *   <li>The destination store is created at migration start, so {@link Store#getCreatedTime()}
-   *       marks the migration boundary there.</li>
-   *   <li>Cloned source versions preserve their source {@code createdTime}, so pre-existing versions
-   *       normally predate that boundary. A source push that completes shortly after migration
-   *       begins may also be cloned; because its timestamp comes from the source controller, this
-   *       comparison relies on normal bounded controller clock skew.</li>
-   *   <li>A push created on the destination receives a fresh {@code createdTime} and normally does
-   *       not predate the boundary.</li>
-   * </ul>
-   * This mirrors the controller's own clone-vs-new-push decision when it adds a version during
-   * migration (an existing source version is cloned; a version beyond the source's current version
-   * is handled as an ongoing new push).
-   *
-   * <p>Both timestamps are read from the same freshly-fetched store snapshot to avoid mixing
-   * lifecycle views. Fails closed: a {@code null} store, a non-migration store, a version missing
-   * from the store, or an unset ({@code <= 0}) {@code createdTime} on either side all keep the
-   * strict (fatal) behavior.
+   * <p>{@link Store#isMigrationDuplicateStore()} alone is too broad — it covers the whole
+   * destination store while migration is active, including brand-new pushes — so it is paired with a
+   * per-version check: the destination store's {@code createdTime} marks the migration boundary,
+   * cloned source versions keep their older source {@code createdTime}, and a push created on the
+   * destination gets a fresh one. For a source push cloned shortly after migration starts, that
+   * comparison relies on normal bounded controller clock skew. Fails closed: missing or non-positive
+   * metadata on either side keeps the strict (fatal) behavior.
    */
   boolean isPreExistingMigrationCloneReplay(Store store) {
     if (store == null || !store.isMigrationDuplicateStore()) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4152,7 +4152,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * {@code server.batch.push.record.count.verification.fail.on.mismatch.enabled} is {@code true}
    * (default), also increments {@code record_count_mismatch_failure} and throws
    * {@link VeniceException} (failing ingestion). DaVinci replicas skip both the failure sensor
-   * and the throw </p>
+   * and the throw.</p>
    *
    * <p>Skip cases (no-op, no metric):</p>
    * <ul>

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4146,9 +4146,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * </ol>
    *
    * <p>If either leg fails: increments {@code batch_push_record_count_mismatch} (informational —
-   * fires regardless of strict-mode state). Migration duplicate stores log a warning and continue
-   * because compacted version-topic replay can legitimately contain fewer records than the original
-   * push count. Other stores log a tagged error string. On a non-DaVinci replica, if the server-level config
+   * fires regardless of strict-mode state). A deficit is treated as nonfatal (warn-and-continue)
+   * ONLY for a pre-existing version that was cloned onto a store-migration destination and is
+   * replaying a source version topic that log compaction may have shrunk below the original
+   * end-of-push count (see {@link #isPreExistingMigrationCloneReplay(Store)}). Every other case —
+   * including a brand-new push started while migration is still active — logs a tagged error string
+   * and, on a non-DaVinci replica, if the server-level config
    * {@code server.batch.push.record.count.verification.fail.on.mismatch.enabled} is {@code true}
    * (default), also increments {@code record_count_mismatch_failure} and throws
    * {@link VeniceException} (failing ingestion). DaVinci replicas skip both the failure sensor
@@ -4218,13 +4221,19 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     if (!counterOk || !hllOk) {
       versionedIngestionStats.recordBatchPushRecordCountMismatch(storeName, versionNumber);
       Store store = storeRepository.getStore(storeName);
-      boolean isMigrationReplay = store != null && store.isMigrationDuplicateStore();
+      boolean isMigrationReplay = isPreExistingMigrationCloneReplay(store);
+      boolean migrationDuplicateStore = store != null && store.isMigrationDuplicateStore();
+      long storeCreatedTime = store == null ? -1 : store.getCreatedTime();
+      Version storeVersion = store == null ? null : store.getVersion(versionNumber);
+      long versionCreatedTime = storeVersion == null ? -1 : storeVersion.getCreatedTime();
       String verificationContext = isMigrationReplay ? "MIGRATION_REPLAY" : "FRESH_PUSH";
-      String taggedMsg = "RECORD_COUNT_DEFICIT:verificationContext=" + verificationContext + ":counterOk=" + counterOk
-          + ":hllOk=" + hllOk + ":expected=" + expectedCount + ":actual=" + actualCount + ":hll=" + hllEstimate
-          + ":hllThreshold=" + hllThreshold + ":replica=" + pcs.getReplicaId() + ":topic=" + kafkaVersionTopic;
+      String taggedMsg = "RECORD_COUNT_DEFICIT:verificationContext=" + verificationContext + ":migrationDuplicateStore="
+          + migrationDuplicateStore + ":storeCreatedTimeMs=" + storeCreatedTime + ":versionCreatedTimeMs="
+          + versionCreatedTime + ":counterOk=" + counterOk + ":hllOk=" + hllOk + ":expected=" + expectedCount
+          + ":actual=" + actualCount + ":hll=" + hllEstimate + ":hllThreshold=" + hllThreshold + ":replica="
+          + pcs.getReplicaId() + ":topic=" + kafkaVersionTopic;
       if (isMigrationReplay) {
-        LOGGER.warn(taggedMsg + ":reason=MIGRATION_DUPLICATE_STORE");
+        LOGGER.warn(taggedMsg + ":reason=PRE_EXISTING_MIGRATION_CLONE");
         return;
       }
       LOGGER.error(taggedMsg);
@@ -4246,6 +4255,52 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           actualCount,
           hllEstimate);
     }
+  }
+
+  /**
+   * Decide whether an end-of-push record-count deficit is the <em>expected</em>, nonfatal kind that
+   * only a store-migration replay of a pre-existing version can produce.
+   *
+   * <p>During store migration the destination replays each source version topic. Kafka log
+   * compaction can remove superseded records from that topic before the destination finishes
+   * replaying it, so the replica legitimately consumes fewer records than the original push's
+   * end-of-push count carried on the "prc" header. That deficit must NOT fail ingestion. A push that
+   * is started fresh while migration is still active, however, is an ordinary push and must keep the
+   * strict (fail-on-deficit) behavior.
+   *
+   * <p>The store-level {@link Store#isMigrationDuplicateStore()} flag alone cannot separate the two:
+   * it is set for the whole destination store while migration is active, including for new pushes.
+   * We therefore combine it with a per-version lifecycle invariant:
+   * <ul>
+   *   <li>The destination store is created at migration start, so {@link Store#getCreatedTime()}
+   *       marks the migration boundary there.</li>
+   *   <li>Cloned source versions preserve their source {@code createdTime}, so pre-existing versions
+   *       normally predate that boundary. A source push that completes shortly after migration
+   *       begins may also be cloned; because its timestamp comes from the source controller, this
+   *       comparison relies on normal bounded controller clock skew.</li>
+   *   <li>A push created on the destination receives a fresh {@code createdTime} and normally does
+   *       not predate the boundary.</li>
+   * </ul>
+   * This mirrors the controller's own clone-vs-new-push decision when it adds a version during
+   * migration (an existing source version is cloned; a version beyond the source's current version
+   * is handled as an ongoing new push).
+   *
+   * <p>Both timestamps are read from the same freshly-fetched store snapshot to avoid mixing
+   * lifecycle views. Fails closed: a {@code null} store, a non-migration store, a version missing
+   * from the store, or an unset ({@code <= 0}) {@code createdTime} on either side all keep the
+   * strict (fatal) behavior.
+   */
+  boolean isPreExistingMigrationCloneReplay(Store store) {
+    if (store == null || !store.isMigrationDuplicateStore()) {
+      return false;
+    }
+    Version storeVersion = store.getVersion(versionNumber);
+    if (storeVersion == null) {
+      return false;
+    }
+    long storeCreatedTime = store.getCreatedTime();
+    long versionCreatedTime = storeVersion.getCreatedTime();
+    return storeCreatedTime > 0 && versionCreatedTime > 0 && versionCreatedTime < storeCreatedTime;
   }
 
   protected void processStartOfIncrementalPush(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4146,8 +4146,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * </ol>
    *
    * <p>If either leg fails: increments {@code batch_push_record_count_mismatch} (informational —
-   * fires regardless of strict-mode state) and logs a tagged error string. On a non-DaVinci
-   * replica, if the server-level config
+   * fires regardless of strict-mode state). Migration duplicate stores log a warning and continue
+   * because compacted version-topic replay can legitimately contain fewer records than the original
+   * push count. Other stores log a tagged error string. On a non-DaVinci replica, if the server-level config
    * {@code server.batch.push.record.count.verification.fail.on.mismatch.enabled} is {@code true}
    * (default), also increments {@code record_count_mismatch_failure} and throws
    * {@link VeniceException} (failing ingestion). DaVinci replicas skip both the failure sensor
@@ -4215,11 +4216,18 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
 
     if (!counterOk || !hllOk) {
-      String taggedMsg = "RECORD_COUNT_DEFICIT:counterOk=" + counterOk + ":hllOk=" + hllOk + ":expected="
-          + expectedCount + ":actual=" + actualCount + ":hll=" + hllEstimate + ":hllThreshold=" + hllThreshold
-          + ":replica=" + pcs.getReplicaId() + ":topic=" + kafkaVersionTopic;
-      LOGGER.error(taggedMsg);
       versionedIngestionStats.recordBatchPushRecordCountMismatch(storeName, versionNumber);
+      Store store = storeRepository.getStore(storeName);
+      boolean isMigrationReplay = store != null && store.isMigrationDuplicateStore();
+      String verificationContext = isMigrationReplay ? "MIGRATION_REPLAY" : "FRESH_PUSH";
+      String taggedMsg = "RECORD_COUNT_DEFICIT:verificationContext=" + verificationContext + ":counterOk=" + counterOk
+          + ":hllOk=" + hllOk + ":expected=" + expectedCount + ":actual=" + actualCount + ":hll=" + hllEstimate
+          + ":hllThreshold=" + hllThreshold + ":replica=" + pcs.getReplicaId() + ":topic=" + kafkaVersionTopic;
+      if (isMigrationReplay) {
+        LOGGER.warn(taggedMsg + ":reason=MIGRATION_DUPLICATE_STORE");
+        return;
+      }
+      LOGGER.error(taggedMsg);
       // Server-side strict-mode is controlled by the cluster-wide config
       // `server.batch.push.record.count.verification.fail.on.mismatch.enabled` (default: true).
       // DaVinci replicas unconditionally skip the throw — DVC failure aggregation is handled

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskRecordCountTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskRecordCountTest.java
@@ -99,8 +99,7 @@ public class StoreIngestionTaskRecordCountTest {
     setField(sit, "versionTopic", vt);
 
     doCallRealMethod().when(sit).verifyBatchPushRecordCount(any(), any());
-    // verifyBatchPushRecordCount calls this helper on `this`; that self-invocation is intercepted by
-    // the mock, so it must also be wired to the real implementation for the per-version gate to run.
+    // The self-invocation from verifyBatchPushRecordCount is intercepted by the mock, so wire it up too.
     doCallRealMethod().when(sit).isPreExistingMigrationCloneReplay(any());
     return sit;
   }
@@ -425,10 +424,6 @@ public class StoreIngestionTaskRecordCountTest {
     verify(stats, never()).recordBatchPushRecordCountMatch(TEST_STORE, TEST_VERSION);
   }
 
-  /**
-   * Same new-push scoping applies to the HLL leg: an HLL deficit on a push begun during migration is
-   * fatal, confirming the per-version gate is independent of which leg detected the deficit.
-   */
   @Test
   public void testVerifyFreshPushDuringMigrationHllDeficitThrowsAndRecordsFailure() throws Exception {
     AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
@@ -441,7 +436,6 @@ public class StoreIngestionTaskRecordCountTest {
         /* isDaVinciClient */ false,
         store);
 
-    // counter=100 >= 100 (passes); hll=50, |50-100|=50 > 5 (fails) -> deficit via HLL leg.
     VeniceException exception = expectThrows(
         VeniceException.class,
         () -> sit.verifyBatchPushRecordCount(pcsWithCountAndHll(100L, 50L), headersWithPrc(100L)));
@@ -761,18 +755,13 @@ public class StoreIngestionTaskRecordCountTest {
     return new VersionImpl(TEST_STORE, TEST_VERSION, createdTimeMs, pushJobId, 1, new PartitionerConfigImpl(), null);
   }
 
-  /**
-   * Realistic-metadata proof (real {@link ZKStore} / {@link VersionImpl}, no mock store): a
-   * pre-existing source version cloned onto the destination keeps its original createdTime via
-   * {@link Version#cloneVersion()}, so it precedes the destination store's createdTime and its
-   * compacted-replay deficit is nonfatal.
-   */
+  /** A cloned pre-existing version keeps its older source createdTime, so its replay deficit is nonfatal. */
   @Test
   public void testRealMetadataMigrationCloneReplayIsNonfatal() throws Exception {
     long migrationStart = 100_000L;
     Version sourceVersion = versionWithCreatedTime(migrationStart - 50_000L, "push-src");
     Version clonedVersion = sourceVersion.cloneVersion();
-    // Sanity: the clone preserves the source's pre-migration createdTime (the invariant this fix relies on).
+    // The clone must preserve the source's pre-migration createdTime.
     assertEquals(clonedVersion.getCreatedTime(), migrationStart - 50_000L);
 
     ZKStore destinationStore = migrationDuplicateZkStore(migrationStart);
@@ -793,11 +782,7 @@ public class StoreIngestionTaskRecordCountTest {
     verify(stats, never()).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
   }
 
-  /**
-   * Realistic-metadata proof (real {@link ZKStore} / {@link VersionImpl}, no mock store): a push
-   * started while migration is active is a fresh version created AFTER the destination store, so its
-   * createdTime does not precede the store's and the deficit stays fatal with the failure sensor.
-   */
+  /** A push started during migration gets a createdTime after the destination store's, so it stays fatal. */
   @Test
   public void testRealMetadataFreshPushDuringMigrationIsFatal() throws Exception {
     long migrationStart = 100_000L;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskRecordCountTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskRecordCountTest.java
@@ -14,11 +14,17 @@ import static org.testng.Assert.expectThrows;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.logger.TestLogAppender;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.pubsub.api.EmptyPubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.server.VersionRole;
 import java.nio.ByteBuffer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.testng.annotations.Test;
 
 
@@ -48,6 +54,17 @@ public class StoreIngestionTaskRecordCountTest {
       VersionRole versionRole,
       boolean hllEnabled,
       boolean isDaVinciClient) throws Exception {
+    Store store = mock(Store.class);
+    return buildSit(failOnMismatchEnabled, statsMock, versionRole, hllEnabled, isDaVinciClient, store);
+  }
+
+  private static StoreIngestionTask buildSit(
+      boolean failOnMismatchEnabled,
+      AggVersionedIngestionStats statsMock,
+      VersionRole versionRole,
+      boolean hllEnabled,
+      boolean isDaVinciClient,
+      Store store) throws Exception {
     StoreIngestionTask sit = mock(StoreIngestionTask.class);
     setField(sit, "versionedIngestionStats", statsMock);
     setField(sit, "kafkaVersionTopic", TEST_TOPIC);
@@ -60,6 +77,10 @@ public class StoreIngestionTaskRecordCountTest {
     VeniceServerConfig serverConfigMock = mock(VeniceServerConfig.class);
     doReturn(failOnMismatchEnabled).when(serverConfigMock).isBatchPushRecordCountVerificationFailOnMismatchEnabled();
     setField(sit, "serverConfig", serverConfigMock);
+
+    ReadOnlyStoreRepository storeRepository = mock(ReadOnlyStoreRepository.class);
+    doReturn(store).when(storeRepository).getStore(TEST_STORE);
+    setField(sit, "storeRepository", storeRepository);
 
     PubSubTopic vt = mock(PubSubTopic.class);
     doReturn(false).when(vt).isViewTopic();
@@ -222,6 +243,7 @@ public class StoreIngestionTaskRecordCountTest {
 
     String msg = ex.getMessage();
     assertTrue(msg.contains("RECORD_COUNT_DEFICIT"), "Tagged error class missing in: " + msg);
+    assertTrue(msg.contains("verificationContext=FRESH_PUSH"), "Verification context missing in: " + msg);
     assertTrue(msg.contains("expected=100"), "expected=N missing in: " + msg);
     assertTrue(msg.contains("actual=50"), "actual=M missing in: " + msg);
     assertTrue(msg.contains("replica=test_replica"), "replica id missing in: " + msg);
@@ -229,6 +251,119 @@ public class StoreIngestionTaskRecordCountTest {
     // Failed-and-throwing mismatches must also increment the dedicated failure sensor — distinct
     // from the informational mismatch sensor, which fires regardless of strict-mode state.
     verify(stats, times(1)).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
+  }
+
+  @Test
+  public void testVerifyMigrationReplayDoesNotThrowOnCounterDeficitInStrictMode() throws Exception {
+    AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
+    Store store = mock(Store.class);
+    doReturn(true).when(store).isMigrationDuplicateStore();
+    StoreIngestionTask sit = buildSit(
+        /* failOnMismatchEnabled */ true,
+        stats,
+        VersionRole.FUTURE,
+        /* hllEnabled */ false,
+        /* isDaVinciClient */ false,
+        store);
+
+    sit.verifyBatchPushRecordCount(pcsWithCount(50L), headersWithPrc(100L));
+
+    verify(stats, times(1)).recordBatchPushRecordCountMismatch(TEST_STORE, TEST_VERSION);
+    verify(stats, never()).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
+    verify(stats, never()).recordBatchPushRecordCountMatch(TEST_STORE, TEST_VERSION);
+  }
+
+  @Test
+  public void testVerifyMigrationReplayDoesNotThrowOnHllDeficitInStrictMode() throws Exception {
+    AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
+    Store store = mock(Store.class);
+    doReturn(true).when(store).isMigrationDuplicateStore();
+    StoreIngestionTask sit = buildSit(
+        /* failOnMismatchEnabled */ true,
+        stats,
+        VersionRole.FUTURE,
+        /* hllEnabled */ true,
+        /* isDaVinciClient */ false,
+        store);
+
+    sit.verifyBatchPushRecordCount(pcsWithCountAndHll(100L, 50L), headersWithPrc(100L));
+
+    verify(stats, times(1)).recordBatchPushRecordCountMismatch(TEST_STORE, TEST_VERSION);
+    verify(stats, never()).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
+    verify(stats, never()).recordBatchPushRecordCountMatch(TEST_STORE, TEST_VERSION);
+  }
+
+  @Test
+  public void testVerifyMigratingSourceStillThrowsOnDeficit() throws Exception {
+    AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
+    Store store = mock(Store.class);
+    doReturn(true).when(store).isMigrating();
+    doReturn(false).when(store).isMigrationDuplicateStore();
+    StoreIngestionTask sit = buildSit(
+        /* failOnMismatchEnabled */ true,
+        stats,
+        VersionRole.FUTURE,
+        /* hllEnabled */ false,
+        /* isDaVinciClient */ false,
+        store);
+
+    VeniceException exception = expectThrows(
+        VeniceException.class,
+        () -> sit.verifyBatchPushRecordCount(pcsWithCount(50L), headersWithPrc(100L)));
+
+    assertTrue(exception.getMessage().contains("verificationContext=FRESH_PUSH"));
+    verify(stats, times(1)).recordBatchPushRecordCountMismatch(TEST_STORE, TEST_VERSION);
+    verify(stats, times(1)).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
+  }
+
+  @Test
+  public void testVerifyMissingStoreMetadataFailsClosed() throws Exception {
+    AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
+    StoreIngestionTask sit = buildSit(
+        /* failOnMismatchEnabled */ true,
+        stats,
+        VersionRole.FUTURE,
+        /* hllEnabled */ false,
+        /* isDaVinciClient */ false,
+        null);
+
+    VeniceException exception = expectThrows(
+        VeniceException.class,
+        () -> sit.verifyBatchPushRecordCount(pcsWithCount(50L), headersWithPrc(100L)));
+
+    assertTrue(exception.getMessage().startsWith("RECORD_COUNT_DEFICIT"));
+    assertTrue(exception.getMessage().contains("verificationContext=FRESH_PUSH"));
+    verify(stats, times(1)).recordBatchPushRecordCountMismatch(TEST_STORE, TEST_VERSION);
+    verify(stats, times(1)).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
+  }
+
+  @Test
+  public void testVerifyMigrationReplayWarningContainsContextAndReason() throws Exception {
+    AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
+    Store store = mock(Store.class);
+    doReturn(true).when(store).isMigrationDuplicateStore();
+    StoreIngestionTask sit = buildSit(
+        /* failOnMismatchEnabled */ true,
+        stats,
+        VersionRole.FUTURE,
+        /* hllEnabled */ false,
+        /* isDaVinciClient */ false,
+        store);
+    TestLogAppender appender =
+        new TestLogAppender("MigrationReplayRecordCountAppender", PatternLayout.createDefaultLayout());
+    appender.start();
+    Logger logger = (Logger) LogManager.getLogger(StoreIngestionTask.class);
+    logger.addAppender(appender);
+    try {
+      sit.verifyBatchPushRecordCount(pcsWithCount(50L), headersWithPrc(100L));
+
+      String log = appender.getLog();
+      assertTrue(log.contains("verificationContext=MIGRATION_REPLAY"), "Missing migration context in: " + log);
+      assertTrue(log.contains("reason=MIGRATION_DUPLICATE_STORE"), "Missing migration reason in: " + log);
+    } finally {
+      logger.removeAppender(appender);
+      appender.stop();
+    }
   }
 
   /** When server strict-mode is disabled, the dedicated failure sensor must NOT fire. */

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskRecordCountTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskRecordCountTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
@@ -15,8 +16,16 @@ import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.logger.TestLogAppender;
+import com.linkedin.venice.meta.OfflinePushStrategy;
+import com.linkedin.venice.meta.PartitionerConfigImpl;
+import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.ReadStrategy;
+import com.linkedin.venice.meta.RoutingStrategy;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionImpl;
+import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.pubsub.api.EmptyPubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
@@ -32,6 +41,9 @@ public class StoreIngestionTaskRecordCountTest {
   private static final String TEST_TOPIC = "test_store_v1";
   private static final String TEST_STORE = "test_store";
   private static final int TEST_VERSION = 1;
+  private static final long PRE_MIGRATION_VERSION_CREATED_TIME_MS = 1_000L;
+  private static final long MIGRATION_STORE_CREATED_TIME_MS = 2_000L;
+  private static final long DURING_MIGRATION_VERSION_CREATED_TIME_MS = 3_000L;
 
   private static StoreIngestionTask buildSit(boolean failOnMismatchEnabled, AggVersionedIngestionStats statsMock)
       throws Exception {
@@ -87,6 +99,9 @@ public class StoreIngestionTaskRecordCountTest {
     setField(sit, "versionTopic", vt);
 
     doCallRealMethod().when(sit).verifyBatchPushRecordCount(any(), any());
+    // verifyBatchPushRecordCount calls this helper on `this`; that self-invocation is intercepted by
+    // the mock, so it must also be wired to the real implementation for the per-version gate to run.
+    doCallRealMethod().when(sit).isPreExistingMigrationCloneReplay(any());
     return sit;
   }
 
@@ -96,6 +111,27 @@ public class StoreIngestionTaskRecordCountTest {
     doReturn(true).when(vt).isViewTopic();
     setField(sit, "versionTopic", vt);
     return sit;
+  }
+
+  private static Version mockVersion(long createdTimeMs) {
+    Version version = mock(Version.class);
+    doReturn(createdTimeMs).when(version).getCreatedTime();
+    return version;
+  }
+
+  private static Store storeWithVersionMetadata(
+      boolean migrationDuplicateStore,
+      long storeCreatedTimeMs,
+      long versionCreatedTimeMs) {
+    Store store = mock(Store.class);
+    doReturn(migrationDuplicateStore).when(store).isMigrationDuplicateStore();
+    doReturn(storeCreatedTimeMs).when(store).getCreatedTime();
+    doReturn(mockVersion(versionCreatedTimeMs)).when(store).getVersion(TEST_VERSION);
+    return store;
+  }
+
+  private static Store migrationDuplicateStore(long storeCreatedTimeMs, long versionCreatedTimeMs) {
+    return storeWithVersionMetadata(true, storeCreatedTimeMs, versionCreatedTimeMs);
   }
 
   private static PartitionConsumptionState pcsWithCount(long count) {
@@ -256,8 +292,7 @@ public class StoreIngestionTaskRecordCountTest {
   @Test
   public void testVerifyMigrationReplayDoesNotThrowOnCounterDeficitInStrictMode() throws Exception {
     AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
-    Store store = mock(Store.class);
-    doReturn(true).when(store).isMigrationDuplicateStore();
+    Store store = migrationDuplicateStore(MIGRATION_STORE_CREATED_TIME_MS, PRE_MIGRATION_VERSION_CREATED_TIME_MS);
     StoreIngestionTask sit = buildSit(
         /* failOnMismatchEnabled */ true,
         stats,
@@ -276,8 +311,7 @@ public class StoreIngestionTaskRecordCountTest {
   @Test
   public void testVerifyMigrationReplayDoesNotThrowOnHllDeficitInStrictMode() throws Exception {
     AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
-    Store store = mock(Store.class);
-    doReturn(true).when(store).isMigrationDuplicateStore();
+    Store store = migrationDuplicateStore(MIGRATION_STORE_CREATED_TIME_MS, PRE_MIGRATION_VERSION_CREATED_TIME_MS);
     StoreIngestionTask sit = buildSit(
         /* failOnMismatchEnabled */ true,
         stats,
@@ -340,8 +374,7 @@ public class StoreIngestionTaskRecordCountTest {
   @Test
   public void testVerifyMigrationReplayWarningContainsContextAndReason() throws Exception {
     AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
-    Store store = mock(Store.class);
-    doReturn(true).when(store).isMigrationDuplicateStore();
+    Store store = migrationDuplicateStore(MIGRATION_STORE_CREATED_TIME_MS, PRE_MIGRATION_VERSION_CREATED_TIME_MS);
     StoreIngestionTask sit = buildSit(
         /* failOnMismatchEnabled */ true,
         stats,
@@ -359,11 +392,144 @@ public class StoreIngestionTaskRecordCountTest {
 
       String log = appender.getLog();
       assertTrue(log.contains("verificationContext=MIGRATION_REPLAY"), "Missing migration context in: " + log);
-      assertTrue(log.contains("reason=MIGRATION_DUPLICATE_STORE"), "Missing migration reason in: " + log);
+      assertTrue(log.contains("reason=PRE_EXISTING_MIGRATION_CLONE"), "Missing migration reason in: " + log);
     } finally {
       logger.removeAppender(appender);
       appender.stop();
     }
+  }
+
+  @Test
+  public void testVerifyFreshPushDuringMigrationThrowsAndRecordsFailure() throws Exception {
+    AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
+    Store store = migrationDuplicateStore(MIGRATION_STORE_CREATED_TIME_MS, DURING_MIGRATION_VERSION_CREATED_TIME_MS);
+    StoreIngestionTask sit = buildSit(
+        /* failOnMismatchEnabled */ true,
+        stats,
+        VersionRole.FUTURE,
+        /* hllEnabled */ false,
+        /* isDaVinciClient */ false,
+        store);
+
+    VeniceException exception = expectThrows(
+        VeniceException.class,
+        () -> sit.verifyBatchPushRecordCount(pcsWithCount(50L), headersWithPrc(100L)));
+
+    String message = exception.getMessage();
+    assertTrue(message.contains("verificationContext=FRESH_PUSH"), message);
+    assertTrue(message.contains("migrationDuplicateStore=true"), message);
+    assertTrue(message.contains("storeCreatedTimeMs=" + MIGRATION_STORE_CREATED_TIME_MS), message);
+    assertTrue(message.contains("versionCreatedTimeMs=" + DURING_MIGRATION_VERSION_CREATED_TIME_MS), message);
+    verify(stats, times(1)).recordBatchPushRecordCountMismatch(TEST_STORE, TEST_VERSION);
+    verify(stats, times(1)).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
+    verify(stats, never()).recordBatchPushRecordCountMatch(TEST_STORE, TEST_VERSION);
+  }
+
+  /**
+   * Same new-push scoping applies to the HLL leg: an HLL deficit on a push begun during migration is
+   * fatal, confirming the per-version gate is independent of which leg detected the deficit.
+   */
+  @Test
+  public void testVerifyFreshPushDuringMigrationHllDeficitThrowsAndRecordsFailure() throws Exception {
+    AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
+    Store store = migrationDuplicateStore(MIGRATION_STORE_CREATED_TIME_MS, DURING_MIGRATION_VERSION_CREATED_TIME_MS);
+    StoreIngestionTask sit = buildSit(
+        /* failOnMismatchEnabled */ true,
+        stats,
+        VersionRole.FUTURE,
+        /* hllEnabled */ true,
+        /* isDaVinciClient */ false,
+        store);
+
+    // counter=100 >= 100 (passes); hll=50, |50-100|=50 > 5 (fails) -> deficit via HLL leg.
+    VeniceException exception = expectThrows(
+        VeniceException.class,
+        () -> sit.verifyBatchPushRecordCount(pcsWithCountAndHll(100L, 50L), headersWithPrc(100L)));
+
+    assertTrue(exception.getMessage().contains("verificationContext=FRESH_PUSH"), exception.getMessage());
+    verify(stats, times(1)).recordBatchPushRecordCountMismatch(TEST_STORE, TEST_VERSION);
+    verify(stats, times(1)).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
+  }
+
+  @Test
+  public void testVerifyVersionCreatedAtStoreBoundaryThrows() throws Exception {
+    AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
+    Store store = migrationDuplicateStore(MIGRATION_STORE_CREATED_TIME_MS, MIGRATION_STORE_CREATED_TIME_MS);
+    StoreIngestionTask sit = buildSit(
+        /* failOnMismatchEnabled */ true,
+        stats,
+        VersionRole.FUTURE,
+        /* hllEnabled */ false,
+        /* isDaVinciClient */ false,
+        store);
+
+    VeniceException exception = expectThrows(
+        VeniceException.class,
+        () -> sit.verifyBatchPushRecordCount(pcsWithCount(50L), headersWithPrc(100L)));
+
+    assertTrue(exception.getMessage().contains("verificationContext=FRESH_PUSH"), exception.getMessage());
+    verify(stats, times(1)).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
+  }
+
+  @Test
+  public void testVerifyNonMigrationStoreWithOlderVersionRemainsStrict() throws Exception {
+    AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
+    Store store =
+        storeWithVersionMetadata(false, MIGRATION_STORE_CREATED_TIME_MS, PRE_MIGRATION_VERSION_CREATED_TIME_MS);
+    StoreIngestionTask sit = buildSit(
+        /* failOnMismatchEnabled */ true,
+        stats,
+        VersionRole.FUTURE,
+        /* hllEnabled */ false,
+        /* isDaVinciClient */ false,
+        store);
+
+    VeniceException exception = expectThrows(
+        VeniceException.class,
+        () -> sit.verifyBatchPushRecordCount(pcsWithCount(50L), headersWithPrc(100L)));
+
+    assertTrue(exception.getMessage().contains("verificationContext=FRESH_PUSH"), exception.getMessage());
+    verify(stats, times(1)).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
+  }
+
+  @Test
+  public void testVerifyMigrationDuplicateStoreWithUnsetVersionCreatedTimeFailsClosed() throws Exception {
+    AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
+    Store store = migrationDuplicateStore(MIGRATION_STORE_CREATED_TIME_MS, 0L);
+    StoreIngestionTask sit = buildSit(
+        /* failOnMismatchEnabled */ true,
+        stats,
+        VersionRole.FUTURE,
+        /* hllEnabled */ false,
+        /* isDaVinciClient */ false,
+        store);
+
+    VeniceException exception = expectThrows(
+        VeniceException.class,
+        () -> sit.verifyBatchPushRecordCount(pcsWithCount(50L), headersWithPrc(100L)));
+
+    assertTrue(exception.getMessage().contains("verificationContext=FRESH_PUSH"), exception.getMessage());
+    verify(stats, times(1)).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
+  }
+
+  @Test
+  public void testVerifyMigrationDuplicateStoreWithUnsetStoreCreatedTimeFailsClosed() throws Exception {
+    AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
+    Store store = migrationDuplicateStore(0L, PRE_MIGRATION_VERSION_CREATED_TIME_MS);
+    StoreIngestionTask sit = buildSit(
+        /* failOnMismatchEnabled */ true,
+        stats,
+        VersionRole.FUTURE,
+        /* hllEnabled */ false,
+        /* isDaVinciClient */ false,
+        store);
+
+    VeniceException exception = expectThrows(
+        VeniceException.class,
+        () -> sit.verifyBatchPushRecordCount(pcsWithCount(50L), headersWithPrc(100L)));
+
+    assertTrue(exception.getMessage().contains("verificationContext=FRESH_PUSH"), exception.getMessage());
+    verify(stats, times(1)).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
   }
 
   /** When server strict-mode is disabled, the dedicated failure sensor must NOT fire. */
@@ -577,4 +743,83 @@ public class StoreIngestionTaskRecordCountTest {
     verify(stats, never()).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
   }
 
+  private static ZKStore migrationDuplicateZkStore(long createdTimeMs) {
+    ZKStore store = new ZKStore(
+        TEST_STORE,
+        "owner",
+        createdTimeMs,
+        PersistenceType.ROCKS_DB,
+        RoutingStrategy.CONSISTENT_HASH,
+        ReadStrategy.ANY_OF_ONLINE,
+        OfflinePushStrategy.WAIT_ALL_REPLICAS,
+        1);
+    store.setMigrationDuplicateStore(true);
+    return store;
+  }
+
+  private static Version versionWithCreatedTime(long createdTimeMs, String pushJobId) {
+    return new VersionImpl(TEST_STORE, TEST_VERSION, createdTimeMs, pushJobId, 1, new PartitionerConfigImpl(), null);
+  }
+
+  /**
+   * Realistic-metadata proof (real {@link ZKStore} / {@link VersionImpl}, no mock store): a
+   * pre-existing source version cloned onto the destination keeps its original createdTime via
+   * {@link Version#cloneVersion()}, so it precedes the destination store's createdTime and its
+   * compacted-replay deficit is nonfatal.
+   */
+  @Test
+  public void testRealMetadataMigrationCloneReplayIsNonfatal() throws Exception {
+    long migrationStart = 100_000L;
+    Version sourceVersion = versionWithCreatedTime(migrationStart - 50_000L, "push-src");
+    Version clonedVersion = sourceVersion.cloneVersion();
+    // Sanity: the clone preserves the source's pre-migration createdTime (the invariant this fix relies on).
+    assertEquals(clonedVersion.getCreatedTime(), migrationStart - 50_000L);
+
+    ZKStore destinationStore = migrationDuplicateZkStore(migrationStart);
+    destinationStore.forceAddVersion(clonedVersion, true);
+
+    AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
+    StoreIngestionTask sit = buildSit(
+        /* failOnMismatchEnabled */ true,
+        stats,
+        VersionRole.FUTURE,
+        /* hllEnabled */ false,
+        /* isDaVinciClient */ false,
+        destinationStore);
+
+    sit.verifyBatchPushRecordCount(pcsWithCount(50L), headersWithPrc(100L));
+
+    verify(stats, times(1)).recordBatchPushRecordCountMismatch(TEST_STORE, TEST_VERSION);
+    verify(stats, never()).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
+  }
+
+  /**
+   * Realistic-metadata proof (real {@link ZKStore} / {@link VersionImpl}, no mock store): a push
+   * started while migration is active is a fresh version created AFTER the destination store, so its
+   * createdTime does not precede the store's and the deficit stays fatal with the failure sensor.
+   */
+  @Test
+  public void testRealMetadataFreshPushDuringMigrationIsFatal() throws Exception {
+    long migrationStart = 100_000L;
+    ZKStore destinationStore = migrationDuplicateZkStore(migrationStart);
+    Version newPushVersion = versionWithCreatedTime(migrationStart + 50_000L, "push-new");
+    destinationStore.forceAddVersion(newPushVersion, false);
+
+    AggVersionedIngestionStats stats = mock(AggVersionedIngestionStats.class);
+    StoreIngestionTask sit = buildSit(
+        /* failOnMismatchEnabled */ true,
+        stats,
+        VersionRole.FUTURE,
+        /* hllEnabled */ false,
+        /* isDaVinciClient */ false,
+        destinationStore);
+
+    VeniceException exception = expectThrows(
+        VeniceException.class,
+        () -> sit.verifyBatchPushRecordCount(pcsWithCount(50L), headersWithPrc(100L)));
+
+    assertTrue(exception.getMessage().contains("verificationContext=FRESH_PUSH"), exception.getMessage());
+    verify(stats, times(1)).recordBatchPushRecordCountMismatch(TEST_STORE, TEST_VERSION);
+    verify(stats, times(1)).recordRecordCountMismatchFailure(TEST_STORE, TEST_VERSION);
+  }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigrationWithCompactedVersionTopic.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigrationWithCompactedVersionTopic.java
@@ -44,6 +44,8 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriter;
 import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -52,7 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.testng.Assert;
@@ -67,6 +69,7 @@ public class TestStoreMigrationWithCompactedVersionTopic {
   private static final int PRODUCED_RECORD_COUNT = 200;
   private static final int UNIQUE_KEY_COUNT = 10;
   private static final int VALUE_PAYLOAD_SIZE = 12 * 1024;
+  private static final List<String> INCOMPRESSIBLE_VALUES = createIncompressibleValues();
   private static final String FABRIC = "dc-0";
   private static final String KEY_SCHEMA = "\"string\"";
   private static final String VALUE_SCHEMA = "\"string\"";
@@ -172,7 +175,7 @@ public class TestStoreMigrationWithCompactedVersionTopic {
           writer
               .put(
                   "key_" + index % UNIQUE_KEY_COUNT,
-                  getIncompressibleValue(index),
+                  INCOMPRESSIBLE_VALUES.get(index),
                   HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID)
               .get();
         }
@@ -239,17 +242,25 @@ public class TestStoreMigrationWithCompactedVersionTopic {
         int lastRecordIndex = PRODUCED_RECORD_COUNT - UNIQUE_KEY_COUNT + keyIndex;
         assertEquals(
             client.get("key_" + keyIndex).get().toString(),
-            getIncompressibleValue(lastRecordIndex),
+            INCOMPRESSIBLE_VALUES.get(lastRecordIndex),
             "Unexpected value after migrating compacted topic for key_" + keyIndex);
       }
     }
   }
 
-  private static String getIncompressibleValue(int index) {
+  private static List<String> createIncompressibleValues() {
     // Deterministic high-entropy values force Kafka log segments to roll even when producer compression is enabled.
-    byte[] payload = new byte[VALUE_PAYLOAD_SIZE];
-    new Random(index).nextBytes(payload);
-    return "value_" + index + "_" + Base64.getEncoder().encodeToString(payload);
+    List<String> values = new ArrayList<>(PRODUCED_RECORD_COUNT);
+    SplittableRandom random = new SplittableRandom(0);
+    for (int index = 0; index < PRODUCED_RECORD_COUNT; index++) {
+      byte[] payload = new byte[VALUE_PAYLOAD_SIZE];
+      ByteBuffer payloadBuffer = ByteBuffer.wrap(payload);
+      while (payloadBuffer.hasRemaining()) {
+        payloadBuffer.putLong(random.nextLong());
+      }
+      values.add("value_" + index + "_" + Base64.getEncoder().encodeToString(payload));
+    }
+    return Collections.unmodifiableList(values);
   }
 
   private int getUserRecordCountBeforeEop(PubSubBrokerWrapper broker, PubSubTopic topic) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigrationWithCompactedVersionTopic.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigrationWithCompactedVersionTopic.java
@@ -1,0 +1,278 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.ConfigKeys.OFFLINE_JOB_START_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
+import com.linkedin.venice.integration.utils.IntegrationTestUtils;
+import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.kafka.protocol.ControlMessage;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.pubsub.PubSubConsumerAdapterContext;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.DefaultPubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.pubsub.api.PubSubSymbolicPosition;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.pubsub.manager.TopicManager;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.StoreMigrationTestUtil;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.writer.VeniceWriter;
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.IOUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+@Test(singleThreaded = true)
+public class TestStoreMigrationWithCompactedVersionTopic {
+  private static final int TEST_TIMEOUT = 180 * Time.MS_PER_SECOND;
+  private static final int PRODUCED_RECORD_COUNT = 200;
+  private static final int UNIQUE_KEY_COUNT = 10;
+  private static final String VALUE_PADDING = String.join("", Collections.nCopies(16 * 1024, "x"));
+  private static final String FABRIC = "dc-0";
+  private static final String KEY_SCHEMA = "\"string\"";
+  private static final String VALUE_SCHEMA = "\"string\"";
+  private static final PubSubTopicRepository PUBSUB_TOPIC_REPOSITORY = new PubSubTopicRepository();
+
+  private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionWrapper;
+  private VeniceMultiClusterWrapper childRegion;
+  private String sourceClusterName;
+  private String destinationClusterName;
+  private String parentControllerUrl;
+  private String childControllerUrl;
+
+  @BeforeClass
+  public void setUp() {
+    Utils.thisIsLocalhost();
+    Properties parentControllerProperties = new Properties();
+    parentControllerProperties
+        .setProperty(TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS, String.valueOf(Long.MAX_VALUE));
+    parentControllerProperties.setProperty(OFFLINE_JOB_START_TIMEOUT_MS, "300000");
+
+    Map<String, String> brokerConfiguration = new HashMap<>();
+    brokerConfiguration.put("log.cleaner.enable", "true");
+    brokerConfiguration.put("log.cleaner.backoff.ms", "100");
+    brokerConfiguration.put("log.cleaner.min.cleanable.ratio", "0.01");
+    brokerConfiguration.put("log.segment.bytes", String.valueOf(256 * 1024));
+    brokerConfiguration.put("log.roll.ms", "1000");
+
+    VeniceMultiRegionClusterCreateOptions options =
+        new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(1)
+            .numberOfClusters(2)
+            .numberOfParentControllers(1)
+            .numberOfChildControllers(1)
+            .numberOfServers(2)
+            .numberOfRouters(1)
+            .replicationFactor(1)
+            .sslToStorageNodes(false)
+            .sslToKafka(false)
+            .forkServer(false)
+            .parentControllerProperties(parentControllerProperties)
+            .additionalBrokerConfiguration(brokerConfiguration)
+            .build();
+    multiRegionWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(options);
+    childRegion = multiRegionWrapper.getChildRegions().get(0);
+    String[] clusterNames = childRegion.getClusterNames();
+    Arrays.sort(clusterNames);
+    sourceClusterName = clusterNames[0];
+    destinationClusterName = clusterNames[1];
+    parentControllerUrl = multiRegionWrapper.getControllerConnectString();
+    childControllerUrl = childRegion.getControllerConnectString();
+    IntegrationTestUtils.waitForParticipantStorePush(clusterNames, childControllerUrl);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    IOUtils.closeQuietly(multiRegionWrapper);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testBatchStoreMigrationReplaysCompactedVersionTopic() throws Exception {
+    testStoreMigrationReplaysCompactedVersionTopic(false);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testHybridStoreMigrationReplaysCompactedVersionTopic() throws Exception {
+    testStoreMigrationReplaysCompactedVersionTopic(true);
+  }
+
+  private void testStoreMigrationReplaysCompactedVersionTopic(boolean hybrid) throws Exception {
+    String storeName = Utils.getUniqueString(hybrid ? "compactedHybridMigration" : "compactedBatchMigration");
+    File inputDir = getTempDataDirectory();
+    Properties pushJobProperties =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionWrapper, "file:" + inputDir.getAbsolutePath(), storeName);
+    UpdateStoreQueryParams storeParams =
+        new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+            .setPartitionCount(1)
+            .setBlobTransferEnabled(false);
+    if (hybrid) {
+      storeParams.setHybridRewindSeconds(60).setHybridOffsetLagThreshold(1);
+    }
+
+    PubSubBrokerWrapper sourceBroker = childRegion.getPubSubBrokerWrapper();
+    try (ControllerClient sourceParentController = IntegrationTestPushUtils
+        .createStoreForJob(sourceClusterName, KEY_SCHEMA, VALUE_SCHEMA, pushJobProperties, storeParams)) {
+      VersionCreationResponse versionCreationResponse = TestUtils.assertCommand(
+          sourceParentController.requestTopicForWrites(
+              storeName,
+              1024,
+              Version.PushType.BATCH,
+              Version.guidBasedDummyPushId(),
+              true,
+              false,
+              false,
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty(),
+              false,
+              -1));
+      assertEquals(versionCreationResponse.getVersion(), 1);
+      try (VeniceWriter<String, String, byte[]> writer =
+          childRegion.getClusters().get(sourceClusterName).getVeniceWriter(versionCreationResponse.getKafkaTopic())) {
+        writer.broadcastStartOfPush(Collections.emptyMap());
+        for (int index = 0; index < PRODUCED_RECORD_COUNT; index++) {
+          writer
+              .put(
+                  "key_" + index % UNIQUE_KEY_COUNT,
+                  "value_" + index + VALUE_PADDING,
+                  HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID)
+              .get();
+        }
+        writer.broadcastEndOfPush(Collections.emptyMap(), Collections.singletonMap(0, (long) PRODUCED_RECORD_COUNT));
+      }
+      TestUtils.waitForNonDeterministicPushCompletion(
+          versionCreationResponse.getKafkaTopic(),
+          sourceParentController,
+          60,
+          TimeUnit.SECONDS);
+    }
+
+    Map<Integer, Long> eopRecordCounts =
+        IntegrationTestPushUtils.getEopPartitionRecordCounts(sourceBroker, storeName, 1, 1);
+    assertEquals(eopRecordCounts.get(0).longValue(), PRODUCED_RECORD_COUNT);
+
+    PubSubTopic versionTopic = PUBSUB_TOPIC_REPOSITORY.getTopic(Version.composeKafkaTopic(storeName, 1));
+    TopicManager topicManager = childRegion.getLeaderController(sourceClusterName).getVeniceAdmin().getTopicManager();
+    topicManager.updateTopicCompactionPolicy(versionTopic, true, 1, Optional.of(TimeUnit.SECONDS.toMillis(1)));
+    TestUtils.waitForNonDeterministicAssertion(
+        30,
+        TimeUnit.SECONDS,
+        () -> assertTrue(topicManager.isTopicCompactionEnabled(versionTopic)));
+
+    TestUtils.waitForNonDeterministicAssertion(90, TimeUnit.SECONDS, true, () -> {
+      int replayedRecordCount = getUserRecordCountBeforeEop(sourceBroker, versionTopic);
+      assertTrue(
+          replayedRecordCount < PRODUCED_RECORD_COUNT,
+          "Expected Kafka compaction to reduce replay records below stale EOP prc " + PRODUCED_RECORD_COUNT
+              + ", but got " + replayedRecordCount);
+    });
+
+    StoreMigrationTestUtil.startMigration(parentControllerUrl, storeName, sourceClusterName, destinationClusterName);
+    try (ControllerClient destinationChildController =
+        new ControllerClient(destinationClusterName, childControllerUrl)) {
+      TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, true, () -> {
+        StoreInfo destinationStore = TestUtils.assertCommand(destinationChildController.getStore(storeName)).getStore();
+        Assert.assertTrue(destinationStore.isMigrationDuplicateStore());
+        Assert.assertEquals(destinationStore.getCurrentVersion(), 1);
+        Assert.assertEquals(destinationStore.getVersion(1).get().getStatus(), VersionStatus.ONLINE);
+      });
+    }
+
+    IntegrationTestPushUtils.assertBatchPushRecordCountSensors(
+        childRegion.getClusters().get(destinationClusterName).getVeniceServers(),
+        storeName,
+        false,
+        true);
+
+    StoreMigrationTestUtil
+        .completeMigration(parentControllerUrl, storeName, sourceClusterName, destinationClusterName, FABRIC);
+    try (ControllerClient destinationChildController =
+        new ControllerClient(destinationClusterName, childControllerUrl)) {
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+        StoreInfo destinationStore = TestUtils.assertCommand(destinationChildController.getStore(storeName)).getStore();
+        Assert.assertEquals(destinationStore.getCurrentVersion(), 1);
+        Assert.assertEquals(destinationStore.getVersion(1).get().getStatus(), VersionStatus.ONLINE);
+      });
+    }
+    try (AvroGenericStoreClient<String, Object> client = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.defaultGenericClientConfig(storeName)
+            .setVeniceURL(childRegion.getClusters().get(destinationClusterName).getRandomRouterURL()))) {
+      for (int keyIndex = 0; keyIndex < UNIQUE_KEY_COUNT; keyIndex++) {
+        int lastRecordIndex = PRODUCED_RECORD_COUNT - UNIQUE_KEY_COUNT + keyIndex;
+        assertEquals(
+            client.get("key_" + keyIndex).get().toString(),
+            "value_" + lastRecordIndex + VALUE_PADDING,
+            "Unexpected value after migrating compacted topic for key_" + keyIndex);
+      }
+    }
+  }
+
+  private int getUserRecordCountBeforeEop(PubSubBrokerWrapper broker, PubSubTopic topic) {
+    Properties consumerProperties = new Properties();
+    consumerProperties.setProperty(com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, broker.getAddress());
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(topic, 0);
+    try (PubSubConsumerAdapter consumer = broker.getPubSubClientsFactory()
+        .getConsumerAdapterFactory()
+        .create(
+            new PubSubConsumerAdapterContext.Builder().setVeniceProperties(new VeniceProperties(consumerProperties))
+                .setPubSubMessageDeserializer(PubSubMessageDeserializer.createDefaultDeserializer())
+                .setPubSubPositionTypeRegistry(broker.getPubSubPositionTypeRegistry())
+                .setConsumerName("compactedMigrationReplayCounter")
+                .build())) {
+      consumer.subscribe(topicPartition, PubSubSymbolicPosition.EARLIEST, false);
+      int userRecordCount = 0;
+      long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+      while (System.currentTimeMillis() < deadline) {
+        Map<PubSubTopicPartition, List<DefaultPubSubMessage>> polledRecords = consumer.poll(1000);
+        for (DefaultPubSubMessage message: polledRecords.getOrDefault(topicPartition, Collections.emptyList())) {
+          if (!message.getKey().isControlMessage()) {
+            userRecordCount++;
+            continue;
+          }
+          KafkaMessageEnvelope envelope = message.getValue();
+          ControlMessage controlMessage = (ControlMessage) envelope.payloadUnion;
+          if (controlMessage.getControlMessageType() == ControlMessageType.END_OF_PUSH.getValue()) {
+            return userRecordCount;
+          }
+        }
+      }
+      throw new AssertionError("Did not observe EOP while replaying compacted topic " + topic);
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigrationWithCompactedVersionTopic.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigrationWithCompactedVersionTopic.java
@@ -45,12 +45,14 @@ import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriter;
 import java.io.File;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.testng.Assert;
@@ -64,7 +66,7 @@ public class TestStoreMigrationWithCompactedVersionTopic {
   private static final int TEST_TIMEOUT = 180 * Time.MS_PER_SECOND;
   private static final int PRODUCED_RECORD_COUNT = 200;
   private static final int UNIQUE_KEY_COUNT = 10;
-  private static final String VALUE_PADDING = String.join("", Collections.nCopies(16 * 1024, "x"));
+  private static final int VALUE_PAYLOAD_SIZE = 12 * 1024;
   private static final String FABRIC = "dc-0";
   private static final String KEY_SCHEMA = "\"string\"";
   private static final String VALUE_SCHEMA = "\"string\"";
@@ -170,7 +172,7 @@ public class TestStoreMigrationWithCompactedVersionTopic {
           writer
               .put(
                   "key_" + index % UNIQUE_KEY_COUNT,
-                  "value_" + index + VALUE_PADDING,
+                  getIncompressibleValue(index),
                   HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID)
               .get();
         }
@@ -237,10 +239,17 @@ public class TestStoreMigrationWithCompactedVersionTopic {
         int lastRecordIndex = PRODUCED_RECORD_COUNT - UNIQUE_KEY_COUNT + keyIndex;
         assertEquals(
             client.get("key_" + keyIndex).get().toString(),
-            "value_" + lastRecordIndex + VALUE_PADDING,
+            getIncompressibleValue(lastRecordIndex),
             "Unexpected value after migrating compacted topic for key_" + keyIndex);
       }
     }
+  }
+
+  private static String getIncompressibleValue(int index) {
+    // Deterministic high-entropy values force Kafka log segments to roll even when producer compression is enabled.
+    byte[] payload = new byte[VALUE_PAYLOAD_SIZE];
+    new Random(index).nextBytes(payload);
+    return "value_" + index + "_" + Base64.getEncoder().encodeToString(payload);
   }
 
   private int getUserRecordCountBeforeEop(PubSubBrokerWrapper broker, PubSubTopic topic) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiRegionClusterCreateOptions.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiRegionClusterCreateOptions.java
@@ -12,6 +12,7 @@ import com.linkedin.venice.authorization.AuthorizerService;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 
@@ -295,7 +296,8 @@ public class VeniceMultiRegionClusterCreateOptions {
     }
 
     public Builder additionalBrokerConfiguration(Map<String, String> additionalBrokerConfiguration) {
-      this.additionalBrokerConfiguration = new HashMap<>(additionalBrokerConfiguration);
+      this.additionalBrokerConfiguration =
+          new HashMap<>(Objects.requireNonNull(additionalBrokerConfiguration, "additionalBrokerConfiguration"));
       return this;
     }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiRegionClusterCreateOptions.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiRegionClusterCreateOptions.java
@@ -9,6 +9,9 @@ import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstant
 
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.authorization.AuthorizerService;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 
@@ -30,6 +33,7 @@ public class VeniceMultiRegionClusterCreateOptions {
   private final String parentVeniceZkBasePath;
   private final String childVeniceZkBasePath;
   private final DynamicAccessController accessController;
+  private final Map<String, String> additionalBrokerConfiguration;
 
   public int getNumberOfRegions() {
     return numberOfRegions;
@@ -97,6 +101,10 @@ public class VeniceMultiRegionClusterCreateOptions {
 
   public DynamicAccessController getAccessController() {
     return accessController;
+  }
+
+  public Map<String, String> getAdditionalBrokerConfiguration() {
+    return additionalBrokerConfiguration;
   }
 
   @Override
@@ -170,6 +178,7 @@ public class VeniceMultiRegionClusterCreateOptions {
     parentVeniceZkBasePath = builder.parentVeniceZkBasePath;
     childVeniceZkBasePath = builder.childVeniceZkBasePath;
     accessController = builder.accessController;
+    additionalBrokerConfiguration = Collections.unmodifiableMap(new HashMap<>(builder.additionalBrokerConfiguration));
   }
 
   public static class Builder {
@@ -190,6 +199,7 @@ public class VeniceMultiRegionClusterCreateOptions {
     private String parentVeniceZkBasePath = "/";
     private String childVeniceZkBasePath = "/";
     private DynamicAccessController accessController;
+    private Map<String, String> additionalBrokerConfiguration = Collections.emptyMap();
 
     public Builder numberOfRegions(int numberOfRegions) {
       this.numberOfRegions = numberOfRegions;
@@ -281,6 +291,11 @@ public class VeniceMultiRegionClusterCreateOptions {
 
     public Builder accessController(DynamicAccessController accessController) {
       this.accessController = accessController;
+      return this;
+    }
+
+    public Builder additionalBrokerConfiguration(Map<String, String> additionalBrokerConfiguration) {
+      this.additionalBrokerConfiguration = new HashMap<>(additionalBrokerConfiguration);
       return this;
     }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
@@ -103,6 +103,7 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
       parentPubSubBrokerWrapper = ServiceFactory.getPubSubBroker(
           new PubSubBrokerConfigs.Builder().setZkWrapper(zkServer)
               .setRegionName(DEFAULT_PARENT_DATA_CENTER_REGION_NAME)
+              .setAdditionalBrokerConfiguration(options.getAdditionalBrokerConfiguration())
               .build());
       allPubSubBrokerWrappers.add(parentPubSubBrokerWrapper);
 
@@ -157,7 +158,10 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
         ZkServerWrapper zkServerWrapper = ServiceFactory.getZkServer();
         IntegrationTestUtils.ensureZkPathExists(zkServer.getAddress(), options.getChildVeniceZkBasePath());
         PubSubBrokerWrapper regionalPubSubBrokerWrapper = ServiceFactory.getPubSubBroker(
-            new PubSubBrokerConfigs.Builder().setZkWrapper(zkServerWrapper).setRegionName(regionName).build());
+            new PubSubBrokerConfigs.Builder().setZkWrapper(zkServerWrapper)
+                .setRegionName(regionName)
+                .setAdditionalBrokerConfiguration(options.getAdditionalBrokerConfiguration())
+                .build());
         allPubSubBrokerWrappers.add(regionalPubSubBrokerWrapper);
         zkServerByRegionName.put(regionName, zkServerWrapper);
         pubSubBrokerByRegionName.put(regionName, regionalPubSubBrokerWrapper);


### PR DESCRIPTION
## Problem Statement

Record-count verification compares the producer's end-of-push count with the records consumed by each replica. During store migration, Kafka compaction can remove superseded records before the destination replays a pre-existing source version topic. That replay can therefore contain fewer records while still producing the complete final key set.

The relaxed behavior must not apply to ordinary pushes started while migration is active.

## Solution

Treat a record-count deficit as nonfatal only for a pre-existing version cloned onto the migration destination. The exemption now requires all of the following:

- the destination store is marked as a migration duplicate;
- the ingested version exists in store metadata;
- both creation timestamps are valid; and
- the version creation time predates the destination store creation time.

Cloned source versions preserve their original creation time, so historical versions satisfy this predicate. A new push created during migration receives a fresh version timestamp and remains a strict `FRESH_PUSH`: its deficit records the failure metric and fails ingestion when strict mode is enabled. Equality, missing metadata, unset timestamps, and non-migration stores also fail closed.

Deficit diagnostics now include the migration-duplicate flag and both creation timestamps. Only historical clone replays use `verificationContext=MIGRATION_REPLAY` with `reason=PRE_EXISTING_MIGRATION_CLONE`.

The integration harness accepts an immutable copy of additional embedded-broker settings. The migration coverage uses deterministic high-entropy values to create compactable version-topic segments, then verifies batch and hybrid replay behavior and final values.

### Code changes

- [ ] Added new code behind **a config**. No production config was added.
- [x] Introduced new **log lines**. The historical migration-replay path emits a warning; strict deficits emit an error with migration timestamp context.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging. These logs are bounded to end-of-push record-count verification.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed. No new synchronization is required.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`). No new shared mutable collection is introduced.
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
- [x] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).
- [x] Local code review completed.

Passed locally:

- `./gradlew --no-daemon :clients:da-vinci-client:test --tests 'com.linkedin.davinci.kafka.consumer.StoreIngestionTaskRecordCountTest'` — 36 tests passed.
- `./gradlew --no-daemon :internal:venice-test-common:integrationTest --tests 'com.linkedin.venice.endToEnd.TestStoreMigrationWithCompactedVersionTopic'` — batch and hybrid cases passed together.
- `./gradlew --no-daemon :internal:venice-test-common:integrationTest --tests 'com.linkedin.venice.endToEnd.TestBatchPushRecordCountVerification.testDeficitFailsPushWhenServerStrictModeDefault'` — passed.
- `./gradlew --no-daemon :internal:venice-test-common:compileIntegrationTestJava` — passed.
- `./gradlew --no-daemon spotlessCheck` — passed.
- `./gradlew --no-daemon :clients:da-vinci-client:spotbugsMain :clients:da-vinci-client:spotbugsTest` — passed.

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
