### PR TITLE
[controller] Make version swap broadcast timeout configurable

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigConstants.java
@@ -20,6 +20,8 @@ public class ConfigConstants {
   public static final long DEFAULT_PUSH_STATUS_STORE_HEARTBEAT_EXPIRATION_TIME_IN_SECONDS =
       TimeUnit.MINUTES.toSeconds(30);
 
+  public static final int DEFAULT_VERSION_SWAP_BROADCAST_TIMEOUT_IN_SECONDS = 120;
+
   public static final String CONTROLLER_DEFAULT_HELIX_RESOURCE_CAPACITY_KEY = "cluster_resource_weight";
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -3595,6 +3595,13 @@ public class ConfigKeys {
       "controller.use.multi.region.real.time.topic.switcher.enabled";
 
   /**
+   * Maximum time in seconds for a multi-region Version Swap Message broadcast, including partition acknowledgements
+   * across all regions. Default is 120 seconds.
+   */
+  public static final String CONTROLLER_VERSION_SWAP_BROADCAST_TIMEOUT_SECONDS =
+      "controller.version.swap.broadcast.timeout.seconds";
+
+  /**
    * Number of consecutive cycles to wait before removing a replica that does not have a corresponding entry in local
    * customized view cache before removing it from lag monitor. e.g. if this config is set to 10, and we are using the
    * default sleep interval of 60 seconds then we will only remove the replica from lag monitor after at least 600

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.CommonConfigKeys.SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.ConfigConstants.CONTROLLER_DEFAULT_HELIX_RESOURCE_CAPACITY_KEY;
 import static com.linkedin.venice.ConfigConstants.DEFAULT_MAX_RECORD_SIZE_BYTES_BACKFILL;
 import static com.linkedin.venice.ConfigConstants.DEFAULT_PUSH_STATUS_STORE_HEARTBEAT_EXPIRATION_TIME_IN_SECONDS;
+import static com.linkedin.venice.ConfigConstants.DEFAULT_VERSION_SWAP_BROADCAST_TIMEOUT_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.ACTIVE_ACTIVE_REAL_TIME_SOURCE_FABRIC_LIST;
 import static com.linkedin.venice.ConfigKeys.ADMIN_CHECK_READ_METHOD_FOR_KAFKA;
 import static com.linkedin.venice.ConfigKeys.ADMIN_CONSUMPTION_CYCLE_TIMEOUT_MS;
@@ -119,6 +120,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_SYSTEM_SCHEMA_CLUSTER_NA
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SYSTEM_STORE_ACL_SYNCHRONIZATION_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_UNUSED_SCHEMA_CLEANUP_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_UNUSED_VALUE_SCHEMA_CLEANUP_ENABLED;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_VERSION_SWAP_BROADCAST_TIMEOUT_SECONDS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ZK_SHARED_META_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_ENABLED;
@@ -718,6 +720,7 @@ public class VeniceControllerClusterConfig {
 
   private final boolean backupVersionReplicaReductionEnabled;
   private final boolean useMultiRegionRealTimeTopicSwitcher;
+  private final int versionSwapBroadcastTimeoutSeconds;
   private final Set<String> activeActiveRealTimeSourceFabrics;
 
   private final boolean isSkipHybridStoreRTTopicCompactionPolicyUpdateEnabled;
@@ -1357,6 +1360,11 @@ public class VeniceControllerClusterConfig {
         props.getBoolean(CONTROLLER_BACKUP_VERSION_REPLICA_REDUCTION_ENABLED, false);
     this.useMultiRegionRealTimeTopicSwitcher =
         props.getBoolean(ConfigKeys.CONTROLLER_USE_MULTI_REGION_REAL_TIME_TOPIC_SWITCHER_ENABLED, false);
+    this.versionSwapBroadcastTimeoutSeconds = props
+        .getInt(CONTROLLER_VERSION_SWAP_BROADCAST_TIMEOUT_SECONDS, DEFAULT_VERSION_SWAP_BROADCAST_TIMEOUT_IN_SECONDS);
+    if (versionSwapBroadcastTimeoutSeconds <= 0) {
+      throw new ConfigurationException(CONTROLLER_VERSION_SWAP_BROADCAST_TIMEOUT_SECONDS + " must be greater than 0.");
+    }
     this.isAdminOperationSystemStoreEnabled =
         props.getBoolean(ConfigKeys.CONTROLLER_ADMIN_OPERATION_SYSTEM_STORE_ENABLED, false);
 
@@ -2590,6 +2598,10 @@ public class VeniceControllerClusterConfig {
 
   public boolean isUseMultiRegionRealTimeTopicSwitcherEnabled() {
     return useMultiRegionRealTimeTopicSwitcher;
+  }
+
+  public int getVersionSwapBroadcastTimeoutSeconds() {
+    return versionSwapBroadcastTimeoutSeconds;
   }
 
   public Set<String> getActiveActiveRealTimeSourceFabrics() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -627,7 +627,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           commonConfig.getProps(),
           pubSubTopicRepository,
           activeActiveRealTimeSourceFabricBrokerUrlMap,
-          localRegionName);
+          localRegionName,
+          commonConfig.getVersionSwapBroadcastTimeoutSeconds());
     } else {
       this.realTimeTopicSwitcher = new RealTimeTopicSwitcher(
           topicManagerRepository.getLocalTopicManager(),

--- a/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcher.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcher.java
@@ -29,9 +29,9 @@ import org.apache.logging.log4j.Logger;
 
 public class MultiRegionRealTimeTopicSwitcher extends RealTimeTopicSwitcher {
   private static final Logger LOGGER = LogManager.getLogger(MultiRegionRealTimeTopicSwitcher.class);
-  private static final int DEFAULT_BROADCAST_TIMEOUT_IN_SECONDS = 60;
   private final Map<String, String> allAASourceDataCenterBrokerAddressMap;
   private final String localDataCenterName;
+  private final int broadcastTimeoutInSeconds;
 
   public MultiRegionRealTimeTopicSwitcher(
       TopicManager topicManager,
@@ -39,10 +39,15 @@ public class MultiRegionRealTimeTopicSwitcher extends RealTimeTopicSwitcher {
       VeniceProperties veniceProperties,
       PubSubTopicRepository pubSubTopicRepository,
       Map<String, String> activeActiveRealTimeSourceFabricBrokerUrlMap,
-      String localDataCenterName) {
+      String localDataCenterName,
+      int broadcastTimeoutInSeconds) {
     super(topicManager, localVeniceWriterFactory, veniceProperties, pubSubTopicRepository);
+    if (broadcastTimeoutInSeconds <= 0) {
+      throw new IllegalArgumentException("Version Swap broadcast timeout must be greater than 0.");
+    }
     this.allAASourceDataCenterBrokerAddressMap = new HashMap<>(activeActiveRealTimeSourceFabricBrokerUrlMap);
     this.localDataCenterName = localDataCenterName;
+    this.broadcastTimeoutInSeconds = broadcastTimeoutInSeconds;
   }
 
   @Override
@@ -69,7 +74,7 @@ public class MultiRegionRealTimeTopicSwitcher extends RealTimeTopicSwitcher {
         new DaemonThreadFactory("Version-Swap-" + storeName));
     Map<String, CompletableFuture<Void>> dataCenterBroadcastFutureMap = new HashMap<>();
     Map<String, VeniceWriter> dataCenterWriterMap = new ConcurrentHashMap<>();
-    long deadlineNs = System.nanoTime() + TimeUnit.SECONDS.toNanos(DEFAULT_BROADCAST_TIMEOUT_IN_SECONDS);
+    long deadlineNs = System.nanoTime() + TimeUnit.SECONDS.toNanos(broadcastTimeoutInSeconds);
     AtomicBoolean broadcastAborted = new AtomicBoolean(false);
     boolean broadcastCompleted = false;
     try {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceControllerClusterConfig.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.controller;
 
 import static com.linkedin.venice.ConfigConstants.CONTROLLER_DEFAULT_HELIX_RESOURCE_CAPACITY_KEY;
+import static com.linkedin.venice.ConfigConstants.DEFAULT_VERSION_SWAP_BROADCAST_TIMEOUT_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.ACTIVE_ACTIVE_REAL_TIME_SOURCE_FABRIC_LIST;
 import static com.linkedin.venice.ConfigKeys.ADMIN_HELIX_MESSAGING_CHANNEL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CHILD_CLUSTER_ALLOWLIST;
@@ -38,6 +39,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_STANDBY_TO_LEADER_TRANSITION_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_STORAGE_CLUSTER_HELIX_CLOUD_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SYSTEM_SCHEMA_CLUSTER_NAME;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_VERSION_SWAP_BROADCAST_TIMEOUT_SECONDS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
@@ -643,6 +645,23 @@ public class TestVeniceControllerClusterConfig {
     baseProps.setProperty(CONTROLLER_STANDBY_TO_LEADER_TRANSITION_TIMEOUT_MS, "12345");
     clusterConfig = new VeniceControllerClusterConfig(new VeniceProperties(baseProps));
     assertEquals(clusterConfig.getControllerStandbyToLeaderTransitionTimeoutMs(), 12345L);
+  }
+
+  public void testVersionSwapBroadcastTimeoutSeconds() {
+    Properties baseProps = getBaseSingleRegionProperties(false);
+    VeniceControllerClusterConfig clusterConfig = new VeniceControllerClusterConfig(new VeniceProperties(baseProps));
+    assertEquals(
+        clusterConfig.getVersionSwapBroadcastTimeoutSeconds(),
+        DEFAULT_VERSION_SWAP_BROADCAST_TIMEOUT_IN_SECONDS);
+
+    baseProps.setProperty(CONTROLLER_VERSION_SWAP_BROADCAST_TIMEOUT_SECONDS, "180");
+    clusterConfig = new VeniceControllerClusterConfig(new VeniceProperties(baseProps));
+    assertEquals(clusterConfig.getVersionSwapBroadcastTimeoutSeconds(), 180);
+
+    baseProps.setProperty(CONTROLLER_VERSION_SWAP_BROADCAST_TIMEOUT_SECONDS, "0");
+    assertThrows(
+        ConfigurationException.class,
+        () -> new VeniceControllerClusterConfig(new VeniceProperties(baseProps)));
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcherTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/MultiRegionRealTimeTopicSwitcherTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.linkedin.venice.ConfigConstants;
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Store;
@@ -155,7 +156,8 @@ public class MultiRegionRealTimeTopicSwitcherTest {
             veniceProperties,
             pubSubTopicRepository,
             brokerMap,
-            localDc));
+            localDc,
+            ConfigConstants.DEFAULT_VERSION_SWAP_BROADCAST_TIMEOUT_IN_SECONDS));
     doReturn(deterministicGenerationId).when(switcher).getVersionSwapGenerationId();
 
     // Act: trigger transmitVersionSwapMessage which will delegate to overridden broadcastVersionSwap
@@ -338,6 +340,23 @@ public class MultiRegionRealTimeTopicSwitcherTest {
     Assert.expectThrows(TimeoutException.class, () -> switcher.getRemainingTimeInMs(System.nanoTime() - 1));
   }
 
+  @Test
+  public void testRejectsNonPositiveBroadcastTimeout() {
+    Properties props = new Properties();
+    props.put(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, "dummy");
+
+    Assert.expectThrows(
+        IllegalArgumentException.class,
+        () -> new MultiRegionRealTimeTopicSwitcher(
+            mock(TopicManager.class),
+            mock(VeniceWriterFactory.class),
+            new VeniceProperties(props),
+            pubSubTopicRepository,
+            Collections.emptyMap(),
+            "dc_local",
+            0));
+  }
+
   private MultiRegionRealTimeTopicSwitcher newSwitcher(
       TopicManager topicManager,
       VeniceWriterFactory writerFactory,
@@ -351,7 +370,8 @@ public class MultiRegionRealTimeTopicSwitcherTest {
         new VeniceProperties(props),
         pubSubTopicRepository,
         brokerMap,
-        localDc);
+        localDc,
+        ConfigConstants.DEFAULT_VERSION_SWAP_BROADCAST_TIMEOUT_IN_SECONDS);
   }
 
   private static Version version(String storeName, int number, int partitionCount) {


### PR DESCRIPTION
## Problem Statement
60s timeout is insufficient for stores with large number of partitions (e.g. 4000+).

## Solution
Add a controller common config with a 120-second default and wire it into multi-region version swap broadcasts.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [ ] Introduced new **log lines**.
  - [ ] Confirmed if logs need to be **rate limited** to avoid excessive logging.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [ ] Code has **no race conditions** or **thread safety issues**.
- [ ] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [ ] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [ ] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [ ] Validated proper exception handling in multi-threaded code to avoid silent thread termination.

## How was this PR tested?

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- [ ] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [ ] Verified backward compatibility (if applicable).

## Does this PR introduce any user-facing or breaking changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Clearly explain the behavior change and its impact.
