### PR TITLE
[fast-client] Disable route metrics by default for RRD and OpenTelemetry

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -40,6 +40,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
 
   private final Client r2Client;
   private final String statsPrefix;
+  private final boolean disableRouteMetrics;
   private final Class<T> specificValueClass;
   private final String storeName;
   private final Map<RequestType, FastClientStats> clientStatsMap = new VeniceConcurrentHashMap<>();
@@ -136,6 +137,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     this.r2Client = builder.r2Client;
     this.storeName = builder.storeName;
     this.statsPrefix = (builder.statsPrefix == null ? "" : builder.statsPrefix);
+    this.disableRouteMetrics = builder.disableRouteMetrics;
     this.metricsRepository = builder.metricsRepository != null
         ? builder.metricsRepository
         : MetricsRepositoryUtils.createMultiThreadedMetricsRepository();
@@ -249,6 +251,10 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
 
   public MetricsRepository getMetricsRepository() {
     return metricsRepository;
+  }
+
+  public boolean isRouteMetricsDisabled() {
+    return disableRouteMetrics;
   }
 
   public FastClientStats getStats(RequestType requestType) {
@@ -432,6 +438,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
   public static class ClientConfigBuilder<K, V, T extends SpecificRecord> {
     private MetricsRepository metricsRepository;
     private String statsPrefix = "";
+    private boolean disableRouteMetrics = true;
     private Class<T> specificValueClass;
     private String storeName;
     private Executor deserializationExecutor;
@@ -504,6 +511,16 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
 
     public ClientConfigBuilder<K, V, T> setStatsPrefix(String statsPrefix) {
       this.statsPrefix = statsPrefix;
+      return this;
+    }
+
+    /**
+     * Disable per-backend-host route metrics for both Tehuti (RRD) and OpenTelemetry.
+     * Defaults to true to avoid high metric cardinality. Store-level request metrics and
+     * aggregate instance-health metrics are unaffected.
+     */
+    public ClientConfigBuilder<K, V, T> setDisableRouteMetrics(boolean disableRouteMetrics) {
+      this.disableRouteMetrics = disableRouteMetrics;
       return this;
     }
 
@@ -741,6 +758,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
           .setR2Client(r2Client)
           .setMetricsRepository(metricsRepository)
           .setStatsPrefix(statsPrefix)
+          .setDisableRouteMetrics(disableRouteMetrics)
           .setSpecificValueClass(specificValueClass)
           .setDeserializationExecutor(deserializationExecutor)
           .setMetadataRefreshExecutor(metadataRefreshExecutor)

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -53,7 +53,8 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
     this.clientStatsForStreamingCompute = clientConfig.getStats(RequestType.COMPUTE_STREAMING);
     this.clusterStats = clientConfig.getClusterStats();
     this.metricsRepository = clientConfig.getMetricsRepository();
-    this.clusterRouteStats = ClusterRouteStats.getInstance(clientConfig.getStoreName());
+    this.clusterRouteStats =
+        clientConfig.isRouteMetricsDisabled() ? null : ClusterRouteStats.getInstance(clientConfig.getStoreName());
   }
 
   @Override
@@ -253,6 +254,9 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
         clusterStats.recordBlockedInstanceCount(monitor.getBlockedInstanceCount());
         clusterStats.recordUnhealthyInstanceCount(monitor.getUnhealthyInstanceCount());
         clusterStats.recordOverloadedInstanceCount(monitor.getOverloadedInstanceCount());
+      }
+      if (clusterRouteStats == null) {
+        return;
       }
       replicaRequestFuture.forEach((instance, future) -> {
         future.whenComplete((status, throwable) -> {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -120,7 +120,7 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
         recordRequestMetrics(requestContext, numberOfKeys, innerFuture, startTimeInNS, clientStats);
     // Record per replica metric
     statFuture.whenComplete((result, throwable) -> {
-      recordPerRouteMetrics(requestContext, clientStats);
+      recordPerRouteMetrics(requestContext);
     });
 
     return AppTimeOutTrackingCompletableFuture.track(statFuture, clientStats);
@@ -245,10 +245,9 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
     });
   }
 
-  private void recordPerRouteMetrics(RequestContext requestContext, FastClientStats clientStats) {
+  private void recordPerRouteMetrics(RequestContext requestContext) {
     final long requestSentTimestampNS = requestContext.requestSentTimestampNS;
     if (requestSentTimestampNS > 0) {
-      Map<String, CompletableFuture<Integer>> replicaRequestFuture = requestContext.routeRequestMap;
       final InstanceHealthMonitor monitor = requestContext.instanceHealthMonitor;
       if (monitor != null) {
         clusterStats.recordBlockedInstanceCount(monitor.getBlockedInstanceCount());
@@ -258,6 +257,7 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
       if (clusterRouteStats == null) {
         return;
       }
+      Map<String, CompletableFuture<Integer>> replicaRequestFuture = requestContext.routeRequestMap;
       replicaRequestFuture.forEach((instance, future) -> {
         future.whenComplete((status, throwable) -> {
           ClusterRouteStats.RouteStats routeStats = clusterRouteStats.getRouteStats(

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/ClientConfigTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/ClientConfigTest.java
@@ -21,6 +21,7 @@ import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.dimensions.HttpResponseStatusEnum;
+import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
@@ -56,6 +57,21 @@ public class ClientConfigTest {
   public void testClientWithAllRequiredInputs() {
     ClientConfig.ClientConfigBuilder clientConfigBuilder = getClientConfigWithMinimumRequiredInputs();
     clientConfigBuilder.build();
+  }
+
+  @Test
+  public void testRouteMetricsDisabledByDefault() {
+    ClientConfig.ClientConfigBuilder clientConfigBuilder = getClientConfigWithMinimumRequiredInputs();
+    assertTrue(clientConfigBuilder.build().isRouteMetricsDisabled());
+    assertTrue(clientConfigBuilder.clone().build().isRouteMetricsDisabled());
+  }
+
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testDisableRouteMetrics(boolean disableRouteMetrics) {
+    ClientConfig.ClientConfigBuilder clientConfigBuilder =
+        getClientConfigWithMinimumRequiredInputs().setDisableRouteMetrics(disableRouteMetrics);
+    assertEquals(clientConfigBuilder.build().isRouteMetricsDisabled(), disableRouteMetrics);
+    assertEquals(clientConfigBuilder.clone().build().isRouteMetricsDisabled(), disableRouteMetrics);
   }
 
   @Test(expectedExceptions = VeniceClientException.class, expectedExceptionsMessageRegExp = "Either param: specificThinClient or param: genericThinClient.*")

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
@@ -171,6 +171,7 @@ public class DispatchingAvroGenericStoreClientTest {
       long routingRequestDefaultTimeOutMS) throws InterruptedException {
 
     clientConfigBuilder = new ClientConfig.ClientConfigBuilder<>().setStoreName(STORE_NAME)
+        .setDisableRouteMetrics(false)
         .setR2Client(getMockR2Client(false))
         .setD2Client(mock(D2Client.class))
         .setClusterDiscoveryD2Service("test_server_discovery")

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClientTest.java
@@ -1,0 +1,194 @@
+package com.linkedin.venice.fastclient;
+
+import static com.linkedin.venice.client.stats.BasicClientStats.CLIENT_METRIC_ENTITIES;
+import static com.linkedin.venice.client.stats.ClientMetricEntity.ROUTE_CALL_COUNT;
+import static com.linkedin.venice.client.stats.ClientMetricEntity.ROUTE_CALL_TIME;
+import static com.linkedin.venice.client.stats.ClientMetricEntity.ROUTE_REQUEST_PENDING_COUNT;
+import static com.linkedin.venice.client.stats.ClientMetricEntity.ROUTE_REQUEST_REJECTION_RATIO;
+import static com.linkedin.venice.stats.ClientType.FAST_CLIENT;
+import static com.linkedin.venice.stats.VeniceMetricsRepository.getVeniceMetricsRepository;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.r2.transport.common.Client;
+import com.linkedin.venice.client.exceptions.VeniceClientException;
+import com.linkedin.venice.client.stats.ClientMetricEntity;
+import com.linkedin.venice.client.store.ComputeGenericRecord;
+import com.linkedin.venice.client.store.streaming.StreamingCallback;
+import com.linkedin.venice.compute.ComputeRequestWrapper;
+import com.linkedin.venice.fastclient.meta.InstanceHealthMonitor;
+import com.linkedin.venice.fastclient.utils.ClientTestUtils;
+import com.linkedin.venice.read.RequestType;
+import com.linkedin.venice.stats.VeniceMetricsRepository;
+import com.linkedin.venice.utils.Utils;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.Metric;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificRecord;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class StatsAvroGenericStoreClientTest {
+  private static final String CLUSTER_NAME = "test_cluster";
+  private static final String ROUTE = "http://backend-1:8080";
+  private static final String PENDING_ROUTE = "http://backend-2:8080";
+
+  @DataProvider(name = "routeMetricsConfigs")
+  public Object[][] routeMetricsConfigs() {
+    List<Object[]> configs = new ArrayList<>();
+    for (Boolean disableRouteMetrics: new Boolean[] { null, true, false }) {
+      for (boolean emitOtelMetrics: new boolean[] { false, true }) {
+        for (RequestType requestType: new RequestType[] { RequestType.SINGLE_GET, RequestType.MULTI_GET_STREAMING,
+            RequestType.COMPUTE_STREAMING }) {
+          configs.add(new Object[] { disableRouteMetrics, emitOtelMetrics, requestType });
+        }
+      }
+    }
+    return configs.toArray(new Object[0][]);
+  }
+
+  @Test(dataProvider = "routeMetricsConfigs")
+  public void testRouteMetrics(Boolean disableRouteMetrics, boolean emitOtelMetrics, RequestType requestType)
+      throws IOException {
+    boolean routeMetricsEnabled = Boolean.FALSE.equals(disableRouteMetrics);
+    String storeName = Utils.getUniqueString("route_metrics");
+    InstanceHealthMonitor monitor = mock(InstanceHealthMonitor.class);
+    when(monitor.getBlockedInstanceCount()).thenReturn(2);
+    when(monitor.getUnhealthyInstanceCount()).thenReturn(3);
+    when(monitor.getOverloadedInstanceCount()).thenReturn(4);
+    when(monitor.getPendingRequestCounter(anyString())).thenReturn(5);
+    when(monitor.getRejectionRatio(anyString())).thenReturn(0.25);
+
+    try (InMemoryMetricReader reader = InMemoryMetricReader.create();
+        VeniceMetricsRepository repository =
+            getVeniceMetricsRepository(FAST_CLIENT, CLIENT_METRIC_ENTITIES, emitOtelMetrics, reader)) {
+      ClientConfig.ClientConfigBuilder<String, String, SpecificRecord> builder =
+          new ClientConfig.ClientConfigBuilder<String, String, SpecificRecord>().setStoreName(storeName)
+              .setR2Client(mock(Client.class))
+              .setD2Client(mock(D2Client.class))
+              .setClusterDiscoveryD2Service("test_discovery")
+              .setMetricsRepository(repository)
+              .setInstanceHealthMonitor(monitor);
+      if (disableRouteMetrics != null) {
+        builder.setDisableRouteMetrics(disableRouteMetrics);
+      }
+      ClientConfig<String, String, SpecificRecord> config = builder.build();
+      InternalAvroStoreClient<String, String> delegate = mock(InternalAvroStoreClient.class);
+      StatsAvroGenericStoreClient<String, String> client = new StatsAvroGenericStoreClient<>(delegate, config);
+      Set<String> keys = Collections.singleton("key");
+      RequestContext requestContext;
+      Runnable request;
+      switch (requestType) {
+        case SINGLE_GET:
+          GetRequestContext<String> getContext = new GetRequestContext<>();
+          when(delegate.get(getContext, "key")).thenReturn(CompletableFuture.completedFuture("value"));
+          requestContext = getContext;
+          request = () -> assertEquals(client.get(getContext, "key").join(), "value");
+          break;
+        case MULTI_GET_STREAMING:
+          BatchGetRequestContext<String, String> batchContext = new BatchGetRequestContext<>(1, false);
+          doAnswer(invocation -> {
+            StreamingCallback<String, String> callback = invocation.getArgument(2);
+            callback.onRecordReceived("key", "value");
+            callback.onCompletion(Optional.empty());
+            return null;
+          }).when(delegate).streamingBatchGet(eq(batchContext), eq(keys), any());
+          requestContext = batchContext;
+          request = () -> client.streamingBatchGet(batchContext, keys, mock(StreamingCallback.class));
+          break;
+        case COMPUTE_STREAMING:
+          ComputeRequestContext<String, String> computeContext = new ComputeRequestContext<>(1, false);
+          ComputeRequestWrapper computeRequest = mock(ComputeRequestWrapper.class);
+          Schema resultSchema = Schema.create(Schema.Type.STRING);
+          doAnswer(invocation -> {
+            StreamingCallback<String, ComputeGenericRecord> callback = invocation.getArgument(4);
+            callback.onRecordReceived("key", mock(ComputeGenericRecord.class));
+            callback.onCompletion(Optional.empty());
+            return null;
+          }).when(delegate).compute(eq(computeContext), eq(computeRequest), eq(keys), eq(resultSchema), any(), eq(0L));
+          requestContext = computeContext;
+          request = () -> client
+              .compute(computeContext, computeRequest, keys, resultSchema, mock(StreamingCallback.class), 0L);
+          break;
+        default:
+          throw new AssertionError("Unexpected request type: " + requestType);
+      }
+
+      CompletableFuture<Integer> pendingRoute = new CompletableFuture<>();
+      requestContext.requestSentTimestampNS = System.nanoTime();
+      requestContext.setServerClusterName(CLUSTER_NAME);
+      requestContext.setInstanceHealthMonitor(monitor);
+      requestContext.routeRequestMap.put(ROUTE, CompletableFuture.completedFuture(200));
+      requestContext.routeRequestMap.put(PENDING_ROUTE, pendingRoute);
+      request.run();
+
+      assertEquals(pendingRoute.getNumberOfDependents(), routeMetricsEnabled ? 1 : 0);
+      pendingRoute.completeExceptionally(new VeniceClientException("Route failed after request completion"));
+
+      Map<String, ? extends Metric> metrics = repository.metrics();
+      if (routeMetricsEnabled) {
+        for (String host: new String[] { "backend-1", "backend-2" }) {
+          String prefix = ClientTestUtils.getMetricPrefix(CLUSTER_NAME + "_" + host, requestType);
+          assertTrue(metrics.get(prefix + "request_count.OccurrenceRate").value() > 0);
+          assertEquals(metrics.get(prefix + "pending_request_count.Max").value(), 5.0);
+          assertEquals(metrics.get(prefix + "rejection_ratio.Max").value(), 0.25);
+          assertNotNull(metrics.get(prefix + "response_waiting_time.99thPercentile"));
+          String statusMetric =
+              host.equals("backend-1") ? "healthy_request_count" : "service_unavailable_request_count";
+          assertTrue(metrics.get(prefix + statusMetric + ".OccurrenceRate").value() > 0);
+        }
+      } else {
+        assertFalse(
+            metrics.keySet().stream().anyMatch(name -> name.startsWith("." + CLUSTER_NAME + "_")),
+            "Disabled route metrics must not register any per-host Tehuti sensors");
+      }
+
+      String requestMetricPrefix = ClientTestUtils.getMetricPrefix(storeName, requestType);
+      assertTrue(metrics.get(requestMetricPrefix + "healthy_request.OccurrenceRate").value() > 0);
+      assertEquals(metrics.get("." + storeName + "--blocked_instance_count.Max").value(), 2.0);
+      assertEquals(metrics.get("." + storeName + "--unhealthy_instance_count.Max").value(), 3.0);
+      assertEquals(metrics.get("." + storeName + "--overloaded_instance_count.Max").value(), 4.0);
+
+      Collection<MetricData> otelMetrics = reader.collectAllMetrics();
+      for (ClientMetricEntity metric: new ClientMetricEntity[] { ROUTE_CALL_COUNT, ROUTE_CALL_TIME,
+          ROUTE_REQUEST_PENDING_COUNT, ROUTE_REQUEST_REJECTION_RATIO }) {
+        assertEquals(
+            otelMetrics.stream()
+                .anyMatch(data -> data.getName().endsWith("." + metric.getMetricEntity().getMetricName())),
+            routeMetricsEnabled && emitOtelMetrics,
+            "Unexpected emission for " + metric);
+      }
+      if (emitOtelMetrics) {
+        assertTrue(
+            otelMetrics.stream()
+                .anyMatch(data -> data.getName().endsWith(".call_count") && !data.getName().contains(".route.")));
+        assertTrue(otelMetrics.stream().anyMatch(data -> data.getName().endsWith(".instance.error_count")));
+        if (!routeMetricsEnabled) {
+          assertFalse(otelMetrics.stream().anyMatch(data -> data.getName().contains(".route.")));
+        }
+      } else {
+        assertTrue(otelMetrics.isEmpty());
+      }
+    }
+  }
+}

--- a/docs/user-guide/read-apis/fast-client.md
+++ b/docs/user-guide/read-apis/fast-client.md
@@ -157,18 +157,24 @@ ClientConfig clientConfig = new ClientConfig.ClientConfigBuilder<>()
 
 Key configuration options for `ClientConfig`:
 
-| Option                                         | Description                                     | Default |
-| ---------------------------------------------- | ----------------------------------------------- | ------- |
-| `setStoreName(String)`                         | Store name (required)                           | -       |
-| `setR2Client(Client)`                          | R2 client for HTTP (required unless using gRPC) | -       |
-| `setD2Client(D2Client)`                        | D2 client for service discovery                 | -       |
-| `setClusterDiscoveryD2Service(String)`         | D2 service name for controller                  | -       |
-| `setMetadataRefreshIntervalInSeconds(long)`    | Metadata refresh interval                       | 60      |
-| `setLongTailRetryEnabledForSingleGet(boolean)` | Enable retry for single get                     | false   |
-| `setLongTailRetryEnabledForBatchGet(boolean)`  | Enable retry for batch get                      | false   |
-| `setRetryBudgetEnabled(boolean)`               | Enable retry budget                             | true    |
-| `setRetryBudgetPercentage(double)`             | Max retry rate percentage (0.0-1.0)             | 0.1     |
-| `setStoreLoadControllerEnabled(boolean)`       | Enable load control                             | false   |
+| Option                                         | Description                                               | Default |
+| ---------------------------------------------- | --------------------------------------------------------- | ------- |
+| `setStoreName(String)`                         | Store name (required)                                     | -       |
+| `setR2Client(Client)`                          | R2 client for HTTP (required unless using gRPC)           | -       |
+| `setD2Client(D2Client)`                        | D2 client for service discovery                           | -       |
+| `setClusterDiscoveryD2Service(String)`         | D2 service name for controller                            | -       |
+| `setMetadataRefreshIntervalInSeconds(long)`    | Metadata refresh interval                                 | 60      |
+| `setLongTailRetryEnabledForSingleGet(boolean)` | Enable retry for single get                               | false   |
+| `setLongTailRetryEnabledForBatchGet(boolean)`  | Enable retry for batch get                                | false   |
+| `setRetryBudgetEnabled(boolean)`               | Enable retry budget                                       | true    |
+| `setRetryBudgetPercentage(double)`             | Max retry rate percentage (0.0-1.0)                       | 0.1     |
+| `setStoreLoadControllerEnabled(boolean)`       | Enable load control                                       | false   |
+| `setDisableRouteMetrics(boolean)`              | Disable per-backend-host metrics in RRD and OpenTelemetry | true    |
+
+Per-backend-host route metrics are disabled by default to limit metric cardinality. This includes route request counts,
+latencies, pending request counts, and rejection ratios for single-get, batch-get, and compute requests. Store-level
+request metrics and aggregate instance-health metrics remain enabled. Set `setDisableRouteMetrics(false)` to opt into
+route metrics for both RRD (Tehuti) and OpenTelemetry.
 
 ### Routing Strategies
 


### PR DESCRIPTION
## Problem Statement
Connections metrics are taking up majority of the metrics bandwidth but it's rarely looked at.
Several factors compound the cardinality:

• Stores span multiple clusters.
• Server rotations continuously introduce new hostname-based metric names.
• Store migrations can temporarily register old and new cluster routes.
• The in-process route map has no eviction.
• The RRD metric catalog retains historical paths.

## Solution
Disabling connection metrics by default and adding a client config to enable it when needed for debugging. For now connection metrics should only be enabled temporarily for debugging purposes.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
