### PR TITLE
[controller][test] Sample parent clock after fetching child store snapshot

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2698,7 +2698,6 @@ public class VeniceParentHelixAdmin implements Admin {
     int minNumberOfStoreVersionsToPreserve = getMultiClusterConfigs().getMinNumberOfStoreVersionsToPreserve();
     long minBackupVersionCleanupDelayMs =
         getMultiClusterConfigs().getControllerConfig(clusterName).getBackupVersionMinCleanupDelayMs();
-    long currentTimeMs = System.currentTimeMillis();
 
     Map<String, ControllerClient> controllerClients = getVeniceHelixAdmin().getControllerClientMap(clusterName);
     if (controllerClients.isEmpty()) {
@@ -2739,6 +2738,7 @@ public class VeniceParentHelixAdmin implements Admin {
             region);
         continue;
       }
+      long currentTimeMs = timer.getMilliseconds();
       VersionLifecyclePolicy.checkRollbackOriginVersionCapacityForNewPush(
           clusterName,
           storeName,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -3336,14 +3337,16 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   @Test
   public void checkNewPushCapacityFromChildrenBlocksWhenChildRolledBackWithinRetention() {
     String store = "npc_from_children_rollback_block";
+    long promotionTimestamp = 1_000_000;
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
     mockNewPushCapacityConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24), 2, TimeUnit.HOURS.toMillis(1));
     doCallRealMethod().when(mockParentAdmin).checkNewPushCapacityFromChildren(any(), any());
+    mockParentAdmin.setTimer(new TestMockTime(promotionTimestamp));
 
     // Child dc-0 still holds a ROLLED_BACK version within retention -> the parent must block the push.
     Map<String, ControllerClient> map = new HashMap<>();
-    map.put("dc-0", childClient(rolledBackOriginStore(store)));
+    map.put("dc-0", childClient(rolledBackOriginStore(store, promotionTimestamp)));
     doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
 
     assertThrows(VeniceException.class, () -> mockParentAdmin.checkNewPushCapacityFromChildren(clusterName, store));
@@ -3352,17 +3355,50 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   @Test
   public void checkNewPushCapacityFromChildrenBlocksWhenChildHasPendingBackupWithinDelay() {
     String store = "npc_from_children_backup_block";
+    long currentTimestamp = 1_000_000;
     VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
     mockNewPushCapacityConfig(mockParentAdmin, TimeUnit.HOURS.toMillis(24), 2, TimeUnit.HOURS.toMillis(1));
     doCallRealMethod().when(mockParentAdmin).checkNewPushCapacityFromChildren(any(), any());
+    TestMockTime mockTime = new TestMockTime(currentTimestamp);
+    mockParentAdmin.setTimer(mockTime);
 
     // Child dc-0 has a KILLED backup pending deletion, promoted just now -> parent must block.
     Map<String, ControllerClient> map = new HashMap<>();
-    map.put("dc-0", childClient(backupPendingStore(store)));
+    map.put("dc-0", childClient(backupPendingStore(store, currentTimestamp)));
     doReturn(map).when(internalAdmin).getControllerClientMap(anyString());
 
     assertThrows(VeniceException.class, () -> mockParentAdmin.checkNewPushCapacityFromChildren(clusterName, store));
+    assertEquals(mockTime.getMilliseconds(), currentTimestamp);
+  }
+
+  @Test
+  public void checkNewPushCapacityFromChildrenSamplesTimeAfterFetchingChildSnapshot() {
+    // Fetching the child snapshot costs a cross-region RPC, so a clock read taken before that call
+    // is already stale by the round-trip duration when compared against the child's promotion
+    // timestamp. Simulate a 50ms RPC across a 20ms retention window: the window has expired by the
+    // time the snapshot is in hand, so the rolled-back version must no longer block the push.
+    String store = "npc_from_children_time_sampled_after_fetch";
+    long promotionTimestamp = 1_000_000;
+    long rpcDurationMs = 50;
+    long rolledBackRetentionMs = 20;
+    VeniceParentHelixAdmin mockParentAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(internalAdmin).when(mockParentAdmin).getVeniceHelixAdmin();
+    mockNewPushCapacityConfig(mockParentAdmin, rolledBackRetentionMs, 2, TimeUnit.HOURS.toMillis(1));
+    doCallRealMethod().when(mockParentAdmin).checkNewPushCapacityFromChildren(any(), any());
+    TestMockTime mockTime = new TestMockTime(promotionTimestamp);
+    mockParentAdmin.setTimer(mockTime);
+
+    ControllerClient slowClient = mock(ControllerClient.class);
+    StoreResponse response = new StoreResponse();
+    response.setStore(StoreInfo.fromStore(rolledBackOriginStore(store, promotionTimestamp)));
+    doAnswer(invocation -> {
+      mockTime.addMilliseconds(rpcDurationMs);
+      return response;
+    }).when(slowClient).getStore(anyString(), anyInt());
+    doReturn(Collections.singletonMap("dc-0", slowClient)).when(internalAdmin).getControllerClientMap(anyString());
+
+    mockParentAdmin.checkNewPushCapacityFromChildren(clusterName, store);
   }
 
   @Test
@@ -3474,17 +3510,19 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(clusterConfig).when(multiConfig).getControllerConfig(anyString());
     doReturn(minVersions).when(multiConfig).getMinNumberOfStoreVersionsToPreserve();
     doReturn(multiConfig).when(admin).getMultiClusterConfigs();
+    doCallRealMethod().when(admin).setTimer(any());
+    admin.setTimer(new TestMockTime(System.currentTimeMillis()));
   }
 
-  private static Store backupPendingStore(String storeName) {
-    Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
+  private static Store backupPendingStore(String storeName, long promotionTimestamp) {
+    Store store = TestUtils.createTestStore(storeName, "owner", promotionTimestamp);
     store.addVersion(new VersionImpl(storeName, 1, "push1"));
     store.addVersion(new VersionImpl(storeName, 2, "push2"));
     // v1 KILLED is always pending deletion (canDelete); v2 was just promoted -> within cleanup delay.
     store.updateVersionStatus(1, VersionStatus.KILLED);
     store.updateVersionStatus(2, VersionStatus.ONLINE);
     store.setCurrentVersion(2);
-    store.setLatestVersionPromoteToCurrentTimestamp(System.currentTimeMillis());
+    store.setLatestVersionPromoteToCurrentTimestamp(promotionTimestamp);
     return store;
   }
 
@@ -3506,14 +3544,14 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     return client;
   }
 
-  private static Store rolledBackOriginStore(String storeName) {
-    Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
+  private static Store rolledBackOriginStore(String storeName, long promotionTimestamp) {
+    Store store = TestUtils.createTestStore(storeName, "owner", promotionTimestamp);
     store.addVersion(new VersionImpl(storeName, 1, "push1"));
     store.addVersion(new VersionImpl(storeName, 2, "push2"));
     store.updateVersionStatus(1, VersionStatus.ONLINE);
     store.updateVersionStatus(2, VersionStatus.ROLLED_BACK);
     store.setCurrentVersion(1);
-    store.setLatestVersionPromoteToCurrentTimestamp(System.currentTimeMillis());
+    store.setLatestVersionPromoteToCurrentTimestamp(promotionTimestamp);
     return store;
   }
 


### PR DESCRIPTION
## Problem Statement

`VeniceParentHelixAdmin.checkNewPushCapacityFromChildren` sampled the wall clock **once, before** the per-region loop:

```java
long currentTimeMs = System.currentTimeMillis();   // sampled here

for (region : controllerClients) {
  StoreInfo childStore = client.getStore(...);      // cross-region RPC
  ...
  checkRollbackOriginVersionCapacityForNewPush(..., currentTimeMs);
  checkBackupVersionCleanupCapacityForNewPush(..., currentTimeMs);
}
```

That reading was then compared against `latestVersionPromoteToCurrentTimestamp`, which comes out of a store snapshot fetched over a **cross-region RPC**. By the time the snapshot was in hand, `currentTimeMs` was already stale by the round-trip duration. Any promotion that landed on the child inside that window produced `currentTimeMs < promoteTs`, and both capacity guards rejected a legitimate push.

### Production evidence

Correlating controller logs from both sides of one rejection shows the race directly. The parent and child are in different regions; all timestamps are UTC on 2026-08-11 and the whole sequence spans 1.2 seconds:

```
  parent controller (region A)                  child controller (region B)
  ───────────────────────────────────────       ───────────────────────────────────────
  00:32:23.282  dispatches roll-forward ──────▶
  00:32:23.452  request_topic POST arrives
  00:32:23.835  CreateVersion begins
                ↳ old code sampled the clock here
                                       ──────▶  00:32:24.101  roll_forward POST received
                                                00:32:24.202  ★ promotion committed,
                                                              promoteTs persisted
                                                00:32:24.236  returns SUCCESS
  00:32:24.478  issues getStore        ──────▶  00:32:24.478  serves GET /store (0ms)
  00:32:24.478  snapshot in hand
                (promoteTs = 00:32:24.202)
  00:32:24.495  ✗ rejects: "still within min cleanup delay (0ms)"
```

Two facts make the diagnosis unambiguous:

1. **The parent sampled its clock at `00:32:23.835`, but the value it judged was written at `00:32:24.202`.** The comparison was inverted by up to **366ms** — the parent was asking "has enough time passed since an event that, from its own point of view, had not happened yet?"
2. **The parent had already read the post-promotion state.** It fetched the snapshot at `00:32:24.478`, **276ms after** the promotion it was rejecting. The correct answer was available; the stale clock reading was the only thing standing in the way.

This is a **read-your-own-write race, not clock skew.** The parent dispatched the roll-forward itself at `00:32:23.282`, so the promotion it was about to judge landed while its own `request_topic` call was still in flight. Perfectly synchronized clocks on both hosts would not prevent this — the inversion comes entirely from *when* the parent sampled, not from *whose* clock it sampled.

The rejection message reads `still within min cleanup delay (0ms)`. With a zero-width delay window the guard reduces to `currentTimeMs <= promoteTs`, so it could only have fired through this inversion.

## Solution

Move the sample inside the loop, after the snapshot is in hand:

```diff
-    long currentTimeMs = System.currentTimeMillis();

     for (region : controllerClients) {
       StoreInfo childStore = client.getStore(...);
       ...
+      long currentTimeMs = timer.getMilliseconds();
       checkRollbackOriginVersionCapacityForNewPush(..., currentTimeMs);
       checkBackupVersionCleanupCapacityForNewPush(..., currentTimeMs);
```

One line, and it fixes every guard in the loop — `checkRollbackOriginVersionCapacityForNewPush`, `checkBackupVersionCleanupCapacityForNewPush`, and anything added later — because they now share a reading that is never older than the state they are judging. Against the timeline above, the sample moves from `00:32:23.835` to `00:32:24.478`, turning a 366ms deficit into a **276ms margin**.

The sample is read from the class's existing injectable `timer` field rather than `System.currentTimeMillis()`:

- **Runtime behaviour is identical.** `timer` is initialized inline to `new SystemTime()`, and `SystemTime.getMilliseconds()` returns `System.currentTimeMillis()`. `setTimer` is package-private, marked `// Visible for testing`, and every caller in the repository is a test.
- **It is what makes the regression test deterministic.** The test needs to assert "the retention window expired during the RPC". With the injectable timer, the `getStore` stub advances a virtual clock by a fixed 50ms. With `System.currentTimeMillis()` the only option is a real `Thread.sleep`, which is a timing race and would be flaky under CI load.
- **It reduces divergence rather than adding it.** The class already used `timer` for its other clock interactions, and this change removes the last direct `System.currentTimeMillis()` call in the file (`grep -c` is now `0`).

### Alternative considered

Relaxing the comparison from `currentTimeMs <= promoteTs` to `<` would only cover a same-millisecond tie. As the timeline shows, the observed relation was strictly less-than by hundreds of milliseconds, so that change would not have prevented this rejection.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
  - No new config. No existing config default is changed.
- [ ] Introduced new **log lines**.
  - No new log lines; no change to logging volume.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.
    - N/A.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
  - This PR removes one. `currentTimeMs` becomes a loop-scoped local instead of a method-scoped one, which is strictly narrower.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
  - Unchanged. No shared mutable state is introduced; the new local is confined to a single loop iteration on the calling thread.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
  - No blocking call is added. `checkNewPushCapacityFromChildren` runs inside `incrementVersionIdempotent` before any lock is acquired.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
  - N/A. No collection is added or modified.
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.
  - Unchanged. The guards still throw `VeniceException` and propagate to the same caller as before.

## How was this PR tested?

- [x] New unit tests added.
  - `checkNewPushCapacityFromChildrenSamplesTimeAfterFetchingChildSnapshot` reproduces the race: a `getStore` stub advances the injected clock by 50ms across a 20ms rolled-back retention window, so the window has expired by the time the snapshot arrives and the push must be allowed.
  - Verified the test is meaningful by mutation: temporarily restoring the pre-loop sampling makes it **fail**; restoring the fix makes it **pass**.
- [ ] New integration tests added.
  - The existing integration tests (`TestPushBlockedWithinMinCleanupDelay`, `TestPushBlockedByRollbackOriginGuard`) use minute-scale windows and are unaffected by a millisecond-scale shift in sampling point.
- [x] Modified or extended existing tests.
  - Store helpers in `TestVeniceParentHelixAdmin` now take explicit promotion timestamps so each test controls its own clock relationship instead of relying on ambient wall-clock time.
- [x] Verified backward compatibility (if applicable).
  - `SystemTime.getMilliseconds()` delegates to `System.currentTimeMillis()`, so production behaviour is byte-for-byte equivalent apart from the intended sampling point.

Commands run:

```
./gradlew :services:venice-controller:test \
  --tests 'com.linkedin.venice.controller.TestVeniceParentHelixAdmin' \
  --tests 'com.linkedin.venice.controller.versionlifecycle.NewPushCapacityGuardsTest' \
  --rerun-tasks
  → 149 passed, 0 failed

./gradlew spotlessJavaCheck
  → BUILD SUCCESSFUL
```

## Does this PR introduce any user-facing or breaking changes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.

Not breaking, but observable.

**Before:** a new push issued shortly after the previous version was rolled forward could be rejected with `Refusing new push ... still within min cleanup delay`, even when the retention window had genuinely elapsed. Callers saw a spurious failure and had to rely on their own retry cadence to get through.

**After:** these pushes proceed. Only the spurious rejections disappear — the guards still reject pushes that are genuinely inside the retention or cleanup-delay window, because the fix changes *when* the clock is read, not *what* is compared.