### PR TITLE
[controller][admin-tool][compat] Wire veniceUnits and workloadType store configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -328,21 +328,11 @@ subprojects {
       // Protocol changes should pin the current version via this override and remove the override in a follow-up PR
       // when actually using the new protocol. Example to pin KME to v12 when introducing v13:
       // project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
+      // StoreMetaValue v49 and AdminOperation v104 are now active: the veniceUnits/workloadType store configs are
+      // wired end to end, so codegen picks up the highest version directory for both. v49 is a superset of the
+      // previously staged v48, so activating it also carries the version-level maxNearlineRecordSizeBytes field
+      // on StoreVersion. That field stays nullable and unwritten until its own follow-up wires the snapshot logic.
       def versionOverrides = [
-          // StoreMetaValue v48 stages the version-level maxNearlineRecordSizeBytes field on StoreVersion. Pinned to
-          // the current active version so the generated classes stay on v47 and no code path can serialize v48 yet.
-          // The override is removed and METADATA_SYSTEM_SCHEMA_STORE is bumped to v48 in the follow-up PR that reads
-          // and snapshots the per-version limit, which is also what makes the controllers register v48.
-          //
-          // StoreMetaValue v49 stages the store-level veniceUnits/workloadType fields (capacity-forecast metadata).
-          // Pinned to the current active version for the same reason as v48 above -- this override is removed and
-          // METADATA_SYSTEM_SCHEMA_STORE is bumped to v49 in a follow-up PR.
-          project(':internal:venice-common').file('src/main/resources/avro/StoreMetaValue/v47', PathValidation.DIRECTORY),
-          // AdminOperation v104 stages the veniceUnits/workloadType fields on UpdateStore (capacity-forecast
-          // metadata). Pinned to the current active version so the generated classes stay
-          // on v103 and no code path can serialize v104 yet. The override is removed and ADMIN_OPERATION is bumped
-          // to v104 in a follow-up PR.
-          project(':services:venice-controller').file('src/main/resources/avro/AdminOperation/v103', PathValidation.DIRECTORY),
       ]
 
       def schemaDirs = [sourceDir]

--- a/build.gradle
+++ b/build.gradle
@@ -328,12 +328,7 @@ subprojects {
       // Protocol changes should pin the current version via this override and remove the override in a follow-up PR
       // when actually using the new protocol. Example to pin KME to v12 when introducing v13:
       // project(':internal:venice-common').file('src/main/resources/avro/KafkaMessageEnvelope/v12', PathValidation.DIRECTORY)
-      // StoreMetaValue v49 and AdminOperation v104 are now active: the veniceUnits/workloadType store configs are
-      // wired end to end, so codegen picks up the highest version directory for both. v49 is a superset of the
-      // previously staged v48, so activating it also carries the version-level maxNearlineRecordSizeBytes field
-      // on StoreVersion. That field stays nullable and unwritten until its own follow-up wires the snapshot logic.
-      def versionOverrides = [
-      ]
+      def versionOverrides = []
 
       def schemaDirs = [sourceDir]
       sourceDir.eachDir { typeDir ->

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1436,6 +1436,8 @@ public class AdminTool {
     longParam(cmd, Arg.MAX_COMPACTION_LAG_SECONDS, p -> params.setMaxCompactionLagSeconds(p), argSet);
     integerParam(cmd, Arg.MAX_RECORD_SIZE_BYTES, params::setMaxRecordSizeBytes, argSet);
     integerParam(cmd, Arg.MAX_NEARLINE_RECORD_SIZE_BYTES, params::setMaxNearlineRecordSizeBytes, argSet);
+    integerParam(cmd, Arg.VENICE_UNITS, params::setVeniceUnits, argSet);
+    genericParam(cmd, Arg.WORKLOAD_TYPE, s -> s, params::setWorkloadType, argSet);
     longParam(cmd, Arg.THROUGHPUT_QUOTA_IN_BYTES, params::setThroughputQuotaInBytes, argSet);
     longParam(cmd, Arg.THROUGHPUT_QUOTA_IN_RECORDS, params::setThroughputQuotaInRecords, argSet);
     booleanParam(cmd, Arg.UNUSED_SCHEMA_DELETION_ENABLED, p -> params.setUnusedSchemaDeletionEnabled(p), argSet);

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -189,6 +189,12 @@ public class AdminTool {
   private static final String STATUS = "status";
   private static final String ERROR = "error";
   private static final String SUCCESS = "success";
+
+  /**
+   * Value an operator passes to a nullable store config's flag to clear it back to null, for example
+   * {@code --workload-type null}. Omitting the flag leaves the config unchanged instead.
+   */
+  private static final String CLEAR_CONFIG_TOKEN = "null";
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
 
   private static ControllerClient controllerClient;
@@ -1282,6 +1288,20 @@ public class AdminTool {
     }
   }
 
+  /**
+   * Same as {@link #genericParam}, but for configs that are nullable. Passing
+   * {@link #CLEAR_CONFIG_TOKEN} as the argument value records an explicit request to clear the
+   * config back to null, which is distinct from omitting the flag altogether (leave unchanged).
+   */
+  private static <TYPE> void nullableParam(
+      CommandLine cmd,
+      Arg param,
+      Function<String, TYPE> parser,
+      Consumer<TYPE> setter,
+      Set<Arg> argSet) {
+    genericParam(cmd, param, s -> CLEAR_CONFIG_TOKEN.equalsIgnoreCase(s) ? null : parser.apply(s), setter, argSet);
+  }
+
   private static void updateStore(CommandLine cmd) {
     UpdateStoreQueryParams params = getUpdateStoreQueryParams(cmd);
     String storeName = getRequiredArgument(cmd, Arg.STORE, Command.UPDATE_STORE);
@@ -1436,8 +1456,13 @@ public class AdminTool {
     longParam(cmd, Arg.MAX_COMPACTION_LAG_SECONDS, p -> params.setMaxCompactionLagSeconds(p), argSet);
     integerParam(cmd, Arg.MAX_RECORD_SIZE_BYTES, params::setMaxRecordSizeBytes, argSet);
     integerParam(cmd, Arg.MAX_NEARLINE_RECORD_SIZE_BYTES, params::setMaxNearlineRecordSizeBytes, argSet);
-    integerParam(cmd, Arg.VENICE_UNITS, params::setVeniceUnits, argSet);
-    genericParam(cmd, Arg.WORKLOAD_TYPE, s -> s, params::setWorkloadType, argSet);
+    nullableParam(
+        cmd,
+        Arg.VENICE_UNITS,
+        s -> Utils.parseIntFromString(s, Arg.VENICE_UNITS.toString()),
+        params::setVeniceUnits,
+        argSet);
+    nullableParam(cmd, Arg.WORKLOAD_TYPE, s -> s, params::setWorkloadType, argSet);
     longParam(cmd, Arg.THROUGHPUT_QUOTA_IN_BYTES, params::setThroughputQuotaInBytes, argSet);
     longParam(cmd, Arg.THROUGHPUT_QUOTA_IN_RECORDS, params::setThroughputQuotaInRecords, argSet);
     booleanParam(cmd, Arg.UNUSED_SCHEMA_DELETION_ENABLED, p -> params.setUnusedSchemaDeletionEnabled(p), argSet);

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -322,9 +322,14 @@ public enum Arg {
   ),
   VENICE_UNITS(
       "venice-units", "vu", true,
-      "Store-level forecasted Venice Units (VU) capacity ask, derived from the store-needs-estimation process."
+      "Store-level forecasted Venice Units (VU) capacity ask, derived from the store-needs-estimation process. "
+          + "Pass 'null' to clear the config; omit the flag to leave it unchanged."
   ),
-  WORKLOAD_TYPE("workload-type", "wlt", true, "Store-level requested class of service. Values: GENERIC, LOW_LATENCY."),
+  WORKLOAD_TYPE(
+      "workload-type", "wlt", true,
+      "Store-level requested class of service. Values: GENERIC, LOW_LATENCY. "
+          + "Pass 'null' to clear the config; omit the flag to leave it unchanged."
+  ),
   THROUGHPUT_QUOTA_IN_BYTES(
       "throughput-quota-in-bytes", "tqib", true,
       "Store-level nearline write quota: maximum throughput in bytes clients can produce into the store. -1 means no limit."

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -320,6 +320,11 @@ public enum Arg {
       "max-nearline-record-size-bytes", "mnrsb", true,
       "Store-level max record size for VeniceWriter to determine whether to pause consumption on nearline jobs with partial updates."
   ),
+  VENICE_UNITS(
+      "venice-units", "vu", true,
+      "Store-level forecasted Venice Units (VU) capacity ask, derived from the store-needs-estimation process."
+  ),
+  WORKLOAD_TYPE("workload-type", "wlt", true, "Store-level requested class of service. Values: GENERIC, LOW_LATENCY."),
   THROUGHPUT_QUOTA_IN_BYTES(
       "throughput-quota-in-bytes", "tqib", true,
       "Store-level nearline write quota: maximum throughput in bytes clients can produce into the store. -1 means no limit."

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -173,6 +173,7 @@ import static com.linkedin.venice.Arg.VALUE_SCHEMA;
 import static com.linkedin.venice.Arg.VALUE_SCHEMA_ID;
 import static com.linkedin.venice.Arg.VENICE_CLIENT_SSL_CONFIG_FILE;
 import static com.linkedin.venice.Arg.VENICE_ETL_STRATEGY;
+import static com.linkedin.venice.Arg.VENICE_UNITS;
 import static com.linkedin.venice.Arg.VENICE_ZOOKEEPER_URL;
 import static com.linkedin.venice.Arg.VERSION;
 import static com.linkedin.venice.Arg.VIEW_CLASS;
@@ -180,6 +181,7 @@ import static com.linkedin.venice.Arg.VIEW_NAME;
 import static com.linkedin.venice.Arg.VIEW_PARAMS;
 import static com.linkedin.venice.Arg.VOLDEMORT_STORE;
 import static com.linkedin.venice.Arg.VSON_STORE;
+import static com.linkedin.venice.Arg.WORKLOAD_TYPE;
 import static com.linkedin.venice.Arg.WRITEABILITY;
 import static com.linkedin.venice.Arg.WRITE_COMPUTATION_ENABLED;
 import static com.linkedin.venice.Arg.ZK_SSL_CONFIG_FILE;
@@ -342,7 +344,7 @@ public enum Command {
           SEPARATE_REALTIME_TOPIC_ENABLED, NEARLINE_PRODUCER_COMPRESSION_ENABLED, NEARLINE_PRODUCER_COUNT_PER_WRITER,
           TARGET_SWAP_REGION, TARGET_SWAP_REGION_WAIT_TIME, DAVINCI_HEARTBEAT_REPORTED, ENABLE_STORE_MIGRATION,
           GLOBAL_RT_DIV_ENABLED, TTL_REPUSH_ENABLED, ENUM_SCHEMA_EVOLUTION_ALLOWED, STORE_LIFECYCLE_HOOKS_LIST,
-          BLOB_TRANSFER_IN_SERVER_ENABLED, FLINK_VENICE_VIEWS_ENABLED, BLOB_DB_ENABLED }
+          BLOB_TRANSFER_IN_SERVER_ENABLED, FLINK_VENICE_VIEWS_ENABLED, BLOB_DB_ENABLED, VENICE_UNITS, WORKLOAD_TYPE }
   ),
   UPDATE_CLUSTER_CONFIG(
       "update-cluster-config", "Update live cluster configs", new Arg[] { URL, CLUSTER },

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/RecoverStoreMetadata.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/RecoverStoreMetadata.java
@@ -265,6 +265,12 @@ public class RecoverStoreMetadata {
             .setIsDavinciHeartbeatReported(deletedStore.getIsDavinciHeartbeatReported())
             .setGlobalRtDivEnabled(deletedStore.isGlobalRtDivEnabled())
             .setFlinkVeniceViewsEnabled(deletedStore.isFlinkVeniceViewsEnabled());
+        if (deletedStore.getVeniceUnits() != null) {
+          updateParams.setVeniceUnits(deletedStore.getVeniceUnits());
+        }
+        if (deletedStore.getWorkloadType() != null) {
+          updateParams.setWorkloadType(deletedStore.getWorkloadType());
+        }
         System.out.println(
             "Updating store: " + storeName + " in cluster: " + recoverCluster + " with params: "
                 + updateParams.toString());

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -139,6 +139,11 @@ public class ControllerApiConstants {
   public static final String VERSION_STORAGE_MODE_UPDATE_REASON = "version_storage_mode_update_reason";
   public static final String EXTERNAL_STORAGE_READ_MODE = "external_storage_read_mode";
 
+  /** Optional forecasted Venice Units (VU) capacity ask for a store; absent means not provided. */
+  public static final String VENICE_UNITS = "venice_units";
+  /** Optional requested class of service for a store; absent means not provided. */
+  public static final String WORKLOAD_TYPE = "workload_type";
+
   public static final String AUTO_SCHEMA_REGISTER_FOR_PUSHJOB_ENABLED = "auto_auto_register_for_pushjob_enabled";
 
   public static final String REGULAR_VERSION_ETL_ENABLED = "regular_version_etl_enabled";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -94,9 +94,11 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.TOPIC_COM
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TO_BE_STOPPED_INSTANCES;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.UPSTREAM_POSITION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VALUE_SCHEMA;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.VENICE_UNITS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION_STORAGE_MODE_UPDATE_REASON;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VOLDEMORT_STORE_NAME;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.WORKLOAD_TYPE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.WRITE_COMPUTATION_ENABLED;
 
 import com.linkedin.venice.HttpMethod;
@@ -144,7 +146,7 @@ public enum ControllerRoute implements VeniceDimensionInterface {
       BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS, HYBRID_STORE_DISK_QUOTA_ENABLED, REGULAR_VERSION_ETL_ENABLED,
       FUTURE_VERSION_ETL_ENABLED, ETLED_PROXY_USER_ACCOUNT, ETL_STRATEGY, ETL_ACTIVE_FABRICS, DISABLE_META_STORE,
       DISABLE_DAVINCI_PUSH_STATUS_STORE, PERSONA_NAME, MAX_RECORD_SIZE_BYTES, MAX_NEARLINE_RECORD_SIZE_BYTES,
-      STORE_MIGRATION, ENABLE_STORE_MIGRATION, LARGEST_USED_RT_VERSION_NUMBER
+      STORE_MIGRATION, ENABLE_STORE_MIGRATION, LARGEST_USED_RT_VERSION_NUMBER, VENICE_UNITS, WORKLOAD_TYPE
   ), SET_VERSION("/set_version", HttpMethod.POST, Arrays.asList(NAME, VERSION)),
   ROLLBACK_TO_BACKUP_VERSION(
       "/rollback_to_backup_version", HttpMethod.POST, Collections.singletonList(NAME), REGIONS_FILTER

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
@@ -89,7 +89,9 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.TIME_LAG_
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TTL_REPUSH_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.UNUSED_SCHEMA_DELETION_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.UPDATED_CONFIGS_LIST;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.VENICE_UNITS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.WORKLOAD_TYPE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.WRITE_COMPUTATION_ENABLED;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -205,6 +207,14 @@ public class UpdateStoreQueryParams extends QueryParams {
 
     if (pubSubEncryptionKeyUrn != null && !pubSubEncryptionKeyUrn.trim().isEmpty()) {
       updateStoreQueryParams.setPubSubEncryptionKeyUrn(pubSubEncryptionKeyUrn);
+    }
+
+    if (srcStore.getVeniceUnits() != null) {
+      updateStoreQueryParams.setVeniceUnits(srcStore.getVeniceUnits());
+    }
+
+    if (srcStore.getWorkloadType() != null) {
+      updateStoreQueryParams.setWorkloadType(srcStore.getWorkloadType());
     }
 
     if (srcStore.getReplicationMetadataVersionId() != -1) {
@@ -617,6 +627,22 @@ public class UpdateStoreQueryParams extends QueryParams {
 
   public Optional<StorageMode> getStorageMode() {
     return Optional.ofNullable(params.get(STORAGE_MODE)).map(StorageMode::valueOf);
+  }
+
+  public UpdateStoreQueryParams setVeniceUnits(int veniceUnits) {
+    return putInteger(VENICE_UNITS, veniceUnits);
+  }
+
+  public Optional<Integer> getVeniceUnits() {
+    return getInteger(VENICE_UNITS);
+  }
+
+  public UpdateStoreQueryParams setWorkloadType(String workloadType) {
+    return putString(WORKLOAD_TYPE, workloadType);
+  }
+
+  public Optional<String> getWorkloadType() {
+    return getString(WORKLOAD_TYPE);
   }
 
   public UpdateStoreQueryParams setExternalStorageReadMode(ExternalStorageReadMode externalStorageReadMode) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
@@ -124,6 +124,16 @@ import java.util.stream.Collectors;
 
 
 public class UpdateStoreQueryParams extends QueryParams {
+  /**
+   * Wire representation of an explicit request to clear a nullable store config back to {@code null}.
+   *
+   * Query params are string valued, so a nullable config needs three distinguishable states: the
+   * param is absent (leave the config unchanged), the param carries a value (set the config to it),
+   * or the param is present but empty (clear the config). The empty string is used for the last case
+   * because it is not a legal value for any of the configs that support clearing.
+   */
+  static final String CLEAR_VALUE = "";
+
   public UpdateStoreQueryParams(Map<String, String> initialParams) {
     super(initialParams);
   }
@@ -629,20 +639,58 @@ public class UpdateStoreQueryParams extends QueryParams {
     return Optional.ofNullable(params.get(STORAGE_MODE)).map(StorageMode::valueOf);
   }
 
-  public UpdateStoreQueryParams setVeniceUnits(int veniceUnits) {
-    return putInteger(VENICE_UNITS, veniceUnits);
+  /**
+   * Sets the store's Venice Units. Passing {@code null} records an explicit request to clear the
+   * config back to {@code null}, which is distinct from not calling this method at all (which
+   * leaves the config unchanged). See {@link #CLEAR_VALUE}.
+   */
+  public UpdateStoreQueryParams setVeniceUnits(Integer veniceUnits) {
+    return veniceUnits == null ? putString(VENICE_UNITS, CLEAR_VALUE) : putInteger(VENICE_UNITS, veniceUnits);
   }
 
-  public Optional<Integer> getVeniceUnits() {
-    return getInteger(VENICE_UNITS);
+  /**
+   * @return whether the caller provided a value for this config at all, including an explicit
+   *         request to clear it. When this returns {@code false} the config must be left unchanged.
+   */
+  public boolean isVeniceUnitsSpecified() {
+    return params.containsKey(VENICE_UNITS);
   }
 
+  /**
+   * @return the requested Venice Units, or {@code null} if the caller asked for the config to be
+   *         cleared. Only meaningful when {@link #isVeniceUnitsSpecified()} returns {@code true};
+   *         otherwise this also returns {@code null}.
+   */
+  public Integer getVeniceUnits() {
+    String value = params.get(VENICE_UNITS);
+    return CLEAR_VALUE.equals(value) ? null : Optional.ofNullable(value).map(Integer::valueOf).orElse(null);
+  }
+
+  /**
+   * Sets the store's workload type. Passing {@code null} records an explicit request to clear the
+   * config back to {@code null}, which is distinct from not calling this method at all (which
+   * leaves the config unchanged). See {@link #CLEAR_VALUE}.
+   */
   public UpdateStoreQueryParams setWorkloadType(String workloadType) {
-    return putString(WORKLOAD_TYPE, workloadType);
+    return putString(WORKLOAD_TYPE, workloadType == null ? CLEAR_VALUE : workloadType);
   }
 
-  public Optional<String> getWorkloadType() {
-    return getString(WORKLOAD_TYPE);
+  /**
+   * @return whether the caller provided a value for this config at all, including an explicit
+   *         request to clear it. When this returns {@code false} the config must be left unchanged.
+   */
+  public boolean isWorkloadTypeSpecified() {
+    return params.containsKey(WORKLOAD_TYPE);
+  }
+
+  /**
+   * @return the requested workload type, or {@code null} if the caller asked for the config to be
+   *         cleared. Only meaningful when {@link #isWorkloadTypeSpecified()} returns {@code true};
+   *         otherwise this also returns {@code null}.
+   */
+  public String getWorkloadType() {
+    String value = params.get(WORKLOAD_TYPE);
+    return CLEAR_VALUE.equals(value) ? null : value;
   }
 
   public UpdateStoreQueryParams setExternalStorageReadMode(ExternalStorageReadMode externalStorageReadMode) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -1115,6 +1115,8 @@ public class ReadOnlyStore implements Store {
     storeProperties.setPreviousCurrentVersion(getPreviousCurrentVersion());
     storeProperties.setExternalStorageReadMode(getExternalStorageReadMode().getValue());
     storeProperties.setStorageMode(getStorageMode().getValue());
+    storeProperties.setVeniceUnits(getVeniceUnits());
+    storeProperties.setWorkloadType(getWorkloadType());
     // Set fields to default values - fields exist in schema but not yet exposed via Store interface
     storeProperties.setTransientRecordCacheEnabled(false);
     storeProperties.setMergedValueRmdColumnFamilyEnabled(false);
@@ -1403,6 +1405,26 @@ public class ReadOnlyStore implements Store {
 
   @Override
   public void setStorageMode(StorageMode storageMode) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Integer getVeniceUnits() {
+    return this.delegate.getVeniceUnits();
+  }
+
+  @Override
+  public void setVeniceUnits(Integer veniceUnits) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getWorkloadType() {
+    return this.delegate.getWorkloadType();
+  }
+
+  @Override
+  public void setWorkloadType(String workloadType) {
     throw new UnsupportedOperationException();
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -1117,7 +1117,8 @@ public class ReadOnlyStore implements Store {
     storeProperties.setStorageMode(getStorageMode().getValue());
     storeProperties.setVeniceUnits(getVeniceUnits());
     storeProperties.setWorkloadType(getWorkloadType());
-    // Set fields to default values - fields exist in schema but not yet exposed via Store interface
+    // transientRecordCacheEnabled and mergedValueRmdColumnFamilyEnabled exist in the schema but are not exposed
+    // via the Store interface, so they are defaulted here.
     storeProperties.setTransientRecordCacheEnabled(false);
     storeProperties.setMergedValueRmdColumnFamilyEnabled(false);
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
@@ -218,6 +218,20 @@ public interface Store {
 
   void setStorageMode(StorageMode storageMode);
 
+  /**
+   * The forecasted Venice Units (VU) capacity ask for this store, or null when it has not been provided.
+   */
+  Integer getVeniceUnits();
+
+  void setVeniceUnits(Integer veniceUnits);
+
+  /**
+   * The requested class of service for this store, or null when it has not been provided.
+   */
+  String getWorkloadType();
+
+  void setWorkloadType(String workloadType);
+
   boolean isSchemaAutoRegisterFromPushJobEnabled();
 
   void setSchemaAutoRegisterFromPushJobEnabled(boolean value);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
@@ -45,6 +45,8 @@ public class StoreInfo {
     storeInfo.setEtlStoreConfig(store.getEtlStoreConfig());
     storeInfo.setExternalStorageReadMode(store.getExternalStorageReadMode());
     storeInfo.setStorageMode(store.getStorageMode());
+    storeInfo.setVeniceUnits(store.getVeniceUnits());
+    storeInfo.setWorkloadType(store.getWorkloadType());
     if (store.isHybrid()) {
       storeInfo.setHybridStoreConfig(store.getHybridStoreConfig());
     }
@@ -412,6 +414,14 @@ public class StoreInfo {
   private boolean separateRealTimeTopicEnabled = false;
   private ExternalStorageReadMode externalStorageReadMode = ExternalStorageReadMode.VENICE_ONLY;
   private StorageMode storageMode = StorageMode.INTERNAL;
+  /**
+   * The forecasted Venice Units (VU) capacity ask for this store, or null when it has not been provided.
+   */
+  private Integer veniceUnits = null;
+  /**
+   * The requested class of service for this store, or null when it has not been provided.
+   */
+  private String workloadType = null;
 
   public StoreInfo() {
   }
@@ -757,6 +767,22 @@ public class StoreInfo {
 
   public void setStorageMode(StorageMode storageMode) {
     this.storageMode = storageMode == null ? StorageMode.INTERNAL : storageMode;
+  }
+
+  public Integer getVeniceUnits() {
+    return veniceUnits;
+  }
+
+  public void setVeniceUnits(Integer veniceUnits) {
+    this.veniceUnits = veniceUnits;
+  }
+
+  public String getWorkloadType() {
+    return workloadType;
+  }
+
+  public void setWorkloadType(String workloadType) {
+    this.workloadType = workloadType;
   }
 
   public boolean isSchemaAutoRegisterFromPushJobEnabled() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStore.java
@@ -517,6 +517,26 @@ public class SystemStore extends AbstractStore {
   }
 
   @Override
+  public Integer getVeniceUnits() {
+    return zkSharedStore.getVeniceUnits();
+  }
+
+  @Override
+  public void setVeniceUnits(Integer veniceUnits) {
+    throwUnsupportedOperationException("setVeniceUnits");
+  }
+
+  @Override
+  public String getWorkloadType() {
+    return zkSharedStore.getWorkloadType();
+  }
+
+  @Override
+  public void setWorkloadType(String workloadType) {
+    throwUnsupportedOperationException("setWorkloadType");
+  }
+
+  @Override
   public boolean isSchemaAutoRegisterFromPushJobEnabled() {
     return zkSharedStore.isSchemaAutoRegisterFromPushJobEnabled();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
@@ -218,6 +218,8 @@ public class ZKStore extends AbstractStore implements DataModelBackedStructure<S
     setIngestionPausedRegions(store.getIngestionPausedRegions());
     setExternalStorageReadMode(store.getExternalStorageReadMode());
     setStorageMode(store.getStorageMode());
+    setVeniceUnits(store.getVeniceUnits());
+    setWorkloadType(store.getWorkloadType());
     setSchemaAutoRegisterFromPushJobEnabled(store.isSchemaAutoRegisterFromPushJobEnabled());
     setLatestSuperSetValueSchemaId(store.getLatestSuperSetValueSchemaId());
     setHybridStoreDiskQuotaEnabled(store.isHybridStoreDiskQuotaEnabled());
@@ -780,6 +782,26 @@ public class ZKStore extends AbstractStore implements DataModelBackedStructure<S
   @Override
   public void setStorageMode(StorageMode storageMode) {
     this.storeProperties.storageMode = storageMode == null ? StorageMode.INTERNAL.getValue() : storageMode.getValue();
+  }
+
+  @Override
+  public Integer getVeniceUnits() {
+    return this.storeProperties.veniceUnits;
+  }
+
+  @Override
+  public void setVeniceUnits(Integer veniceUnits) {
+    this.storeProperties.veniceUnits = veniceUnits;
+  }
+
+  @Override
+  public String getWorkloadType() {
+    return this.storeProperties.workloadType == null ? null : this.storeProperties.workloadType.toString();
+  }
+
+  @Override
+  public void setWorkloadType(String workloadType) {
+    this.storeProperties.workloadType = workloadType;
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -79,7 +79,7 @@ public enum AvroProtocolDefinition {
    *
    * TODO: Move AdminOperation to venice-common module so that we can properly reference it here.
    */
-  ADMIN_OPERATION(103, SpecificData.get().getSchema(ByteBuffer.class), "AdminOperation"),
+  ADMIN_OPERATION(104, SpecificData.get().getSchema(ByteBuffer.class), "AdminOperation"),
 
   /**
    * Single chunk of a large multi-chunk value. Just a bunch of bytes.
@@ -119,7 +119,7 @@ public enum AvroProtocolDefinition {
   /**
    * Value schema for metadata system store.
    */
-  METADATA_SYSTEM_SCHEMA_STORE(47, StoreMetaValue.class),
+  METADATA_SYSTEM_SCHEMA_STORE(49, StoreMetaValue.class),
 
   /*
     Value Schema for Parent Controller Metadata system store

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParamsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParamsTest.java
@@ -2,6 +2,8 @@ package com.linkedin.venice.controllerapi;
 
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_STORE_MIGRATION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_MIGRATION;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.VENICE_UNITS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.WORKLOAD_TYPE;
 import static org.testng.Assert.assertEquals;
 
 import com.linkedin.venice.meta.ExternalStorageReadMode;
@@ -10,8 +12,11 @@ import com.linkedin.venice.meta.StorageMode;
 import com.linkedin.venice.meta.StoreInfo;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import org.apache.http.NameValuePair;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -56,6 +61,80 @@ public class UpdateStoreQueryParamsTest {
   public void testStorageModeUnsetIsEmpty() {
     UpdateStoreQueryParams params = new UpdateStoreQueryParams();
     Assert.assertFalse(params.getStorageMode().isPresent());
+  }
+
+  @Test
+  public void testVeniceUnitsAndWorkloadTypeTriState() {
+    // Not provided at all: leave the config unchanged.
+    UpdateStoreQueryParams unset = new UpdateStoreQueryParams();
+    Assert.assertFalse(unset.isVeniceUnitsSpecified());
+    Assert.assertNull(unset.getVeniceUnits());
+    Assert.assertFalse(unset.isWorkloadTypeSpecified());
+    Assert.assertNull(unset.getWorkloadType());
+
+    // Provided with a value: set the config.
+    UpdateStoreQueryParams set = new UpdateStoreQueryParams().setVeniceUnits(42).setWorkloadType("LOW_LATENCY");
+    Assert.assertTrue(set.isVeniceUnitsSpecified());
+    Assert.assertEquals(set.getVeniceUnits(), Integer.valueOf(42));
+    Assert.assertTrue(set.isWorkloadTypeSpecified());
+    Assert.assertEquals(set.getWorkloadType(), "LOW_LATENCY");
+
+    // Provided as null: explicitly clear the config. This must stay distinguishable from "not provided".
+    UpdateStoreQueryParams cleared = new UpdateStoreQueryParams().setVeniceUnits(null).setWorkloadType(null);
+    Assert.assertTrue(cleared.isVeniceUnitsSpecified());
+    Assert.assertNull(cleared.getVeniceUnits());
+    Assert.assertTrue(cleared.isWorkloadTypeSpecified());
+    Assert.assertNull(cleared.getWorkloadType());
+
+    // A previously set value can be cleared afterwards.
+    set.setVeniceUnits(null).setWorkloadType(null);
+    Assert.assertTrue(set.isVeniceUnitsSpecified());
+    Assert.assertNull(set.getVeniceUnits());
+    Assert.assertTrue(set.isWorkloadTypeSpecified());
+    Assert.assertNull(set.getWorkloadType());
+  }
+
+  @Test
+  public void testVeniceUnitsAndWorkloadTypeClearSurvivesWireRoundTrip() {
+    // An explicit clear has to survive the query-param serialization used between the client and the
+    // controller, otherwise the clear degrades into "leave unchanged" on the server side.
+    UpdateStoreQueryParams cleared = new UpdateStoreQueryParams().setVeniceUnits(null).setWorkloadType(null);
+    UpdateStoreQueryParams received = new UpdateStoreQueryParams(toWireMap(cleared));
+    Assert.assertTrue(received.isVeniceUnitsSpecified());
+    Assert.assertNull(received.getVeniceUnits());
+    Assert.assertTrue(received.isWorkloadTypeSpecified());
+    Assert.assertNull(received.getWorkloadType());
+
+    UpdateStoreQueryParams valued = new UpdateStoreQueryParams().setVeniceUnits(7).setWorkloadType("GENERIC");
+    UpdateStoreQueryParams receivedValued = new UpdateStoreQueryParams(toWireMap(valued));
+    Assert.assertEquals(receivedValued.getVeniceUnits(), Integer.valueOf(7));
+    Assert.assertEquals(receivedValued.getWorkloadType(), "GENERIC");
+
+    UpdateStoreQueryParams receivedUnset = new UpdateStoreQueryParams(toWireMap(new UpdateStoreQueryParams()));
+    Assert.assertFalse(receivedUnset.isVeniceUnitsSpecified());
+    Assert.assertFalse(receivedUnset.isWorkloadTypeSpecified());
+  }
+
+  @Test
+  public void testVeniceUnitsAndWorkloadTypeClearSurvivesCloneConfig() {
+    // The child controller rebuilds params by cloning only the configs named in updatedConfigsList,
+    // so an explicit clear must survive that filtering too.
+    UpdateStoreQueryParams source = new UpdateStoreQueryParams().setVeniceUnits(null).setWorkloadType(null);
+    UpdateStoreQueryParams target = new UpdateStoreQueryParams();
+    target.cloneConfig(VENICE_UNITS, source);
+    target.cloneConfig(WORKLOAD_TYPE, source);
+    Assert.assertTrue(target.isVeniceUnitsSpecified());
+    Assert.assertNull(target.getVeniceUnits());
+    Assert.assertTrue(target.isWorkloadTypeSpecified());
+    Assert.assertNull(target.getWorkloadType());
+  }
+
+  private static Map<String, String> toWireMap(UpdateStoreQueryParams params) {
+    Map<String, String> wireMap = new HashMap<>();
+    for (NameValuePair pair: params.getNameValuePairs()) {
+      wireMap.put(pair.getName(), pair.getValue());
+    }
+    return wireMap;
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestStoreJsonSerializer.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestStoreJsonSerializer.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.helix;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.meta.BufferReplayPolicy;
 import com.linkedin.venice.meta.HybridStoreConfig;
@@ -12,6 +13,7 @@ import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.ViewConfig;
 import com.linkedin.venice.meta.ViewConfigImpl;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
+import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.TestUtils;
 import java.io.IOException;
 import java.util.Arrays;
@@ -112,6 +114,55 @@ public class TestStoreJsonSerializer {
             BufferReplayPolicy.REWIND_FROM_EOP));
     Assert.assertNotEquals(store, newStore);
     Assert.assertNotEquals(store.getHybridStoreConfig(), newStore.getHybridStoreConfig());
+  }
+
+  /**
+   * Stores are persisted to ZK as JSON, which is a separate path from the Avro store-properties
+   * schema. These two configs are nullable, so this covers that a value survives the ZK round trip,
+   * that an unset or explicitly cleared config stays null rather than being resurrected as a
+   * default, and that znodes written before these fields existed still deserialize.
+   */
+  @Test
+  public void testSerializeAndDeserializeVeniceUnitsAndWorkloadType() throws IOException {
+    StoreJSONSerializer serializer = new StoreJSONSerializer();
+
+    Store store = TestUtils.createTestStore("s1", "owner", 1L);
+    store.setVeniceUnits(42);
+    store.setWorkloadType("LOW_LATENCY");
+
+    byte[] serialized = serializer.serialize(store, "");
+    // Assert on the persisted znode itself, so a field silently missing from the JSON is caught here
+    // rather than being masked by an in-memory cache on read.
+    JsonNode znode = ObjectMapperFactory.getInstance().readTree(serialized);
+    Assert.assertEquals(znode.get("veniceUnits").intValue(), 42, "veniceUnits must be written to the znode");
+    Assert.assertEquals(
+        znode.get("workloadType").textValue(),
+        "LOW_LATENCY",
+        "workloadType must be written to the znode");
+
+    Store roundTripped = serializer.deserialize(serialized, "");
+    Assert.assertEquals(roundTripped.getVeniceUnits(), Integer.valueOf(42));
+    Assert.assertEquals(roundTripped.getWorkloadType(), "LOW_LATENCY");
+    Assert.assertEquals(store, roundTripped);
+
+    // A store that never had either config set stays null through the round trip.
+    Store unset = TestUtils.createTestStore("s2", "owner", 1L);
+    Store unsetRoundTripped = serializer.deserialize(serializer.serialize(unset, ""), "");
+    Assert.assertNull(unsetRoundTripped.getVeniceUnits());
+    Assert.assertNull(unsetRoundTripped.getWorkloadType());
+
+    // Clearing a previously set config persists as null rather than reverting to the old value.
+    store.setVeniceUnits(null);
+    store.setWorkloadType(null);
+    Store clearedRoundTripped = serializer.deserialize(serializer.serialize(store, ""), "");
+    Assert.assertNull(clearedRoundTripped.getVeniceUnits(), "A cleared veniceUnits must persist as null");
+    Assert.assertNull(clearedRoundTripped.getWorkloadType(), "A cleared workloadType must persist as null");
+    Assert.assertEquals(store, clearedRoundTripped);
+
+    // Znodes written before these fields existed must still deserialize, with both configs unset.
+    Store legacy = serializer.deserialize("{\"name\":\"s1\"}".getBytes(), "");
+    Assert.assertNull(legacy.getVeniceUnits());
+    Assert.assertNull(legacy.getWorkloadType());
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/ReadOnlyStoreTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/ReadOnlyStoreTest.java
@@ -3,6 +3,8 @@ package com.linkedin.venice.meta;
 import static com.linkedin.venice.utils.ConfigCommonUtils.ActivationState;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.exceptions.VeniceException;
@@ -109,6 +111,8 @@ public class ReadOnlyStoreTest {
     assertEquals(storeProperties.getMaxCompactionLagSeconds(), store.getMaxCompactionLagSeconds());
     assertEquals(storeProperties.getMaxRecordSizeBytes(), store.getMaxRecordSizeBytes());
     assertEquals(storeProperties.getMaxNearlineRecordSizeBytes(), store.getMaxNearlineRecordSizeBytes());
+    assertEquals(storeProperties.getVeniceUnits(), store.getVeniceUnits());
+    assertEquals(storeProperties.getWorkloadType().toString(), store.getWorkloadType());
     assertEquals(storeProperties.getUnusedSchemaDeletionEnabled(), store.isUnusedSchemaDeletionEnabled());
     assertEquals(storeProperties.getVersions().size(), store.getVersions().size());
     assertEqualsSystemStores(storeProperties.getSystemStores(), store.getSystemStores());
@@ -324,6 +328,38 @@ public class ReadOnlyStoreTest {
     assertEquals(cloned.getBlobDbEnabled(), ActivationState.DISABLED.name());
     assertEquals(cloned.getVersions().size(), 1);
     assertEquals(cloned.getVersions().get(0).getBlobDbEnabled(), ActivationState.DISABLED.name());
+  }
+
+  @Test
+  public void testVeniceUnitsAndWorkloadTypeDefaultToNullAndRoundTrip() {
+    ZKStore store = (ZKStore) TestUtils.createTestStore(
+        Long.toString(RANDOM.nextLong()),
+        Long.toString(RANDOM.nextLong()),
+        System.currentTimeMillis());
+
+    // Unset fields stay null rather than falling back to a sentinel value.
+    assertNull(store.getVeniceUnits());
+    assertNull(store.getWorkloadType());
+    StoreProperties unsetProperties = new ReadOnlyStore(store).cloneStoreProperties();
+    assertNull(unsetProperties.getVeniceUnits());
+    assertNull(unsetProperties.getWorkloadType());
+
+    store.setVeniceUnits(42);
+    store.setWorkloadType("LOW_LATENCY");
+    assertEquals(store.getVeniceUnits(), Integer.valueOf(42));
+    assertEquals(store.getWorkloadType(), "LOW_LATENCY");
+
+    ReadOnlyStore readOnlyStore = new ReadOnlyStore(store);
+    assertEquals(readOnlyStore.getVeniceUnits(), Integer.valueOf(42));
+    assertEquals(readOnlyStore.getWorkloadType(), "LOW_LATENCY");
+    assertThrows(UnsupportedOperationException.class, () -> readOnlyStore.setVeniceUnits(1));
+    assertThrows(UnsupportedOperationException.class, () -> readOnlyStore.setWorkloadType("GENERIC"));
+
+    // Explicitly clearing the fields is honored.
+    store.setVeniceUnits(null);
+    store.setWorkloadType(null);
+    assertNull(store.getVeniceUnits());
+    assertNull(store.getWorkloadType());
   }
 
   @Test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminSchemaTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminSchemaTest.java
@@ -10,6 +10,7 @@ import static com.linkedin.venice.controller.SchemaConstants.VALUE_SCHEMA_FOR_WR
 import static com.linkedin.venice.controller.SchemaConstants.VALUE_SCHEMA_FOR_WRITE_COMPUTE_V4;
 import static com.linkedin.venice.controller.SchemaConstants.VALUE_SCHEMA_FOR_WRITE_COMPUTE_V5;
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
+import static com.linkedin.venice.utils.TestUtils.assertCommand;
 import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicAssertion;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -609,6 +610,58 @@ public class VeniceParentHelixAdminSchemaTest {
     testUpdateCompactionThreshold(parentControllerClient, childControllerClient);
     testUpdateEnumSchemaEvolution(parentControllerClient, childControllerClient);
     testUpdateStoreFlinkVeniceViewsEnable(parentControllerClient, childControllerClient);
+    testUpdateVeniceUnitsAndWorkloadType(parentControllerClient, childControllerClient);
+  }
+
+  /**
+   * Exercises the full update-store path for the two nullable capacity-planning configs: parent
+   * controller HTTP request -> admin topic -> child controller -> ZK, for all three states the
+   * params support. The clear case is the interesting one: an explicit clear has to stay
+   * distinguishable from "config not provided" all the way through, otherwise a config that has
+   * been set once can never be unset.
+   */
+  private void testUpdateVeniceUnitsAndWorkloadType(ControllerClient parentClient, ControllerClient childClient) {
+    String storeName = Utils.getUniqueString("test_store");
+    parentClient.createNewStore(storeName, "test_owner", "\"long\"", generateSchema(false).toString());
+
+    // Both configs start out unset.
+    assertVeniceUnitsAndWorkloadType(parentClient, childClient, storeName, null, null);
+
+    // Set both configs.
+    assertCommand(
+        parentClient
+            .updateStore(storeName, new UpdateStoreQueryParams().setVeniceUnits(42).setWorkloadType("GENERIC")));
+    assertVeniceUnitsAndWorkloadType(parentClient, childClient, storeName, 42, "GENERIC");
+
+    // An unrelated update must leave both configs alone.
+    assertCommand(parentClient.updateStore(storeName, new UpdateStoreQueryParams().setBatchGetLimit(100)));
+    assertVeniceUnitsAndWorkloadType(parentClient, childClient, storeName, 42, "GENERIC");
+
+    // Update one config without touching the other.
+    assertCommand(parentClient.updateStore(storeName, new UpdateStoreQueryParams().setWorkloadType("LOW_LATENCY")));
+    assertVeniceUnitsAndWorkloadType(parentClient, childClient, storeName, 42, "LOW_LATENCY");
+
+    // Clear both configs back to null.
+    assertCommand(
+        parentClient.updateStore(storeName, new UpdateStoreQueryParams().setVeniceUnits(null).setWorkloadType(null)));
+    assertVeniceUnitsAndWorkloadType(parentClient, childClient, storeName, null, null);
+  }
+
+  private void assertVeniceUnitsAndWorkloadType(
+      ControllerClient parentClient,
+      ControllerClient childClient,
+      String storeName,
+      Integer expectedVeniceUnits,
+      String expectedWorkloadType) {
+    StoreInfo parentStore = assertCommand(parentClient.getStore(storeName)).getStore();
+    Assert.assertEquals(parentStore.getVeniceUnits(), expectedVeniceUnits, "Parent veniceUnits mismatch");
+    Assert.assertEquals(parentStore.getWorkloadType(), expectedWorkloadType, "Parent workloadType mismatch");
+
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+      StoreInfo childStore = assertCommand(childClient.getStore(storeName)).getStore();
+      Assert.assertEquals(childStore.getVeniceUnits(), expectedVeniceUnits, "Child veniceUnits mismatch");
+      Assert.assertEquals(childStore.getWorkloadType(), expectedWorkloadType, "Child workloadType mismatch");
+    });
   }
 
   private void testUpdateConfig(

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -602,6 +602,8 @@ public class TestUtils {
     store.setBlobTransferEnabled(true);
     store.setNearlineProducerCompressionEnabled(true);
     store.setNearlineProducerCountPerWriter(random.nextInt());
+    store.setVeniceUnits(random.nextInt());
+    store.setWorkloadType("GENERIC");
     return store;
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
@@ -671,12 +671,11 @@ public class AdminExecutionTask implements Callable<Void> {
     params.setMaxNearlineRecordSizeBytes(message.maxNearlineRecordSizeBytes);
     params.setThroughputQuotaInBytes(message.throughputQuotaInBytes);
     params.setThroughputQuotaInRecords(message.throughputQuotaInRecords);
-    if (message.veniceUnits != null) {
-      params.setVeniceUnits(message.veniceUnits);
-    }
-    if (message.workloadType != null) {
-      params.setWorkloadType(message.workloadType.toString());
-    }
+    // Both configs are nullable, so map them unconditionally: a null on the message means the field
+    // should be cleared, and the setters encode that as an explicit clear rather than dropping it.
+    // Whether the clear is actually applied is still gated by updatedConfigsList below.
+    params.setVeniceUnits(message.veniceUnits);
+    params.setWorkloadType(message.workloadType == null ? null : message.workloadType.toString());
 
     final UpdateStoreQueryParams finalParams;
     if (message.replicateAllConfigs) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
@@ -671,6 +671,12 @@ public class AdminExecutionTask implements Callable<Void> {
     params.setMaxNearlineRecordSizeBytes(message.maxNearlineRecordSizeBytes);
     params.setThroughputQuotaInBytes(message.throughputQuotaInBytes);
     params.setThroughputQuotaInRecords(message.throughputQuotaInRecords);
+    if (message.veniceUnits != null) {
+      params.setVeniceUnits(message.veniceUnits);
+    }
+    if (message.workloadType != null) {
+      params.setWorkloadType(message.workloadType.toString());
+    }
 
     final UpdateStoreQueryParams finalParams;
     if (message.replicateAllConfigs) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreConfigUpdater.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreConfigUpdater.java
@@ -74,7 +74,9 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.THROUGHPU
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.THROUGHPUT_QUOTA_IN_RECORDS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TTL_REPUSH_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.UNUSED_SCHEMA_DELETION_ENABLED;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.VENICE_UNITS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.WORKLOAD_TYPE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.WRITE_COMPUTATION_ENABLED;
 import static com.linkedin.venice.utils.RegionUtils.parseRegionsFilterList;
 
@@ -330,6 +332,8 @@ public final class StoreConfigUpdater {
     Optional<IngestionPauseMode> ingestionPauseMode = params.getIngestionPauseMode();
     Optional<List<String>> ingestionPausedRegions = params.getIngestionPausedRegions();
     Optional<StorageMode> storageMode = params.getStorageMode();
+    Optional<Integer> veniceUnits = params.getVeniceUnits();
+    Optional<String> workloadType = params.getWorkloadType();
     Optional<ExternalStorageReadMode> externalStorageReadMode = params.getExternalStorageReadMode();
     Optional<Boolean> autoSchemaRegisterPushJobEnabled = params.getAutoSchemaRegisterPushJobEnabled();
     Optional<Boolean> hybridStoreDiskQuotaEnabled = params.getHybridStoreDiskQuotaEnabled();
@@ -796,6 +800,16 @@ public final class StoreConfigUpdater {
             return store;
           }));
 
+      veniceUnits.ifPresent(aInt -> admin.storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
+        store.setVeniceUnits(aInt);
+        return store;
+      }));
+
+      workloadType.ifPresent(aString -> admin.storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
+        store.setWorkloadType(aString);
+        return store;
+      }));
+
       throughputQuotaInBytes
           .ifPresent(aLong -> admin.storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
             store.setThroughputQuotaInBytes(aLong);
@@ -987,6 +1001,8 @@ public final class StoreConfigUpdater {
     Optional<IngestionPauseMode> ingestionPauseMode = params.getIngestionPauseMode();
     Optional<List<String>> ingestionPausedRegions = params.getIngestionPausedRegions();
     Optional<StorageMode> storageMode = params.getStorageMode();
+    Optional<Integer> veniceUnits = params.getVeniceUnits();
+    Optional<String> workloadType = params.getWorkloadType();
     Optional<ExternalStorageReadMode> externalStorageReadMode = params.getExternalStorageReadMode();
     Optional<Boolean> autoSchemaRegisterPushJobEnabled = params.getAutoSchemaRegisterPushJobEnabled();
     Optional<Boolean> hybridStoreDiskQuotaEnabled = params.getHybridStoreDiskQuotaEnabled();
@@ -1429,6 +1445,10 @@ public final class StoreConfigUpdater {
     setStore.maxNearlineRecordSizeBytes =
         maxNearlineRecordSizeBytes.map(admin.addToUpdatedConfigList(updatedConfigsList, MAX_NEARLINE_RECORD_SIZE_BYTES))
             .orElseGet(currStore::getMaxNearlineRecordSizeBytes);
+    setStore.veniceUnits = veniceUnits.map(admin.addToUpdatedConfigList(updatedConfigsList, VENICE_UNITS))
+        .orElseGet(currStore::getVeniceUnits);
+    setStore.workloadType = workloadType.map(admin.addToUpdatedConfigList(updatedConfigsList, WORKLOAD_TYPE))
+        .orElseGet(currStore::getWorkloadType);
     setStore.throughputQuotaInBytes =
         throughputQuotaInBytes.map(admin.addToUpdatedConfigList(updatedConfigsList, THROUGHPUT_QUOTA_IN_BYTES))
             .orElseGet(currStore::getThroughputQuotaInBytes);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreConfigUpdater.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/storeconfig/StoreConfigUpdater.java
@@ -332,8 +332,13 @@ public final class StoreConfigUpdater {
     Optional<IngestionPauseMode> ingestionPauseMode = params.getIngestionPauseMode();
     Optional<List<String>> ingestionPausedRegions = params.getIngestionPausedRegions();
     Optional<StorageMode> storageMode = params.getStorageMode();
-    Optional<Integer> veniceUnits = params.getVeniceUnits();
-    Optional<String> workloadType = params.getWorkloadType();
+    // These two configs are nullable, so presence of the param and the value it carries are tracked
+    // separately: an absent param means "leave unchanged", while a present param with a null value
+    // means "clear back to null".
+    boolean veniceUnitsSpecified = params.isVeniceUnitsSpecified();
+    Integer veniceUnits = params.getVeniceUnits();
+    boolean workloadTypeSpecified = params.isWorkloadTypeSpecified();
+    String workloadType = params.getWorkloadType();
     Optional<ExternalStorageReadMode> externalStorageReadMode = params.getExternalStorageReadMode();
     Optional<Boolean> autoSchemaRegisterPushJobEnabled = params.getAutoSchemaRegisterPushJobEnabled();
     Optional<Boolean> hybridStoreDiskQuotaEnabled = params.getHybridStoreDiskQuotaEnabled();
@@ -800,15 +805,19 @@ public final class StoreConfigUpdater {
             return store;
           }));
 
-      veniceUnits.ifPresent(aInt -> admin.storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
-        store.setVeniceUnits(aInt);
-        return store;
-      }));
+      if (veniceUnitsSpecified) {
+        admin.storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
+          store.setVeniceUnits(veniceUnits);
+          return store;
+        });
+      }
 
-      workloadType.ifPresent(aString -> admin.storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
-        store.setWorkloadType(aString);
-        return store;
-      }));
+      if (workloadTypeSpecified) {
+        admin.storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
+          store.setWorkloadType(workloadType);
+          return store;
+        });
+      }
 
       throughputQuotaInBytes
           .ifPresent(aLong -> admin.storeMetadataUpdate(clusterName, storeName, (store, resources) -> {
@@ -1001,8 +1010,13 @@ public final class StoreConfigUpdater {
     Optional<IngestionPauseMode> ingestionPauseMode = params.getIngestionPauseMode();
     Optional<List<String>> ingestionPausedRegions = params.getIngestionPausedRegions();
     Optional<StorageMode> storageMode = params.getStorageMode();
-    Optional<Integer> veniceUnits = params.getVeniceUnits();
-    Optional<String> workloadType = params.getWorkloadType();
+    // These two configs are nullable, so presence of the param and the value it carries are tracked
+    // separately: an absent param means "leave unchanged", while a present param with a null value
+    // means "clear back to null".
+    boolean veniceUnitsSpecified = params.isVeniceUnitsSpecified();
+    Integer veniceUnits = params.getVeniceUnits();
+    boolean workloadTypeSpecified = params.isWorkloadTypeSpecified();
+    String workloadType = params.getWorkloadType();
     Optional<ExternalStorageReadMode> externalStorageReadMode = params.getExternalStorageReadMode();
     Optional<Boolean> autoSchemaRegisterPushJobEnabled = params.getAutoSchemaRegisterPushJobEnabled();
     Optional<Boolean> hybridStoreDiskQuotaEnabled = params.getHybridStoreDiskQuotaEnabled();
@@ -1445,10 +1459,18 @@ public final class StoreConfigUpdater {
     setStore.maxNearlineRecordSizeBytes =
         maxNearlineRecordSizeBytes.map(admin.addToUpdatedConfigList(updatedConfigsList, MAX_NEARLINE_RECORD_SIZE_BYTES))
             .orElseGet(currStore::getMaxNearlineRecordSizeBytes);
-    setStore.veniceUnits = veniceUnits.map(admin.addToUpdatedConfigList(updatedConfigsList, VENICE_UNITS))
-        .orElseGet(currStore::getVeniceUnits);
-    setStore.workloadType = workloadType.map(admin.addToUpdatedConfigList(updatedConfigsList, WORKLOAD_TYPE))
-        .orElseGet(currStore::getWorkloadType);
+    if (veniceUnitsSpecified) {
+      updatedConfigsList.add(VENICE_UNITS);
+      setStore.veniceUnits = veniceUnits;
+    } else {
+      setStore.veniceUnits = currStore.getVeniceUnits();
+    }
+    if (workloadTypeSpecified) {
+      updatedConfigsList.add(WORKLOAD_TYPE);
+      setStore.workloadType = workloadType;
+    } else {
+      setStore.workloadType = currStore.getWorkloadType();
+    }
     setStore.throughputQuotaInBytes =
         throughputQuotaInBytes.map(admin.addToUpdatedConfigList(updatedConfigsList, THROUGHPUT_QUOTA_IN_BYTES))
             .orElseGet(currStore::getThroughputQuotaInBytes);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/StoreConfigUpdaterTest.java
@@ -27,6 +27,8 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_N
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_QUOTA_IN_BYTE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TARGET_REGION_PROMOTED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TTL_REPUSH_ENABLED;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.VENICE_UNITS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.WORKLOAD_TYPE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -41,6 +43,7 @@ import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
@@ -989,6 +992,47 @@ public class StoreConfigUpdaterTest extends AbstractTestVeniceParentHelixAdmin {
     assertTrue(
         updatedKeys.contains(TARGET_REGION_PROMOTED),
         "updatedConfigsList must contain '" + TARGET_REGION_PROMOTED + "' but got: " + updatedKeys);
+  }
+
+  @Test
+  public void testApplyOnParent_VeniceUnitsAndWorkloadType_SetAndClear() {
+    String storeName = Utils.getUniqueString("parent-vu");
+    Store store = TestUtils.createTestStore(storeName, "test-owner", System.currentTimeMillis());
+    store.setVeniceUnits(42);
+    store.setWorkloadType("LOW_LATENCY");
+    doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
+    parentAdmin.initStorageCluster(clusterName);
+
+    // Not provided: the current store values are carried over and neither config is marked updated.
+    parentAdmin.updateStore(clusterName, storeName, new UpdateStoreQueryParams().setBatchGetLimit(100));
+    UpdateStore untouched = captureLastUpdateStore();
+    assertEquals(untouched.veniceUnits, Integer.valueOf(42));
+    assertEquals(untouched.workloadType.toString(), "LOW_LATENCY");
+    Set<String> untouchedKeys = updatedConfigKeys(untouched);
+    assertFalse(untouchedKeys.contains(VENICE_UNITS), "Unprovided config must not be marked updated");
+    assertFalse(untouchedKeys.contains(WORKLOAD_TYPE), "Unprovided config must not be marked updated");
+
+    // Provided with a value.
+    parentAdmin
+        .updateStore(clusterName, storeName, new UpdateStoreQueryParams().setVeniceUnits(7).setWorkloadType("GENERIC"));
+    UpdateStore set = captureLastUpdateStore();
+    assertEquals(set.veniceUnits, Integer.valueOf(7));
+    assertEquals(set.workloadType.toString(), "GENERIC");
+    assertTrue(updatedConfigKeys(set).containsAll(Arrays.asList(VENICE_UNITS, WORKLOAD_TYPE)));
+
+    // Provided as null: the clear must reach the admin message rather than being read as "unchanged".
+    parentAdmin
+        .updateStore(clusterName, storeName, new UpdateStoreQueryParams().setVeniceUnits(null).setWorkloadType(null));
+    UpdateStore cleared = captureLastUpdateStore();
+    assertNull(cleared.veniceUnits, "An explicit clear must null out veniceUnits on the admin message");
+    assertNull(cleared.workloadType, "An explicit clear must null out workloadType on the admin message");
+    assertTrue(
+        updatedConfigKeys(cleared).containsAll(Arrays.asList(VENICE_UNITS, WORKLOAD_TYPE)),
+        "An explicit clear must be replicated to child controllers");
+  }
+
+  private static Set<String> updatedConfigKeys(UpdateStore msg) {
+    return msg.updatedConfigsList.stream().map(CharSequence::toString).collect(Collectors.toSet());
   }
 
   /**


### PR DESCRIPTION
## Problem Statement

The `veniceUnits` and `workloadType` store configs were added to
`StoreMetaValue` v49 and `AdminOperation` v104 in #3007. That change was
deliberately limited to the schema files: both new versions were pinned via
`versionOverrides` in `build.gradle` so code generation kept producing the
previous versions and nothing in the codebase referenced the new fields.

As a result the fields exist on paper but cannot be read or written. There is
no way for an operator to record either value on a store, and no way for
anything downstream to consume them.

- `veniceUnits` records the forecasted Venice Units (VU) capacity ask for a
  store, produced by the store-needs-estimation process.
- `workloadType` records the requested class of service for the store —
  `GENERIC` or `LOW_LATENCY`.

## Solution

Activate the staged schema versions and wire both fields end to end.

**Schema activation**
- `build.gradle`: clear the `versionOverrides` list so code generation picks
  up `StoreMetaValue` v49 and `AdminOperation` v104.
- `AvroProtocolDefinition`: bump `ADMIN_OPERATION` to 104 and
  `METADATA_SYSTEM_SCHEMA_STORE` to 49.

**Store model**
- `Store`, `ZKStore`, `ReadOnlyStore`, `SystemStore`, `StoreInfo`: add
  `getVeniceUnits` / `setVeniceUnits` and `getWorkloadType` /
  `setWorkloadType`. `ReadOnlyStore` and `SystemStore` throw
  `UnsupportedOperationException` from the setters, matching the surrounding
  configs.

**Controller API**
- `ControllerApiConstants` / `ControllerRoute`: add `venice_units` and
  `workload_type` as optional `update-store` parameters.
- `UpdateStoreQueryParams`: add setters/getters, and copy both fields in the
  `srcStore` path only when they are actually set. Because both configs are
  nullable, they are modelled as a tri-state — absent (leave unchanged), set to
  a value, or explicitly cleared. `setVeniceUnits` / `setWorkloadType` accept
  `null` to record a clear, and `isVeniceUnitsSpecified()` /
  `isWorkloadTypeSpecified()` let callers tell "not provided" from "explicitly
  cleared". Query params are string valued, so the clear is encoded on the wire
  as a present-but-empty param; the empty string is safe as a sentinel because
  it is not a legal value for either config.
- `StoreConfigUpdater`: apply both configs on the local store metadata path,
  and propagate them on the parent `UpdateStore` admin message. Both paths are
  gated on whether the config was specified rather than on the value being
  present, so an explicit clear propagates and lands in `updatedConfigsList`.
- `AdminExecutionTask`: map both fields back out of a consumed `UpdateStore`
  message. The mapping is unconditional so a `null` on the message is carried
  through as a clear; which configs actually get applied is still gated by
  `updatedConfigsList`.

**Admin tool**
- `update-store` gains `--venice-units` / `-vu` and `--workload-type` /
  `-wlt`. Passing `null` to either flag clears the config; omitting the flag
  leaves it unchanged.
- `RecoverStoreMetadata` carries both fields through store recovery.

### Trade-offs and notes

Both fields are nullable with a `null` default rather than using sentinel
values such as `-1` or `""`. This keeps "never set" distinguishable from
"explicitly set", at the cost of null handling in the accessors and of the
tri-state plumbing described above, which is what makes a config that has been
set recoverable back to `null`.

`workloadType` is stored as a plain string rather than an enum, matching the
schema. No value validation is performed in this change.

Activating v49 also brings `StoreMetaValue` v48 into the active schema, since
v48 was likewise staged and inert. v48 adds a version-level
`maxNearlineRecordSizeBytes`. This is safe: v49 is a strict superset of v48,
the field is nullable and defaults to null, and no code reads or writes it, so
it remains fully inert until it is wired separately.

### Code changes

- [x] Added new code behind **a config**. If so list the config names and their default values in the PR description.
  - `venice_units` (admin tool: `--venice-units` / `-vu`), default `null` (unset).
  - `workload_type` (admin tool: `--workload-type` / `-wlt`), default `null` (unset).
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [x] New unit tests added.
  - `ReadOnlyStoreTest.testVeniceUnitsAndWorkloadTypeDefaultToNullAndRoundTrip`
    covers the unset (`null`) default on both the store and the cloned
    `StoreProperties`, the set/get round trip, explicit clearing back to
    `null`, and the read-only setters throwing
    `UnsupportedOperationException`.
  - `UpdateStoreQueryParamsTest` covers all three states, that a previously set
    value can later be cleared, and that an explicit clear survives both the
    query-param wire round trip and `cloneConfig` filtering.
  - `TestStoreJsonSerializer.testSerializeAndDeserializeVeniceUnitsAndWorkloadType`
    covers ZK persistence, which is a separate path from the Avro store-properties
    schema: it asserts on the serialized znode directly and then round trips it,
    covering a written value, a never-set config, a cleared config persisting as
    null, and znodes written before these fields existed still deserializing.
  - `StoreConfigUpdaterTest.testApplyOnParent_VeniceUnitsAndWorkloadType_SetAndClear`
    asserts on the parent admin message that an unprovided config is carried
    over and not marked updated, a provided value is set and marked updated,
    and an explicit clear nulls the field while still being marked updated so
    it replicates to child controllers.
- [x] New integration tests added.
  - `VeniceParentHelixAdminSchemaTest.testUpdateVeniceUnitsAndWorkloadType`
    runs against real parent and child controllers and walks a single store
    through every state both configs support: both unset on a new store, both
    set, an unrelated update that must not disturb them, one config updated
    without touching the other, and both explicitly cleared back to `null` —
    asserting on the parent and on the child each time.
- [x] Modified or extended existing tests.
  - `ReadOnlyStoreTest.testCloneStoreProperties` now asserts both fields
    survive `cloneStoreProperties`.
  - `TestUtils.populateZKStore` populates both fields, so the existing
    round-trip serde tests exercise them.
- [x] Verified backward compatibility (if applicable).
  - Both fields are nullable with a `null` default, so records written by
    older writers deserialize unchanged and existing stores are unaffected
    until an operator explicitly sets a value.

Locally ran: `ReadOnlyStoreTest`, `TestZKStore`, `UpdateStoreQueryParamsTest`,
`StoreConfigUpdaterTest`, `AdminOperationSerializerTest`,
`AdminExecutionTaskTest`, `TestVeniceParentHelixAdmin`, the full
`venice-admin-tool` test suite, `spotlessCheck`, and the
`VeniceParentHelixAdminSchemaTest.testStoreMetaDataUpdateFromParentToChildController`
integration test that hosts the new end-to-end coverage.

The integration run also confirms the wire format behaves as intended: the
controller logs contain `venice_units=42`, `workload_type=GENERIC` and
`workload_type=LOW_LATENCY` for the set cases, and `venice_units=` /
`workload_type=` for the clear cases, so the empty-string clear sentinel
survives the round trip instead of being dropped as an absent param.

## Does this PR introduce any user-facing or breaking changes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.

This is additive and not breaking. `update-store` accepts two new optional
parameters, and `StoreInfo` responses carry two new fields. Both default to
`null`, so behavior is unchanged for any store where they are not set.

Because the active `AdminOperation` version moves to 104, parent and child
controllers should be deployed together per the usual admin protocol
rollout, so that a child controller is not asked to consume a message
serialized with a version it does not yet know.



