### PR TITLE
[da-vinci][changelog] Keep lag reporter alive when recordStats fails

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImpl.java
@@ -605,7 +605,14 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImpl<K, V>
     public void run() {
       while (!Thread.interrupted()) {
         try {
-          recordStats();
+          try {
+            recordStats();
+          } catch (Exception e) {
+            // This thread is started at most once per consumer and is never restarted, so letting an
+            // exception escape would silently stop heartbeat lag and consuming version reporting for the
+            // remaining lifetime of the consumer. Skip this cycle and retry on the next one instead.
+            LOGGER.error("Failed to record change capture stats. Skipping this reporting cycle.", e);
+          }
           TimeUnit.SECONDS.sleep(changelogClientConfig.getBackgroundReporterThreadSleepIntervalInSeconds());
         } catch (InterruptedException e) {
           LOGGER.warn("BackgroundReporterThread interrupted!  Shutting down...", e);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -1248,7 +1248,14 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     public void run() {
       while (!Thread.interrupted()) {
         try {
-          recordStats(getLastHeartbeatPerPartition(), changeCaptureStats, getTopicAssignment());
+          try {
+            recordStats(getLastHeartbeatPerPartition(), changeCaptureStats, getTopicAssignment());
+          } catch (Exception e) {
+            // This thread is started at most once per consumer and is never restarted, so letting an
+            // exception escape would silently stop heartbeat lag and consuming version reporting for the
+            // remaining lifetime of the consumer. Skip this cycle and retry on the next one instead.
+            LOGGER.error("Failed to record change capture stats. Skipping this reporting cycle.", e);
+          }
           TimeUnit.SECONDS.sleep(changelogClientConfig.getBackgroundReporterThreadSleepIntervalInSeconds());
         } catch (InterruptedException e) {
           LOGGER.warn("Lag Monitoring thread interrupted!  Shutting down...", e);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerDaVinciRecordTransformerImplTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
@@ -759,6 +760,51 @@ public class VeniceChangelogConsumerDaVinciRecordTransformerImplTest {
           .emitCurrentConsumingVersionMetrics(CURRENT_STORE_VERSION, FUTURE_STORE_VERSION);
       verify(changeCaptureStats, atLeastOnce()).emitHeartBeatDelayMetrics(anyLong());
     });
+  }
+
+  @Test
+  public void testMetricReportingThreadSurvivesRecordStatsFailure() {
+    // Keep the interval short so a surviving loop completes several cycles well within the test timeout.
+    changelogClientConfig.setBackgroundReporterThreadSleepIntervalInSeconds(1L);
+
+    // emitCurrentConsumingVersionMetrics is the last statement of recordStats, so throwing here fails the
+    // whole reporting cycle the same way a malformed topic name would.
+    doThrow(new NumberFormatException("Simulated failure while computing stats")).when(changeCaptureStats)
+        .emitCurrentConsumingVersionMetrics(anyInt(), anyInt());
+
+    veniceChangelogConsumer.start();
+    onStartVersionIngestionHelper(true, true);
+
+    int partitionId = 0;
+    recordTransformer.processPut(keys.get(partitionId), lazyValue, partitionId, recordMetadata);
+    recordTransformer.onHeartbeat(partitionId, 1L);
+
+    Thread reporterThread = null;
+    try {
+      /**
+       * Require a second cycle rather than a single one: the first invocation is recorded before the
+       * exception finishes unwinding, so asserting on it alone could observe a thread that is already
+       * terminating. A second call only happens if the loop resumed.
+       */
+      TestUtils.waitForNonDeterministicAssertion(
+          30,
+          TimeUnit.SECONDS,
+          true,
+          () -> verify(changeCaptureStats, atLeast(2)).emitCurrentConsumingVersionMetrics(anyInt(), anyInt()));
+
+      reporterThread = veniceChangelogConsumer.getBackgroundReporterThread();
+      assertNotNull(reporterThread, "Background reporter thread should have been started.");
+      assertTrue(
+          reporterThread.isAlive(),
+          "Reporter thread must stay alive after recordStats throws, otherwise lag reporting stops permanently.");
+    } finally {
+      if (reporterThread == null) {
+        reporterThread = veniceChangelogConsumer.getBackgroundReporterThread();
+      }
+      if (reporterThread != null) {
+        reporterThread.interrupt();
+      }
+    }
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -705,6 +706,8 @@ public class VeniceChangelogConsumerImplTest {
 
   @Test
   public void testMetricReportingThreadSurvivesRecordStatsFailure() {
+    // Keep the interval short so a surviving loop completes several cycles well within the test timeout.
+    changelogClientConfig.setBackgroundReporterThreadSleepIntervalInSeconds(1L);
     prepareVersionTopicRecordsToBePolled(0L, 5L, mockPubSubConsumer, oldVersionTopic, 0, true);
     VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceAfterImageConsumerImpl<>(
         changelogClientConfig,
@@ -720,10 +723,15 @@ public class VeniceChangelogConsumerImplTest {
         veniceChangelogConsumer.getHeartbeatReporterThread();
     try {
       reporterThread.start();
+      /**
+       * Require a second cycle rather than a single one: the first invocation is recorded before the
+       * exception finishes unwinding, so asserting on it alone could observe a thread that is already
+       * terminating. A second call only happens if the loop resumed.
+       */
       TestUtils.waitForNonDeterministicAssertion(
-          5,
+          30,
           TimeUnit.SECONDS,
-          () -> Mockito.verify(mockPubSubConsumer, atLeastOnce()).getAssignment());
+          () -> Mockito.verify(mockPubSubConsumer, atLeast(2)).getAssignment());
       assertTrue(
           reporterThread.isAlive(),
           "Reporter thread must stay alive after recordStats throws, otherwise lag reporting stops permanently.");

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -704,6 +704,35 @@ public class VeniceChangelogConsumerImplTest {
   }
 
   @Test
+  public void testMetricReportingThreadSurvivesRecordStatsFailure() {
+    prepareVersionTopicRecordsToBePolled(0L, 5L, mockPubSubConsumer, oldVersionTopic, 0, true);
+    VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceAfterImageConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        PubSubMessageDeserializer.createDefaultDeserializer(),
+        veniceChangelogConsumerClientFactory);
+    veniceChangelogConsumer.setStoreRepository(mockRepository);
+
+    doThrow(new NumberFormatException("Simulated failure while computing stats")).when(mockPubSubConsumer)
+        .getAssignment();
+
+    VeniceChangelogConsumerImpl.HeartbeatReporterThread reporterThread =
+        veniceChangelogConsumer.getHeartbeatReporterThread();
+    try {
+      reporterThread.start();
+      TestUtils.waitForNonDeterministicAssertion(
+          5,
+          TimeUnit.SECONDS,
+          () -> Mockito.verify(mockPubSubConsumer, atLeastOnce()).getAssignment());
+      assertTrue(
+          reporterThread.isAlive(),
+          "Reporter thread must stay alive after recordStats throws, otherwise lag reporting stops permanently.");
+    } finally {
+      reporterThread.interrupt();
+    }
+  }
+
+  @Test
   public void testChunkingSuccess() throws NoSuchFieldException, IllegalAccessException {
     VeniceChangelogConsumerImpl veniceChangelogConsumer = mock(VeniceChangelogConsumerImpl.class);
 


### PR DESCRIPTION
## Problem Statement

The changelog consumer's background reporter thread emits two metrics on a fixed interval:
`HeartBeatDelay` and `CurrentConsumingVersion`. It is started at most once per consumer, and
`startHeartbeatReporterIfNeeded()` guards the start with a `Thread.State.NEW` check, so once the
thread terminates it is never restarted.

The run loop only caught `InterruptedException`:

```java
while (!Thread.interrupted()) {
  try {
    recordStats(getLastHeartbeatPerPartition(), changeCaptureStats, getTopicAssignment());
    TimeUnit.SECONDS.sleep(...);
  } catch (InterruptedException e) {
    ...
  }
}
```

Any `RuntimeException` escaping `recordStats` therefore propagates out of `run()` and permanently
kills lag reporting for the rest of the consumer's lifetime. `recordStats` is not exception-free —
it calls `Version.parseVersionFromKafkaTopicName`, which does an unguarded `Integer.parseInt` on the
topic name and throws `NumberFormatException` for any assignment entry that is not a versioned topic.

Two things make this failure mode hard to notice:

1. The poll-path metrics (`PollCount`, `RecordsConsumedCount`, `VersionSwapCount`) are emitted from a
   different code path and keep reporting normally, so the consumer still looks healthy. Only the two
   reporter-thread metrics go silent.
2. An uncaught exception in a thread is routed to the default handler and written to stderr, so it
   does not go through the application logger and can be absent from log aggregation entirely.

## Solution

Wrap the `recordStats` call so that a failed reporting cycle is logged and the loop continues on the
next interval, instead of terminating the thread. The `InterruptedException` handling is unchanged,
so shutdown behaviour on `close()` is preserved.

The same loop pattern exists in both `VeniceChangelogConsumerImpl.HeartbeatReporterThread` and
`VeniceChangelogConsumerDaVinciRecordTransformerImpl.BackgroundReporterThread`, so both are updated.

`Exception` is caught rather than `Throwable`, so `Error` conditions such as `OutOfMemoryError` still
propagate rather than being swallowed and retried every interval.

### Code changes

- [ ] Added new code behind **a config**. If so list the config names and their default values in the PR description.
- [x] Introduced new **log lines**.
  - [x] Confirmed if logs need to be **rate limited** to avoid excessive logging.
    - The new `LOGGER.error` can fire at most once per reporter interval
      (`backgroundReporterThreadSleepIntervalInSeconds`, default 60s) per consumer, so it is
      inherently rate limited and does not need additional throttling.

### **Concurrency-Specific Checks**

Both reviewer and PR author to verify

- [x] Code has **no race conditions** or **thread safety issues**.
- [x] Proper **synchronization mechanisms** (e.g., `synchronized`, `RWLock`) are used where needed.
- [x] No **blocking calls** inside critical sections that could lead to deadlocks or performance degradation.
- [x] Verified **thread-safe collections** are used (e.g., `ConcurrentHashMap`, `CopyOnWriteArrayList`).
- [x] Validated proper exception handling in multi-threaded code to avoid silent thread termination.
  - This is precisely what the PR fixes.

## How was this PR tested?

- [x] New unit tests added.
- [ ] New integration tests added.
- [ ] Modified or extended existing tests.
- [x] Verified backward compatibility (if applicable).

Added `testMetricReportingThreadSurvivesRecordStatsFailure`, which drives the failure through the
production path by making `getTopicAssignment()` throw, starts the real reporter thread, and asserts
the thread is still alive after a reporting cycle.

The test was verified to be a genuine regression test: it **fails** on the unmodified source (the
thread terminates) and **passes** with the fix applied. `VeniceChangelogConsumerImplTest` and
`VeniceChangelogConsumerDaVinciRecordTransformerImplTest` both pass, and root `spotlessCheck` is clean.

## Does this PR introduce any user-facing or breaking changes?

No. This only changes failure handling inside an internal reporter thread. In the failure case the
thread now survives and keeps emitting metrics on subsequent intervals instead of stopping silently;
the success path is unchanged.

---

🤖 Generated with [GitHub Copilot CLI](https://github.com/features/copilot/cli)
