### PR TITLE
[da-vinci][changelog] Start lag reporter after seek subscriptions

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -684,8 +684,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     currentVersionLastHeartbeat.put(topicPartition.getPartitionNumber(), System.currentTimeMillis());
   }
 
-  private void startHeartbeatReporterIfNeeded() {
-    if (changeCaptureStats != null && !heartbeatReporterThread.isAlive()) {
+  private synchronized void startHeartbeatReporterIfNeeded() {
+    if (changeCaptureStats != null && heartbeatReporterThread.getState() == Thread.State.NEW) {
       heartbeatReporterThread.start();
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -386,16 +386,12 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
             getPartitionListToSubscribe(partitions, Collections.EMPTY_SET, topicToSubscribe);
         for (PubSubTopicPartition topicPartition: topicPartitionListToSeek) {
           pubSubConsumer.subscribe(topicPartition, PubSubSymbolicPosition.EARLIEST);
-          currentVersionLastHeartbeat.put(topicPartition.getPartitionNumber(), System.currentTimeMillis());
+          recordSubscriptionForHeartbeatReporting(topicPartition);
         }
       } finally {
         subscriptionLock.writeLock().unlock();
       }
-      if (changeCaptureStats != null) {
-        if (!heartbeatReporterThread.isAlive()) {
-          heartbeatReporterThread.start();
-        }
-      }
+      startHeartbeatReporterIfNeeded();
       isSubscribed.set(true);
       return null;
     }, seekExecutorService);
@@ -658,6 +654,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   }
 
   protected void synchronousSeek(Set<Integer> partitions, PubSubTopic targetTopic, SeekFunction seekAction) {
+    List<PubSubTopicPartition> topicPartitionListToSeek;
     subscriptionLock.writeLock().lock();
     try {
       // Prune out current subscriptions
@@ -668,14 +665,28 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
         }
       }
 
-      List<PubSubTopicPartition> topicPartitionListToSeek =
-          getPartitionListToSubscribe(partitions, Collections.EMPTY_SET, targetTopic);
+      topicPartitionListToSeek = getPartitionListToSubscribe(partitions, Collections.EMPTY_SET, targetTopic);
 
       for (PubSubTopicPartition topicPartition: topicPartitionListToSeek) {
         seekAction.apply(topicPartition);
+        recordSubscriptionForHeartbeatReporting(topicPartition);
       }
     } finally {
       subscriptionLock.writeLock().unlock();
+    }
+    if (!topicPartitionListToSeek.isEmpty()) {
+      startHeartbeatReporterIfNeeded();
+      isSubscribed.set(true);
+    }
+  }
+
+  private void recordSubscriptionForHeartbeatReporting(PubSubTopicPartition topicPartition) {
+    currentVersionLastHeartbeat.put(topicPartition.getPartitionNumber(), System.currentTimeMillis());
+  }
+
+  private void startHeartbeatReporterIfNeeded() {
+    if (changeCaptureStats != null && !heartbeatReporterThread.isAlive()) {
+      heartbeatReporterThread.start();
     }
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -302,14 +302,17 @@ public class VeniceChangelogConsumerImplTest {
     veniceChangelogConsumer.setStoreRepository(mockRepository);
 
     try {
+      long beforeSeek = System.currentTimeMillis();
       veniceChangelogConsumer.seekToTail(Collections.singleton(0)).get(10, TimeUnit.SECONDS);
+      long afterSeek = System.currentTimeMillis();
 
       PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(oldVersionTopic, 0);
       verify(mockPubSubConsumer).subscribe(eq(pubSubTopicPartition), eq(tailPosition), eq(true));
       Map<Integer, Long> lastHeartbeat = veniceChangelogConsumer.getLastHeartbeatPerPartition();
       assertEquals(lastHeartbeat.size(), 1);
       assertTrue(lastHeartbeat.containsKey(0));
-      assertTrue(lastHeartbeat.get(0) <= System.currentTimeMillis());
+      assertTrue(lastHeartbeat.get(0) >= beforeSeek);
+      assertTrue(lastHeartbeat.get(0) <= afterSeek);
       assertTrue(veniceChangelogConsumer.subscribed());
       TestUtils.waitForNonDeterministicAssertion(
           5,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -284,6 +284,43 @@ public class VeniceChangelogConsumerImplTest {
   }
 
   @Test
+  public void testSeekToTailStartsHeartbeatReporter() throws Exception {
+    PubSubPosition tailPosition = mock(PubSubPosition.class);
+    Set<PubSubTopicPartition> assignments = Collections.synchronizedSet(new HashSet<>());
+    when(mockPubSubConsumer.getAssignment()).thenReturn(assignments);
+    when(mockPubSubConsumer.endPosition(any())).thenReturn(tailPosition);
+    doAnswer(invocation -> {
+      assignments.add(invocation.getArgument(0));
+      return null;
+    }).when(mockPubSubConsumer).subscribe(any(PubSubTopicPartition.class), any(PubSubPosition.class), eq(true));
+
+    VeniceAfterImageConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceAfterImageConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer(),
+        veniceChangelogConsumerClientFactory);
+    veniceChangelogConsumer.setStoreRepository(mockRepository);
+
+    try {
+      veniceChangelogConsumer.seekToTail(Collections.singleton(0)).get(10, TimeUnit.SECONDS);
+
+      PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(oldVersionTopic, 0);
+      verify(mockPubSubConsumer).subscribe(eq(pubSubTopicPartition), eq(tailPosition), eq(true));
+      Map<Integer, Long> lastHeartbeat = veniceChangelogConsumer.getLastHeartbeatPerPartition();
+      assertEquals(lastHeartbeat.size(), 1);
+      assertTrue(lastHeartbeat.containsKey(0));
+      assertTrue(lastHeartbeat.get(0) <= System.currentTimeMillis());
+      assertTrue(veniceChangelogConsumer.subscribed());
+      TestUtils.waitForNonDeterministicAssertion(
+          5,
+          TimeUnit.SECONDS,
+          () -> assertTrue(veniceChangelogConsumer.getHeartbeatReporterThread().isAlive()));
+    } finally {
+      veniceChangelogConsumer.close();
+    }
+  }
+
+  @Test
   public void testAdjustCheckpoints() {
     PubSubConsumerAdapter mockConsumer = Mockito.mock(PubSubConsumerAdapter.class);
     Map<Integer, VeniceChangeCoordinate> checkpoints = new HashMap<>();


### PR DESCRIPTION
## Problem Statement

Venice changelog consumers that begin with `subscribe()` initialize heartbeat tracking and start `HeartbeatReporterThread`, which records the Tehuti `max_partition_lag` metric. Consumers that begin through seek-based subscriptions, such as Flink CDC sources starting at tail, bypassed that setup. As a result, those consumers could subscribe successfully but never record heartbeat lag values.

## Solution

Start heartbeat lag reporting for successful seek-based subscriptions as well as normal subscriptions. The shared seek path now records an initial heartbeat timestamp for each sought partition, starts the heartbeat reporter when metrics are enabled, and marks the consumer subscribed after a successful seek.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

- [ ] Local code review completed
- [x] New unit tests added.
- [ ] New integration tests added.
- [x] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

```bash
./gradlew :clients:da-vinci-client:test --tests com.linkedin.davinci.consumer.VeniceChangelogConsumerImplTest --console=plain
```

## Does this PR introduce any user-facing or breaking changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
