### PR TITLE
[da-vinci][server] Downgrade P2PFileTransferServerHandler ERROR logs to WARN and DEBUG

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/server/P2PFileTransferServerHandler.java
@@ -202,7 +202,7 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
           String errMessage =
               "The number of concurrent snapshot users exceeds the limit of " + maxAllowedConcurrentSnapshotUsers
                   + ", won't be able to process the request for " + blobTransferRequest.getFullResourceName();
-          LOGGER.error(errMessage);
+          LOGGER.warn(errMessage);
           setupResponseAndFlush(HttpResponseStatus.TOO_MANY_REQUESTS, errMessage.getBytes(), false, ctx);
           return;
         }
@@ -217,7 +217,7 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
               String errMessage =
                   "The number of concurrent snapshot users exceeds the limit of " + maxAllowedConcurrentSnapshotUsers
                       + ", won't be able to process the request for " + blobTransferRequest.getFullResourceName();
-              LOGGER.error(errMessage);
+              LOGGER.warn(errMessage);
               setupResponseAndFlush(HttpResponseStatus.TOO_MANY_REQUESTS, errMessage.getBytes(), false, ctx);
               return;
             }
@@ -267,7 +267,7 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
       if (System.currentTimeMillis() - startTime >= TimeUnit.MINUTES.toMillis(blobTransferMaxTimeoutInMin)) {
         String errMessage =
             String.format(TRANSFER_TIMEOUT_ERROR_MSG_FORMAT, blobTransferRequest.getFullResourceName(), file.getName());
-        LOGGER.error(errMessage);
+        LOGGER.warn(errMessage);
         setupResponseAndFlush(
             HttpResponseStatus.REQUEST_TIMEOUT,
             errMessage.getBytes(),
@@ -289,7 +289,7 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
       if (future.isSuccess()) {
         LOGGER.info("All files sent successfully for {} to host {}", replicaInfo, ctx.channel().remoteAddress());
       } else {
-        LOGGER.error(
+        LOGGER.warn(
             "Failed to send all files for {} to host {}",
             replicaInfo,
             ctx.channel().remoteAddress(),
@@ -317,7 +317,7 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
           globalConcurrentTransferRequests.decrementAndGet();
         }
       } catch (Exception e) {
-        LOGGER.error("Failed to decrease the snapshot concurrent user count for request {}", blobTransferRequest, e);
+        LOGGER.warn("Failed to decrease the snapshot concurrent user count for request {}", blobTransferRequest, e);
       }
     }
     if (clientOrigin) {
@@ -406,7 +406,7 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
             replicaInfo,
             ctx.channel().remoteAddress());
       } else {
-        LOGGER.error(
+        LOGGER.debug(
             "Failed to send file: {} for replica: {} to host: {}",
             file.getName(),
             replicaInfo,
@@ -442,7 +442,7 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
             Utils.getReplicaId(metadata.getTopicName(), metadata.getPartitionId()),
             metadataBytes.length);
       } else {
-        LOGGER.error(
+        LOGGER.warn(
             "Failed to send metadata for {}",
             Utils.getReplicaId(metadata.getTopicName(), metadata.getPartitionId()),
             future.cause());


### PR DESCRIPTION
## Problem Statement

`P2PFileTransferServerHandler` attaches a `ChannelFuture` listener to every chunked file
send and logs one ERROR line per `.sst` file when the send fails. A snapshot can contain
hundreds of `.sst` files per replica, so a single dropped connection to one peer produces
one ERROR line per file still in flight rather than one line for the failed transfer.

On the 2026-09-03 deploy this tripped `inlogs-excessive-error-log-check` for a
venice-server canary (10x more ERROR lines than control). Roughly 114-150 real dropped
connections (`ClosedChannelException` / channel closed mid-flush) fanned out into 24,942
ERROR lines on the 6 canary pods, and 580,143 across the full venice-2 / prod-lor1 cluster
(149 hosts) in the same 1-hour window. One replica, `FeedEngagementCountsHistory_v293-926`,
logged 1,841 ERROR lines for a single failed transfer. Per-host error rate was nearly
identical between canary (4,157/pod) and the rest of the fleet (3,883/pod), confirming a
fleet-wide bootstrap side effect rather than a canary code regression.

Two consequences:

- Starting 2026-09-14 this check becomes SEV1-blocking, so a routine cluster-wide
  blob-transfer bootstrap wave (rebalances, host replacements, concurrent restarts) that
  overlaps a deploy will block an otherwise-healthy release with no regression behind it.
- 580K ERROR lines in one cluster in one hour make it impractical to spot genuine
  blob-transfer failures in the same log stream.

The severity is also simply wrong. None of these conditions are server faults: dropped peer
connections, transfer timeouts, and concurrent-snapshot-user limits are expected during
bootstrap, are driven by the peer or by load, and are already surfaced to the client through
the HTTP response status (429 / 408 / 404).

Jira: VENG-12911

## Solution

Downgrade all 7 `LOGGER.error` call sites in `P2PFileTransferServerHandler`. Six move to
`LOGGER.warn`; the per-file `Failed to send file` line - the one responsible for the
fan-out - moves to `LOGGER.debug`. No logic, protocol, retry, or control-flow change - only
the severity of existing messages.

| Call site | New level | Condition |
| --- | --- | --- |
| Concurrent snapshot-user limit (pre-check) | WARN | Load shedding; client already receives 429 |
| Concurrent snapshot-user limit (post-increment) | WARN | Same |
| Per-partition transfer timeout | WARN | Client already receives 408 |
| `Failed to send all files` | WARN | Peer dropped the connection; fires once per transfer |
| `Failed to decrease the snapshot concurrent user count` | WARN | Cleanup failure on channel close |
| `Failed to send metadata` | WARN | Peer dropped the connection; fires once per transfer |
| `Failed to send file` | DEBUG | Peer dropped the connection - **the amplifying call site**, fires once per file |

Trade-offs, called out explicitly:

- **The fan-out is eliminated, not relabelled.** Moving the per-file line to DEBUG is what
  actually removes the volume: it is the only call site that fires per `.sst` file rather
  than per transfer. A failed transfer that previously emitted ~1,841 ERROR lines now emits
  2 WARN lines - `Failed to send metadata` and `Failed to send all files` - because a
  dropped connection fails those writes too. The 580K lines from the incident window
  collapse to roughly 300 cluster-wide, with no aggregation or dedup state needed to get
  there.
- **Per-file failure detail is no longer visible in production.** If a single file's send
  fails while the channel stays open - for example an `IOException` reading the file off
  local disk - the server still logs `All files sent successfully` at INFO and the reason
  sits at DEBUG. This does not affect correctness: `P2PFileTransferClientHandler` validates
  a per-file `CONTENT_MD5` and throws `VeniceException` on mismatch, so the client fails the
  transfer and retries another peer regardless of what the server logged. It does mean
  diagnosing that specific case requires enabling DEBUG on the handler.
- **`Failed to decrease the snapshot concurrent user count` is the weakest of the seven.**
  Unlike the others it is not peer-caused: a leaked snapshot-user count is a genuine
  server-side bug that can wedge later transfers against `maxAllowedConcurrentSnapshotUsers`.
  It is included for consistency and because it is not part of the amplification (once per
  channel, not once per file). Happy to leave this one at ERROR if reviewers prefer.

No performance impact; WARN and ERROR go to the same appenders at the same cost.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
    - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

No new log lines and no new config - only severity changes to existing lines. On rate
limiting: the line that needed it was the per-file one, and moving it to DEBUG addresses
that directly. The remaining WARN lines fire at most twice per failed transfer, so no
explicit rate limiter is warranted.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

This PR changes only log severity; it introduces no new state, no new shared data
structures, and no new synchronization. The `ChannelFuture` listeners and the existing
`AtomicInteger` / `AtomicBoolean` usage are untouched, so the concurrency profile of the
handler is byte-for-byte the same apart from the log level.

## How was this PR tested?

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

No new or modified tests. The change is a log-severity edit with no observable behavior to
assert on, and the existing suite already covers every affected code path, including the
failure branches whose severity changed.

Validation performed:

- `./gradlew :clients:da-vinci-client:test --tests "com.linkedin.davinci.blobtransfer.TestP2PFileTransferServerHandler"`
  - all 19 tests pass, covering the transfer-timeout, too-many-requests, metadata-failure,
    snapshot-missing and concurrent-user-cleanup paths.
- `./gradlew :clients:da-vinci-client:compileJava` - clean.
- `./gradlew spotlessCheck` - clean.
- Verified by inspection that zero `LOGGER.error` call sites remain in the file.

## Does this PR introduce any user-facing or breaking changes?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Clearly explain the behavior change and its impact.

No API, protocol, config, or wire-format change, and no change to what a client observes -
the same HTTP status codes are still returned for every condition.

There is, however, an **operational** behavior change worth flagging for on-call owners:
these seven messages previously appeared at ERROR. Six now appear at WARN, and the per-file
`Failed to send file` moves to DEBUG, so it is not emitted in production under the default
log level. Any alert, dashboard, saved query, or log filter keyed on ERROR severity for
these strings will stop matching. Concretely:

- Intended effect: `inlogs-excessive-error-log-check` will no longer count blob-transfer
  bootstrap noise, which is the point of this change.
- A genuine, sustained blob-transfer send failure now surfaces at WARN rather than ERROR,
  once per failed transfer instead of once per file.
- Anything filtering on the text `Failed to send file` will stop matching in production.
  Enable DEBUG on `com.linkedin.davinci.blobtransfer.server.P2PFileTransferServerHandler`
  to recover the per-file detail when investigating.
