### PR TITLE
[fast-client] Skip metrics for disabled dual-read and load control

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -146,7 +146,13 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     for (RequestType requestType: RequestType.values()) {
       clientStatsMap.put(
           requestType,
-          FastClientStats.getClientStats(this.metricsRepository, this.statsPrefix, storeName, requestType));
+          FastClientStats.getClientStats(
+              this.metricsRepository,
+              this.statsPrefix,
+              storeName,
+              requestType,
+              builder.dualReadEnabled,
+              builder.storeLoadControllerEnabled));
     }
     this.clusterStats = new ClusterStats(this.metricsRepository, storeName);
     this.specificValueClass = builder.specificValueClass;

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/FastClientStats.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/FastClientStats.java
@@ -40,6 +40,7 @@ import java.util.stream.IntStream;
 
 public class FastClientStats extends ClientStats {
   private final String storeName;
+  private final boolean storeLoadControllerEnabled;
 
   private volatile MetricEntityStateOneEnum<RejectionReason> noAvailableReplicaRequestCount;
   private volatile MetricEntityStateOneEnum<RejectionReason> rejectedRequestCountByLoadController;
@@ -61,42 +62,73 @@ public class FastClientStats extends ClientStats {
   private volatile MetricEntityStateOneEnum<RequestFanoutType> originalFanoutSize;
   private long cacheTimeStampInMs = 0;
 
+  /**
+   * Preserves registration of all optional feature metrics for callers without client feature flags.
+   */
   public static FastClientStats getClientStats(
       MetricsRepository metricsRepository,
       String statsPrefix,
       String storeName,
       RequestType requestType) {
-    String metricName = statsPrefix.isEmpty() ? storeName : statsPrefix + "." + storeName;
-    return new FastClientStats(metricsRepository, metricName, requestType);
+    return getClientStats(metricsRepository, statsPrefix, storeName, requestType, true, true);
   }
 
-  private FastClientStats(MetricsRepository metricsRepository, String storeName, RequestType requestType) {
+  /**
+   * Registers optional feature metrics only when the corresponding client feature is enabled.
+   */
+  public static FastClientStats getClientStats(
+      MetricsRepository metricsRepository,
+      String statsPrefix,
+      String storeName,
+      RequestType requestType,
+      boolean dualReadEnabled,
+      boolean storeLoadControllerEnabled) {
+    String metricName = statsPrefix.isEmpty() ? storeName : statsPrefix + "." + storeName;
+    return new FastClientStats(metricsRepository, metricName, requestType, dualReadEnabled, storeLoadControllerEnabled);
+  }
+
+  private FastClientStats(
+      MetricsRepository metricsRepository,
+      String storeName,
+      RequestType requestType,
+      boolean dualReadEnabled,
+      boolean storeLoadControllerEnabled) {
     super(metricsRepository, storeName, requestType, FAST_CLIENT);
 
     this.storeName = storeName;
+    this.storeLoadControllerEnabled = storeLoadControllerEnabled;
 
     buildFastClientOtelStats();
 
-    Rate requestRate = getRequestRate();
-    Rate fastClientSlowerRequestRate = new OccurrenceRate();
-    this.dualReadFastClientSlowerRequestCountSensor =
-        registerSensor("dual_read_fastclient_slower_request_count", fastClientSlowerRequestRate);
-    this.dualReadFastClientSlowerRequestRatioSensor = registerSensor(
-        new TehutiUtils.SimpleRatioStat(
-            fastClientSlowerRequestRate,
-            requestRate,
-            "dual_read_fastclient_slower_request_ratio"));
-    Rate fastClientErrorThinClientSucceedRequestRate = new OccurrenceRate();
-    this.dualReadFastClientErrorThinClientSucceedRequestCountSensor = registerSensor(
-        "dual_read_fastclient_error_thinclient_succeed_request_count",
-        fastClientErrorThinClientSucceedRequestRate);
-    this.dualReadFastClientErrorThinClientSucceedRequestRatioSensor = registerSensor(
-        new TehutiUtils.SimpleRatioStat(
-            fastClientErrorThinClientSucceedRequestRate,
-            requestRate,
-            "dual_read_fastclient_error_thinclient_succeed_request_ratio"));
-    this.dualReadThinClientFastClientLatencyDeltaSensor =
-        registerSensorWithDetailedPercentiles("dual_read_thinclient_fastclient_latency_delta", new Max(), new Avg());
+    if (dualReadEnabled) {
+      Rate requestRate = getRequestRate();
+      Rate fastClientSlowerRequestRate = new OccurrenceRate();
+      this.dualReadFastClientSlowerRequestCountSensor =
+          registerSensor("dual_read_fastclient_slower_request_count", fastClientSlowerRequestRate);
+      this.dualReadFastClientSlowerRequestRatioSensor = registerSensor(
+          new TehutiUtils.SimpleRatioStat(
+              fastClientSlowerRequestRate,
+              requestRate,
+              "dual_read_fastclient_slower_request_ratio"));
+      Rate fastClientErrorThinClientSucceedRequestRate = new OccurrenceRate();
+      this.dualReadFastClientErrorThinClientSucceedRequestCountSensor = registerSensor(
+          "dual_read_fastclient_error_thinclient_succeed_request_count",
+          fastClientErrorThinClientSucceedRequestRate);
+      this.dualReadFastClientErrorThinClientSucceedRequestRatioSensor = registerSensor(
+          new TehutiUtils.SimpleRatioStat(
+              fastClientErrorThinClientSucceedRequestRate,
+              requestRate,
+              "dual_read_fastclient_error_thinclient_succeed_request_ratio"));
+      this.dualReadThinClientFastClientLatencyDeltaSensor =
+          registerSensorWithDetailedPercentiles("dual_read_thinclient_fastclient_latency_delta", new Max(), new Avg());
+    } else {
+      Sensor noopSensor = metricsRepository.getNoopSensor("dual_read");
+      this.dualReadFastClientSlowerRequestCountSensor = noopSensor;
+      this.dualReadFastClientSlowerRequestRatioSensor = noopSensor;
+      this.dualReadFastClientErrorThinClientSucceedRequestCountSensor = noopSensor;
+      this.dualReadFastClientErrorThinClientSucceedRequestRatioSensor = noopSensor;
+      this.dualReadThinClientFastClientLatencyDeltaSensor = noopSensor;
+    }
     this.leakedRequestCountSensor = registerSensor("leaked_request_count", new OccurrenceRate());
   }
 
@@ -116,23 +148,31 @@ public class FastClientStats extends ClientStats {
         baseDimensionsMap,
         RejectionReason.class);
 
-    this.rejectedRequestCountByLoadController = MetricEntityStateOneEnum.create(
-        FastClientMetricEntity.REQUEST_REJECTION_COUNT.getMetricEntity(),
-        otelRepository,
-        this::registerSensor,
-        FastClientTehutiMetricName.REJECTED_REQUEST_COUNT_BY_LOAD_CONTROLLER,
-        Collections.singletonList(new OccurrenceRate()),
-        baseDimensionsMap,
-        RejectionReason.class);
+    if (storeLoadControllerEnabled) {
+      this.rejectedRequestCountByLoadController = MetricEntityStateOneEnum.create(
+          FastClientMetricEntity.REQUEST_REJECTION_COUNT.getMetricEntity(),
+          otelRepository,
+          this::registerSensor,
+          FastClientTehutiMetricName.REJECTED_REQUEST_COUNT_BY_LOAD_CONTROLLER,
+          Collections.singletonList(new OccurrenceRate()),
+          baseDimensionsMap,
+          RejectionReason.class);
 
-    this.rejectionRatio = MetricEntityStateOneEnum.create(
-        FastClientMetricEntity.REQUEST_REJECTION_RATIO.getMetricEntity(),
-        otelRepository,
-        this::registerSensor,
-        FastClientTehutiMetricName.REJECTION_RATIO,
-        Arrays.asList(new Avg(), new Max()),
-        baseDimensionsMap,
-        RejectionReason.class);
+      this.rejectionRatio = MetricEntityStateOneEnum.create(
+          FastClientMetricEntity.REQUEST_REJECTION_RATIO.getMetricEntity(),
+          otelRepository,
+          this::registerSensor,
+          FastClientTehutiMetricName.REJECTION_RATIO,
+          Arrays.asList(new Avg(), new Max()),
+          baseDimensionsMap,
+          RejectionReason.class);
+    } else {
+      // Omitting the OTel repository and Tehuti registration makes these states no-ops for both backends.
+      this.rejectedRequestCountByLoadController = MetricEntityStateOneEnum
+          .create(FastClientMetricEntity.REQUEST_REJECTION_COUNT.getMetricEntity(), null, null, RejectionReason.class);
+      this.rejectionRatio = MetricEntityStateOneEnum
+          .create(FastClientMetricEntity.REQUEST_REJECTION_RATIO.getMetricEntity(), null, null, RejectionReason.class);
+    }
 
     this.longTailRetry = MetricEntityStateOneEnum.create(
         RETRY_CALL_COUNT.getMetricEntity(),

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/ClientConfigTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/ClientConfigTest.java
@@ -1,11 +1,17 @@
 package com.linkedin.venice.fastclient;
 
 import static com.linkedin.venice.client.stats.BasicClientStats.CLIENT_METRIC_ENTITIES;
+import static com.linkedin.venice.fastclient.stats.FastClientMetricEntity.REQUEST_REJECTION_COUNT;
+import static com.linkedin.venice.fastclient.stats.FastClientMetricEntity.REQUEST_REJECTION_RATIO;
 import static com.linkedin.venice.read.RequestType.MULTI_GET;
 import static com.linkedin.venice.read.RequestType.SINGLE_GET;
 import static com.linkedin.venice.stats.ClientType.FAST_CLIENT;
 import static com.linkedin.venice.stats.VeniceMetricsRepository.getVeniceMetricsRepository;
+import static com.linkedin.venice.stats.dimensions.RejectionReason.NO_REPLICAS_AVAILABLE;
+import static com.linkedin.venice.stats.dimensions.RejectionReason.THROTTLED_BY_LOAD_CONTROLLER;
+import static com.linkedin.venice.stats.dimensions.VeniceMetricsDimensions.VENICE_REQUEST_REJECTION_REASON;
 import static com.linkedin.venice.stats.dimensions.VeniceResponseStatusCategory.SUCCESS;
+import static com.linkedin.venice.utils.OpenTelemetryDataTestUtils.validateHistogramPointData;
 import static com.linkedin.venice.utils.OpenTelemetryDataTestUtils.validateLongPointDataFromCounter;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -15,17 +21,29 @@ import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.r2.transport.common.Client;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.fastclient.meta.InstanceHealthMonitor;
+import com.linkedin.venice.fastclient.stats.FastClientMetricEntity;
 import com.linkedin.venice.fastclient.stats.FastClientStats;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.stats.OpenTelemetryMetricsSetup;
+import com.linkedin.venice.stats.VeniceMetricsConfig;
 import com.linkedin.venice.stats.VeniceMetricsRepository;
 import com.linkedin.venice.stats.dimensions.HttpResponseStatusEnum;
+import com.linkedin.venice.stats.metrics.MetricEntity;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.OpenTelemetryDataTestUtils;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.tehuti.metrics.MetricsRepository;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import org.apache.avro.Schema;
 import org.testng.annotations.Test;
 
@@ -72,6 +90,191 @@ public class ClientConfigTest {
         getClientConfigWithMinimumRequiredInputs().setDisableRouteMetrics(disableRouteMetrics);
     assertEquals(clientConfigBuilder.build().isRouteMetricsDisabled(), disableRouteMetrics);
     assertEquals(clientConfigBuilder.clone().build().isRouteMetricsDisabled(), disableRouteMetrics);
+  }
+
+  @Test
+  public void testFeatureMetricsDisabledByDefault() {
+    MetricsRepository repository = new MetricsRepository();
+    MetricsRepository legacyRepository = new MetricsRepository();
+    try {
+      ClientConfig config = getClientConfigWithMinimumRequiredInputs().setMetricsRepository(repository)
+          .setInstanceHealthMonitor(mock(InstanceHealthMonitor.class))
+          .build();
+      assertFalse(config.isDualReadEnabled());
+      assertFalse(config.isStoreLoadControllerEnabled());
+
+      for (RequestType requestType: RequestType.values()) {
+        FastClientStats.getClientStats(legacyRepository, "", config.getStoreName(), requestType);
+        assertFeatureMetricRegistration(repository, requestType, false, false, true);
+      }
+      Set<String> omittedMetrics = new HashSet<>(legacyRepository.metrics().keySet());
+      omittedMetrics.removeAll(repository.metrics().keySet());
+      assertEquals(omittedMetrics.size(), 65);
+      assertTrue(
+          omittedMetrics.stream()
+              .allMatch(
+                  name -> name.contains("dual_read_") || name.contains("rejected_request_count_by_load_controller")
+                      || name.contains("rejection_ratio.")),
+          "Only dual-read and store-load-controller metrics should be omitted");
+    } finally {
+      repository.close();
+      legacyRepository.close();
+    }
+  }
+
+  @Test(dataProvider = "Four-True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testFeatureMetricsFollowClientConfig(
+      boolean dualReadEnabled,
+      boolean storeLoadControllerEnabled,
+      boolean emitTehutiMetrics,
+      boolean emitOtelMetrics) throws IOException {
+    Set<MetricEntity> metricEntities = new HashSet<>(CLIENT_METRIC_ENTITIES);
+    for (FastClientMetricEntity entity: FastClientMetricEntity.values()) {
+      metricEntities.add(entity.getMetricEntity());
+    }
+    try (InMemoryMetricReader reader = InMemoryMetricReader.create();
+        VeniceMetricsRepository repository = new VeniceMetricsRepository(
+            new VeniceMetricsConfig.Builder().setServiceName(FAST_CLIENT.getName())
+                .setMetricPrefix(FAST_CLIENT.getMetricsPrefix())
+                .setMetricEntities(metricEntities)
+                .emitTehutiMetrics(emitTehutiMetrics)
+                .setEmitOtelMetrics(emitOtelMetrics)
+                .setOtelAdditionalMetricsReader(reader)
+                .build())) {
+      ClientConfig config = getClientConfigWithMinimumRequiredInputs().setMetricsRepository(repository)
+          .setInstanceHealthMonitor(mock(InstanceHealthMonitor.class))
+          .setDualReadEnabled(dualReadEnabled)
+          .setGenericThinClient(dualReadEnabled ? mock(AvroGenericStoreClient.class) : null)
+          .setStoreLoadControllerEnabled(storeLoadControllerEnabled)
+          .build();
+      for (RequestType requestType: RequestType.values()) {
+        assertFeatureMetricRegistration(
+            repository,
+            requestType,
+            dualReadEnabled,
+            storeLoadControllerEnabled,
+            emitTehutiMetrics);
+      }
+
+      for (String clusterName: new String[] { OpenTelemetryMetricsSetup.UNKNOWN_CLUSTER_NAME, "migrated_cluster" }) {
+        config.onClusterNameUpdated(clusterName);
+        for (RequestType requestType: RequestType.values()) {
+          FastClientStats stats = config.getStats(requestType);
+          stats.emitHealthyRequestMetricsNonDavinciClient(1, 1, 1);
+          stats.recordFastClientSlowerRequest();
+          stats.recordFastClientErrorThinClientSucceedRequest();
+          stats.recordThinClientFastClientLatencyDelta(8);
+          stats.recordRejectionRatio(0);
+          stats.recordRejectionRatio(0.25);
+          stats.recordRejectedRequestByLoadController();
+          stats.recordNoAvailableReplicaRequest();
+
+          assertFeatureMetricRegistration(
+              repository,
+              requestType,
+              dualReadEnabled,
+              storeLoadControllerEnabled,
+              emitTehutiMetrics);
+          String prefix = ".test_store--" + requestType.getMetricPrefix();
+          if (emitTehutiMetrics) {
+            assertTrue(repository.getMetric(prefix + "request.OccurrenceRate").value() > 0);
+            assertTrue(repository.getMetric(prefix + "no_available_replica_request_count.OccurrenceRate").value() > 0);
+            if (dualReadEnabled) {
+              assertTrue(
+                  repository.getMetric(prefix + "dual_read_fastclient_slower_request_count.OccurrenceRate")
+                      .value() > 0);
+              assertTrue(
+                  repository
+                      .getMetric(prefix + "dual_read_fastclient_error_thinclient_succeed_request_count.OccurrenceRate")
+                      .value() > 0);
+              assertEquals(
+                  repository.getMetric(prefix + "dual_read_thinclient_fastclient_latency_delta.Max").value(),
+                  8.0);
+            }
+            if (storeLoadControllerEnabled) {
+              assertTrue(
+                  repository.getMetric(prefix + "rejected_request_count_by_load_controller.OccurrenceRate")
+                      .value() > 0);
+              assertEquals(repository.getMetric(prefix + "rejection_ratio.Max").value(), 0.25);
+            }
+          }
+          if (emitOtelMetrics) {
+            Attributes attributes =
+                new OpenTelemetryDataTestUtils.OpenTelemetryAttributesBuilder().setStoreName(config.getStoreName())
+                    .setRequestType(requestType)
+                    .setClusterName(clusterName)
+                    .build();
+            String rejectionReason = VENICE_REQUEST_REJECTION_REASON.getDimensionNameInDefaultFormat();
+            validateLongPointDataFromCounter(
+                reader,
+                1,
+                attributes.toBuilder().put(rejectionReason, NO_REPLICAS_AVAILABLE.getDimensionValue()).build(),
+                REQUEST_REJECTION_COUNT.getMetricEntity().getMetricName(),
+                FAST_CLIENT.getMetricsPrefix());
+            if (storeLoadControllerEnabled) {
+              Attributes loadControllerAttributes =
+                  attributes.toBuilder().put(rejectionReason, THROTTLED_BY_LOAD_CONTROLLER.getDimensionValue()).build();
+              validateLongPointDataFromCounter(
+                  reader,
+                  1,
+                  loadControllerAttributes,
+                  REQUEST_REJECTION_COUNT.getMetricEntity().getMetricName(),
+                  FAST_CLIENT.getMetricsPrefix());
+              validateHistogramPointData(
+                  reader,
+                  0,
+                  0.25,
+                  2,
+                  0.25,
+                  loadControllerAttributes,
+                  REQUEST_REJECTION_RATIO.getMetricEntity().getMetricName(),
+                  FAST_CLIENT.getMetricsPrefix());
+            }
+          }
+        }
+        Collection<MetricData> otelMetrics = reader.collectAllMetrics();
+        if (emitOtelMetrics) {
+          AttributeKey<String> rejectionReasonKey =
+              AttributeKey.stringKey(VENICE_REQUEST_REJECTION_REASON.getDimensionNameInDefaultFormat());
+          assertEquals(
+              otelMetrics.stream().anyMatch(metric -> metric.getName().endsWith(".request.rejection_ratio")),
+              storeLoadControllerEnabled);
+          assertEquals(
+              otelMetrics.stream()
+                  .filter(metric -> metric.getName().endsWith(".request.rejection_count"))
+                  .flatMap(metric -> metric.getLongSumData().getPoints().stream())
+                  .anyMatch(
+                      point -> THROTTLED_BY_LOAD_CONTROLLER.getDimensionValue()
+                          .equals(point.getAttributes().get(rejectionReasonKey))),
+              storeLoadControllerEnabled,
+              "Disabled load control must not emit its rejection reason on the shared counter");
+        } else {
+          assertTrue(otelMetrics.isEmpty());
+        }
+      }
+    }
+  }
+
+  private void assertFeatureMetricRegistration(
+      MetricsRepository repository,
+      RequestType requestType,
+      boolean dualReadEnabled,
+      boolean storeLoadControllerEnabled,
+      boolean emitTehutiMetrics) {
+    String prefix = ".test_store--" + requestType.getMetricPrefix();
+    Set<String> metrics = repository.metrics().keySet();
+    assertEquals(
+        metrics.stream().filter(name -> name.startsWith(prefix + "dual_read_")).count(),
+        emitTehutiMetrics && dualReadEnabled ? 10L : 0L);
+    for (String suffix: new String[] { "rejected_request_count_by_load_controller.OccurrenceRate",
+        "rejection_ratio.Avg", "rejection_ratio.Max" }) {
+      assertEquals(metrics.contains(prefix + suffix), emitTehutiMetrics && storeLoadControllerEnabled, prefix + suffix);
+    }
+    assertEquals(metrics.contains(prefix + "request.OccurrenceRate"), emitTehutiMetrics);
+    assertEquals(metrics.contains(prefix + "no_available_replica_request_count.OccurrenceRate"), emitTehutiMetrics);
+    if (!emitTehutiMetrics) {
+      assertTrue(metrics.isEmpty());
+    }
   }
 
   @Test(expectedExceptions = VeniceClientException.class, expectedExceptionsMessageRegExp = "Either param: specificThinClient or param: genericThinClient.*")

--- a/docs/user-guide/read-apis/fast-client.md
+++ b/docs/user-guide/read-apis/fast-client.md
@@ -153,6 +153,11 @@ ClientConfig clientConfig = new ClientConfig.ClientConfigBuilder<>()
     .build();
 ```
 
+Dual-read metrics are registered in RRD (Tehuti) only when `setDualReadEnabled(true)` is configured.
+Store-load-controller metrics are registered and emitted in RRD and OpenTelemetry only when
+`setStoreLoadControllerEnabled(true)` is configured. Both features are disabled by default. These settings do not
+disable core request metrics, no-available-replica metrics, or aggregate instance-health metrics.
+
 ## Configuration Options
 
 Key configuration options for `ClientConfig`:


### PR DESCRIPTION
## Problem Statement
Fast Client eagerly creates statistics for all five request types, including optional features that are disabled. 

## Solution
Lazy registration based on request types and some other store configs such as compression and read compute will involve a lot of refactor. Since we already have plans to disable rrd altogether and otel doesn't produce data points for unused metrics, avoid registering unused feature metrics by honoring the existing client configuration is implemented here as a simple fix to get some reduction (about a 12% reduction).

- Pass dualReadEnabled and storeLoadControllerEnabled from ClientConfig into a new FastClientStats factory overload. Keep the original overload fully enabled for compatibility with existing direct callers.
- Use no-op dual-read sensors when dual read is disabled, avoiding its count, ratio, and latency metric registrations and allocations.
- Create and record store-load-controller rejection count and rejection ratio metrics only when load control is enabled, suppressing both RRD and OpenTelemetry output, including zero-valued ratio observations.
- Keep NO_REPLICAS_AVAILABLE creation and recording unconditional so the shared OpenTelemetry request.rejection_count counter remains usable with load control and RRD disabled. Preserve this separation when cluster dimensions are rebuilt.
- Omit 65 RRD metric names per store with the default configuration: 50 dual-read names and 15 load-controller names across five request types. Leave core request, retry, route, and aggregate instance-health metric behavior unchanged.
- Cover all 16 combinations of feature and backend flags, all request types, disabled recording calls, cluster migration, the shared OTel counter, and the exact default registration reduction.
- Document how the existing client feature flags control metric registration and emission.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
